### PR TITLE
Fix webhooks and document repository

### DIFF
--- a/components/director/internal/domain/document/repository.go
+++ b/components/director/internal/domain/document/repository.go
@@ -2,7 +2,6 @@ package document
 
 import (
 	"errors"
-	"fmt"
 
 	"github.com/kyma-incubator/compass/components/director/internal/model"
 	"github.com/kyma-incubator/compass/components/director/pkg/pagination"
@@ -60,10 +59,6 @@ func (r *inMemoryRepository) ListByApplicationID(applicationID string, pageSize 
 func (r *inMemoryRepository) Create(item *model.Document) error {
 	if item == nil {
 		return errors.New("item can not be empty")
-	}
-
-	if r.store[item.ApplicationID] == nil {
-		return errors.New(fmt.Sprintf("application with ID %s not found", item.ApplicationID))
 	}
 
 	r.store[item.ID] = item

--- a/components/director/internal/domain/webhook/repository.go
+++ b/components/director/internal/domain/webhook/repository.go
@@ -2,7 +2,6 @@ package webhook
 
 import (
 	"errors"
-	"fmt"
 
 	"github.com/kyma-incubator/compass/components/director/internal/model"
 )
@@ -39,10 +38,6 @@ func (r *inMemoryRepository) ListByApplicationID(applicationID string) ([]*model
 func (r *inMemoryRepository) Create(item *model.ApplicationWebhook) error {
 	if item == nil {
 		return errors.New("item can not be empty")
-	}
-
-	if r.store[item.ApplicationID] == nil {
-		return errors.New(fmt.Sprintf("application with ID %s not found", item.ApplicationID))
 	}
 
 	r.store[item.ID] = item


### PR DESCRIPTION
Webhooks and document repository have an incorrect implementation of Create method: both of them checks in webhooks store(document store) if application exists (but the application is stored in a different place). This check is already done on the service level, where at the beginning we create an app, and then related resources. 