### PR TITLE
Adjust chart to run on Kyma

### DIFF
--- a/chart/compass/templates/test-compass-end-to-end.yaml
+++ b/chart/compass/templates/test-compass-end-to-end.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
     {{ if .Values.global.isLocalEnv }}
       hostAliases:
-        - ip: {{ .Values.minikubeIP }}
+        - ip: {{ .Values.compass.integrationtest.minikubeIP }}
           hostnames:
           - "{{ .Values.global.gateway.host }}.{{ .Values.global.ingress.domainName }}"
     {{ end }}

--- a/installation/cmd/run.sh
+++ b/installation/cmd/run.sh
@@ -17,4 +17,4 @@ kubectl get -n kyma-installer secret helm-secret -o jsonpath="{.data['global\.he
 echo "Secrets with Tiller tls client certificates have been created \n"
 
 minikubeIP=$(eval minikube ip)
-helm install --set=compass.integrationtest.minikubeIP=${minikubeIP} --name "${COMPASS_HELM_RELEASE_NAME}" --namespace "${COMPASS_HELM_RELEASE_NAMESPACE}" "${ROOT_PATH}"/chart/compass --tls
+helm install --set=compass.integrationtest.minikubeIP=${minikubeIP} --name "${COMPASS_HELM_RELEASE_NAME}" --namespace "${COMPASS_HELM_RELEASE_NAMESPACE}" "${ROOT_PATH}"/chart/compass --tls --wait

--- a/installation/cmd/run.sh
+++ b/installation/cmd/run.sh
@@ -17,4 +17,4 @@ kubectl get -n kyma-installer secret helm-secret -o jsonpath="{.data['global\.he
 echo "Secrets with Tiller tls client certificates have been created \n"
 
 minikubeIP=$(eval minikube ip)
-helm install --set=minikubeIP=${minikubeIP} --name "${COMPASS_HELM_RELEASE_NAME}" --namespace "${COMPASS_HELM_RELEASE_NAMESPACE}" "${ROOT_PATH}"/chart/compass --tls
+helm install --set=compass.integrationtest.minikubeIP=${minikubeIP} --name "${COMPASS_HELM_RELEASE_NAME}" --namespace "${COMPASS_HELM_RELEASE_NAMESPACE}" "${ROOT_PATH}"/chart/compass --tls

--- a/installation/resources/installer-config.yaml
+++ b/installation/resources/installer-config.yaml
@@ -11,3 +11,4 @@ data:
   gateway.gateway.enabled: "true"
   global.istio.gateway.name: "compass-istio-gateway"
   global.istio.gateway.namespace: "compass-system"
+  compass.integrationtest.minikubeIP: ""


### PR DESCRIPTION
- Minikube IP is set in the same way as it is done in kyma-project - in Kyma installation process there is a "magic" that set this value if the variable has a proper name
- waits for charts installation

This PR is connected with: https://github.com/kyma-project/kyma/pull/4881