### PR TITLE
Integration tests: set insecureSkipVerify to true for HttpClient

### DIFF
--- a/tests/end-to-end/director/common_test.go
+++ b/tests/end-to-end/director/common_test.go
@@ -2,14 +2,32 @@ package director
 
 import (
 	"context"
+	"crypto/tls"
+	"net/http"
 	"os"
 	"reflect"
 	"testing"
+	"time"
 
 	gcli "github.com/machinebox/graphql"
 )
 
-var tc = testContext{graphqlizer: graphqlizer{}, gqlFieldsProvider: gqlFieldsProvider{}, cli: gcli.NewClient(getDirectorURL())}
+var tc = testContext{graphqlizer: graphqlizer{}, gqlFieldsProvider: gqlFieldsProvider{}, cli: newGraphqlClient()}
+
+func newGraphqlClient() *gcli.Client {
+	return gcli.NewClient(getDirectorURL(), gcli.WithHTTPClient(newAuthorizedHttpClient()))
+}
+
+func newAuthorizedHttpClient() *http.Client {
+	transport := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	}
+
+	return &http.Client{
+		Transport: transport,
+		Timeout:   time.Second * 30,
+	}
+}
 
 func (tc *testContext) RunQuery(ctx context.Context, req *gcli.Request, resp interface{}) error {
 	if req.Header["Tenant"] == nil {


### PR DESCRIPTION
Our integration tests should test whole infrastructure, like gateway, virtual service etc. Because of that we should use https instead of http and allow to run tests against kyma using self-signed cert. 