### PR TITLE
Allow specify different credentials per runtime

### DIFF
--- a/components/gateway/internal/gqlschema/examples/01_get_apps.graphql
+++ b/components/gateway/internal/gqlschema/examples/01_get_apps.graphql
@@ -19,8 +19,8 @@ query {
         webhooks {
             type
             url
-            credential {
-                data {
+            auth {
+                credential {
                     __typename
                     ... on BasicCredentialData {
                         username
@@ -44,7 +44,7 @@ query {
                 credential {
                     additionalHeaders
                     additionalQueryParams
-                    data {
+                    credential {
                         __typename
                         ... on BasicCredentialData {
                             username

--- a/components/gateway/internal/gqlschema/examples/01_get_apps.graphql
+++ b/components/gateway/internal/gqlschema/examples/01_get_apps.graphql
@@ -1,6 +1,6 @@
 query {
     applications(
-        filer: [
+        filter: [
             { label: "group", values: ["production", "experimental"], operator: ANY },
             {label: "region", values:["us"]}
         ]
@@ -22,7 +22,7 @@ query {
             credential {
                 data {
                     __typename
-                   ... on BasicCredentialData {
+                    ... on BasicCredentialData {
                         username
                         password
                     }
@@ -38,59 +38,66 @@ query {
         apis {
             id
             targetURL
-            credential {
-                data {
-                    __typename
-                    ... on BasicCredentialData {
-                        username
-                        password
-                    }
-                    ... on OAuthCredentialData {
-                        clientId
-                        clientSecret
-                        url
-                    }
-                }
-            }
-            spec {
-                type
-                data
-            }
-            additionalHeaders
-            additionalQueryParams
-            version {
-                value
-                deprecated
-                deprecatedSince
-                forRemoval
-            }
-        }
-        eventAPIs {
-            id
-            spec {
-                type
-                data
-                fetchRequest {
-                    url
-                    credential {
-                        data {
-                            __typename
-                            ... on BasicCredentialData {
-                                username
-                                password
-                            }
-                            ... on OAuthCredentialData {
-                                clientId
-                                clientSecret
-                                url
-                            }
+            credentials {
+                runtimeID
+
+                credential {
+                    additionalHeaders
+                    additionalQueryParams
+                    data {
+                        __typename
+                        ... on BasicCredentialData {
+                            username
+                            password
+                        }
+                        ... on OAuthCredentialData {
+                            clientId
+                            clientSecret
+                            url
                         }
                     }
                 }
             }
-            version {
-                value
-            }
+        }
+        spec {
+            type
+            data
+        }
+        additionalHeaders
+        additionalQueryParams
+        version {
+            value
+            deprecated
+            deprecatedSince
+            forRemoval
         }
     }
+    eventAPIs {
+        id
+        spec {
+            type
+            data
+            fetchRequest {
+                url
+                credential {
+                    data {
+                        __typename
+                        ... on BasicCredentialData {
+                            username
+                            password
+                        }
+                        ... on OAuthCredentialData {
+                            clientId
+                            clientSecret
+                            url
+                        }
+                    }
+                }
+            }
+        }
+        version {
+            value
+        }
+    }
+}
 }

--- a/components/gateway/internal/gqlschema/examples/01_get_apps.graphql
+++ b/components/gateway/internal/gqlschema/examples/01_get_apps.graphql
@@ -38,10 +38,9 @@ query {
         apis {
             id
             targetURL
-            credentials {
+            auths {
                 runtimeID
-
-                credential {
+                auth {
                     additionalHeaders
                     additionalQueryParams
                     credential {
@@ -58,46 +57,41 @@ query {
                     }
                 }
             }
+            version {
+                value
+                deprecated
+                deprecatedSince
+                forRemoval
+            }
+            group
         }
-        spec {
-            type
-            data
-        }
-        additionalHeaders
-        additionalQueryParams
-        version {
-            value
-            deprecated
-            deprecatedSince
-            forRemoval
-        }
-    }
-    eventAPIs {
-        id
-        spec {
-            type
-            data
-            fetchRequest {
-                url
-                credential {
-                    data {
-                        __typename
-                        ... on BasicCredentialData {
-                            username
-                            password
-                        }
-                        ... on OAuthCredentialData {
-                            clientId
-                            clientSecret
-                            url
+
+        eventAPIs {
+            id
+            spec {
+                type
+                data
+                fetchRequest {
+                    url
+                    auth {
+                        credential {
+                            __typename
+                            ... on BasicCredentialData {
+                                username
+                                password
+                            }
+                            ... on OAuthCredentialData {
+                                clientId
+                                clientSecret
+                                url
+                            }
                         }
                     }
                 }
             }
-        }
-        version {
-            value
+            version {
+                value
+            }
         }
     }
-}
 }

--- a/components/gateway/internal/gqlschema/examples/06_get_labels.graphql
+++ b/components/gateway/internal/gqlschema/examples/06_get_labels.graphql
@@ -1,3 +1,0 @@
-query {
-    labels(key:"group")
-}

--- a/components/gateway/internal/gqlschema/examples/07_create_app.graphql
+++ b/components/gateway/internal/gqlschema/examples/07_create_app.graphql
@@ -5,7 +5,7 @@ mutation {
             description: "TODO",
             labels: "",
             annotations: "",
-            webhooks: [{type:CONFIGURATION_CHANGED,url: "",credential: {data: { basic: {
+            webhooks: [{type:CONFIGURATION_CHANGED,url: "",auth: {credential: { basic: {
                 password: "aaa",
                 username: "bbb",
             }}}}],
@@ -13,35 +13,11 @@ mutation {
             apis: [
                 {
                     targetURL: "",
-                    credential: {
-                        data: {
-                            basic: {
-                                username: "aaa",
-                                password: "bbb",
-                            }
-                        }
-                    },
-                    additionalHeaders: "",
-                    additionalQueryParams: "",
                     spec: {
                         type: OPEN_API,
                         format: JSON,
                         data: "",
                     },
-                    variants: [
-                        {
-                            runtimeID: "kyma-1",
-                            credential: {
-                                data: {
-                                    basic: {
-                                        username: "fff",
-                                        password: "ggg",
-                                    }
-                                }
-
-                            }
-                        },
-                    ],
                 }
             ],
             events: [

--- a/components/gateway/internal/gqlschema/examples/07_create_app.graphql
+++ b/components/gateway/internal/gqlschema/examples/07_create_app.graphql
@@ -21,12 +21,27 @@ mutation {
                             }
                         }
                     },
-                    injectHeaders: "",
-                    injectQueryParams: "",
+                    additionalHeaders: "",
+                    additionalQueryParams: "",
                     spec: {
-                        apiSpecType: OPEN_API,
+                        type: OPEN_API,
+                        format: JSON,
                         data: "",
                     },
+                    variants: [
+                        {
+                            runtimeID: "kyma-1",
+                            credential: {
+                                data: {
+                                    basic: {
+                                        username: "fff",
+                                        password: "ggg",
+                                    }
+                                }
+
+                            }
+                        },
+                    ],
                 }
             ],
             events: [

--- a/components/gateway/internal/gqlschema/examples/08_update_app.graphql
+++ b/components/gateway/internal/gqlschema/examples/08_update_app.graphql
@@ -22,10 +22,11 @@ mutation {
                             }
                         }
                     },
-                    injectHeaders: "",
-                    injectQueryParams: "",
+                    additionalHeaders: "",
+                    additionalQueryParams: "",
                     spec: {
-                        apiSpecType: OPEN_API,
+                        type: OPEN_API,
+                        format: JSON,
                         data: "",
                     },
                 }

--- a/components/gateway/internal/gqlschema/examples/08_update_app.graphql
+++ b/components/gateway/internal/gqlschema/examples/08_update_app.graphql
@@ -6,7 +6,7 @@ mutation {
             description: "TODO",
             labels: "",
             annotations: "",
-            webhooks: [{type:CONFIGURATION_CHANGED,url: "",credential: {data: { basic: {
+            webhooks: [{type:CONFIGURATION_CHANGED,url: "",auth: {credential: { basic: {
                 password: "aaa",
                 username: "bbb",
             }}}}],
@@ -14,16 +14,6 @@ mutation {
             apis: [
                 {
                     targetURL: "",
-                    credential: {
-                        data: {
-                            basic: {
-                                username: "aaa",
-                                password: "bbb",
-                            }
-                        }
-                    },
-                    additionalHeaders: "",
-                    additionalQueryParams: "",
                     spec: {
                         type: OPEN_API,
                         format: JSON,

--- a/components/gateway/internal/gqlschema/examples/12_manage_api.graphql
+++ b/components/gateway/internal/gqlschema/examples/12_manage_api.graphql
@@ -32,7 +32,7 @@ mutation {
     }
 
     setAPICredential(apiID:  456, in: {
-        data: {
+        credential: {
             basic: {
                 username: "aaa",
                 password: "bbb",
@@ -44,7 +44,7 @@ mutation {
         }
     }
     setAPICredential(apiID:  456, in: {
-        data: {
+        credential: {
             basic: {
                 username: "aaa",
                 password: "bbb",
@@ -57,7 +57,7 @@ mutation {
     }
 
     setAPICredential(apiID: 567, in: {
-        data: {
+        credential: {
             basic: {
                 username: "fff",
                 password: "fff"

--- a/components/gateway/internal/gqlschema/examples/12_manage_api.graphql
+++ b/components/gateway/internal/gqlschema/examples/12_manage_api.graphql
@@ -31,7 +31,7 @@ mutation {
 
     }
 
-    setAPICredential(apiID:  456, in: {
+    setAPIAuth(apiID:  456, in: {
         credential: {
             basic: {
                 username: "aaa",
@@ -43,7 +43,7 @@ mutation {
             __typename
         }
     }
-    setAPICredential(apiID:  456, in: {
+    setAPIAuth(apiID:  456, in: {
         credential: {
             basic: {
                 username: "aaa",
@@ -56,7 +56,7 @@ mutation {
         }
     }
 
-    setAPICredential(apiID: 567, in: {
+    setAPIAuth(apiID: 567, in: {
         credential: {
             basic: {
                 username: "fff",

--- a/components/gateway/internal/gqlschema/examples/12_manage_api.graphql
+++ b/components/gateway/internal/gqlschema/examples/12_manage_api.graphql
@@ -31,7 +31,7 @@ mutation {
 
     }
 
-    firstSet: setAPIAuth(apiID:  "456", in: {
+    firstSet: setAPIAuth(apiID:  "456", runtimeID: "999",in: {
         credential: {
             basic: {
                 username: "aaa",

--- a/components/gateway/internal/gqlschema/examples/12_manage_api.graphql
+++ b/components/gateway/internal/gqlschema/examples/12_manage_api.graphql
@@ -31,7 +31,7 @@ mutation {
 
     }
 
-    setAPIAuth(apiID:  456, in: {
+    firstSet: setAPIAuth(apiID:  "456", in: {
         credential: {
             basic: {
                 username: "aaa",
@@ -39,11 +39,13 @@ mutation {
             }
         }
     })  {
-        data {
+
+        auth {
             __typename
         }
+        runtimeID
     }
-    setAPIAuth(apiID:  456, in: {
+    secondSet: setAPIAuth(apiID:  "456", runtimeID: "789",in: {
         credential: {
             basic: {
                 username: "aaa",
@@ -51,28 +53,11 @@ mutation {
             }
         }
     })  {
-        data {
+        auth {
             __typename
         }
+        runtimeID
     }
 
-    setAPIAuth(apiID: 567, in: {
-        credential: {
-            basic: {
-                username: "fff",
-                password: "fff"
-            }
-        }
-    }) {
-        data {
-            __typename
-        }
-    }
-
-    deleteAPICredential(apiID: 456) {
-        data {
-            __typename
-        }
-    }
 
 }

--- a/components/gateway/internal/gqlschema/examples/12_manage_api.graphql
+++ b/components/gateway/internal/gqlschema/examples/12_manage_api.graphql
@@ -1,7 +1,8 @@
 mutation {
     addAPI(applicationID: "123", in: {
         targetURL: "",
-        spec: {apiSpecType: OPEN_API,
+        spec: {type: OPEN_API,
+            format: JSON,
             data: ""}
     }) {
         id
@@ -9,7 +10,8 @@ mutation {
 
     updateAPI(id:"456", in: {
         targetURL: "",
-        spec: {apiSpecType: OPEN_API,
+        spec: {type: OPEN_API,
+            format: JSON,
             data: ""}
     }) {
         id
@@ -37,6 +39,31 @@ mutation {
             }
         }
     })  {
+        data {
+            __typename
+        }
+    }
+    setAPICredential(apiID:  456, in: {
+        data: {
+            basic: {
+                username: "aaa",
+                password: "bbb",
+            }
+        }
+    })  {
+        data {
+            __typename
+        }
+    }
+
+    setAPICredential(apiID: 567, in: {
+        data: {
+            basic: {
+                username: "fff",
+                password: "fff"
+            }
+        }
+    }) {
         data {
             __typename
         }

--- a/components/gateway/internal/gqlschema/examples/14_create_runtime.graphql
+++ b/components/gateway/internal/gqlschema/examples/14_create_runtime.graphql
@@ -6,8 +6,8 @@ mutation {
     }){
         id
         name
-        agentCredential {
-            data {
+        agentAuth {
+            credential {
                 __typename
                 ... on BasicCredentialData {
                     username

--- a/components/gateway/internal/gqlschema/models_gen.go
+++ b/components/gateway/internal/gqlschema/models_gen.go
@@ -17,10 +17,12 @@ type APIDefinition struct {
 	Spec      *APISpec `json:"spec"`
 	TargetURL string   `json:"targetURL"`
 	//  group allows you to find the same API but in different version
-	Group   *string           `json:"group"`
-	Auth    *Auth             `json:"auth"`
-	Auths   []*AuthForRuntime `json:"auths"`
-	Version *Version          `json:"version"`
+	Group *string `json:"group"`
+	// " If runtime does not exist, error will be returned. If runtime exist but does not have Auth defined, nil is returned
+	Auth *Auth `json:"auth"`
+	//  Auths returns information for all runtimes, even for given runtime Auth is not yet specified
+	Auths   []*RuntimeAuth `json:"auths"`
+	Version *Version       `json:"version"`
 }
 
 type APIDefinitionInput struct {
@@ -55,8 +57,9 @@ type Application struct {
 	Status         *ApplicationStatus    `json:"status"`
 	Webhooks       []*ApplicationWebhook `json:"webhooks"`
 	HealthCheckURL *string               `json:"healthCheckURL"`
-	//  groupName allows to find different versions of the same API
-	Apis      []*APIDefinition      `json:"apis"`
+	//  group allows to find different versions of the same API
+	Apis []*APIDefinition `json:"apis"`
+	//  group allows to find different versions of the same event API
 	EventAPIs []*EventAPIDefinition `json:"eventAPIs"`
 	Documents []*Document           `json:"documents"`
 }
@@ -96,11 +99,6 @@ type Auth struct {
 	AdditionalHeaders     *HttpHeaders           `json:"additionalHeaders"`
 	AdditionalQueryParams *QueryParams           `json:"additionalQueryParams"`
 	RequestAuth           *CredentialRequestAuth `json:"requestAuth"`
-}
-
-type AuthForRuntime struct {
-	RuntimeID string `json:"runtimeID"`
-	Auth      *Auth  `json:"auth"`
 }
 
 type AuthInput struct {
@@ -251,6 +249,11 @@ type Runtime struct {
 	Status      *RuntimeStatus `json:"status"`
 	// directive for checking auth
 	AgentAuth *Auth `json:"agentAuth"`
+}
+
+type RuntimeAuth struct {
+	RuntimeID string `json:"runtimeID"`
+	Auth      *Auth  `json:"auth"`
 }
 
 type RuntimeInput struct {

--- a/components/gateway/internal/gqlschema/models_gen.go
+++ b/components/gateway/internal/gqlschema/models_gen.go
@@ -17,14 +17,15 @@ type APIDefinition struct {
 	Spec      *APISpec `json:"spec"`
 	TargetURL string   `json:"targetURL"`
 	//  group allows you to find the same API but in different version
-	Group       *string              `json:"group"`
-	Credential  *Credential          `json:"credential"`
-	Credentials []*RuntimeCredential `json:"credentials"`
-	Version     *Version             `json:"version"`
+	Group   *string           `json:"group"`
+	Auth    *Auth             `json:"auth"`
+	Auths   []*AuthForRuntime `json:"auths"`
+	Version *Version          `json:"version"`
 }
 
 type APIDefinitionInput struct {
 	TargetURL string        `json:"targetURL"`
+	Group     *string       `json:"group"`
 	Spec      *APISpecInput `json:"spec"`
 	Version   *VersionInput `json:"version"`
 }
@@ -78,16 +79,35 @@ type ApplicationStatus struct {
 }
 
 type ApplicationWebhook struct {
-	ID         string                 `json:"id"`
-	Type       ApplicationWebhookType `json:"type"`
-	URL        string                 `json:"url"`
-	Credential *Credential            `json:"credential"`
+	ID   string                 `json:"id"`
+	Type ApplicationWebhookType `json:"type"`
+	URL  string                 `json:"url"`
+	Auth *Auth                  `json:"auth"`
 }
 
 type ApplicationWebhookInput struct {
-	Type       ApplicationWebhookType `json:"type"`
-	URL        string                 `json:"url"`
-	Credential *CredentialInput       `json:"credential"`
+	Type ApplicationWebhookType `json:"type"`
+	URL  string                 `json:"url"`
+	Auth *AuthInput             `json:"auth"`
+}
+
+type Auth struct {
+	Credential            CredentialData         `json:"credential"`
+	AdditionalHeaders     *HttpHeaders           `json:"additionalHeaders"`
+	AdditionalQueryParams *QueryParams           `json:"additionalQueryParams"`
+	RequestAuth           *CredentialRequestAuth `json:"requestAuth"`
+}
+
+type AuthForRuntime struct {
+	RuntimeID string `json:"runtimeID"`
+	Auth      *Auth  `json:"auth"`
+}
+
+type AuthInput struct {
+	Credential            *CredentialDataInput        `json:"credential"`
+	AdditionalHeaders     *HttpHeaders                `json:"additionalHeaders"`
+	AdditionalQueryParams *QueryParams                `json:"additionalQueryParams"`
+	RequestAuth           *CredentialRequestAuthInput `json:"requestAuth"`
 }
 
 type BasicCredentialData struct {
@@ -110,23 +130,9 @@ type CSRFTokenCredentialRequestAuthInput struct {
 	Token string `json:"token"`
 }
 
-type Credential struct {
-	Data                  CredentialData         `json:"data"`
-	AdditionalHeaders     *HttpHeaders           `json:"additionalHeaders"`
-	AdditionalQueryParams *QueryParams           `json:"additionalQueryParams"`
-	RequestAuth           *CredentialRequestAuth `json:"requestAuth"`
-}
-
 type CredentialDataInput struct {
 	Basic *BasicCredentialDataInput `json:"basic"`
 	Oauth *OAuthCredentialDataInput `json:"oauth"`
-}
-
-type CredentialInput struct {
-	Data                  *CredentialDataInput        `json:"data"`
-	AdditionalHeaders     *HttpHeaders                `json:"additionalHeaders"`
-	AdditionalQueryParams *QueryParams                `json:"additionalQueryParams"`
-	RequestAuth           *CredentialRequestAuthInput `json:"requestAuth"`
 }
 
 type CredentialRequestAuth struct {
@@ -168,7 +174,9 @@ type EventAPIDefinition struct {
 }
 
 type EventDefinitionInput struct {
-	Spec *EventSpecInput `json:"spec"`
+	Spec    *EventSpecInput `json:"spec"`
+	Group   *string         `json:"group"`
+	Version *VersionInput   `json:"version"`
 }
 
 type EventSpec struct {
@@ -186,18 +194,18 @@ type EventSpecInput struct {
 
 //  Compass performs fetch to validate if request is correct and stores a copy
 type FetchRequest struct {
-	URL        string              `json:"url"`
-	Credential *Credential         `json:"credential"`
-	Mode       FetchMode           `json:"mode"`
-	Filter     *string             `json:"filter"`
-	Status     *FetchRequestStatus `json:"status"`
+	URL    string              `json:"url"`
+	Auth   *Auth               `json:"auth"`
+	Mode   FetchMode           `json:"mode"`
+	Filter *string             `json:"filter"`
+	Status *FetchRequestStatus `json:"status"`
 }
 
 type FetchRequestInput struct {
-	URL        string           `json:"url"`
-	Credential *CredentialInput `json:"credential"`
-	Mode       *FetchMode       `json:"mode"`
-	Filter     *string          `json:"filter"`
+	URL    string     `json:"url"`
+	Auth   *AuthInput `json:"auth"`
+	Mode   *FetchMode `json:"mode"`
+	Filter *string    `json:"filter"`
 }
 
 type FetchRequestStatus struct {
@@ -242,12 +250,7 @@ type Runtime struct {
 	Annotations Annotations    `json:"annotations"`
 	Status      *RuntimeStatus `json:"status"`
 	// directive for checking auth
-	AgentCredential *Credential `json:"agentCredential"`
-}
-
-type RuntimeCredential struct {
-	RuntimeID  string      `json:"runtimeID"`
-	Credential *Credential `json:"credential"`
+	AgentAuth *Auth `json:"agentAuth"`
 }
 
 type RuntimeInput struct {

--- a/components/gateway/internal/gqlschema/models_gen.go
+++ b/components/gateway/internal/gqlschema/models_gen.go
@@ -18,18 +18,21 @@ type APIDefinition struct {
 	TargetURL string   `json:"targetURL"`
 	//  group allows you to find the same API but in different version
 	Group *string `json:"group"`
-	// "If runtime does not exist, an error will be returned. If runtime exists but does not have Auth defined, null is returned
-	Auth *Auth `json:"auth"`
-	// Returns authentication details for all runtimes, even for a runtime, where Auth is not yet specified
-	Auths   []*RuntimeAuth `json:"auths"`
-	Version *Version       `json:"version"`
+	// "If runtime does not exist, an error is returned. If runtime exists but Auth for it is not set, defaultAuth is returned if specified.
+	Auth *RuntimeAuth `json:"auth"`
+	// Returns authentication details for all runtimes, even for a runtime, where Auth is not yet specified.
+	Auths []*RuntimeAuth `json:"auths"`
+	// If defaultAuth is specified, it will be used for all Runtimes that does not specify Auth explicitly.
+	DefaultAuth *Auth    `json:"defaultAuth"`
+	Version     *Version `json:"version"`
 }
 
 type APIDefinitionInput struct {
-	TargetURL string        `json:"targetURL"`
-	Group     *string       `json:"group"`
-	Spec      *APISpecInput `json:"spec"`
-	Version   *VersionInput `json:"version"`
+	TargetURL   string        `json:"targetURL"`
+	Group       *string       `json:"group"`
+	Spec        *APISpecInput `json:"spec"`
+	Version     *VersionInput `json:"version"`
+	DefaultAuth *AuthInput    `json:"defaultAuth"`
 }
 
 type APISpec struct {

--- a/components/gateway/internal/gqlschema/models_gen.go
+++ b/components/gateway/internal/gqlschema/models_gen.go
@@ -13,21 +13,20 @@ type CredentialData interface {
 }
 
 type APIDefinition struct {
-	ID                    string       `json:"id"`
-	Spec                  *APISpec     `json:"spec"`
-	TargetURL             string       `json:"targetURL"`
-	Credential            *Credential  `json:"credential"`
-	AdditionalHeaders     *HttpHeaders `json:"additionalHeaders"`
-	AdditionalQueryParams *QueryParams `json:"additionalQueryParams"`
-	Version               *Version     `json:"version"`
+	ID        string   `json:"id"`
+	Spec      *APISpec `json:"spec"`
+	TargetURL string   `json:"targetURL"`
+	//  group allows you to find the same API but in different version
+	Group       *string              `json:"group"`
+	Credential  *Credential          `json:"credential"`
+	Credentials []*RuntimeCredential `json:"credentials"`
+	Version     *Version             `json:"version"`
 }
 
 type APIDefinitionInput struct {
-	TargetURL         string           `json:"targetURL"`
-	Credential        *CredentialInput `json:"credential"`
-	Spec              *APISpecInput    `json:"spec"`
-	InjectHeaders     *HttpHeaders     `json:"injectHeaders"`
-	InjectQueryParams *QueryParams     `json:"injectQueryParams"`
+	TargetURL string        `json:"targetURL"`
+	Spec      *APISpecInput `json:"spec"`
+	Version   *VersionInput `json:"version"`
 }
 
 type APISpec struct {
@@ -55,9 +54,10 @@ type Application struct {
 	Status         *ApplicationStatus    `json:"status"`
 	Webhooks       []*ApplicationWebhook `json:"webhooks"`
 	HealthCheckURL *string               `json:"healthCheckURL"`
-	Apis           []*APIDefinition      `json:"apis"`
-	EventAPIs      []*EventAPIDefinition `json:"eventAPIs"`
-	Documents      []*Document           `json:"documents"`
+	//  groupName allows to find different versions of the same API
+	Apis      []*APIDefinition      `json:"apis"`
+	EventAPIs []*EventAPIDefinition `json:"eventAPIs"`
+	Documents []*Document           `json:"documents"`
 }
 
 type ApplicationInput struct {
@@ -111,8 +111,10 @@ type CSRFTokenCredentialRequestAuthInput struct {
 }
 
 type Credential struct {
-	Data        CredentialData         `json:"data"`
-	RequestAuth *CredentialRequestAuth `json:"requestAuth"`
+	Data                  CredentialData         `json:"data"`
+	AdditionalHeaders     *HttpHeaders           `json:"additionalHeaders"`
+	AdditionalQueryParams *QueryParams           `json:"additionalQueryParams"`
+	RequestAuth           *CredentialRequestAuth `json:"requestAuth"`
 }
 
 type CredentialDataInput struct {
@@ -121,8 +123,10 @@ type CredentialDataInput struct {
 }
 
 type CredentialInput struct {
-	Data        *CredentialDataInput        `json:"data"`
-	RequestAuth *CredentialRequestAuthInput `json:"requestAuth"`
+	Data                  *CredentialDataInput        `json:"data"`
+	AdditionalHeaders     *HttpHeaders                `json:"additionalHeaders"`
+	AdditionalQueryParams *QueryParams                `json:"additionalQueryParams"`
+	RequestAuth           *CredentialRequestAuthInput `json:"requestAuth"`
 }
 
 type CredentialRequestAuth struct {
@@ -156,7 +160,9 @@ type DocumentInput struct {
 }
 
 type EventAPIDefinition struct {
-	ID      string     `json:"id"`
+	ID string `json:"id"`
+	// group allows you to find the same API but in different version
+	Group   *string    `json:"group"`
 	Spec    *EventSpec `json:"spec"`
 	Version *Version   `json:"version"`
 }
@@ -239,6 +245,11 @@ type Runtime struct {
 	AgentCredential *Credential `json:"agentCredential"`
 }
 
+type RuntimeCredential struct {
+	RuntimeID  string      `json:"runtimeID"`
+	Credential *Credential `json:"credential"`
+}
+
 type RuntimeInput struct {
 	Name        string       `json:"name"`
 	Description *string      `json:"description"`
@@ -259,6 +270,13 @@ type Version struct {
 	DeprecatedSince *string `json:"deprecatedSince"`
 	// if true, will be removed in the next version
 	ForRemoval *bool `json:"forRemoval"`
+}
+
+type VersionInput struct {
+	Value           string  `json:"value"`
+	Deprecated      *bool   `json:"deprecated"`
+	DeprecatedSince *string `json:"deprecatedSince"`
+	ForRemoval      *bool   `json:"forRemoval"`
 }
 
 type APISpecType string

--- a/components/gateway/internal/gqlschema/models_gen.go
+++ b/components/gateway/internal/gqlschema/models_gen.go
@@ -18,9 +18,9 @@ type APIDefinition struct {
 	TargetURL string   `json:"targetURL"`
 	//  group allows you to find the same API but in different version
 	Group *string `json:"group"`
-	// " If runtime does not exist, error will be returned. If runtime exist but does not have Auth defined, nil is returned
+	// "If runtime does not exist, an error will be returned. If runtime exists but does not have Auth defined, null is returned
 	Auth *Auth `json:"auth"`
-	//  Auths returns information for all runtimes, even for given runtime Auth is not yet specified
+	// Returns authentication details for all runtimes, even for a runtime, where Auth is not yet specified
 	Auths   []*RuntimeAuth `json:"auths"`
 	Version *Version       `json:"version"`
 }

--- a/components/gateway/internal/gqlschema/schema.graphql
+++ b/components/gateway/internal/gqlschema/schema.graphql
@@ -25,7 +25,7 @@ type Runtime {
     annotations(key: String): Annotations!
     status: RuntimeStatus!
     """directive for checking auth"""
-    agentCredential: Credential!
+    agentAuth: Auth!
 }
 
 type RuntimeStatus {
@@ -73,7 +73,7 @@ type ApplicationWebhook {
     id: ID!
     type: ApplicationWebhookType!
     url: String!
-    credential: Credential
+    auth: Auth
 }
 
 enum ApplicationWebhookType {
@@ -98,14 +98,14 @@ type APIDefinition {
     targetURL: String!
     """ group allows you to find the same API but in different version """
     group: String
-    credential(runtimeID: ID!): Credential
-    credentials: [RuntimeCredential!]
+    auth(runtimeID: ID!): Auth
+    auths: [AuthForRuntime!]
     version: Version
 }
 
-type RuntimeCredential {
+type AuthForRuntime {
     runtimeID: ID!
-    credential: Credential!
+    auth: Auth!
 }
 
 type APISpec {
@@ -167,7 +167,7 @@ enum DocumentFormat {
 """ Compass performs fetch to validate if request is correct and stores a copy"""
 type FetchRequest {
     url: String!
-    credential: Credential
+    auth: Auth
     mode: FetchMode!
     filter: String
     status: FetchRequestStatus!
@@ -190,9 +190,9 @@ enum FetchMode {
     INDEX
 }
 
-# Credential
-type Credential {
-    data: CredentialData!
+# Authentication
+type Auth {
+    credential: CredentialData!
     additionalHeaders: HttpHeaders
     additionalQueryParams: QueryParams
     requestAuth: CredentialRequestAuth
@@ -274,7 +274,7 @@ input RuntimeInput {
 
 input FetchRequestInput {
     url: String!
-    credential: CredentialInput
+    auth: AuthInput
     mode: FetchMode
     filter: String
 }
@@ -284,13 +284,14 @@ input FetchRequestInput {
 input ApplicationWebhookInput {
     type: ApplicationWebhookType!
     url: String!
-    credential: CredentialInput
+    auth: AuthInput
 }
 
 # API Input
-# you need to perform separate call to set credentials
+# you need to perform separate call to set auth
 input APIDefinitionInput {
     targetURL: String!
+    group: String
     spec: APISpecInput
     version: VersionInput
 }
@@ -313,7 +314,9 @@ input APISpecInput {
 # Event Input
 
 input EventDefinitionInput {
-    spec: EventSpecInput
+    spec: EventSpecInput!
+    group: String
+    version: VersionInput
 }
 
 input EventSpecInput {
@@ -335,10 +338,10 @@ input DocumentInput {
 }
 
 
-# Credential Input
+# Auth Input
 
-input CredentialInput {
-    data: CredentialDataInput!
+input AuthInput {
+    credential: CredentialDataInput!
     additionalHeaders: HttpHeaders #
     additionalQueryParams: QueryParams
     requestAuth: CredentialRequestAuthInput
@@ -417,8 +420,8 @@ type Mutation {
     If runtimeID not provided, the samec credential will be set for every runtime already available
     Returns information for which runtime it was configured
     """
-    setAPICredential(apiID: ID!, runtimeID: ID, in: CredentialInput!): [RuntimeCredential!]!
-    deleteAPICredential(apiID: ID!, runtimeID: ID): [RuntimeCredential!]!
+    setAPICredential(apiID: ID!, runtimeID: ID, in: AuthInput!): [AuthForRuntime!]!
+    deleteAPICredential(apiID: ID!, runtimeID: ID): [AuthForRuntime!]!
 
 
     addEvent(applicationID: ID!, in: EventDefinitionInput!): EventAPIDefinition!

--- a/components/gateway/internal/gqlschema/schema.graphql
+++ b/components/gateway/internal/gqlschema/schema.graphql
@@ -417,11 +417,11 @@ type Mutation {
     refetchAPISpec(apiID: ID!): APISpec
 
     """
-    If runtimeID not provided, the samec credential will be set for every runtime already available
+    If runtimeID not provided, the samec auth will be set for every runtime already available
     Returns information for which runtime it was configured
     """
-    setAPICredential(apiID: ID!, runtimeID: ID, in: AuthInput!): [AuthForRuntime!]!
-    deleteAPICredential(apiID: ID!, runtimeID: ID): [AuthForRuntime!]!
+    setAPIAuth(apiID: ID!, runtimeID: ID, in: AuthInput!): [AuthForRuntime!]!
+    deleteAPIAuth(apiID: ID!, runtimeID: ID): [AuthForRuntime!]!
 
 
     addEvent(applicationID: ID!, in: EventDefinitionInput!): EventAPIDefinition!

--- a/components/gateway/internal/gqlschema/schema.graphql
+++ b/components/gateway/internal/gqlschema/schema.graphql
@@ -99,9 +99,9 @@ type APIDefinition {
     targetURL: String!
     """ group allows you to find the same API but in different version """
     group: String
-    """" If runtime does not exist, error will be returned. If runtime exist but does not have Auth defined, nil is returned """
+    """"If runtime does not exist, an error will be returned. If runtime exists but does not have Auth defined, null is returned"""
     auth(runtimeID: ID!): Auth
-    """ Auths returns information for all runtimes, even for given runtime Auth is not yet specified """
+    """Returns authentication details for all runtimes, even for a runtime, where Auth is not yet specified"""
     auths: [RuntimeAuth!]!
     version: Version
 }
@@ -420,8 +420,8 @@ type Mutation {
     refetchAPISpec(apiID: ID!): APISpec
 
     """
-    If runtimeID not provided, the same auth will be set for every runtime already available
-    Returns information for which runtime it was configured
+    If runtimeID is not provided, the same authentication details will be set for every runtime already available.
+    Returns information for which runtime it was configured.
     """
     setAPIAuth(apiID: ID!, runtimeID: ID, in: AuthInput!): [RuntimeAuth!]!
     deleteAPIAuth(apiID: ID!, runtimeID: ID): [RuntimeAuth!]!

--- a/components/gateway/internal/gqlschema/schema.graphql
+++ b/components/gateway/internal/gqlschema/schema.graphql
@@ -427,7 +427,7 @@ type Mutation {
     Returns information about all Auths for given applicationID. To set default Auth for API, use updateAPI mutation
     """
     setAPIAuth(apiID: ID!, runtimeID: ID!, in: AuthInput!): [RuntimeAuth!]!
-    deleteAPIAuth(apiID: ID!, runtimeID: ID): [RuntimeAuth!]!
+    deleteAPIAuth(apiID: ID!, runtimeID: ID!): [RuntimeAuth!]!
 
 
     addEvent(applicationID: ID!, in: EventDefinitionInput!): EventAPIDefinition!

--- a/components/gateway/internal/gqlschema/schema.graphql
+++ b/components/gateway/internal/gqlschema/schema.graphql
@@ -51,9 +51,10 @@ type Application {
     status: ApplicationStatus!
     webhooks: [ApplicationWebhook!]!
     healthCheckURL: String
-    """ groupName allows to find different versions of the same API """
-    apis(groupName: String): [APIDefinition!]!
-    eventAPIs(groupName: String): [EventAPIDefinition!]!
+    """ group allows to find different versions of the same API """
+    apis(group: String): [APIDefinition!]!
+    """ group allows to find different versions of the same event API """
+    eventAPIs(group: String): [EventAPIDefinition!]!
     documents: [Document!]!
 }
 
@@ -98,14 +99,16 @@ type APIDefinition {
     targetURL: String!
     """ group allows you to find the same API but in different version """
     group: String
+    """" If runtime does not exist, error will be returned. If runtime exist but does not have Auth defined, nil is returned """
     auth(runtimeID: ID!): Auth
-    auths: [AuthForRuntime!]
+    """ Auths returns information for all runtimes, even for given runtime Auth is not yet specified """
+    auths: [RuntimeAuth!]!
     version: Version
 }
 
-type AuthForRuntime {
+type RuntimeAuth {
     runtimeID: ID!
-    auth: Auth!
+    auth: Auth
 }
 
 type APISpec {
@@ -417,11 +420,11 @@ type Mutation {
     refetchAPISpec(apiID: ID!): APISpec
 
     """
-    If runtimeID not provided, the samec auth will be set for every runtime already available
+    If runtimeID not provided, the same auth will be set for every runtime already available
     Returns information for which runtime it was configured
     """
-    setAPIAuth(apiID: ID!, runtimeID: ID, in: AuthInput!): [AuthForRuntime!]!
-    deleteAPIAuth(apiID: ID!, runtimeID: ID): [AuthForRuntime!]!
+    setAPIAuth(apiID: ID!, runtimeID: ID, in: AuthInput!): [RuntimeAuth!]!
+    deleteAPIAuth(apiID: ID!, runtimeID: ID): [RuntimeAuth!]!
 
 
     addEvent(applicationID: ID!, in: EventDefinitionInput!): EventAPIDefinition!

--- a/components/gateway/internal/gqlschema/schema.graphql
+++ b/components/gateway/internal/gqlschema/schema.graphql
@@ -51,8 +51,9 @@ type Application {
     status: ApplicationStatus!
     webhooks: [ApplicationWebhook!]!
     healthCheckURL: String
-    apis: [APIDefinition!]!
-    eventAPIs: [EventAPIDefinition!]!
+    """ groupName allows to find different versions of the same API """
+    apis(groupName: String): [APIDefinition!]!
+    eventAPIs(groupName: String): [EventAPIDefinition!]!
     documents: [Document!]!
 }
 
@@ -89,17 +90,22 @@ type Version {
     deprecatedSince: String
     """if true, will be removed in the next version"""
     forRemoval: Boolean
-
 }
 
 type APIDefinition {
     id: ID!
     spec: APISpec
     targetURL: String!
-    credential: Credential
-    additionalHeaders: HttpHeaders #
-    additionalQueryParams: QueryParams
+    """ group allows you to find the same API but in different version """
+    group: String
+    credential(runtimeID: ID!): Credential
+    credentials: [RuntimeCredential!]
     version: Version
+}
+
+type RuntimeCredential {
+    runtimeID: ID!
+    credential: Credential!
 }
 
 type APISpec {
@@ -128,6 +134,8 @@ enum EventSpecType {
 
 type EventAPIDefinition {
     id: ID!
+    """group allows you to find the same API but in different version"""
+    group: String
     spec: EventSpec!
     version: Version
 }
@@ -185,6 +193,8 @@ enum FetchMode {
 # Credential
 type Credential {
     data: CredentialData!
+    additionalHeaders: HttpHeaders
+    additionalQueryParams: QueryParams
     requestAuth: CredentialRequestAuth
 }
 
@@ -278,14 +288,20 @@ input ApplicationWebhookInput {
 }
 
 # API Input
-
+# you need to perform separate call to set credentials
 input APIDefinitionInput {
     targetURL: String!
-    credential: CredentialInput
     spec: APISpecInput
-    injectHeaders: HttpHeaders
-    injectQueryParams: QueryParams
+    version: VersionInput
 }
+
+input VersionInput {
+    value: String!
+    deprecated: Boolean = false
+    deprecatedSince: String
+    forRemoval: Boolean = false
+}
+
 
 input APISpecInput {
     data: CLOB
@@ -323,6 +339,8 @@ input DocumentInput {
 
 input CredentialInput {
     data: CredentialDataInput!
+    additionalHeaders: HttpHeaders #
+    additionalQueryParams: QueryParams
     requestAuth: CredentialRequestAuthInput
 }
 
@@ -395,8 +413,13 @@ type Mutation {
     deleteAPI(id: ID!): APIDefinition
     refetchAPISpec(apiID: ID!): APISpec
 
-    setAPICredential(apiID: ID!, in: CredentialInput!): Credential!
-    deleteAPICredential(apiID: ID!): Credential
+    """
+    If runtimeID not provided, the samec credential will be set for every runtime already available
+    Returns information for which runtime it was configured
+    """
+    setAPICredential(apiID: ID!, runtimeID: ID, in: CredentialInput!): [RuntimeCredential!]!
+    deleteAPICredential(apiID: ID!, runtimeID: ID): [RuntimeCredential!]!
+
 
     addEvent(applicationID: ID!, in: EventDefinitionInput!): EventAPIDefinition!
     updateEvent(id: ID!, in: EventDefinitionInput!): EventAPIDefinition!

--- a/components/gateway/internal/gqlschema/schema.graphql
+++ b/components/gateway/internal/gqlschema/schema.graphql
@@ -99,10 +99,12 @@ type APIDefinition {
     targetURL: String!
     """ group allows you to find the same API but in different version """
     group: String
-    """"If runtime does not exist, an error will be returned. If runtime exists but does not have Auth defined, null is returned"""
-    auth(runtimeID: ID!): Auth
-    """Returns authentication details for all runtimes, even for a runtime, where Auth is not yet specified"""
+    """"If runtime does not exist, an error is returned. If runtime exists but Auth for it is not set, defaultAuth is returned if specified."""
+    auth(runtimeID: ID!): RuntimeAuth
+    """Returns authentication details for all runtimes, even for a runtime, where Auth is not yet specified."""
     auths: [RuntimeAuth!]!
+    """If defaultAuth is specified, it will be used for all Runtimes that does not specify Auth explicitly."""
+    defaultAuth: Auth
     version: Version
 }
 
@@ -291,12 +293,14 @@ input ApplicationWebhookInput {
 }
 
 # API Input
-# you need to perform separate call to set auth
+# You can specify defaultAuth to specify Auth used for all runtimes. If you want to specify auth only for a dedicated Runtime,
+# you need to perform separate mutation setAPIAuth.
 input APIDefinitionInput {
     targetURL: String!
     group: String
     spec: APISpecInput
     version: VersionInput
+    defaultAuth: AuthInput
 }
 
 input VersionInput {
@@ -420,10 +424,9 @@ type Mutation {
     refetchAPISpec(apiID: ID!): APISpec
 
     """
-    If runtimeID is not provided, the same authentication details will be set for every runtime already available.
-    Returns information for which runtime it was configured.
+    Returns information about all Auths for given applicationID. To set default Auth for API, use updateAPI mutation
     """
-    setAPIAuth(apiID: ID!, runtimeID: ID, in: AuthInput!): [RuntimeAuth!]!
+    setAPIAuth(apiID: ID!, runtimeID: ID!, in: AuthInput!): [RuntimeAuth!]!
     deleteAPIAuth(apiID: ID!, runtimeID: ID): [RuntimeAuth!]!
 
 

--- a/components/gateway/internal/gqlschema/schema_gen.go
+++ b/components/gateway/internal/gqlschema/schema_gen.go
@@ -44,13 +44,13 @@ type DirectiveRoot struct {
 
 type ComplexityRoot struct {
 	APIDefinition struct {
-		Credential  func(childComplexity int, runtimeID string) int
-		Credentials func(childComplexity int) int
-		Group       func(childComplexity int) int
-		ID          func(childComplexity int) int
-		Spec        func(childComplexity int) int
-		TargetURL   func(childComplexity int) int
-		Version     func(childComplexity int) int
+		Auth      func(childComplexity int, runtimeID string) int
+		Auths     func(childComplexity int) int
+		Group     func(childComplexity int) int
+		ID        func(childComplexity int) int
+		Spec      func(childComplexity int) int
+		TargetURL func(childComplexity int) int
+		Version   func(childComplexity int) int
 	}
 
 	APISpec struct {
@@ -81,10 +81,22 @@ type ComplexityRoot struct {
 	}
 
 	ApplicationWebhook struct {
-		Credential func(childComplexity int) int
-		ID         func(childComplexity int) int
-		Type       func(childComplexity int) int
-		URL        func(childComplexity int) int
+		Auth func(childComplexity int) int
+		ID   func(childComplexity int) int
+		Type func(childComplexity int) int
+		URL  func(childComplexity int) int
+	}
+
+	Auth struct {
+		AdditionalHeaders     func(childComplexity int) int
+		AdditionalQueryParams func(childComplexity int) int
+		Credential            func(childComplexity int) int
+		RequestAuth           func(childComplexity int) int
+	}
+
+	AuthForRuntime struct {
+		Auth      func(childComplexity int) int
+		RuntimeID func(childComplexity int) int
 	}
 
 	BasicCredentialData struct {
@@ -94,13 +106,6 @@ type ComplexityRoot struct {
 
 	CSRFTokenCredentialRequestAuth struct {
 		Token func(childComplexity int) int
-	}
-
-	Credential struct {
-		AdditionalHeaders     func(childComplexity int) int
-		AdditionalQueryParams func(childComplexity int) int
-		Data                  func(childComplexity int) int
-		RequestAuth           func(childComplexity int) int
 	}
 
 	CredentialRequestAuth struct {
@@ -132,11 +137,11 @@ type ComplexityRoot struct {
 	}
 
 	FetchRequest struct {
-		Credential func(childComplexity int) int
-		Filter     func(childComplexity int) int
-		Mode       func(childComplexity int) int
-		Status     func(childComplexity int) int
-		URL        func(childComplexity int) int
+		Auth   func(childComplexity int) int
+		Filter func(childComplexity int) int
+		Mode   func(childComplexity int) int
+		Status func(childComplexity int) int
+		URL    func(childComplexity int) int
 	}
 
 	FetchRequestStatus struct {
@@ -174,7 +179,7 @@ type ComplexityRoot struct {
 		DeleteRuntimeLabel          func(childComplexity int, id string, key string, values []string) int
 		RefetchAPISpec              func(childComplexity int, apiID string) int
 		RefetchEventSpec            func(childComplexity int, eventID string) int
-		SetAPICredential            func(childComplexity int, apiID string, runtimeID *string, in CredentialInput) int
+		SetAPICredential            func(childComplexity int, apiID string, runtimeID *string, in AuthInput) int
 		UpdateAPI                   func(childComplexity int, id string, in APIDefinitionInput) int
 		UpdateApplication           func(childComplexity int, id string, in ApplicationInput) int
 		UpdateApplicationWebhook    func(childComplexity int, webhookID string, in ApplicationWebhookInput) int
@@ -197,19 +202,14 @@ type ComplexityRoot struct {
 	}
 
 	Runtime struct {
-		AgentCredential func(childComplexity int) int
-		Annotations     func(childComplexity int, key *string) int
-		Description     func(childComplexity int) int
-		ID              func(childComplexity int) int
-		Labels          func(childComplexity int, key *string) int
-		Name            func(childComplexity int) int
-		Status          func(childComplexity int) int
-		Tenant          func(childComplexity int) int
-	}
-
-	RuntimeCredential struct {
-		Credential func(childComplexity int) int
-		RuntimeID  func(childComplexity int) int
+		AgentAuth   func(childComplexity int) int
+		Annotations func(childComplexity int, key *string) int
+		Description func(childComplexity int) int
+		ID          func(childComplexity int) int
+		Labels      func(childComplexity int, key *string) int
+		Name        func(childComplexity int) int
+		Status      func(childComplexity int) int
+		Tenant      func(childComplexity int) int
 	}
 
 	RuntimeStatus struct {
@@ -240,8 +240,8 @@ type MutationResolver interface {
 	UpdateAPI(ctx context.Context, id string, in APIDefinitionInput) (*APIDefinition, error)
 	DeleteAPI(ctx context.Context, id string) (*APIDefinition, error)
 	RefetchAPISpec(ctx context.Context, apiID string) (*APISpec, error)
-	SetAPICredential(ctx context.Context, apiID string, runtimeID *string, in CredentialInput) ([]*RuntimeCredential, error)
-	DeleteAPICredential(ctx context.Context, apiID string, runtimeID *string) ([]*RuntimeCredential, error)
+	SetAPICredential(ctx context.Context, apiID string, runtimeID *string, in AuthInput) ([]*AuthForRuntime, error)
+	DeleteAPICredential(ctx context.Context, apiID string, runtimeID *string) ([]*AuthForRuntime, error)
 	AddEvent(ctx context.Context, applicationID string, in EventDefinitionInput) (*EventAPIDefinition, error)
 	UpdateEvent(ctx context.Context, id string, in EventDefinitionInput) (*EventAPIDefinition, error)
 	DeleteEvent(ctx context.Context, id string) (*EventAPIDefinition, error)
@@ -277,24 +277,24 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 	_ = ec
 	switch typeName + "." + field {
 
-	case "APIDefinition.credential":
-		if e.complexity.APIDefinition.Credential == nil {
+	case "APIDefinition.auth":
+		if e.complexity.APIDefinition.Auth == nil {
 			break
 		}
 
-		args, err := ec.field_APIDefinition_credential_args(context.TODO(), rawArgs)
+		args, err := ec.field_APIDefinition_auth_args(context.TODO(), rawArgs)
 		if err != nil {
 			return 0, false
 		}
 
-		return e.complexity.APIDefinition.Credential(childComplexity, args["runtimeID"].(string)), true
+		return e.complexity.APIDefinition.Auth(childComplexity, args["runtimeID"].(string)), true
 
-	case "APIDefinition.credentials":
-		if e.complexity.APIDefinition.Credentials == nil {
+	case "APIDefinition.auths":
+		if e.complexity.APIDefinition.Auths == nil {
 			break
 		}
 
-		return e.complexity.APIDefinition.Credentials(childComplexity), true
+		return e.complexity.APIDefinition.Auths(childComplexity), true
 
 	case "APIDefinition.group":
 		if e.complexity.APIDefinition.Group == nil {
@@ -477,12 +477,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.ApplicationStatus.Timestamp(childComplexity), true
 
-	case "ApplicationWebhook.credential":
-		if e.complexity.ApplicationWebhook.Credential == nil {
+	case "ApplicationWebhook.auth":
+		if e.complexity.ApplicationWebhook.Auth == nil {
 			break
 		}
 
-		return e.complexity.ApplicationWebhook.Credential(childComplexity), true
+		return e.complexity.ApplicationWebhook.Auth(childComplexity), true
 
 	case "ApplicationWebhook.id":
 		if e.complexity.ApplicationWebhook.ID == nil {
@@ -505,6 +505,48 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.ApplicationWebhook.URL(childComplexity), true
 
+	case "Auth.additionalHeaders":
+		if e.complexity.Auth.AdditionalHeaders == nil {
+			break
+		}
+
+		return e.complexity.Auth.AdditionalHeaders(childComplexity), true
+
+	case "Auth.additionalQueryParams":
+		if e.complexity.Auth.AdditionalQueryParams == nil {
+			break
+		}
+
+		return e.complexity.Auth.AdditionalQueryParams(childComplexity), true
+
+	case "Auth.credential":
+		if e.complexity.Auth.Credential == nil {
+			break
+		}
+
+		return e.complexity.Auth.Credential(childComplexity), true
+
+	case "Auth.requestAuth":
+		if e.complexity.Auth.RequestAuth == nil {
+			break
+		}
+
+		return e.complexity.Auth.RequestAuth(childComplexity), true
+
+	case "AuthForRuntime.auth":
+		if e.complexity.AuthForRuntime.Auth == nil {
+			break
+		}
+
+		return e.complexity.AuthForRuntime.Auth(childComplexity), true
+
+	case "AuthForRuntime.runtimeID":
+		if e.complexity.AuthForRuntime.RuntimeID == nil {
+			break
+		}
+
+		return e.complexity.AuthForRuntime.RuntimeID(childComplexity), true
+
 	case "BasicCredentialData.password":
 		if e.complexity.BasicCredentialData.Password == nil {
 			break
@@ -525,34 +567,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.CSRFTokenCredentialRequestAuth.Token(childComplexity), true
-
-	case "Credential.additionalHeaders":
-		if e.complexity.Credential.AdditionalHeaders == nil {
-			break
-		}
-
-		return e.complexity.Credential.AdditionalHeaders(childComplexity), true
-
-	case "Credential.additionalQueryParams":
-		if e.complexity.Credential.AdditionalQueryParams == nil {
-			break
-		}
-
-		return e.complexity.Credential.AdditionalQueryParams(childComplexity), true
-
-	case "Credential.data":
-		if e.complexity.Credential.Data == nil {
-			break
-		}
-
-		return e.complexity.Credential.Data(childComplexity), true
-
-	case "Credential.requestAuth":
-		if e.complexity.Credential.RequestAuth == nil {
-			break
-		}
-
-		return e.complexity.Credential.RequestAuth(childComplexity), true
 
 	case "CredentialRequestAuth.csrf":
 		if e.complexity.CredentialRequestAuth.Csrf == nil {
@@ -666,12 +680,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.EventSpec.Type(childComplexity), true
 
-	case "FetchRequest.credential":
-		if e.complexity.FetchRequest.Credential == nil {
+	case "FetchRequest.auth":
+		if e.complexity.FetchRequest.Auth == nil {
 			break
 		}
 
-		return e.complexity.FetchRequest.Credential(childComplexity), true
+		return e.complexity.FetchRequest.Auth(childComplexity), true
 
 	case "FetchRequest.filter":
 		if e.complexity.FetchRequest.Filter == nil {
@@ -1012,7 +1026,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Mutation.SetAPICredential(childComplexity, args["apiID"].(string), args["runtimeID"].(*string), args["in"].(CredentialInput)), true
+		return e.complexity.Mutation.SetAPICredential(childComplexity, args["apiID"].(string), args["runtimeID"].(*string), args["in"].(AuthInput)), true
 
 	case "Mutation.updateAPI":
 		if e.complexity.Mutation.UpdateAPI == nil {
@@ -1155,12 +1169,12 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Query.Runtimes(childComplexity, args["filter"].([]*LabelFilter)), true
 
-	case "Runtime.agentCredential":
-		if e.complexity.Runtime.AgentCredential == nil {
+	case "Runtime.agentAuth":
+		if e.complexity.Runtime.AgentAuth == nil {
 			break
 		}
 
-		return e.complexity.Runtime.AgentCredential(childComplexity), true
+		return e.complexity.Runtime.AgentAuth(childComplexity), true
 
 	case "Runtime.annotations":
 		if e.complexity.Runtime.Annotations == nil {
@@ -1220,20 +1234,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.Runtime.Tenant(childComplexity), true
-
-	case "RuntimeCredential.credential":
-		if e.complexity.RuntimeCredential.Credential == nil {
-			break
-		}
-
-		return e.complexity.RuntimeCredential.Credential(childComplexity), true
-
-	case "RuntimeCredential.runtimeID":
-		if e.complexity.RuntimeCredential.RuntimeID == nil {
-			break
-		}
-
-		return e.complexity.RuntimeCredential.RuntimeID(childComplexity), true
 
 	case "RuntimeStatus.condition":
 		if e.complexity.RuntimeStatus.Condition == nil {
@@ -1381,7 +1381,7 @@ type Runtime {
     annotations(key: String): Annotations!
     status: RuntimeStatus!
     """directive for checking auth"""
-    agentCredential: Credential!
+    agentAuth: Auth!
 }
 
 type RuntimeStatus {
@@ -1429,7 +1429,7 @@ type ApplicationWebhook {
     id: ID!
     type: ApplicationWebhookType!
     url: String!
-    credential: Credential
+    auth: Auth
 }
 
 enum ApplicationWebhookType {
@@ -1454,14 +1454,14 @@ type APIDefinition {
     targetURL: String!
     """ group allows you to find the same API but in different version """
     group: String
-    credential(runtimeID: ID!): Credential
-    credentials: [RuntimeCredential!]
+    auth(runtimeID: ID!): Auth
+    auths: [AuthForRuntime!]
     version: Version
 }
 
-type RuntimeCredential {
+type AuthForRuntime {
     runtimeID: ID!
-    credential: Credential!
+    auth: Auth!
 }
 
 type APISpec {
@@ -1523,7 +1523,7 @@ enum DocumentFormat {
 """ Compass performs fetch to validate if request is correct and stores a copy"""
 type FetchRequest {
     url: String!
-    credential: Credential
+    auth: Auth
     mode: FetchMode!
     filter: String
     status: FetchRequestStatus!
@@ -1546,9 +1546,9 @@ enum FetchMode {
     INDEX
 }
 
-# Credential
-type Credential {
-    data: CredentialData!
+# Authentication
+type Auth {
+    credential: CredentialData!
     additionalHeaders: HttpHeaders
     additionalQueryParams: QueryParams
     requestAuth: CredentialRequestAuth
@@ -1630,7 +1630,7 @@ input RuntimeInput {
 
 input FetchRequestInput {
     url: String!
-    credential: CredentialInput
+    auth: AuthInput
     mode: FetchMode
     filter: String
 }
@@ -1640,13 +1640,14 @@ input FetchRequestInput {
 input ApplicationWebhookInput {
     type: ApplicationWebhookType!
     url: String!
-    credential: CredentialInput
+    auth: AuthInput
 }
 
 # API Input
-# you need to perform separate call to set credentials
+# you need to perform separate call to set auth
 input APIDefinitionInput {
     targetURL: String!
+    group: String
     spec: APISpecInput
     version: VersionInput
 }
@@ -1669,7 +1670,9 @@ input APISpecInput {
 # Event Input
 
 input EventDefinitionInput {
-    spec: EventSpecInput
+    spec: EventSpecInput!
+    group: String
+    version: VersionInput
 }
 
 input EventSpecInput {
@@ -1691,10 +1694,10 @@ input DocumentInput {
 }
 
 
-# Credential Input
+# Auth Input
 
-input CredentialInput {
-    data: CredentialDataInput!
+input AuthInput {
+    credential: CredentialDataInput!
     additionalHeaders: HttpHeaders #
     additionalQueryParams: QueryParams
     requestAuth: CredentialRequestAuthInput
@@ -1773,8 +1776,8 @@ type Mutation {
     If runtimeID not provided, the samec credential will be set for every runtime already available
     Returns information for which runtime it was configured
     """
-    setAPICredential(apiID: ID!, runtimeID: ID, in: CredentialInput!): [RuntimeCredential!]!
-    deleteAPICredential(apiID: ID!, runtimeID: ID): [RuntimeCredential!]!
+    setAPICredential(apiID: ID!, runtimeID: ID, in: AuthInput!): [AuthForRuntime!]!
+    deleteAPICredential(apiID: ID!, runtimeID: ID): [AuthForRuntime!]!
 
 
     addEvent(applicationID: ID!, in: EventDefinitionInput!): EventAPIDefinition!
@@ -1801,7 +1804,7 @@ type Mutation {
 
 // region    ***************************** args.gotpl *****************************
 
-func (ec *executionContext) field_APIDefinition_credential_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+func (ec *executionContext) field_APIDefinition_auth_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
 	var err error
 	args := map[string]interface{}{}
 	var arg0 string
@@ -2328,9 +2331,9 @@ func (ec *executionContext) field_Mutation_setAPICredential_args(ctx context.Con
 		}
 	}
 	args["runtimeID"] = arg1
-	var arg2 CredentialInput
+	var arg2 AuthInput
 	if tmp, ok := rawArgs["in"]; ok {
-		arg2, err = ec.unmarshalNCredentialInput2githubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋgatewayᚋinternalᚋgqlschemaᚐCredentialInput(ctx, tmp)
+		arg2, err = ec.unmarshalNAuthInput2githubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋgatewayᚋinternalᚋgqlschemaᚐAuthInput(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
@@ -2703,7 +2706,7 @@ func (ec *executionContext) _APIDefinition_group(ctx context.Context, field grap
 	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) _APIDefinition_credential(ctx context.Context, field graphql.CollectedField, obj *APIDefinition) graphql.Marshaler {
+func (ec *executionContext) _APIDefinition_auth(ctx context.Context, field graphql.CollectedField, obj *APIDefinition) graphql.Marshaler {
 	ctx = ec.Tracer.StartFieldExecution(ctx, field)
 	defer func() { ec.Tracer.EndFieldExecution(ctx) }()
 	rctx := &graphql.ResolverContext{
@@ -2714,7 +2717,7 @@ func (ec *executionContext) _APIDefinition_credential(ctx context.Context, field
 	}
 	ctx = graphql.WithResolverContext(ctx, rctx)
 	rawArgs := field.ArgumentMap(ec.Variables)
-	args, err := ec.field_APIDefinition_credential_args(ctx, rawArgs)
+	args, err := ec.field_APIDefinition_auth_args(ctx, rawArgs)
 	if err != nil {
 		ec.Error(ctx, err)
 		return graphql.Null
@@ -2723,18 +2726,18 @@ func (ec *executionContext) _APIDefinition_credential(ctx context.Context, field
 	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
 	resTmp := ec.FieldMiddleware(ctx, obj, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.Credential, nil
+		return obj.Auth, nil
 	})
 	if resTmp == nil {
 		return graphql.Null
 	}
-	res := resTmp.(*Credential)
+	res := resTmp.(*Auth)
 	rctx.Result = res
 	ctx = ec.Tracer.StartFieldChildExecution(ctx)
-	return ec.marshalOCredential2ᚖgithubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋgatewayᚋinternalᚋgqlschemaᚐCredential(ctx, field.Selections, res)
+	return ec.marshalOAuth2ᚖgithubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋgatewayᚋinternalᚋgqlschemaᚐAuth(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) _APIDefinition_credentials(ctx context.Context, field graphql.CollectedField, obj *APIDefinition) graphql.Marshaler {
+func (ec *executionContext) _APIDefinition_auths(ctx context.Context, field graphql.CollectedField, obj *APIDefinition) graphql.Marshaler {
 	ctx = ec.Tracer.StartFieldExecution(ctx, field)
 	defer func() { ec.Tracer.EndFieldExecution(ctx) }()
 	rctx := &graphql.ResolverContext{
@@ -2747,15 +2750,15 @@ func (ec *executionContext) _APIDefinition_credentials(ctx context.Context, fiel
 	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
 	resTmp := ec.FieldMiddleware(ctx, obj, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.Credentials, nil
+		return obj.Auths, nil
 	})
 	if resTmp == nil {
 		return graphql.Null
 	}
-	res := resTmp.([]*RuntimeCredential)
+	res := resTmp.([]*AuthForRuntime)
 	rctx.Result = res
 	ctx = ec.Tracer.StartFieldChildExecution(ctx)
-	return ec.marshalORuntimeCredential2ᚕᚖgithubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋgatewayᚋinternalᚋgqlschemaᚐRuntimeCredential(ctx, field.Selections, res)
+	return ec.marshalOAuthForRuntime2ᚕᚖgithubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋgatewayᚋinternalᚋgqlschemaᚐAuthForRuntime(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _APIDefinition_version(ctx context.Context, field graphql.CollectedField, obj *APIDefinition) graphql.Marshaler {
@@ -3362,7 +3365,7 @@ func (ec *executionContext) _ApplicationWebhook_url(ctx context.Context, field g
 	return ec.marshalNString2string(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) _ApplicationWebhook_credential(ctx context.Context, field graphql.CollectedField, obj *ApplicationWebhook) graphql.Marshaler {
+func (ec *executionContext) _ApplicationWebhook_auth(ctx context.Context, field graphql.CollectedField, obj *ApplicationWebhook) graphql.Marshaler {
 	ctx = ec.Tracer.StartFieldExecution(ctx, field)
 	defer func() { ec.Tracer.EndFieldExecution(ctx) }()
 	rctx := &graphql.ResolverContext{
@@ -3375,15 +3378,168 @@ func (ec *executionContext) _ApplicationWebhook_credential(ctx context.Context, 
 	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
 	resTmp := ec.FieldMiddleware(ctx, obj, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.Credential, nil
+		return obj.Auth, nil
 	})
 	if resTmp == nil {
 		return graphql.Null
 	}
-	res := resTmp.(*Credential)
+	res := resTmp.(*Auth)
 	rctx.Result = res
 	ctx = ec.Tracer.StartFieldChildExecution(ctx)
-	return ec.marshalOCredential2ᚖgithubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋgatewayᚋinternalᚋgqlschemaᚐCredential(ctx, field.Selections, res)
+	return ec.marshalOAuth2ᚖgithubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋgatewayᚋinternalᚋgqlschemaᚐAuth(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Auth_credential(ctx context.Context, field graphql.CollectedField, obj *Auth) graphql.Marshaler {
+	ctx = ec.Tracer.StartFieldExecution(ctx, field)
+	defer func() { ec.Tracer.EndFieldExecution(ctx) }()
+	rctx := &graphql.ResolverContext{
+		Object:   "Auth",
+		Field:    field,
+		Args:     nil,
+		IsMethod: false,
+	}
+	ctx = graphql.WithResolverContext(ctx, rctx)
+	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
+	resTmp := ec.FieldMiddleware(ctx, obj, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Credential, nil
+	})
+	if resTmp == nil {
+		if !ec.HasError(rctx) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(CredentialData)
+	rctx.Result = res
+	ctx = ec.Tracer.StartFieldChildExecution(ctx)
+	return ec.marshalNCredentialData2githubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋgatewayᚋinternalᚋgqlschemaᚐCredentialData(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Auth_additionalHeaders(ctx context.Context, field graphql.CollectedField, obj *Auth) graphql.Marshaler {
+	ctx = ec.Tracer.StartFieldExecution(ctx, field)
+	defer func() { ec.Tracer.EndFieldExecution(ctx) }()
+	rctx := &graphql.ResolverContext{
+		Object:   "Auth",
+		Field:    field,
+		Args:     nil,
+		IsMethod: false,
+	}
+	ctx = graphql.WithResolverContext(ctx, rctx)
+	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
+	resTmp := ec.FieldMiddleware(ctx, obj, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.AdditionalHeaders, nil
+	})
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*HttpHeaders)
+	rctx.Result = res
+	ctx = ec.Tracer.StartFieldChildExecution(ctx)
+	return ec.marshalOHttpHeaders2ᚖgithubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋgatewayᚋinternalᚋgqlschemaᚐHttpHeaders(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Auth_additionalQueryParams(ctx context.Context, field graphql.CollectedField, obj *Auth) graphql.Marshaler {
+	ctx = ec.Tracer.StartFieldExecution(ctx, field)
+	defer func() { ec.Tracer.EndFieldExecution(ctx) }()
+	rctx := &graphql.ResolverContext{
+		Object:   "Auth",
+		Field:    field,
+		Args:     nil,
+		IsMethod: false,
+	}
+	ctx = graphql.WithResolverContext(ctx, rctx)
+	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
+	resTmp := ec.FieldMiddleware(ctx, obj, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.AdditionalQueryParams, nil
+	})
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*QueryParams)
+	rctx.Result = res
+	ctx = ec.Tracer.StartFieldChildExecution(ctx)
+	return ec.marshalOQueryParams2ᚖgithubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋgatewayᚋinternalᚋgqlschemaᚐQueryParams(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _Auth_requestAuth(ctx context.Context, field graphql.CollectedField, obj *Auth) graphql.Marshaler {
+	ctx = ec.Tracer.StartFieldExecution(ctx, field)
+	defer func() { ec.Tracer.EndFieldExecution(ctx) }()
+	rctx := &graphql.ResolverContext{
+		Object:   "Auth",
+		Field:    field,
+		Args:     nil,
+		IsMethod: false,
+	}
+	ctx = graphql.WithResolverContext(ctx, rctx)
+	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
+	resTmp := ec.FieldMiddleware(ctx, obj, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.RequestAuth, nil
+	})
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*CredentialRequestAuth)
+	rctx.Result = res
+	ctx = ec.Tracer.StartFieldChildExecution(ctx)
+	return ec.marshalOCredentialRequestAuth2ᚖgithubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋgatewayᚋinternalᚋgqlschemaᚐCredentialRequestAuth(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _AuthForRuntime_runtimeID(ctx context.Context, field graphql.CollectedField, obj *AuthForRuntime) graphql.Marshaler {
+	ctx = ec.Tracer.StartFieldExecution(ctx, field)
+	defer func() { ec.Tracer.EndFieldExecution(ctx) }()
+	rctx := &graphql.ResolverContext{
+		Object:   "AuthForRuntime",
+		Field:    field,
+		Args:     nil,
+		IsMethod: false,
+	}
+	ctx = graphql.WithResolverContext(ctx, rctx)
+	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
+	resTmp := ec.FieldMiddleware(ctx, obj, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.RuntimeID, nil
+	})
+	if resTmp == nil {
+		if !ec.HasError(rctx) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	rctx.Result = res
+	ctx = ec.Tracer.StartFieldChildExecution(ctx)
+	return ec.marshalNID2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _AuthForRuntime_auth(ctx context.Context, field graphql.CollectedField, obj *AuthForRuntime) graphql.Marshaler {
+	ctx = ec.Tracer.StartFieldExecution(ctx, field)
+	defer func() { ec.Tracer.EndFieldExecution(ctx) }()
+	rctx := &graphql.ResolverContext{
+		Object:   "AuthForRuntime",
+		Field:    field,
+		Args:     nil,
+		IsMethod: false,
+	}
+	ctx = graphql.WithResolverContext(ctx, rctx)
+	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
+	resTmp := ec.FieldMiddleware(ctx, obj, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Auth, nil
+	})
+	if resTmp == nil {
+		if !ec.HasError(rctx) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*Auth)
+	rctx.Result = res
+	ctx = ec.Tracer.StartFieldChildExecution(ctx)
+	return ec.marshalNAuth2ᚖgithubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋgatewayᚋinternalᚋgqlschemaᚐAuth(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _BasicCredentialData_username(ctx context.Context, field graphql.CollectedField, obj *BasicCredentialData) graphql.Marshaler {
@@ -3465,105 +3621,6 @@ func (ec *executionContext) _CSRFTokenCredentialRequestAuth_token(ctx context.Co
 	rctx.Result = res
 	ctx = ec.Tracer.StartFieldChildExecution(ctx)
 	return ec.marshalNString2string(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) _Credential_data(ctx context.Context, field graphql.CollectedField, obj *Credential) graphql.Marshaler {
-	ctx = ec.Tracer.StartFieldExecution(ctx, field)
-	defer func() { ec.Tracer.EndFieldExecution(ctx) }()
-	rctx := &graphql.ResolverContext{
-		Object:   "Credential",
-		Field:    field,
-		Args:     nil,
-		IsMethod: false,
-	}
-	ctx = graphql.WithResolverContext(ctx, rctx)
-	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
-	resTmp := ec.FieldMiddleware(ctx, obj, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.Data, nil
-	})
-	if resTmp == nil {
-		if !ec.HasError(rctx) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(CredentialData)
-	rctx.Result = res
-	ctx = ec.Tracer.StartFieldChildExecution(ctx)
-	return ec.marshalNCredentialData2githubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋgatewayᚋinternalᚋgqlschemaᚐCredentialData(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) _Credential_additionalHeaders(ctx context.Context, field graphql.CollectedField, obj *Credential) graphql.Marshaler {
-	ctx = ec.Tracer.StartFieldExecution(ctx, field)
-	defer func() { ec.Tracer.EndFieldExecution(ctx) }()
-	rctx := &graphql.ResolverContext{
-		Object:   "Credential",
-		Field:    field,
-		Args:     nil,
-		IsMethod: false,
-	}
-	ctx = graphql.WithResolverContext(ctx, rctx)
-	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
-	resTmp := ec.FieldMiddleware(ctx, obj, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.AdditionalHeaders, nil
-	})
-	if resTmp == nil {
-		return graphql.Null
-	}
-	res := resTmp.(*HttpHeaders)
-	rctx.Result = res
-	ctx = ec.Tracer.StartFieldChildExecution(ctx)
-	return ec.marshalOHttpHeaders2ᚖgithubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋgatewayᚋinternalᚋgqlschemaᚐHttpHeaders(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) _Credential_additionalQueryParams(ctx context.Context, field graphql.CollectedField, obj *Credential) graphql.Marshaler {
-	ctx = ec.Tracer.StartFieldExecution(ctx, field)
-	defer func() { ec.Tracer.EndFieldExecution(ctx) }()
-	rctx := &graphql.ResolverContext{
-		Object:   "Credential",
-		Field:    field,
-		Args:     nil,
-		IsMethod: false,
-	}
-	ctx = graphql.WithResolverContext(ctx, rctx)
-	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
-	resTmp := ec.FieldMiddleware(ctx, obj, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.AdditionalQueryParams, nil
-	})
-	if resTmp == nil {
-		return graphql.Null
-	}
-	res := resTmp.(*QueryParams)
-	rctx.Result = res
-	ctx = ec.Tracer.StartFieldChildExecution(ctx)
-	return ec.marshalOQueryParams2ᚖgithubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋgatewayᚋinternalᚋgqlschemaᚐQueryParams(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) _Credential_requestAuth(ctx context.Context, field graphql.CollectedField, obj *Credential) graphql.Marshaler {
-	ctx = ec.Tracer.StartFieldExecution(ctx, field)
-	defer func() { ec.Tracer.EndFieldExecution(ctx) }()
-	rctx := &graphql.ResolverContext{
-		Object:   "Credential",
-		Field:    field,
-		Args:     nil,
-		IsMethod: false,
-	}
-	ctx = graphql.WithResolverContext(ctx, rctx)
-	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
-	resTmp := ec.FieldMiddleware(ctx, obj, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.RequestAuth, nil
-	})
-	if resTmp == nil {
-		return graphql.Null
-	}
-	res := resTmp.(*CredentialRequestAuth)
-	rctx.Result = res
-	ctx = ec.Tracer.StartFieldChildExecution(ctx)
-	return ec.marshalOCredentialRequestAuth2ᚖgithubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋgatewayᚋinternalᚋgqlschemaᚐCredentialRequestAuth(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _CredentialRequestAuth_type(ctx context.Context, field graphql.CollectedField, obj *CredentialRequestAuth) graphql.Marshaler {
@@ -3998,7 +4055,7 @@ func (ec *executionContext) _FetchRequest_url(ctx context.Context, field graphql
 	return ec.marshalNString2string(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) _FetchRequest_credential(ctx context.Context, field graphql.CollectedField, obj *FetchRequest) graphql.Marshaler {
+func (ec *executionContext) _FetchRequest_auth(ctx context.Context, field graphql.CollectedField, obj *FetchRequest) graphql.Marshaler {
 	ctx = ec.Tracer.StartFieldExecution(ctx, field)
 	defer func() { ec.Tracer.EndFieldExecution(ctx) }()
 	rctx := &graphql.ResolverContext{
@@ -4011,15 +4068,15 @@ func (ec *executionContext) _FetchRequest_credential(ctx context.Context, field 
 	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
 	resTmp := ec.FieldMiddleware(ctx, obj, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.Credential, nil
+		return obj.Auth, nil
 	})
 	if resTmp == nil {
 		return graphql.Null
 	}
-	res := resTmp.(*Credential)
+	res := resTmp.(*Auth)
 	rctx.Result = res
 	ctx = ec.Tracer.StartFieldChildExecution(ctx)
-	return ec.marshalOCredential2ᚖgithubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋgatewayᚋinternalᚋgqlschemaᚐCredential(ctx, field.Selections, res)
+	return ec.marshalOAuth2ᚖgithubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋgatewayᚋinternalᚋgqlschemaᚐAuth(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _FetchRequest_mode(ctx context.Context, field graphql.CollectedField, obj *FetchRequest) graphql.Marshaler {
@@ -4761,7 +4818,7 @@ func (ec *executionContext) _Mutation_setAPICredential(ctx context.Context, fiel
 	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
 	resTmp := ec.FieldMiddleware(ctx, nil, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Mutation().SetAPICredential(rctx, args["apiID"].(string), args["runtimeID"].(*string), args["in"].(CredentialInput))
+		return ec.resolvers.Mutation().SetAPICredential(rctx, args["apiID"].(string), args["runtimeID"].(*string), args["in"].(AuthInput))
 	})
 	if resTmp == nil {
 		if !ec.HasError(rctx) {
@@ -4769,10 +4826,10 @@ func (ec *executionContext) _Mutation_setAPICredential(ctx context.Context, fiel
 		}
 		return graphql.Null
 	}
-	res := resTmp.([]*RuntimeCredential)
+	res := resTmp.([]*AuthForRuntime)
 	rctx.Result = res
 	ctx = ec.Tracer.StartFieldChildExecution(ctx)
-	return ec.marshalNRuntimeCredential2ᚕᚖgithubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋgatewayᚋinternalᚋgqlschemaᚐRuntimeCredential(ctx, field.Selections, res)
+	return ec.marshalNAuthForRuntime2ᚕᚖgithubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋgatewayᚋinternalᚋgqlschemaᚐAuthForRuntime(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _Mutation_deleteAPICredential(ctx context.Context, field graphql.CollectedField) graphql.Marshaler {
@@ -4803,10 +4860,10 @@ func (ec *executionContext) _Mutation_deleteAPICredential(ctx context.Context, f
 		}
 		return graphql.Null
 	}
-	res := resTmp.([]*RuntimeCredential)
+	res := resTmp.([]*AuthForRuntime)
 	rctx.Result = res
 	ctx = ec.Tracer.StartFieldChildExecution(ctx)
-	return ec.marshalNRuntimeCredential2ᚕᚖgithubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋgatewayᚋinternalᚋgqlschemaᚐRuntimeCredential(ctx, field.Selections, res)
+	return ec.marshalNAuthForRuntime2ᚕᚖgithubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋgatewayᚋinternalᚋgqlschemaᚐAuthForRuntime(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _Mutation_addEvent(ctx context.Context, field graphql.CollectedField) graphql.Marshaler {
@@ -5668,7 +5725,7 @@ func (ec *executionContext) _Runtime_status(ctx context.Context, field graphql.C
 	return ec.marshalNRuntimeStatus2ᚖgithubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋgatewayᚋinternalᚋgqlschemaᚐRuntimeStatus(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) _Runtime_agentCredential(ctx context.Context, field graphql.CollectedField, obj *Runtime) graphql.Marshaler {
+func (ec *executionContext) _Runtime_agentAuth(ctx context.Context, field graphql.CollectedField, obj *Runtime) graphql.Marshaler {
 	ctx = ec.Tracer.StartFieldExecution(ctx, field)
 	defer func() { ec.Tracer.EndFieldExecution(ctx) }()
 	rctx := &graphql.ResolverContext{
@@ -5681,7 +5738,7 @@ func (ec *executionContext) _Runtime_agentCredential(ctx context.Context, field 
 	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
 	resTmp := ec.FieldMiddleware(ctx, obj, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return obj.AgentCredential, nil
+		return obj.AgentAuth, nil
 	})
 	if resTmp == nil {
 		if !ec.HasError(rctx) {
@@ -5689,64 +5746,10 @@ func (ec *executionContext) _Runtime_agentCredential(ctx context.Context, field 
 		}
 		return graphql.Null
 	}
-	res := resTmp.(*Credential)
+	res := resTmp.(*Auth)
 	rctx.Result = res
 	ctx = ec.Tracer.StartFieldChildExecution(ctx)
-	return ec.marshalNCredential2ᚖgithubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋgatewayᚋinternalᚋgqlschemaᚐCredential(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) _RuntimeCredential_runtimeID(ctx context.Context, field graphql.CollectedField, obj *RuntimeCredential) graphql.Marshaler {
-	ctx = ec.Tracer.StartFieldExecution(ctx, field)
-	defer func() { ec.Tracer.EndFieldExecution(ctx) }()
-	rctx := &graphql.ResolverContext{
-		Object:   "RuntimeCredential",
-		Field:    field,
-		Args:     nil,
-		IsMethod: false,
-	}
-	ctx = graphql.WithResolverContext(ctx, rctx)
-	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
-	resTmp := ec.FieldMiddleware(ctx, obj, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.RuntimeID, nil
-	})
-	if resTmp == nil {
-		if !ec.HasError(rctx) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(string)
-	rctx.Result = res
-	ctx = ec.Tracer.StartFieldChildExecution(ctx)
-	return ec.marshalNID2string(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) _RuntimeCredential_credential(ctx context.Context, field graphql.CollectedField, obj *RuntimeCredential) graphql.Marshaler {
-	ctx = ec.Tracer.StartFieldExecution(ctx, field)
-	defer func() { ec.Tracer.EndFieldExecution(ctx) }()
-	rctx := &graphql.ResolverContext{
-		Object:   "RuntimeCredential",
-		Field:    field,
-		Args:     nil,
-		IsMethod: false,
-	}
-	ctx = graphql.WithResolverContext(ctx, rctx)
-	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
-	resTmp := ec.FieldMiddleware(ctx, obj, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.Credential, nil
-	})
-	if resTmp == nil {
-		if !ec.HasError(rctx) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(*Credential)
-	rctx.Result = res
-	ctx = ec.Tracer.StartFieldChildExecution(ctx)
-	return ec.marshalNCredential2ᚖgithubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋgatewayᚋinternalᚋgqlschemaᚐCredential(ctx, field.Selections, res)
+	return ec.marshalNAuth2ᚖgithubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋgatewayᚋinternalᚋgqlschemaᚐAuth(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _RuntimeStatus_condition(ctx context.Context, field graphql.CollectedField, obj *RuntimeStatus) graphql.Marshaler {
@@ -6745,6 +6748,12 @@ func (ec *executionContext) unmarshalInputAPIDefinitionInput(ctx context.Context
 			if err != nil {
 				return it, err
 			}
+		case "group":
+			var err error
+			it.Group, err = ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
 		case "spec":
 			var err error
 			it.Spec, err = ec.unmarshalOAPISpecInput2ᚖgithubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋgatewayᚋinternalᚋgqlschemaᚐAPISpecInput(ctx, v)
@@ -6883,9 +6892,45 @@ func (ec *executionContext) unmarshalInputApplicationWebhookInput(ctx context.Co
 			if err != nil {
 				return it, err
 			}
+		case "auth":
+			var err error
+			it.Auth, err = ec.unmarshalOAuthInput2ᚖgithubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋgatewayᚋinternalᚋgqlschemaᚐAuthInput(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		}
+	}
+
+	return it, nil
+}
+
+func (ec *executionContext) unmarshalInputAuthInput(ctx context.Context, v interface{}) (AuthInput, error) {
+	var it AuthInput
+	var asMap = v.(map[string]interface{})
+
+	for k, v := range asMap {
+		switch k {
 		case "credential":
 			var err error
-			it.Credential, err = ec.unmarshalOCredentialInput2ᚖgithubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋgatewayᚋinternalᚋgqlschemaᚐCredentialInput(ctx, v)
+			it.Credential, err = ec.unmarshalNCredentialDataInput2ᚖgithubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋgatewayᚋinternalᚋgqlschemaᚐCredentialDataInput(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		case "additionalHeaders":
+			var err error
+			it.AdditionalHeaders, err = ec.unmarshalOHttpHeaders2ᚖgithubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋgatewayᚋinternalᚋgqlschemaᚐHttpHeaders(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		case "additionalQueryParams":
+			var err error
+			it.AdditionalQueryParams, err = ec.unmarshalOQueryParams2ᚖgithubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋgatewayᚋinternalᚋgqlschemaᚐQueryParams(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		case "requestAuth":
+			var err error
+			it.RequestAuth, err = ec.unmarshalOCredentialRequestAuthInput2ᚖgithubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋgatewayᚋinternalᚋgqlschemaᚐCredentialRequestAuthInput(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -6952,42 +6997,6 @@ func (ec *executionContext) unmarshalInputCredentialDataInput(ctx context.Contex
 		case "oauth":
 			var err error
 			it.Oauth, err = ec.unmarshalOOAuthCredentialDataInput2ᚖgithubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋgatewayᚋinternalᚋgqlschemaᚐOAuthCredentialDataInput(ctx, v)
-			if err != nil {
-				return it, err
-			}
-		}
-	}
-
-	return it, nil
-}
-
-func (ec *executionContext) unmarshalInputCredentialInput(ctx context.Context, v interface{}) (CredentialInput, error) {
-	var it CredentialInput
-	var asMap = v.(map[string]interface{})
-
-	for k, v := range asMap {
-		switch k {
-		case "data":
-			var err error
-			it.Data, err = ec.unmarshalNCredentialDataInput2ᚖgithubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋgatewayᚋinternalᚋgqlschemaᚐCredentialDataInput(ctx, v)
-			if err != nil {
-				return it, err
-			}
-		case "additionalHeaders":
-			var err error
-			it.AdditionalHeaders, err = ec.unmarshalOHttpHeaders2ᚖgithubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋgatewayᚋinternalᚋgqlschemaᚐHttpHeaders(ctx, v)
-			if err != nil {
-				return it, err
-			}
-		case "additionalQueryParams":
-			var err error
-			it.AdditionalQueryParams, err = ec.unmarshalOQueryParams2ᚖgithubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋgatewayᚋinternalᚋgqlschemaᚐQueryParams(ctx, v)
-			if err != nil {
-				return it, err
-			}
-		case "requestAuth":
-			var err error
-			it.RequestAuth, err = ec.unmarshalOCredentialRequestAuthInput2ᚖgithubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋgatewayᚋinternalᚋgqlschemaᚐCredentialRequestAuthInput(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -7083,7 +7092,19 @@ func (ec *executionContext) unmarshalInputEventDefinitionInput(ctx context.Conte
 		switch k {
 		case "spec":
 			var err error
-			it.Spec, err = ec.unmarshalOEventSpecInput2ᚖgithubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋgatewayᚋinternalᚋgqlschemaᚐEventSpecInput(ctx, v)
+			it.Spec, err = ec.unmarshalNEventSpecInput2ᚖgithubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋgatewayᚋinternalᚋgqlschemaᚐEventSpecInput(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		case "group":
+			var err error
+			it.Group, err = ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		case "version":
+			var err error
+			it.Version, err = ec.unmarshalOVersionInput2ᚖgithubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋgatewayᚋinternalᚋgqlschemaᚐVersionInput(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -7135,9 +7156,9 @@ func (ec *executionContext) unmarshalInputFetchRequestInput(ctx context.Context,
 			if err != nil {
 				return it, err
 			}
-		case "credential":
+		case "auth":
 			var err error
-			it.Credential, err = ec.unmarshalOCredentialInput2ᚖgithubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋgatewayᚋinternalᚋgqlschemaᚐCredentialInput(ctx, v)
+			it.Auth, err = ec.unmarshalOAuthInput2ᚖgithubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋgatewayᚋinternalᚋgqlschemaᚐAuthInput(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -7345,10 +7366,10 @@ func (ec *executionContext) _APIDefinition(ctx context.Context, sel ast.Selectio
 			}
 		case "group":
 			out.Values[i] = ec._APIDefinition_group(ctx, field, obj)
-		case "credential":
-			out.Values[i] = ec._APIDefinition_credential(ctx, field, obj)
-		case "credentials":
-			out.Values[i] = ec._APIDefinition_credentials(ctx, field, obj)
+		case "auth":
+			out.Values[i] = ec._APIDefinition_auth(ctx, field, obj)
+		case "auths":
+			out.Values[i] = ec._APIDefinition_auths(ctx, field, obj)
 		case "version":
 			out.Values[i] = ec._APIDefinition_version(ctx, field, obj)
 		default:
@@ -7529,8 +7550,73 @@ func (ec *executionContext) _ApplicationWebhook(ctx context.Context, sel ast.Sel
 			if out.Values[i] == graphql.Null {
 				invalids++
 			}
+		case "auth":
+			out.Values[i] = ec._ApplicationWebhook_auth(ctx, field, obj)
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch()
+	if invalids > 0 {
+		return graphql.Null
+	}
+	return out
+}
+
+var authImplementors = []string{"Auth"}
+
+func (ec *executionContext) _Auth(ctx context.Context, sel ast.SelectionSet, obj *Auth) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.RequestContext, sel, authImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	var invalids uint32
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("Auth")
 		case "credential":
-			out.Values[i] = ec._ApplicationWebhook_credential(ctx, field, obj)
+			out.Values[i] = ec._Auth_credential(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "additionalHeaders":
+			out.Values[i] = ec._Auth_additionalHeaders(ctx, field, obj)
+		case "additionalQueryParams":
+			out.Values[i] = ec._Auth_additionalQueryParams(ctx, field, obj)
+		case "requestAuth":
+			out.Values[i] = ec._Auth_requestAuth(ctx, field, obj)
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch()
+	if invalids > 0 {
+		return graphql.Null
+	}
+	return out
+}
+
+var authForRuntimeImplementors = []string{"AuthForRuntime"}
+
+func (ec *executionContext) _AuthForRuntime(ctx context.Context, sel ast.SelectionSet, obj *AuthForRuntime) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.RequestContext, sel, authForRuntimeImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	var invalids uint32
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("AuthForRuntime")
+		case "runtimeID":
+			out.Values[i] = ec._AuthForRuntime_runtimeID(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "auth":
+			out.Values[i] = ec._AuthForRuntime_auth(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -7590,39 +7676,6 @@ func (ec *executionContext) _CSRFTokenCredentialRequestAuth(ctx context.Context,
 			if out.Values[i] == graphql.Null {
 				invalids++
 			}
-		default:
-			panic("unknown field " + strconv.Quote(field.Name))
-		}
-	}
-	out.Dispatch()
-	if invalids > 0 {
-		return graphql.Null
-	}
-	return out
-}
-
-var credentialImplementors = []string{"Credential"}
-
-func (ec *executionContext) _Credential(ctx context.Context, sel ast.SelectionSet, obj *Credential) graphql.Marshaler {
-	fields := graphql.CollectFields(ec.RequestContext, sel, credentialImplementors)
-
-	out := graphql.NewFieldSet(fields)
-	var invalids uint32
-	for i, field := range fields {
-		switch field.Name {
-		case "__typename":
-			out.Values[i] = graphql.MarshalString("Credential")
-		case "data":
-			out.Values[i] = ec._Credential_data(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				invalids++
-			}
-		case "additionalHeaders":
-			out.Values[i] = ec._Credential_additionalHeaders(ctx, field, obj)
-		case "additionalQueryParams":
-			out.Values[i] = ec._Credential_additionalQueryParams(ctx, field, obj)
-		case "requestAuth":
-			out.Values[i] = ec._Credential_requestAuth(ctx, field, obj)
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -7791,8 +7844,8 @@ func (ec *executionContext) _FetchRequest(ctx context.Context, sel ast.Selection
 			if out.Values[i] == graphql.Null {
 				invalids++
 			}
-		case "credential":
-			out.Values[i] = ec._FetchRequest_credential(ctx, field, obj)
+		case "auth":
+			out.Values[i] = ec._FetchRequest_auth(ctx, field, obj)
 		case "mode":
 			out.Values[i] = ec._FetchRequest_mode(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
@@ -8191,40 +8244,8 @@ func (ec *executionContext) _Runtime(ctx context.Context, sel ast.SelectionSet, 
 			if out.Values[i] == graphql.Null {
 				invalids++
 			}
-		case "agentCredential":
-			out.Values[i] = ec._Runtime_agentCredential(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				invalids++
-			}
-		default:
-			panic("unknown field " + strconv.Quote(field.Name))
-		}
-	}
-	out.Dispatch()
-	if invalids > 0 {
-		return graphql.Null
-	}
-	return out
-}
-
-var runtimeCredentialImplementors = []string{"RuntimeCredential"}
-
-func (ec *executionContext) _RuntimeCredential(ctx context.Context, sel ast.SelectionSet, obj *RuntimeCredential) graphql.Marshaler {
-	fields := graphql.CollectFields(ec.RequestContext, sel, runtimeCredentialImplementors)
-
-	out := graphql.NewFieldSet(fields)
-	var invalids uint32
-	for i, field := range fields {
-		switch field.Name {
-		case "__typename":
-			out.Values[i] = graphql.MarshalString("RuntimeCredential")
-		case "runtimeID":
-			out.Values[i] = ec._RuntimeCredential_runtimeID(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				invalids++
-			}
-		case "credential":
-			out.Values[i] = ec._RuntimeCredential_credential(ctx, field, obj)
+		case "agentAuth":
+			out.Values[i] = ec._Runtime_agentAuth(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				invalids++
 			}
@@ -8772,6 +8793,75 @@ func (ec *executionContext) marshalNApplicationWebhookType2githubᚗcomᚋkyma�
 	return v
 }
 
+func (ec *executionContext) marshalNAuth2githubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋgatewayᚋinternalᚋgqlschemaᚐAuth(ctx context.Context, sel ast.SelectionSet, v Auth) graphql.Marshaler {
+	return ec._Auth(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNAuth2ᚖgithubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋgatewayᚋinternalᚋgqlschemaᚐAuth(ctx context.Context, sel ast.SelectionSet, v *Auth) graphql.Marshaler {
+	if v == nil {
+		if !ec.HasError(graphql.GetResolverContext(ctx)) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	return ec._Auth(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalNAuthForRuntime2githubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋgatewayᚋinternalᚋgqlschemaᚐAuthForRuntime(ctx context.Context, sel ast.SelectionSet, v AuthForRuntime) graphql.Marshaler {
+	return ec._AuthForRuntime(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNAuthForRuntime2ᚕᚖgithubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋgatewayᚋinternalᚋgqlschemaᚐAuthForRuntime(ctx context.Context, sel ast.SelectionSet, v []*AuthForRuntime) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		rctx := &graphql.ResolverContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithResolverContext(ctx, rctx)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNAuthForRuntime2ᚖgithubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋgatewayᚋinternalᚋgqlschemaᚐAuthForRuntime(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+	return ret
+}
+
+func (ec *executionContext) marshalNAuthForRuntime2ᚖgithubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋgatewayᚋinternalᚋgqlschemaᚐAuthForRuntime(ctx context.Context, sel ast.SelectionSet, v *AuthForRuntime) graphql.Marshaler {
+	if v == nil {
+		if !ec.HasError(graphql.GetResolverContext(ctx)) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	return ec._AuthForRuntime(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalNAuthInput2githubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋgatewayᚋinternalᚋgqlschemaᚐAuthInput(ctx context.Context, v interface{}) (AuthInput, error) {
+	return ec.unmarshalInputAuthInput(ctx, v)
+}
+
 func (ec *executionContext) unmarshalNBoolean2bool(ctx context.Context, v interface{}) (bool, error) {
 	return graphql.UnmarshalBoolean(v)
 }
@@ -8784,20 +8874,6 @@ func (ec *executionContext) marshalNBoolean2bool(ctx context.Context, sel ast.Se
 		}
 	}
 	return res
-}
-
-func (ec *executionContext) marshalNCredential2githubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋgatewayᚋinternalᚋgqlschemaᚐCredential(ctx context.Context, sel ast.SelectionSet, v Credential) graphql.Marshaler {
-	return ec._Credential(ctx, sel, &v)
-}
-
-func (ec *executionContext) marshalNCredential2ᚖgithubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋgatewayᚋinternalᚋgqlschemaᚐCredential(ctx context.Context, sel ast.SelectionSet, v *Credential) graphql.Marshaler {
-	if v == nil {
-		if !ec.HasError(graphql.GetResolverContext(ctx)) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	return ec._Credential(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalNCredentialData2githubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋgatewayᚋinternalᚋgqlschemaᚐCredentialData(ctx context.Context, sel ast.SelectionSet, v CredentialData) graphql.Marshaler {
@@ -8814,10 +8890,6 @@ func (ec *executionContext) unmarshalNCredentialDataInput2ᚖgithubᚗcomᚋkyma
 	}
 	res, err := ec.unmarshalNCredentialDataInput2githubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋgatewayᚋinternalᚋgqlschemaᚐCredentialDataInput(ctx, v)
 	return &res, err
-}
-
-func (ec *executionContext) unmarshalNCredentialInput2githubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋgatewayᚋinternalᚋgqlschemaᚐCredentialInput(ctx context.Context, v interface{}) (CredentialInput, error) {
-	return ec.unmarshalInputCredentialInput(ctx, v)
 }
 
 func (ec *executionContext) unmarshalNCredentialRequestAuthType2githubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋgatewayᚋinternalᚋgqlschemaᚐCredentialRequestAuthType(ctx context.Context, v interface{}) (CredentialRequestAuthType, error) {
@@ -8976,6 +9048,18 @@ func (ec *executionContext) marshalNEventSpec2ᚖgithubᚗcomᚋkymaᚑincubator
 		return graphql.Null
 	}
 	return ec._EventSpec(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalNEventSpecInput2githubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋgatewayᚋinternalᚋgqlschemaᚐEventSpecInput(ctx context.Context, v interface{}) (EventSpecInput, error) {
+	return ec.unmarshalInputEventSpecInput(ctx, v)
+}
+
+func (ec *executionContext) unmarshalNEventSpecInput2ᚖgithubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋgatewayᚋinternalᚋgqlschemaᚐEventSpecInput(ctx context.Context, v interface{}) (*EventSpecInput, error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := ec.unmarshalNEventSpecInput2githubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋgatewayᚋinternalᚋgqlschemaᚐEventSpecInput(ctx, v)
+	return &res, err
 }
 
 func (ec *executionContext) unmarshalNEventSpecType2githubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋgatewayᚋinternalᚋgqlschemaᚐEventSpecType(ctx context.Context, v interface{}) (EventSpecType, error) {
@@ -9172,57 +9256,6 @@ func (ec *executionContext) marshalNRuntime2ᚖgithubᚗcomᚋkymaᚑincubator�
 		return graphql.Null
 	}
 	return ec._Runtime(ctx, sel, v)
-}
-
-func (ec *executionContext) marshalNRuntimeCredential2githubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋgatewayᚋinternalᚋgqlschemaᚐRuntimeCredential(ctx context.Context, sel ast.SelectionSet, v RuntimeCredential) graphql.Marshaler {
-	return ec._RuntimeCredential(ctx, sel, &v)
-}
-
-func (ec *executionContext) marshalNRuntimeCredential2ᚕᚖgithubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋgatewayᚋinternalᚋgqlschemaᚐRuntimeCredential(ctx context.Context, sel ast.SelectionSet, v []*RuntimeCredential) graphql.Marshaler {
-	ret := make(graphql.Array, len(v))
-	var wg sync.WaitGroup
-	isLen1 := len(v) == 1
-	if !isLen1 {
-		wg.Add(len(v))
-	}
-	for i := range v {
-		i := i
-		rctx := &graphql.ResolverContext{
-			Index:  &i,
-			Result: &v[i],
-		}
-		ctx := graphql.WithResolverContext(ctx, rctx)
-		f := func(i int) {
-			defer func() {
-				if r := recover(); r != nil {
-					ec.Error(ctx, ec.Recover(ctx, r))
-					ret = nil
-				}
-			}()
-			if !isLen1 {
-				defer wg.Done()
-			}
-			ret[i] = ec.marshalNRuntimeCredential2ᚖgithubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋgatewayᚋinternalᚋgqlschemaᚐRuntimeCredential(ctx, sel, v[i])
-		}
-		if isLen1 {
-			f(i)
-		} else {
-			go f(i)
-		}
-
-	}
-	wg.Wait()
-	return ret
-}
-
-func (ec *executionContext) marshalNRuntimeCredential2ᚖgithubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋgatewayᚋinternalᚋgqlschemaᚐRuntimeCredential(ctx context.Context, sel ast.SelectionSet, v *RuntimeCredential) graphql.Marshaler {
-	if v == nil {
-		if !ec.HasError(graphql.GetResolverContext(ctx)) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	return ec._RuntimeCredential(ctx, sel, v)
 }
 
 func (ec *executionContext) unmarshalNRuntimeInput2githubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋgatewayᚋinternalᚋgqlschemaᚐRuntimeInput(ctx context.Context, v interface{}) (RuntimeInput, error) {
@@ -9680,6 +9713,69 @@ func (ec *executionContext) unmarshalOApplicationWebhookInput2ᚖgithubᚗcomᚋ
 	return &res, err
 }
 
+func (ec *executionContext) marshalOAuth2githubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋgatewayᚋinternalᚋgqlschemaᚐAuth(ctx context.Context, sel ast.SelectionSet, v Auth) graphql.Marshaler {
+	return ec._Auth(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalOAuth2ᚖgithubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋgatewayᚋinternalᚋgqlschemaᚐAuth(ctx context.Context, sel ast.SelectionSet, v *Auth) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._Auth(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalOAuthForRuntime2ᚕᚖgithubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋgatewayᚋinternalᚋgqlschemaᚐAuthForRuntime(ctx context.Context, sel ast.SelectionSet, v []*AuthForRuntime) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		rctx := &graphql.ResolverContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithResolverContext(ctx, rctx)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNAuthForRuntime2ᚖgithubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋgatewayᚋinternalᚋgqlschemaᚐAuthForRuntime(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+	return ret
+}
+
+func (ec *executionContext) unmarshalOAuthInput2githubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋgatewayᚋinternalᚋgqlschemaᚐAuthInput(ctx context.Context, v interface{}) (AuthInput, error) {
+	return ec.unmarshalInputAuthInput(ctx, v)
+}
+
+func (ec *executionContext) unmarshalOAuthInput2ᚖgithubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋgatewayᚋinternalᚋgqlschemaᚐAuthInput(ctx context.Context, v interface{}) (*AuthInput, error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := ec.unmarshalOAuthInput2githubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋgatewayᚋinternalᚋgqlschemaᚐAuthInput(ctx, v)
+	return &res, err
+}
+
 func (ec *executionContext) unmarshalOBasicCredentialDataInput2githubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋgatewayᚋinternalᚋgqlschemaᚐBasicCredentialDataInput(ctx context.Context, v interface{}) (BasicCredentialDataInput, error) {
 	return ec.unmarshalInputBasicCredentialDataInput(ctx, v)
 }
@@ -9758,29 +9854,6 @@ func (ec *executionContext) unmarshalOCSRFTokenCredentialRequestAuthInput2ᚖgit
 		return nil, nil
 	}
 	res, err := ec.unmarshalOCSRFTokenCredentialRequestAuthInput2githubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋgatewayᚋinternalᚋgqlschemaᚐCSRFTokenCredentialRequestAuthInput(ctx, v)
-	return &res, err
-}
-
-func (ec *executionContext) marshalOCredential2githubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋgatewayᚋinternalᚋgqlschemaᚐCredential(ctx context.Context, sel ast.SelectionSet, v Credential) graphql.Marshaler {
-	return ec._Credential(ctx, sel, &v)
-}
-
-func (ec *executionContext) marshalOCredential2ᚖgithubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋgatewayᚋinternalᚋgqlschemaᚐCredential(ctx context.Context, sel ast.SelectionSet, v *Credential) graphql.Marshaler {
-	if v == nil {
-		return graphql.Null
-	}
-	return ec._Credential(ctx, sel, v)
-}
-
-func (ec *executionContext) unmarshalOCredentialInput2githubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋgatewayᚋinternalᚋgqlschemaᚐCredentialInput(ctx context.Context, v interface{}) (CredentialInput, error) {
-	return ec.unmarshalInputCredentialInput(ctx, v)
-}
-
-func (ec *executionContext) unmarshalOCredentialInput2ᚖgithubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋgatewayᚋinternalᚋgqlschemaᚐCredentialInput(ctx context.Context, v interface{}) (*CredentialInput, error) {
-	if v == nil {
-		return nil, nil
-	}
-	res, err := ec.unmarshalOCredentialInput2githubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋgatewayᚋinternalᚋgqlschemaᚐCredentialInput(ctx, v)
 	return &res, err
 }
 
@@ -9867,18 +9940,6 @@ func (ec *executionContext) marshalOEventSpec2ᚖgithubᚗcomᚋkymaᚑincubator
 		return graphql.Null
 	}
 	return ec._EventSpec(ctx, sel, v)
-}
-
-func (ec *executionContext) unmarshalOEventSpecInput2githubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋgatewayᚋinternalᚋgqlschemaᚐEventSpecInput(ctx context.Context, v interface{}) (EventSpecInput, error) {
-	return ec.unmarshalInputEventSpecInput(ctx, v)
-}
-
-func (ec *executionContext) unmarshalOEventSpecInput2ᚖgithubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋgatewayᚋinternalᚋgqlschemaᚐEventSpecInput(ctx context.Context, v interface{}) (*EventSpecInput, error) {
-	if v == nil {
-		return nil, nil
-	}
-	res, err := ec.unmarshalOEventSpecInput2githubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋgatewayᚋinternalᚋgqlschemaᚐEventSpecInput(ctx, v)
-	return &res, err
 }
 
 func (ec *executionContext) unmarshalOFetchMode2githubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋgatewayᚋinternalᚋgqlschemaᚐFetchMode(ctx context.Context, v interface{}) (FetchMode, error) {
@@ -10148,46 +10209,6 @@ func (ec *executionContext) marshalORuntime2ᚖgithubᚗcomᚋkymaᚑincubator�
 		return graphql.Null
 	}
 	return ec._Runtime(ctx, sel, v)
-}
-
-func (ec *executionContext) marshalORuntimeCredential2ᚕᚖgithubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋgatewayᚋinternalᚋgqlschemaᚐRuntimeCredential(ctx context.Context, sel ast.SelectionSet, v []*RuntimeCredential) graphql.Marshaler {
-	if v == nil {
-		return graphql.Null
-	}
-	ret := make(graphql.Array, len(v))
-	var wg sync.WaitGroup
-	isLen1 := len(v) == 1
-	if !isLen1 {
-		wg.Add(len(v))
-	}
-	for i := range v {
-		i := i
-		rctx := &graphql.ResolverContext{
-			Index:  &i,
-			Result: &v[i],
-		}
-		ctx := graphql.WithResolverContext(ctx, rctx)
-		f := func(i int) {
-			defer func() {
-				if r := recover(); r != nil {
-					ec.Error(ctx, ec.Recover(ctx, r))
-					ret = nil
-				}
-			}()
-			if !isLen1 {
-				defer wg.Done()
-			}
-			ret[i] = ec.marshalNRuntimeCredential2ᚖgithubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋgatewayᚋinternalᚋgqlschemaᚐRuntimeCredential(ctx, sel, v[i])
-		}
-		if isLen1 {
-			f(i)
-		} else {
-			go f(i)
-		}
-
-	}
-	wg.Wait()
-	return ret
 }
 
 func (ec *executionContext) unmarshalOSpecFormat2githubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋgatewayᚋinternalᚋgqlschemaᚐSpecFormat(ctx context.Context, v interface{}) (SpecFormat, error) {

--- a/components/gateway/internal/gqlschema/schema_gen.go
+++ b/components/gateway/internal/gqlschema/schema_gen.go
@@ -1455,9 +1455,9 @@ type APIDefinition {
     targetURL: String!
     """ group allows you to find the same API but in different version """
     group: String
-    """" If runtime does not exist, error will be returned. If runtime exist but does not have Auth defined, nil is returned """
+    """"If runtime does not exist, an error will be returned. If runtime exists but does not have Auth defined, null is returned"""
     auth(runtimeID: ID!): Auth
-    """ Auths returns information for all runtimes, even for given runtime Auth is not yet specified """
+    """Returns authentication details for all runtimes, even for a runtime, where Auth is not yet specified"""
     auths: [RuntimeAuth!]!
     version: Version
 }
@@ -1776,8 +1776,8 @@ type Mutation {
     refetchAPISpec(apiID: ID!): APISpec
 
     """
-    If runtimeID not provided, the same auth will be set for every runtime already available
-    Returns information for which runtime it was configured
+    If runtimeID is not provided, the same authentication details will be set for every runtime already available.
+    Returns information for which runtime it was configured.
     """
     setAPIAuth(apiID: ID!, runtimeID: ID, in: AuthInput!): [RuntimeAuth!]!
     deleteAPIAuth(apiID: ID!, runtimeID: ID): [RuntimeAuth!]!

--- a/components/gateway/internal/gqlschema/schema_gen.go
+++ b/components/gateway/internal/gqlschema/schema_gen.go
@@ -164,7 +164,7 @@ type ComplexityRoot struct {
 		CreateApplication           func(childComplexity int, in ApplicationInput) int
 		CreateRuntime               func(childComplexity int, in RuntimeInput) int
 		DeleteAPI                   func(childComplexity int, id string) int
-		DeleteAPIAuth               func(childComplexity int, apiID string, runtimeID *string) int
+		DeleteAPIAuth               func(childComplexity int, apiID string, runtimeID string) int
 		DeleteApplication           func(childComplexity int, id string) int
 		DeleteApplicationAnnotation func(childComplexity int, applicationID string, annotation string) int
 		DeleteApplicationLabel      func(childComplexity int, applicationID string, label string, values []string) int
@@ -242,7 +242,7 @@ type MutationResolver interface {
 	DeleteAPI(ctx context.Context, id string) (*APIDefinition, error)
 	RefetchAPISpec(ctx context.Context, apiID string) (*APISpec, error)
 	SetAPIAuth(ctx context.Context, apiID string, runtimeID string, in AuthInput) ([]*RuntimeAuth, error)
-	DeleteAPIAuth(ctx context.Context, apiID string, runtimeID *string) ([]*RuntimeAuth, error)
+	DeleteAPIAuth(ctx context.Context, apiID string, runtimeID string) ([]*RuntimeAuth, error)
 	AddEvent(ctx context.Context, applicationID string, in EventDefinitionInput) (*EventAPIDefinition, error)
 	UpdateEvent(ctx context.Context, id string, in EventDefinitionInput) (*EventAPIDefinition, error)
 	DeleteEvent(ctx context.Context, id string) (*EventAPIDefinition, error)
@@ -888,7 +888,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Mutation.DeleteAPIAuth(childComplexity, args["apiID"].(string), args["runtimeID"].(*string)), true
+		return e.complexity.Mutation.DeleteAPIAuth(childComplexity, args["apiID"].(string), args["runtimeID"].(string)), true
 
 	case "Mutation.deleteApplication":
 		if e.complexity.Mutation.DeleteApplication == nil {
@@ -1791,7 +1791,7 @@ type Mutation {
     Returns information about all Auths for given applicationID. To set default Auth for API, use updateAPI mutation
     """
     setAPIAuth(apiID: ID!, runtimeID: ID!, in: AuthInput!): [RuntimeAuth!]!
-    deleteAPIAuth(apiID: ID!, runtimeID: ID): [RuntimeAuth!]!
+    deleteAPIAuth(apiID: ID!, runtimeID: ID!): [RuntimeAuth!]!
 
 
     addEvent(applicationID: ID!, in: EventDefinitionInput!): EventAPIDefinition!
@@ -2113,9 +2113,9 @@ func (ec *executionContext) field_Mutation_deleteAPIAuth_args(ctx context.Contex
 		}
 	}
 	args["apiID"] = arg0
-	var arg1 *string
+	var arg1 string
 	if tmp, ok := rawArgs["runtimeID"]; ok {
-		arg1, err = ec.unmarshalOID2ᚖstring(ctx, tmp)
+		arg1, err = ec.unmarshalNID2string(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
@@ -4839,7 +4839,7 @@ func (ec *executionContext) _Mutation_deleteAPIAuth(ctx context.Context, field g
 	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
 	resTmp := ec.FieldMiddleware(ctx, nil, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Mutation().DeleteAPIAuth(rctx, args["apiID"].(string), args["runtimeID"].(*string))
+		return ec.resolvers.Mutation().DeleteAPIAuth(rctx, args["apiID"].(string), args["runtimeID"].(string))
 	})
 	if resTmp == nil {
 		if !ec.HasError(rctx) {

--- a/components/gateway/internal/gqlschema/schema_gen.go
+++ b/components/gateway/internal/gqlschema/schema_gen.go
@@ -168,7 +168,7 @@ type ComplexityRoot struct {
 		CreateApplication           func(childComplexity int, in ApplicationInput) int
 		CreateRuntime               func(childComplexity int, in RuntimeInput) int
 		DeleteAPI                   func(childComplexity int, id string) int
-		DeleteAPICredential         func(childComplexity int, apiID string, runtimeID *string) int
+		DeleteAPIAuth               func(childComplexity int, apiID string, runtimeID *string) int
 		DeleteApplication           func(childComplexity int, id string) int
 		DeleteApplicationAnnotation func(childComplexity int, applicationID string, annotation string) int
 		DeleteApplicationLabel      func(childComplexity int, applicationID string, label string, values []string) int
@@ -179,7 +179,7 @@ type ComplexityRoot struct {
 		DeleteRuntimeLabel          func(childComplexity int, id string, key string, values []string) int
 		RefetchAPISpec              func(childComplexity int, apiID string) int
 		RefetchEventSpec            func(childComplexity int, eventID string) int
-		SetAPICredential            func(childComplexity int, apiID string, runtimeID *string, in AuthInput) int
+		SetAPIAuth                  func(childComplexity int, apiID string, runtimeID *string, in AuthInput) int
 		UpdateAPI                   func(childComplexity int, id string, in APIDefinitionInput) int
 		UpdateApplication           func(childComplexity int, id string, in ApplicationInput) int
 		UpdateApplicationWebhook    func(childComplexity int, webhookID string, in ApplicationWebhookInput) int
@@ -240,8 +240,8 @@ type MutationResolver interface {
 	UpdateAPI(ctx context.Context, id string, in APIDefinitionInput) (*APIDefinition, error)
 	DeleteAPI(ctx context.Context, id string) (*APIDefinition, error)
 	RefetchAPISpec(ctx context.Context, apiID string) (*APISpec, error)
-	SetAPICredential(ctx context.Context, apiID string, runtimeID *string, in AuthInput) ([]*AuthForRuntime, error)
-	DeleteAPICredential(ctx context.Context, apiID string, runtimeID *string) ([]*AuthForRuntime, error)
+	SetAPIAuth(ctx context.Context, apiID string, runtimeID *string, in AuthInput) ([]*AuthForRuntime, error)
+	DeleteAPIAuth(ctx context.Context, apiID string, runtimeID *string) ([]*AuthForRuntime, error)
 	AddEvent(ctx context.Context, applicationID string, in EventDefinitionInput) (*EventAPIDefinition, error)
 	UpdateEvent(ctx context.Context, id string, in EventDefinitionInput) (*EventAPIDefinition, error)
 	DeleteEvent(ctx context.Context, id string) (*EventAPIDefinition, error)
@@ -884,17 +884,17 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Mutation.DeleteAPI(childComplexity, args["id"].(string)), true
 
-	case "Mutation.deleteAPICredential":
-		if e.complexity.Mutation.DeleteAPICredential == nil {
+	case "Mutation.deleteAPIAuth":
+		if e.complexity.Mutation.DeleteAPIAuth == nil {
 			break
 		}
 
-		args, err := ec.field_Mutation_deleteAPICredential_args(context.TODO(), rawArgs)
+		args, err := ec.field_Mutation_deleteAPIAuth_args(context.TODO(), rawArgs)
 		if err != nil {
 			return 0, false
 		}
 
-		return e.complexity.Mutation.DeleteAPICredential(childComplexity, args["apiID"].(string), args["runtimeID"].(*string)), true
+		return e.complexity.Mutation.DeleteAPIAuth(childComplexity, args["apiID"].(string), args["runtimeID"].(*string)), true
 
 	case "Mutation.deleteApplication":
 		if e.complexity.Mutation.DeleteApplication == nil {
@@ -1016,17 +1016,17 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.Mutation.RefetchEventSpec(childComplexity, args["eventID"].(string)), true
 
-	case "Mutation.setAPICredential":
-		if e.complexity.Mutation.SetAPICredential == nil {
+	case "Mutation.setAPIAuth":
+		if e.complexity.Mutation.SetAPIAuth == nil {
 			break
 		}
 
-		args, err := ec.field_Mutation_setAPICredential_args(context.TODO(), rawArgs)
+		args, err := ec.field_Mutation_setAPIAuth_args(context.TODO(), rawArgs)
 		if err != nil {
 			return 0, false
 		}
 
-		return e.complexity.Mutation.SetAPICredential(childComplexity, args["apiID"].(string), args["runtimeID"].(*string), args["in"].(AuthInput)), true
+		return e.complexity.Mutation.SetAPIAuth(childComplexity, args["apiID"].(string), args["runtimeID"].(*string), args["in"].(AuthInput)), true
 
 	case "Mutation.updateAPI":
 		if e.complexity.Mutation.UpdateAPI == nil {
@@ -1773,11 +1773,11 @@ type Mutation {
     refetchAPISpec(apiID: ID!): APISpec
 
     """
-    If runtimeID not provided, the samec credential will be set for every runtime already available
+    If runtimeID not provided, the samec auth will be set for every runtime already available
     Returns information for which runtime it was configured
     """
-    setAPICredential(apiID: ID!, runtimeID: ID, in: AuthInput!): [AuthForRuntime!]!
-    deleteAPICredential(apiID: ID!, runtimeID: ID): [AuthForRuntime!]!
+    setAPIAuth(apiID: ID!, runtimeID: ID, in: AuthInput!): [AuthForRuntime!]!
+    deleteAPIAuth(apiID: ID!, runtimeID: ID): [AuthForRuntime!]!
 
 
     addEvent(applicationID: ID!, in: EventDefinitionInput!): EventAPIDefinition!
@@ -2088,7 +2088,7 @@ func (ec *executionContext) field_Mutation_createRuntime_args(ctx context.Contex
 	return args, nil
 }
 
-func (ec *executionContext) field_Mutation_deleteAPICredential_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+func (ec *executionContext) field_Mutation_deleteAPIAuth_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
 	var err error
 	args := map[string]interface{}{}
 	var arg0 string
@@ -2312,7 +2312,7 @@ func (ec *executionContext) field_Mutation_refetchEventSpec_args(ctx context.Con
 	return args, nil
 }
 
-func (ec *executionContext) field_Mutation_setAPICredential_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
+func (ec *executionContext) field_Mutation_setAPIAuth_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
 	var err error
 	args := map[string]interface{}{}
 	var arg0 string
@@ -4798,7 +4798,7 @@ func (ec *executionContext) _Mutation_refetchAPISpec(ctx context.Context, field 
 	return ec.marshalOAPISpec2ᚖgithubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋgatewayᚋinternalᚋgqlschemaᚐAPISpec(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) _Mutation_setAPICredential(ctx context.Context, field graphql.CollectedField) graphql.Marshaler {
+func (ec *executionContext) _Mutation_setAPIAuth(ctx context.Context, field graphql.CollectedField) graphql.Marshaler {
 	ctx = ec.Tracer.StartFieldExecution(ctx, field)
 	defer func() { ec.Tracer.EndFieldExecution(ctx) }()
 	rctx := &graphql.ResolverContext{
@@ -4809,7 +4809,7 @@ func (ec *executionContext) _Mutation_setAPICredential(ctx context.Context, fiel
 	}
 	ctx = graphql.WithResolverContext(ctx, rctx)
 	rawArgs := field.ArgumentMap(ec.Variables)
-	args, err := ec.field_Mutation_setAPICredential_args(ctx, rawArgs)
+	args, err := ec.field_Mutation_setAPIAuth_args(ctx, rawArgs)
 	if err != nil {
 		ec.Error(ctx, err)
 		return graphql.Null
@@ -4818,7 +4818,7 @@ func (ec *executionContext) _Mutation_setAPICredential(ctx context.Context, fiel
 	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
 	resTmp := ec.FieldMiddleware(ctx, nil, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Mutation().SetAPICredential(rctx, args["apiID"].(string), args["runtimeID"].(*string), args["in"].(AuthInput))
+		return ec.resolvers.Mutation().SetAPIAuth(rctx, args["apiID"].(string), args["runtimeID"].(*string), args["in"].(AuthInput))
 	})
 	if resTmp == nil {
 		if !ec.HasError(rctx) {
@@ -4832,7 +4832,7 @@ func (ec *executionContext) _Mutation_setAPICredential(ctx context.Context, fiel
 	return ec.marshalNAuthForRuntime2ᚕᚖgithubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋgatewayᚋinternalᚋgqlschemaᚐAuthForRuntime(ctx, field.Selections, res)
 }
 
-func (ec *executionContext) _Mutation_deleteAPICredential(ctx context.Context, field graphql.CollectedField) graphql.Marshaler {
+func (ec *executionContext) _Mutation_deleteAPIAuth(ctx context.Context, field graphql.CollectedField) graphql.Marshaler {
 	ctx = ec.Tracer.StartFieldExecution(ctx, field)
 	defer func() { ec.Tracer.EndFieldExecution(ctx) }()
 	rctx := &graphql.ResolverContext{
@@ -4843,7 +4843,7 @@ func (ec *executionContext) _Mutation_deleteAPICredential(ctx context.Context, f
 	}
 	ctx = graphql.WithResolverContext(ctx, rctx)
 	rawArgs := field.ArgumentMap(ec.Variables)
-	args, err := ec.field_Mutation_deleteAPICredential_args(ctx, rawArgs)
+	args, err := ec.field_Mutation_deleteAPIAuth_args(ctx, rawArgs)
 	if err != nil {
 		ec.Error(ctx, err)
 		return graphql.Null
@@ -4852,7 +4852,7 @@ func (ec *executionContext) _Mutation_deleteAPICredential(ctx context.Context, f
 	ctx = ec.Tracer.StartFieldResolverExecution(ctx, rctx)
 	resTmp := ec.FieldMiddleware(ctx, nil, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Mutation().DeleteAPICredential(rctx, args["apiID"].(string), args["runtimeID"].(*string))
+		return ec.resolvers.Mutation().DeleteAPIAuth(rctx, args["apiID"].(string), args["runtimeID"].(*string))
 	})
 	if resTmp == nil {
 		if !ec.HasError(rctx) {
@@ -8009,13 +8009,13 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 			out.Values[i] = ec._Mutation_deleteAPI(ctx, field)
 		case "refetchAPISpec":
 			out.Values[i] = ec._Mutation_refetchAPISpec(ctx, field)
-		case "setAPICredential":
-			out.Values[i] = ec._Mutation_setAPICredential(ctx, field)
+		case "setAPIAuth":
+			out.Values[i] = ec._Mutation_setAPIAuth(ctx, field)
 			if out.Values[i] == graphql.Null {
 				invalids++
 			}
-		case "deleteAPICredential":
-			out.Values[i] = ec._Mutation_deleteAPICredential(ctx, field)
+		case "deleteAPIAuth":
+			out.Values[i] = ec._Mutation_deleteAPIAuth(ctx, field)
 			if out.Values[i] == graphql.Null {
 				invalids++
 			}


### PR DESCRIPTION
In this PR, the following issues are addressed:
- allow specifying different credentials for given API that differs between runtimes
- allow specifying authentication headers for fetching specification or documentation via `FetchRequest`:
FetchRequest contains auth field of type Auth (previously it was called Credential). Auth contains credential data, but also additional headers and query params. 
- allow grouping API to find APIs which represents the same API but with different versions:
We have field version in `APIDefinition`, but we cannot express that given API is a successor for another API. To show that 2 API represents the same API but in a different version, I added field `group` on `APIDefinition` level. 


Flow for specifying different credentials: 
Use case: there are three Runtimes already defined
  - create the application - at this point, it is not possible to specify credentials - I would like to have only one flow for providing credentials

```
createApplication(in: ApplicationInput!): Application!
```
1. If the application has configured webhook, it will be called 3 times with the following data:
```
{
  "webhookType": "CREDENTIAL_FOR_RUNTIME",
  "runtimeID": {runtimeID},
  "targetURL": {targetURL},
  "apiID": {apiID} 
}
```

  -  an application set authorization for every runtime by calling 3 times following mutation:
```
setAPIAuth(apiID, runtimeID, auth)
```
apiID and runtimeID were provided by webhook. 

2. If Application does not implement webhooks, an administrator has to periodically query for Application. For every `api` (`APIDefinition`) he gets `auths`. If given runtime has not yet specified `Auth`, `AuthForRuntime` returns `auth = null`. Thanks to that, an administrator know which runtimes are not yet configured and for which he should execute `setAPIAuth`. 

In this PR following issues are not addressed:
- CSRF Token: our API is designed in a way that this token is static. In application-registry it is a URL for fetching it: 
https://github.com/kyma-project/kyma/blob/master/components/application-registry/internal/metadata/model/model.go
https://github.com/kyma-project/kyma/issues/2852