### PR TITLE
Fix handling nil clobs

### DIFF
--- a/components/director/internal/domain/api/converter.go
+++ b/components/director/internal/domain/api/converter.go
@@ -95,9 +95,10 @@ func (c *converter) apiSpecToGraphQL(in *model.APISpec) *graphql.APISpec {
 		return nil
 	}
 
-	var data graphql.CLOB
+	var data *graphql.CLOB
 	if in.Data != nil {
-		data = graphql.CLOB(*in.Data)
+		tmp := graphql.CLOB(*in.Data)
+		data = &tmp
 	}
 
 	var format *graphql.SpecFormat
@@ -107,7 +108,7 @@ func (c *converter) apiSpecToGraphQL(in *model.APISpec) *graphql.APISpec {
 	}
 
 	return &graphql.APISpec{
-		Data:         &data,
+		Data:         data,
 		Type:         graphql.APISpecType(in.Type),
 		Format:       format,
 		FetchRequest: c.fr.ToGraphQL(in.FetchRequest),
@@ -119,18 +120,13 @@ func (c *converter) apiSpecInputFromGraphQL(in *graphql.APISpecInput) *model.API
 		return nil
 	}
 
-	var data []byte
-	if in.Data != nil {
-		data = []byte(*in.Data)
-	}
-
 	var format model.SpecFormat
 	if in.Format != "" {
 		format = model.SpecFormat(in.Format)
 	}
 
 	return &model.APISpecInput{
-		Data:         &data,
+		Data:         (*string)(in.Data),
 		Type:         model.APISpecType(in.Type),
 		Format:       &format,
 		FetchRequest: c.fr.InputFromGraphQL(in.FetchRequest),

--- a/components/director/internal/domain/api/fixtures_test.go
+++ b/components/director/internal/domain/api/fixtures_test.go
@@ -26,7 +26,7 @@ func fixGQLAPIDefinition(id, appId, name, description string) *graphql.APIDefini
 }
 
 func fixDetailedModelAPIDefinition(t *testing.T, id, name, description string, group string) *model.APIDefinition {
-	data := []byte("data")
+	data := "data"
 	format := model.SpecFormatJSON
 
 	spec := &model.APISpec{
@@ -119,7 +119,7 @@ func fixDetailedGQLAPIDefinition(t *testing.T, id, name, description string, gro
 }
 
 func fixModelAPIDefinitionInput(name, description string, group string) *model.APIDefinitionInput {
-	data := []byte("data")
+	data := "data"
 	format := model.SpecFormatYaml
 
 	spec := &model.APISpecInput{

--- a/components/director/internal/domain/api/resolver_test.go
+++ b/components/director/internal/domain/api/resolver_test.go
@@ -437,11 +437,11 @@ func TestResolver_DeleteAPIAuth(t *testing.T) {
 
 func TestResolver_RefetchAPISpec(t *testing.T) {
 	// given
-	testErr := errors.New("Test error")
+	testErr := errors.New("test error")
 
 	apiID := "apiID"
 
-	dataBytes := []byte("data")
+	dataBytes := "data"
 	modelAPISpec := &model.APISpec{
 		Data: &dataBytes,
 	}

--- a/components/director/internal/domain/api/service_test.go
+++ b/components/director/internal/domain/api/service_test.go
@@ -650,7 +650,7 @@ func TestService_RefetchAPISpec(t *testing.T) {
 	ctx := context.TODO()
 	ctx = tenant.SaveToContext(ctx, "tenant")
 
-	dataBytes := []byte("data")
+	dataBytes := "data"
 	modelAPISpec := &model.APISpec{
 		Data: &dataBytes,
 	}

--- a/components/director/internal/domain/eventapi/converter.go
+++ b/components/director/internal/domain/eventapi/converter.go
@@ -83,9 +83,10 @@ func (c *converter) eventAPISpecToGraphQL(in *model.EventAPISpec) *graphql.Event
 		return nil
 	}
 
-	var data graphql.CLOB
+	var data *graphql.CLOB
 	if in.Data != nil {
-		data = graphql.CLOB(*in.Data)
+		tmp := graphql.CLOB(*in.Data)
+		data = &tmp
 	}
 
 	var format *graphql.SpecFormat
@@ -95,7 +96,7 @@ func (c *converter) eventAPISpecToGraphQL(in *model.EventAPISpec) *graphql.Event
 	}
 
 	return &graphql.EventAPISpec{
-		Data:         &data,
+		Data:         data,
 		Type:         graphql.EventAPISpecType(in.Type),
 		Format:       format,
 		FetchRequest: c.fr.ToGraphQL(in.FetchRequest),
@@ -107,18 +108,13 @@ func (c *converter) eventAPISpecInputFromGraphQL(in *graphql.EventAPISpecInput) 
 		return nil
 	}
 
-	var data []byte
-	if in.Data != nil {
-		data = []byte(*in.Data)
-	}
-
 	var format model.SpecFormat
 	if in.Format != "" {
 		format = model.SpecFormat(in.Format)
 	}
 
 	return &model.EventAPISpecInput{
-		Data:          &data,
+		Data:          (*string)(in.Data),
 		Format:        &format,
 		EventSpecType: model.EventAPISpecType(in.EventSpecType),
 		FetchRequest:  c.fr.InputFromGraphQL(in.FetchRequest),

--- a/components/director/internal/domain/eventapi/converter_test.go
+++ b/components/director/internal/domain/eventapi/converter_test.go
@@ -277,7 +277,7 @@ func TestConverter_MultipleInputFromGraphQL(t *testing.T) {
 	}
 }
 
-func TestApiSpecDataConversionNilStaysNil(t *testing.T) {
+func TestEventApiSpecDataConversionNilStaysNil(t *testing.T) {
 	// GIVEN
 	mockFrConv := &automock.FetchRequestConverter{}
 	defer mockFrConv.AssertExpectations(t)

--- a/components/director/internal/domain/eventapi/converter_test.go
+++ b/components/director/internal/domain/eventapi/converter_test.go
@@ -4,6 +4,9 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
 	"github.com/kyma-incubator/compass/components/director/internal/domain/eventapi"
 
 	"github.com/kyma-incubator/compass/components/director/internal/model"
@@ -272,4 +275,29 @@ func TestConverter_MultipleInputFromGraphQL(t *testing.T) {
 			versionConverter.AssertExpectations(t)
 		})
 	}
+}
+
+func TestApiSpecDataConversionNilStaysNil(t *testing.T) {
+	// GIVEN
+	mockFrConv := &automock.FetchRequestConverter{}
+	defer mockFrConv.AssertExpectations(t)
+	mockFrConv.On("InputFromGraphQL", mock.Anything).Return(nil)
+	mockFrConv.On("ToGraphQL", mock.Anything).Return(nil)
+
+	mockVersionConv := &automock.VersionConverter{}
+	defer mockVersionConv.AssertExpectations(t)
+	mockVersionConv.On("InputFromGraphQL", mock.Anything).Return(nil)
+	mockVersionConv.On("ToGraphQL", mock.Anything).Return(nil)
+
+	converter := eventapi.NewConverter(mockFrConv, mockVersionConv)
+	// WHEN & THEN
+	convertedInputModel := converter.InputFromGraphQL(&graphql.EventAPIDefinitionInput{Spec: &graphql.EventAPISpecInput{}})
+	require.NotNil(t, convertedInputModel)
+	require.NotNil(t, convertedInputModel.Spec)
+	require.Nil(t, convertedInputModel.Spec.Data)
+	convertedEvAPIDef := convertedInputModel.ToEventAPIDefinition("id", "app_id")
+	require.NotNil(t, convertedEvAPIDef)
+	convertedGraphqlEvAPIDef := converter.ToGraphQL(convertedEvAPIDef)
+	require.NotNil(t, convertedGraphqlEvAPIDef)
+	assert.Nil(t, convertedGraphqlEvAPIDef.Spec.Data)
 }

--- a/components/director/internal/domain/eventapi/fixtures_test.go
+++ b/components/director/internal/domain/eventapi/fixtures_test.go
@@ -26,7 +26,7 @@ func fixGQLEventAPIDefinition(id, appID, name, description string) *graphql.Even
 }
 
 func fixDetailedModelEventAPIDefinition(t *testing.T, id, name, description string, group string) *model.EventAPIDefinition {
-	data := []byte("data")
+	data := "data"
 	format := model.SpecFormatJSON
 
 	spec := &model.EventAPISpec{
@@ -92,7 +92,7 @@ func fixDetailedGQLEventAPIDefinition(t *testing.T, id, name, description string
 }
 
 func fixModelEventAPIDefinitionInput(name, description string, group string) *model.EventAPIDefinitionInput {
-	data := []byte("data")
+	data := "data"
 	format := model.SpecFormatYaml
 
 	spec := &model.EventAPISpecInput{

--- a/components/director/internal/domain/eventapi/resolver_test.go
+++ b/components/director/internal/domain/eventapi/resolver_test.go
@@ -285,11 +285,11 @@ func TestResolver_UpdateEventAPI(t *testing.T) {
 
 func TestResolver_RefetchAPISpec(t *testing.T) {
 	// given
-	testErr := errors.New("Test error")
+	testErr := errors.New("test error")
 
 	apiID := "apiID"
 
-	dataBytes := []byte("data")
+	dataBytes := "data"
 	modelEventAPISpec := &model.EventAPISpec{
 		Data: &dataBytes,
 	}

--- a/components/director/internal/domain/eventapi/service_test.go
+++ b/components/director/internal/domain/eventapi/service_test.go
@@ -445,7 +445,7 @@ func TestService_RefetchAPISpec(t *testing.T) {
 	ctx := context.TODO()
 	ctx = tenant.SaveToContext(ctx, "tenant")
 
-	dataBytes := []byte("data")
+	dataBytes := "data"
 	modelAPISpec := &model.EventAPISpec{
 		Data: &dataBytes,
 	}

--- a/components/director/internal/model/api.go
+++ b/components/director/internal/model/api.go
@@ -24,7 +24,7 @@ type APIDefinition struct {
 
 type APISpec struct {
 	// when fetch request specified, data will be automatically populated
-	Data         *[]byte
+	Data         *string
 	Format       *SpecFormat
 	Type         APISpecType
 	FetchRequest *FetchRequest
@@ -50,7 +50,7 @@ type APIDefinitionInput struct {
 }
 
 type APISpecInput struct {
-	Data         *[]byte
+	Data         *string
 	Type         APISpecType
 	Format       *SpecFormat
 	FetchRequest *FetchRequestInput

--- a/components/director/internal/model/api_test.go
+++ b/components/director/internal/model/api_test.go
@@ -60,7 +60,7 @@ func TestAPIDefinitionInput_ToAPIDefinition(t *testing.T) {
 
 func TestAPIDefinitionInput_ToAPISpec(t *testing.T) {
 	// given
-	data := []byte("bar")
+	data := "bar"
 	format := model.SpecFormat("Sample")
 	specType := model.APISpecType("sample")
 

--- a/components/director/internal/model/eventapi.go
+++ b/components/director/internal/model/eventapi.go
@@ -23,7 +23,7 @@ const (
 )
 
 type EventAPISpec struct {
-	Data         *[]byte
+	Data         *string
 	Type         EventAPISpecType
 	Format       *SpecFormat
 	FetchRequest *FetchRequest
@@ -46,7 +46,7 @@ type EventAPIDefinitionInput struct {
 }
 
 type EventAPISpecInput struct {
-	Data          *[]byte
+	Data          *string
 	EventSpecType EventAPISpecType
 	Format        *SpecFormat
 	FetchRequest  *FetchRequestInput

--- a/components/director/internal/model/eventapi_test.go
+++ b/components/director/internal/model/eventapi_test.go
@@ -57,7 +57,7 @@ func TestEventAPIDefinitionInput_ToEventAPIDefinition(t *testing.T) {
 
 func TestEventAPIDefinitionInput_ToEventAPISpec(t *testing.T) {
 	// given
-	data := []byte("bar")
+	data := "bar"
 	format := model.SpecFormat("Sample")
 	specType := model.EventAPISpecType("sample")
 


### PR DESCRIPTION
Problem: when I created a new application with `ApiSpec`/`EventApiSpec`, but `Data` was not provided, in return I got Data with `""`, instead of nil.
 