### PR TITLE
Add validation on Application/Runtime name in graphql mutations

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -7,7 +7,7 @@ global:
       version: "PR-99"
     director:
       dir: pr/
-      version: "PR-139"
+      version: "PR-147"
     gateway:
       dir: pr/
       version: "PR-100"
@@ -17,7 +17,7 @@ global:
     tests:
       e2e:
         dir: pr/
-        version: "PR-139"
+        version: "PR-147"
 
   isLocalEnv: true
   

--- a/components/director/Gopkg.lock
+++ b/components/director/Gopkg.lock
@@ -42,6 +42,25 @@
   version = "v1.1.1"
 
 [[projects]]
+  digest = "1:4d02824a56d268f74a6b6fdd944b20b58a77c3d70e81008b3ee0c4f1a6777340"
+  name = "github.com/gogo/protobuf"
+  packages = [
+    "proto",
+    "sortkeys",
+  ]
+  pruneopts = "UT"
+  revision = "ba06b47c162d49f2af050fb4c75bcbc86a159d5c"
+  version = "v1.2.1"
+
+[[projects]]
+  digest = "1:a6181aca1fd5e27103f9a920876f29ac72854df7345a39f3b01e61c8c94cc8af"
+  name = "github.com/google/gofuzz"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "f140a6486e521aad38f5917de355cbf147cc0496"
+  version = "v1.0.0"
+
+[[projects]]
   digest = "1:582b704bebaa06b48c29b0cec224a6058a09c86883aaddabde889cd1a5f73e1b"
   name = "github.com/google/uuid"
   packages = ["."]
@@ -172,11 +191,49 @@
 
 [[projects]]
   branch = "master"
+  digest = "1:ac3a95fb47a3b5ad909204de06eed59b019252203c18d3747b0090723c3fc4b7"
+  name = "golang.org/x/net"
+  packages = [
+    "http/httpguts",
+    "http2",
+    "http2/hpack",
+    "idna",
+  ]
+  pruneopts = "UT"
+  revision = "da137c7871d730100384dbcf36e6f8fa493aef5b"
+
+[[projects]]
+  branch = "master"
   digest = "1:249fd56fb36a223aee164e2dc35e3b3a1b92dd3873dfb60216280b9fb9d4a784"
   name = "golang.org/x/sys"
   packages = ["unix"]
   pruneopts = "UT"
   revision = "15dcb6c0061f497a3f66e3ea034b629c6dd4d99e"
+
+[[projects]]
+  digest = "1:8d8faad6b12a3a4c819a3f9618cb6ee1fa1cfc33253abeeea8b55336721e3405"
+  name = "golang.org/x/text"
+  packages = [
+    "collate",
+    "collate/build",
+    "internal/colltab",
+    "internal/gen",
+    "internal/language",
+    "internal/language/compact",
+    "internal/tag",
+    "internal/triegen",
+    "internal/ucd",
+    "language",
+    "secure/bidirule",
+    "transform",
+    "unicode/bidi",
+    "unicode/cldr",
+    "unicode/norm",
+    "unicode/rangetable",
+  ]
+  pruneopts = "UT"
+  revision = "342b2e1fbaa52c93f31447ad2c6abc048c63e475"
+  version = "v0.3.2"
 
 [[projects]]
   branch = "master"
@@ -201,12 +258,63 @@
   revision = "d4e310b4a8a5f0fe33e0a7e813a14ff19b433da4"
 
 [[projects]]
+  digest = "1:2d1fbdc6777e5408cabeb02bf336305e724b925ff4546ded0fa8715a7267922a"
+  name = "gopkg.in/inf.v0"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "d2d2541c53f18d2a059457998ce2876cc8e67cbf"
+  version = "v0.9.1"
+
+[[projects]]
   digest = "1:4d2e5a73dc1500038e504a8d78b986630e3626dc027bc030ba5c75da257cdb96"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
   pruneopts = "UT"
   revision = "51d6538a90f86fe93ac480b35f37b2be17fef232"
   version = "v2.2.2"
+
+[[projects]]
+  digest = "1:7a2c7542693e1878fea119497f18374f2917473929740f175eda368d5b313103"
+  name = "k8s.io/apimachinery"
+  packages = [
+    "pkg/api/equality",
+    "pkg/api/meta",
+    "pkg/api/resource",
+    "pkg/api/validation",
+    "pkg/apis/meta/v1",
+    "pkg/apis/meta/v1/validation",
+    "pkg/apis/meta/v1beta1",
+    "pkg/conversion",
+    "pkg/conversion/queryparams",
+    "pkg/fields",
+    "pkg/labels",
+    "pkg/runtime",
+    "pkg/runtime/schema",
+    "pkg/selection",
+    "pkg/types",
+    "pkg/util/errors",
+    "pkg/util/intstr",
+    "pkg/util/json",
+    "pkg/util/naming",
+    "pkg/util/net",
+    "pkg/util/runtime",
+    "pkg/util/sets",
+    "pkg/util/validation",
+    "pkg/util/validation/field",
+    "pkg/watch",
+    "third_party/forked/golang/reflect",
+  ]
+  pruneopts = "UT"
+  revision = "6a84e37a896db9780c75367af8d2ed2bb944022e"
+  version = "kubernetes-1.14.4"
+
+[[projects]]
+  digest = "1:c283ca5951eb7d723d3300762f96ff94c2ea11eaceb788279e2b7327f92e4f2a"
+  name = "k8s.io/klog"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "d98d8acdac006fb39831f1b25640813fef9c314f"
+  version = "v0.3.3"
 
 [solve-meta]
   analyzer-name = "dep"
@@ -228,6 +336,7 @@
     "github.com/vektah/gqlparser/ast",
     "github.com/vrischmann/envconfig",
     "golang.org/x/tools/cmd/goimports",
+    "k8s.io/apimachinery/pkg/api/validation",
   ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/components/director/Gopkg.toml
+++ b/components/director/Gopkg.toml
@@ -14,6 +14,11 @@ required = [
 [[constraint]]
   name = "github.com/stretchr/testify"
   version = "1.3.0"
+
+[[constraint]]
+  name = "k8s.io/apimachinery"
+  version = "kubernetes-1.14.4"
+
 [prune]
   go-tests = true
   unused-packages = true

--- a/components/director/internal/domain/application/repository.go
+++ b/components/director/internal/domain/application/repository.go
@@ -60,6 +60,11 @@ func (r *inMemoryRepository) Create(item *model.Application) error {
 		return errors.New("item can not be empty")
 	}
 
+	found := r.findApplicationName(item.Name)
+	if found {
+		return errors.New("Application name is not unique")
+	}
+
 	r.store[item.ID] = item
 
 	return nil
@@ -68,6 +73,11 @@ func (r *inMemoryRepository) Create(item *model.Application) error {
 func (r *inMemoryRepository) Update(item *model.Application) error {
 	if item == nil {
 		return errors.New("item can not be empty")
+	}
+
+	found := r.findApplicationName(item.Name)
+	if found {
+		return errors.New("Application name is not unique")
 	}
 
 	if r.store[item.ID] == nil {
@@ -87,4 +97,13 @@ func (r *inMemoryRepository) Delete(item *model.Application) error {
 	delete(r.store, item.ID)
 
 	return nil
+}
+
+func (r *inMemoryRepository) findApplicationName(name string) bool {
+	for _, app := range r.store {
+		if app.Name == name {
+			return true
+		}
+	}
+	return false
 }

--- a/components/director/internal/domain/application/service.go
+++ b/components/director/internal/domain/application/service.go
@@ -108,10 +108,10 @@ func (s *service) Create(ctx context.Context, in model.ApplicationInput) (string
 		return "", errors.Wrapf(err, "while loading tenant from context")
 	}
 
-	validationErrorMsgs := in.Validate()
+	err = in.Validate()
 
-	if validationErrorMsgs != nil {
-		return "", errors.Errorf("%v", validationErrorMsgs)
+	if err != nil {
+		return "", errors.Wrapf(err, "while validating Application input")
 	}
 
 	id := s.uidService.Generate()

--- a/components/director/internal/domain/application/service.go
+++ b/components/director/internal/domain/application/service.go
@@ -108,7 +108,7 @@ func (s *service) Create(ctx context.Context, in model.ApplicationInput) (string
 		return "", errors.Wrapf(err, "while loading tenant from context")
 	}
 
-	validationErrorMsgs := in.ValidateInput()
+	validationErrorMsgs := in.Validate()
 
 	if validationErrorMsgs != nil {
 		return "", errors.Errorf("%v", validationErrorMsgs)
@@ -131,7 +131,7 @@ func (s *service) Create(ctx context.Context, in model.ApplicationInput) (string
 }
 
 func (s *service) Update(ctx context.Context, id string, in model.ApplicationInput) error {
-	validationErrorMsgs := in.ValidateInput()
+	validationErrorMsgs := in.Validate()
 
 	if validationErrorMsgs != nil {
 		return errors.Errorf("%v", validationErrorMsgs)

--- a/components/director/internal/domain/application/service.go
+++ b/components/director/internal/domain/application/service.go
@@ -105,13 +105,12 @@ func (s *service) Exist(ctx context.Context, id string) (bool, error) {
 func (s *service) Create(ctx context.Context, in model.ApplicationInput) (string, error) {
 	appTenant, err := tenant.LoadFromContext(ctx)
 	if err != nil {
-		return "", errors.Wrapf(err, "while loading tenant from context")
+		return "", errors.Wrap(err, "while loading tenant from context")
 	}
 
 	err = in.Validate()
-
 	if err != nil {
-		return "", errors.Wrapf(err, "while validating Application input")
+		return "", errors.Wrap(err, "while validating Application input")
 	}
 
 	id := s.uidService.Generate()
@@ -124,17 +123,16 @@ func (s *service) Create(ctx context.Context, in model.ApplicationInput) (string
 
 	err = s.createRelatedResources(in, app.ID)
 	if err != nil {
-		return "", errors.Wrapf(err, "while creating related Application resources")
+		return "", errors.Wrap(err, "while creating related Application resources")
 	}
 
 	return id, nil
 }
 
 func (s *service) Update(ctx context.Context, id string, in model.ApplicationInput) error {
-	validationErrorMsgs := in.Validate()
-
-	if validationErrorMsgs != nil {
-		return errors.Errorf("%v", validationErrorMsgs)
+	err := in.Validate()
+	if err != nil {
+		return errors.Wrap(err, "while validating Application input")
 	}
 
 	app, err := s.Get(ctx, id)
@@ -145,17 +143,17 @@ func (s *service) Update(ctx context.Context, id string, in model.ApplicationInp
 
 	err = s.app.Update(app)
 	if err != nil {
-		return errors.Wrapf(err, "while updating Application")
+		return errors.Wrap(err, "while updating Application")
 	}
 
 	err = s.deleteRelatedResources(id)
 	if err != nil {
-		return errors.Wrapf(err, "while deleting related Application resources")
+		return errors.Wrap(err, "while deleting related Application resources")
 	}
 
 	err = s.createRelatedResources(in, app.ID)
 	if err != nil {
-		return errors.Wrapf(err, "while creating related Application resources")
+		return errors.Wrap(err, "while creating related Application resources")
 	}
 
 	return nil

--- a/components/director/internal/domain/application/service_test.go
+++ b/components/director/internal/domain/application/service_test.go
@@ -22,7 +22,7 @@ func TestService_Create(t *testing.T) {
 	// given
 	testErr := errors.New("Test error")
 	modelInput := model.ApplicationInput{
-		Name: "Foo",
+		Name: "foo.bar-not",
 		Webhooks: []*model.WebhookInput{
 			{URL: "test.foo.com"},
 			{URL: "test.bar.com"},
@@ -93,6 +93,93 @@ func TestService_Create(t *testing.T) {
 			ExpectedErr: nil,
 		},
 		{
+			Name: "Returns error when application name is empty",
+			AppRepoFn: func() *automock.ApplicationRepository {
+				repo := &automock.ApplicationRepository{}
+				return repo
+			},
+			WebhookRepoFn: func() *automock.WebhookRepository {
+				repo := &automock.WebhookRepository{}
+				return repo
+			},
+			APIRepoFn: func() *automock.APIRepository {
+				repo := &automock.APIRepository{}
+				return repo
+			},
+			EventAPIRepoFn: func() *automock.EventAPIRepository {
+				repo := &automock.EventAPIRepository{}
+				return repo
+			},
+			DocumentRepoFn: func() *automock.DocumentRepository {
+				repo := &automock.DocumentRepository{}
+				return repo
+			},
+			UIDServiceFn: func() *automock.UIDService {
+				svc := &automock.UIDService{}
+				return svc
+			},
+			Input:       model.ApplicationInput{Name: ""},
+			ExpectedErr: errors.New("Application name is not correct. You can only use lowercase letters, underscores and dots"),
+		},
+		{
+			Name: "Returns error when application name contains numbers",
+			AppRepoFn: func() *automock.ApplicationRepository {
+				repo := &automock.ApplicationRepository{}
+				return repo
+			},
+			WebhookRepoFn: func() *automock.WebhookRepository {
+				repo := &automock.WebhookRepository{}
+				return repo
+			},
+			APIRepoFn: func() *automock.APIRepository {
+				repo := &automock.APIRepository{}
+				return repo
+			},
+			EventAPIRepoFn: func() *automock.EventAPIRepository {
+				repo := &automock.EventAPIRepository{}
+				return repo
+			},
+			DocumentRepoFn: func() *automock.DocumentRepository {
+				repo := &automock.DocumentRepository{}
+				return repo
+			},
+			UIDServiceFn: func() *automock.UIDService {
+				svc := &automock.UIDService{}
+				return svc
+			},
+			Input:       model.ApplicationInput{Name: "foo5bar"},
+			ExpectedErr: errors.New("Application name is not correct. You can only use lowercase letters, underscores and dots"),
+		},
+		{
+			Name: "Returns error when application name contains uppercase letter",
+			AppRepoFn: func() *automock.ApplicationRepository {
+				repo := &automock.ApplicationRepository{}
+				return repo
+			},
+			WebhookRepoFn: func() *automock.WebhookRepository {
+				repo := &automock.WebhookRepository{}
+				return repo
+			},
+			APIRepoFn: func() *automock.APIRepository {
+				repo := &automock.APIRepository{}
+				return repo
+			},
+			EventAPIRepoFn: func() *automock.EventAPIRepository {
+				repo := &automock.EventAPIRepository{}
+				return repo
+			},
+			DocumentRepoFn: func() *automock.DocumentRepository {
+				repo := &automock.DocumentRepository{}
+				return repo
+			},
+			UIDServiceFn: func() *automock.UIDService {
+				svc := &automock.UIDService{}
+				return svc
+			},
+			Input:       model.ApplicationInput{Name: "upperCase"},
+			ExpectedErr: errors.New("Application name is not correct. You can only use lowercase letters, underscores and dots"),
+		},
+		{
 			Name: "Returns error when application creation failed",
 			AppRepoFn: func() *automock.ApplicationRepository {
 				repo := &automock.ApplicationRepository{}
@@ -140,7 +227,11 @@ func TestService_Create(t *testing.T) {
 
 			// then
 			assert.IsType(t, "string", result)
-			assert.Equal(t, testCase.ExpectedErr, err)
+			if err == nil {
+				require.Nil(t, testCase.ExpectedErr)
+			} else {
+				assert.Error(t, testCase.ExpectedErr, err)
+			}
 
 			appRepo.AssertExpectations(t)
 			webhookRepo.AssertExpectations(t)
@@ -158,7 +249,7 @@ func TestService_Update(t *testing.T) {
 
 	desc := "Lorem ipsum"
 	modelInput := model.ApplicationInput{
-		Name: "Bar",
+		Name: "bar",
 	}
 	id := "foo"
 
@@ -170,7 +261,7 @@ func TestService_Update(t *testing.T) {
 
 	applicationModel := &model.Application{
 		ID:          id,
-		Name:        "Foo",
+		Name:        "foo",
 		Description: &desc,
 	}
 
@@ -252,6 +343,84 @@ func TestService_Update(t *testing.T) {
 			InputID:            "foo",
 			Input:              modelInput,
 			ExpectedErrMessage: testErr.Error(),
+		},
+		{
+			Name: "Returns error when application name is empty",
+			AppRepoFn: func() *automock.ApplicationRepository {
+				repo := &automock.ApplicationRepository{}
+				return repo
+			},
+			WebhookRepoFn: func() *automock.WebhookRepository {
+				repo := &automock.WebhookRepository{}
+				return repo
+			},
+			APIRepoFn: func() *automock.APIRepository {
+				repo := &automock.APIRepository{}
+				return repo
+			},
+			EventAPIRepoFn: func() *automock.EventAPIRepository {
+				repo := &automock.EventAPIRepository{}
+				return repo
+			},
+			DocumentRepoFn: func() *automock.DocumentRepository {
+				repo := &automock.DocumentRepository{}
+				return repo
+			},
+			InputID:            "foo",
+			Input:              model.ApplicationInput{Name: ""},
+			ExpectedErrMessage: "Application name is not correct. You can only use lowercase letters, underscores and dots",
+		},
+		{
+			Name: "Returns error when application name contains numbers",
+			AppRepoFn: func() *automock.ApplicationRepository {
+				repo := &automock.ApplicationRepository{}
+				return repo
+			},
+			WebhookRepoFn: func() *automock.WebhookRepository {
+				repo := &automock.WebhookRepository{}
+				return repo
+			},
+			APIRepoFn: func() *automock.APIRepository {
+				repo := &automock.APIRepository{}
+				return repo
+			},
+			EventAPIRepoFn: func() *automock.EventAPIRepository {
+				repo := &automock.EventAPIRepository{}
+				return repo
+			},
+			DocumentRepoFn: func() *automock.DocumentRepository {
+				repo := &automock.DocumentRepository{}
+				return repo
+			},
+			InputID:            "foo",
+			Input:              model.ApplicationInput{Name: "foo5bar"},
+			ExpectedErrMessage: "Application name is not correct. You can only use lowercase letters, underscores and dots",
+		},
+		{
+			Name: "Returns error when application name contains upper case letter",
+			AppRepoFn: func() *automock.ApplicationRepository {
+				repo := &automock.ApplicationRepository{}
+				return repo
+			},
+			WebhookRepoFn: func() *automock.WebhookRepository {
+				repo := &automock.WebhookRepository{}
+				return repo
+			},
+			APIRepoFn: func() *automock.APIRepository {
+				repo := &automock.APIRepository{}
+				return repo
+			},
+			EventAPIRepoFn: func() *automock.EventAPIRepository {
+				repo := &automock.EventAPIRepository{}
+				return repo
+			},
+			DocumentRepoFn: func() *automock.DocumentRepository {
+				repo := &automock.DocumentRepository{}
+				return repo
+			},
+			InputID:            "foo",
+			Input:              model.ApplicationInput{Name: "upperCase"},
+			ExpectedErrMessage: "Application name is not correct. You can only use lowercase letters, underscores and dots",
 		},
 		{
 			Name: "Returns error when application retrieval failed",
@@ -350,7 +519,7 @@ func TestService_Delete(t *testing.T) {
 
 	applicationModel := &model.Application{
 		ID:          id,
-		Name:        "Foo",
+		Name:        "foo",
 		Description: &desc,
 	}
 
@@ -525,7 +694,7 @@ func TestService_Get(t *testing.T) {
 
 	applicationModel := &model.Application{
 		ID:          "foo",
-		Name:        "Foo",
+		Name:        "foo",
 		Description: &desc,
 	}
 
@@ -592,8 +761,8 @@ func TestService_List(t *testing.T) {
 	testErr := errors.New("Test error")
 
 	modelApplications := []*model.Application{
-		fixModelApplication("foo", "Foo", "Lorem Ipsum"),
-		fixModelApplication("bar", "Bar", "Lorem Ipsum"),
+		fixModelApplication("foo", "foo", "Lorem Ipsum"),
+		fixModelApplication("bar", "bar", "Lorem Ipsum"),
 	}
 	applicationPage := &model.ApplicationPage{
 		Data:       modelApplications,
@@ -757,7 +926,7 @@ func TestService_AddLabel(t *testing.T) {
 	desc := "Lorem ipsum"
 
 	applicationID := "foo"
-	modifiedApplicationModel := fixModelApplicationWithLabels(applicationID, "Foo", map[string][]string{
+	modifiedApplicationModel := fixModelApplicationWithLabels(applicationID, "foo", map[string][]string{
 		"key": {"value1"},
 	})
 	modifiedApplicationModel.Description = &desc
@@ -777,7 +946,7 @@ func TestService_AddLabel(t *testing.T) {
 			Name: "Success",
 			RepositoryFn: func() *automock.ApplicationRepository {
 				repo := &automock.ApplicationRepository{}
-				repo.On("GetByID", tnt, applicationID).Return(fixModelApplication(applicationID, "Foo", desc), nil).Once()
+				repo.On("GetByID", tnt, applicationID).Return(fixModelApplication(applicationID, "foo", desc), nil).Once()
 				repo.On("Update", modifiedApplicationModel).Return(nil).Once()
 
 				return repo
@@ -791,7 +960,7 @@ func TestService_AddLabel(t *testing.T) {
 			Name: "Returns error when application update failed",
 			RepositoryFn: func() *automock.ApplicationRepository {
 				repo := &automock.ApplicationRepository{}
-				repo.On("GetByID", tnt, applicationID).Return(fixModelApplication(applicationID, "Foo", desc), nil).Once()
+				repo.On("GetByID", tnt, applicationID).Return(fixModelApplication(applicationID, "foo", desc), nil).Once()
 				repo.On("Update", modifiedApplicationModel).Return(testErr).Once()
 
 				return repo
@@ -846,7 +1015,7 @@ func TestService_DeleteLabel(t *testing.T) {
 	testErr := errors.New("Test error")
 
 	applicationID := "foo"
-	modifiedApplicationModel := fixModelApplicationWithLabels(applicationID, "Foo", map[string][]string{})
+	modifiedApplicationModel := fixModelApplicationWithLabels(applicationID, "foo", map[string][]string{})
 
 	labelKey := "key"
 	labelValues := []string{"value1", "value2"}
@@ -864,7 +1033,7 @@ func TestService_DeleteLabel(t *testing.T) {
 			RepositoryFn: func() *automock.ApplicationRepository {
 				repo := &automock.ApplicationRepository{}
 				repo.On("GetByID", tnt, applicationID).Return(
-					fixModelApplicationWithLabels(applicationID, "Foo", map[string][]string{
+					fixModelApplicationWithLabels(applicationID, "foo", map[string][]string{
 						"key": {"value1", "value2"},
 					}), nil).Once()
 				repo.On("Update", modifiedApplicationModel).Return(nil).Once()
@@ -881,7 +1050,7 @@ func TestService_DeleteLabel(t *testing.T) {
 			RepositoryFn: func() *automock.ApplicationRepository {
 				repo := &automock.ApplicationRepository{}
 				repo.On("GetByID", tnt, applicationID).Return(
-					fixModelApplicationWithLabels(applicationID, "Foo", map[string][]string{
+					fixModelApplicationWithLabels(applicationID, "foo", map[string][]string{
 						"key": {"value1", "value2"},
 					}), nil).Once()
 				repo.On("Update", modifiedApplicationModel).Return(testErr).Once()

--- a/components/director/internal/domain/application/service_test.go
+++ b/components/director/internal/domain/application/service_test.go
@@ -119,36 +119,7 @@ func TestService_Create(t *testing.T) {
 				return svc
 			},
 			Input:       model.ApplicationInput{Name: ""},
-			ExpectedErr: errors.New("Application name is not correct. You can only use lowercase letters, underscores and dots"),
-		},
-		{
-			Name: "Returns error when application name contains numbers",
-			AppRepoFn: func() *automock.ApplicationRepository {
-				repo := &automock.ApplicationRepository{}
-				return repo
-			},
-			WebhookRepoFn: func() *automock.WebhookRepository {
-				repo := &automock.WebhookRepository{}
-				return repo
-			},
-			APIRepoFn: func() *automock.APIRepository {
-				repo := &automock.APIRepository{}
-				return repo
-			},
-			EventAPIRepoFn: func() *automock.EventAPIRepository {
-				repo := &automock.EventAPIRepository{}
-				return repo
-			},
-			DocumentRepoFn: func() *automock.DocumentRepository {
-				repo := &automock.DocumentRepository{}
-				return repo
-			},
-			UIDServiceFn: func() *automock.UIDService {
-				svc := &automock.UIDService{}
-				return svc
-			},
-			Input:       model.ApplicationInput{Name: "foo5bar"},
-			ExpectedErr: errors.New("Application name is not correct. You can only use lowercase letters, underscores and dots"),
+			ExpectedErr: errors.New("a DNS-1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character"),
 		},
 		{
 			Name: "Returns error when application name contains uppercase letter",
@@ -177,7 +148,7 @@ func TestService_Create(t *testing.T) {
 				return svc
 			},
 			Input:       model.ApplicationInput{Name: "upperCase"},
-			ExpectedErr: errors.New("Application name is not correct. You can only use lowercase letters, underscores and dots"),
+			ExpectedErr: errors.New("a DNS-1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character"),
 		},
 		{
 			Name: "Returns error when application creation failed",
@@ -230,7 +201,7 @@ func TestService_Create(t *testing.T) {
 			if err == nil {
 				require.Nil(t, testCase.ExpectedErr)
 			} else {
-				assert.Error(t, testCase.ExpectedErr, err)
+				assert.Contains(t, err.Error(), testCase.ExpectedErr.Error())
 			}
 
 			appRepo.AssertExpectations(t)
@@ -368,33 +339,7 @@ func TestService_Update(t *testing.T) {
 			},
 			InputID:            "foo",
 			Input:              model.ApplicationInput{Name: ""},
-			ExpectedErrMessage: "Application name is not correct. You can only use lowercase letters, underscores and dots",
-		},
-		{
-			Name: "Returns error when application name contains numbers",
-			AppRepoFn: func() *automock.ApplicationRepository {
-				repo := &automock.ApplicationRepository{}
-				return repo
-			},
-			WebhookRepoFn: func() *automock.WebhookRepository {
-				repo := &automock.WebhookRepository{}
-				return repo
-			},
-			APIRepoFn: func() *automock.APIRepository {
-				repo := &automock.APIRepository{}
-				return repo
-			},
-			EventAPIRepoFn: func() *automock.EventAPIRepository {
-				repo := &automock.EventAPIRepository{}
-				return repo
-			},
-			DocumentRepoFn: func() *automock.DocumentRepository {
-				repo := &automock.DocumentRepository{}
-				return repo
-			},
-			InputID:            "foo",
-			Input:              model.ApplicationInput{Name: "foo5bar"},
-			ExpectedErrMessage: "Application name is not correct. You can only use lowercase letters, underscores and dots",
+			ExpectedErrMessage: "a DNS-1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character",
 		},
 		{
 			Name: "Returns error when application name contains upper case letter",
@@ -420,7 +365,7 @@ func TestService_Update(t *testing.T) {
 			},
 			InputID:            "foo",
 			Input:              model.ApplicationInput{Name: "upperCase"},
-			ExpectedErrMessage: "Application name is not correct. You can only use lowercase letters, underscores and dots",
+			ExpectedErrMessage: "a DNS-1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character",
 		},
 		{
 			Name: "Returns error when application retrieval failed",

--- a/components/director/internal/domain/application/service_test.go
+++ b/components/director/internal/domain/application/service_test.go
@@ -141,10 +141,11 @@ func TestService_Create(t *testing.T) {
 
 			// then
 			assert.IsType(t, "string", result)
-			if err == nil {
-				require.Nil(t, testCase.ExpectedErr)
-			} else {
+			if testCase.ExpectedErr != nil {
+				require.NotNil(t, err)
 				assert.Contains(t, err.Error(), testCase.ExpectedErr.Error())
+			} else {
+				require.Nil(t, err)
 			}
 
 			appRepo.AssertExpectations(t)
@@ -190,6 +191,7 @@ func TestService_CreateWithInvalidNames(t *testing.T) {
 			_, err := svc.Create(ctx, testCase.Input)
 
 			//THEN
+			require.NotNil(t, err)
 			assert.Contains(t, err.Error(), testCase.ExpectedErrMessage)
 		})
 	}

--- a/components/director/internal/domain/application/service_test.go
+++ b/components/director/internal/domain/application/service_test.go
@@ -176,12 +176,7 @@ func TestService_CreateWithInvalidNames(t *testing.T) {
 			Input:              model.ApplicationInput{Name: ""},
 			ExpectedErrMessage: "a DNS-1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character",
 		},
-		{
-			Name:               "Returns error when application name contains upper case letter",
-			InputID:            "foo",
-			Input:              model.ApplicationInput{Name: "upperCase"},
-			ExpectedErrMessage: "a DNS-1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character",
-		}}
+	}
 
 	for _, testCase := range testCases {
 		t.Run(testCase.Name, func(t *testing.T) {

--- a/components/director/internal/domain/application/service_test.go
+++ b/components/director/internal/domain/application/service_test.go
@@ -214,6 +214,45 @@ func TestService_Create(t *testing.T) {
 	}
 }
 
+func TestService_CreateWithInvalidNames(t *testing.T) {
+	//GIVEN
+	tnt := "tenant"
+	ctx := context.TODO()
+	ctx = tenant.SaveToContext(ctx, tnt)
+
+	testCases := []struct {
+		Name               string
+		InputID            string
+		Input              model.ApplicationInput
+		ExpectedErrMessage string
+	}{
+		{
+			Name:               "Returns error when application name is empty",
+			InputID:            "foo",
+			Input:              model.ApplicationInput{Name: ""},
+			ExpectedErrMessage: "a DNS-1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character",
+		},
+		{
+			Name:               "Returns error when application name contains upper case letter",
+			InputID:            "foo",
+			Input:              model.ApplicationInput{Name: "upperCase"},
+			ExpectedErrMessage: "a DNS-1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character",
+		}}
+
+	for _, testCase := range (testCases) {
+		t.Run(testCase.Name, func(t *testing.T) {
+			svc := application.NewService(nil, nil, nil, nil, nil, nil)
+
+			//WHEN
+			_, err := svc.Create(ctx, testCase.Input)
+
+			//THEN
+			assert.Contains(t, err.Error(), testCase.ExpectedErrMessage)
+		})
+
+	}
+}
+
 func TestService_Update(t *testing.T) {
 	// given
 	testErr := errors.New("Test error")
@@ -316,58 +355,6 @@ func TestService_Update(t *testing.T) {
 			ExpectedErrMessage: testErr.Error(),
 		},
 		{
-			Name: "Returns error when application name is empty",
-			AppRepoFn: func() *automock.ApplicationRepository {
-				repo := &automock.ApplicationRepository{}
-				return repo
-			},
-			WebhookRepoFn: func() *automock.WebhookRepository {
-				repo := &automock.WebhookRepository{}
-				return repo
-			},
-			APIRepoFn: func() *automock.APIRepository {
-				repo := &automock.APIRepository{}
-				return repo
-			},
-			EventAPIRepoFn: func() *automock.EventAPIRepository {
-				repo := &automock.EventAPIRepository{}
-				return repo
-			},
-			DocumentRepoFn: func() *automock.DocumentRepository {
-				repo := &automock.DocumentRepository{}
-				return repo
-			},
-			InputID:            "foo",
-			Input:              model.ApplicationInput{Name: ""},
-			ExpectedErrMessage: "a DNS-1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character",
-		},
-		{
-			Name: "Returns error when application name contains upper case letter",
-			AppRepoFn: func() *automock.ApplicationRepository {
-				repo := &automock.ApplicationRepository{}
-				return repo
-			},
-			WebhookRepoFn: func() *automock.WebhookRepository {
-				repo := &automock.WebhookRepository{}
-				return repo
-			},
-			APIRepoFn: func() *automock.APIRepository {
-				repo := &automock.APIRepository{}
-				return repo
-			},
-			EventAPIRepoFn: func() *automock.EventAPIRepository {
-				repo := &automock.EventAPIRepository{}
-				return repo
-			},
-			DocumentRepoFn: func() *automock.DocumentRepository {
-				repo := &automock.DocumentRepository{}
-				return repo
-			},
-			InputID:            "foo",
-			Input:              model.ApplicationInput{Name: "upperCase"},
-			ExpectedErrMessage: "a DNS-1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character",
-		},
-		{
 			Name: "Returns error when application retrieval failed",
 			AppRepoFn: func() *automock.ApplicationRepository {
 				repo := &automock.ApplicationRepository{}
@@ -451,6 +438,46 @@ func TestService_Update(t *testing.T) {
 			eventAPIRepo.AssertExpectations(t)
 			documentRepo.AssertExpectations(t)
 		})
+	}
+}
+
+func TestService_UpdateWithInvalidNames(t *testing.T) {
+	//GIVEN
+	tnt := "tenant"
+	appID := ""
+	ctx := context.TODO()
+	ctx = tenant.SaveToContext(ctx, tnt)
+
+	testCases := []struct {
+		Name               string
+		InputID            string
+		Input              model.ApplicationInput
+		ExpectedErrMessage string
+	}{
+		{
+			Name:               "Returns error when application name is empty",
+			InputID:            "foo",
+			Input:              model.ApplicationInput{Name: ""},
+			ExpectedErrMessage: "a DNS-1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character",
+		},
+		{
+			Name:               "Returns error when application name contains upper case letter",
+			InputID:            "foo",
+			Input:              model.ApplicationInput{Name: "upperCase"},
+			ExpectedErrMessage: "a DNS-1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character",
+		}}
+
+	for _, testCase := range (testCases) {
+		t.Run(testCase.Name, func(t *testing.T) {
+			svc := application.NewService(nil, nil, nil, nil, nil, nil)
+
+			//WHEN
+			err := svc.Update(ctx, appID, testCase.Input)
+
+			//THEN
+			assert.Contains(t, err.Error(), testCase.ExpectedErrMessage)
+		})
+
 	}
 }
 

--- a/components/director/internal/domain/runtime/repository.go
+++ b/components/director/internal/domain/runtime/repository.go
@@ -2,6 +2,7 @@ package runtime
 
 import (
 	"errors"
+
 	"github.com/kyma-incubator/compass/components/director/internal/labelfilter"
 	"github.com/kyma-incubator/compass/components/director/internal/model"
 	"github.com/kyma-incubator/compass/components/director/pkg/pagination"
@@ -64,20 +65,21 @@ func (r *inMemoryRepository) Update(item *model.Runtime) error {
 		return errors.New("item can not be empty")
 	}
 
-	oldRuntine := r.store[item.ID]
-	if oldRuntine == nil {
+	rtm := r.store[item.ID]
+	if rtm == nil {
 		return errors.New("Runtime not found")
 	}
 
-	if oldRuntine.Name != item.Name {
-
+	if rtm.Name != item.Name {
 		found := r.findRuntimeNameWithinTenant(item.Tenant, item.Name)
 		if found {
 			return errors.New("Runtime name is not unique within tenant")
 		}
 	}
 
-	r.store[item.ID] = item
+	rtm.Name = item.Name
+	rtm.Description = item.Description
+	rtm.Labels = item.Labels
 
 	return nil
 }

--- a/components/director/internal/domain/runtime/repository.go
+++ b/components/director/internal/domain/runtime/repository.go
@@ -50,6 +50,11 @@ func (r *inMemoryRepository) Create(item *model.Runtime) error {
 		return errors.New("item can not be empty")
 	}
 
+	found := r.findRuntimeName(item.Name)
+	if found {
+		return errors.New("Runtime name is not unique")
+	}
+
 	r.store[item.ID] = item
 
 	return nil
@@ -60,8 +65,13 @@ func (r *inMemoryRepository) Update(item *model.Runtime) error {
 		return errors.New("item can not be empty")
 	}
 
+	found := r.findRuntimeName(item.Name)
+	if found {
+		return errors.New("Runtime name is not unique")
+	}
+
 	if r.store[item.ID] == nil {
-		return errors.New("application not found")
+		return errors.New("Runtime not found")
 	}
 
 	r.store[item.ID] = item
@@ -77,4 +87,13 @@ func (r *inMemoryRepository) Delete(item *model.Runtime) error {
 	delete(r.store, item.ID)
 
 	return nil
+}
+
+func (r *inMemoryRepository) findRuntimeName(name string) bool {
+	for _, runtime := range r.store {
+		if runtime.Name == name {
+			return true
+		}
+	}
+	return false
 }

--- a/components/director/internal/domain/runtime/service.go
+++ b/components/director/internal/domain/runtime/service.go
@@ -95,9 +95,9 @@ func (s *service) Create(ctx context.Context, in model.RuntimeInput) (string, er
 }
 
 func (s *service) Update(ctx context.Context, id string, in model.RuntimeInput) error {
-	validationMsgs := validation.NameIsDNSSubdomain(in.Name, false)
-	if validationMsgs != nil {
-		return errors.Errorf("%v", validationMsgs)
+	err := in.Validate()
+	if err != nil {
+		return errors.Wrapf(err, "while validating Runtime input")
 	}
 
 	rtm, err := s.Get(ctx, id)

--- a/components/director/internal/domain/runtime/service.go
+++ b/components/director/internal/domain/runtime/service.go
@@ -105,9 +105,7 @@ func (s *service) Update(ctx context.Context, id string, in model.RuntimeInput) 
 		return errors.Wrap(err, "while getting Runtime")
 	}
 
-	rtm.Name = in.Name
-	rtm.Description = in.Description
-	rtm.Labels = in.Labels
+	rtm = in.ToRuntime(id, rtm.Tenant)
 
 	err = s.repo.Update(rtm)
 	if err != nil {

--- a/components/director/internal/domain/runtime/service.go
+++ b/components/director/internal/domain/runtime/service.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/kyma-incubator/compass/components/director/internal/model"
+	"k8s.io/apimachinery/pkg/api/validation"
 
 	"github.com/kyma-incubator/compass/components/director/internal/labelfilter"
 
@@ -59,6 +60,11 @@ func (s *service) Get(ctx context.Context, id string) (*model.Runtime, error) {
 }
 
 func (s *service) Create(ctx context.Context, in model.RuntimeInput) (string, error) {
+	validationMsgs := validation.NameIsDNSSubdomain(in.Name, false)
+	if validationMsgs != nil {
+		return "", errors.Errorf("%v", validationMsgs)
+	}
+
 	runtimeTenant, err := tenant.LoadFromContext(ctx)
 	if err != nil {
 		return "", errors.Wrapf(err, "while loading tenant from context")
@@ -89,6 +95,11 @@ func (s *service) Create(ctx context.Context, in model.RuntimeInput) (string, er
 }
 
 func (s *service) Update(ctx context.Context, id string, in model.RuntimeInput) error {
+	validationMsgs := validation.NameIsDNSSubdomain(in.Name, false)
+	if validationMsgs != nil {
+		return errors.Errorf("%v", validationMsgs)
+	}
+
 	rtm, err := s.Get(ctx, id)
 	if err != nil {
 		return errors.Wrap(err, "while getting Runtime")

--- a/components/director/internal/domain/runtime/service.go
+++ b/components/director/internal/domain/runtime/service.go
@@ -4,10 +4,8 @@ import (
 	"context"
 	"time"
 
-	"github.com/kyma-incubator/compass/components/director/internal/model"
-	"k8s.io/apimachinery/pkg/api/validation"
-
 	"github.com/kyma-incubator/compass/components/director/internal/labelfilter"
+	"github.com/kyma-incubator/compass/components/director/internal/model"
 
 	"github.com/kyma-incubator/compass/components/director/internal/tenant"
 	"github.com/pkg/errors"
@@ -60,9 +58,9 @@ func (s *service) Get(ctx context.Context, id string) (*model.Runtime, error) {
 }
 
 func (s *service) Create(ctx context.Context, in model.RuntimeInput) (string, error) {
-	validationMsgs := validation.NameIsDNSSubdomain(in.Name, false)
-	if validationMsgs != nil {
-		return "", errors.Errorf("%v", validationMsgs)
+	err := in.Validate()
+	if err != nil {
+		return "", errors.Wrap(err, "while validating Runtime input")
 	}
 
 	runtimeTenant, err := tenant.LoadFromContext(ctx)
@@ -97,7 +95,7 @@ func (s *service) Create(ctx context.Context, in model.RuntimeInput) (string, er
 func (s *service) Update(ctx context.Context, id string, in model.RuntimeInput) error {
 	err := in.Validate()
 	if err != nil {
-		return errors.Wrapf(err, "while validating Runtime input")
+		return errors.Wrap(err, "while validating Runtime input")
 	}
 
 	rtm, err := s.Get(ctx, id)
@@ -109,7 +107,7 @@ func (s *service) Update(ctx context.Context, id string, in model.RuntimeInput) 
 
 	err = s.repo.Update(rtm)
 	if err != nil {
-		return errors.Wrapf(err, "while updating Runtime")
+		return errors.Wrap(err, "while updating Runtime")
 	}
 
 	return nil

--- a/components/director/internal/domain/runtime/service_test.go
+++ b/components/director/internal/domain/runtime/service_test.go
@@ -175,15 +175,6 @@ func TestService_Update(t *testing.T) {
 			ExpectedErrMessage: "a DNS-1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character",
 		},
 		{
-			Name: "Returns error when name contains upper case letter",
-			RepositoryFn: func() *automock.RuntimeRepository {
-				repo := &automock.RuntimeRepository{}
-				return repo
-			},
-			Input:              model.RuntimeInput{Name: "upperCase"},
-			ExpectedErrMessage: "a DNS-1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character",
-		},
-		{
 			Name: "Returns error when application update failed",
 			RepositoryFn: func() *automock.RuntimeRepository {
 				repo := &automock.RuntimeRepository{}

--- a/components/director/internal/domain/runtime/service_test.go
+++ b/components/director/internal/domain/runtime/service_test.go
@@ -23,7 +23,7 @@ func TestService_Create(t *testing.T) {
 	id := "foo"
 	desc := "Lorem ipsum"
 	modelInput := model.RuntimeInput{
-		Name:        "Foo",
+		Name:        "foo.bar-not",
 		Description: &desc,
 	}
 
@@ -59,6 +59,31 @@ func TestService_Create(t *testing.T) {
 			ExpectedErr: nil,
 		},
 		{
+			Name: "Returns error when name is empty",
+			RepositoryFn: func() *automock.RuntimeRepository {
+				repo := &automock.RuntimeRepository{}
+				return repo
+			},
+			UIDServiceFn: func() *automock.UIDService {
+				svc := &automock.UIDService{}
+				return svc
+			},
+			Input:       model.RuntimeInput{Name: ""},
+			ExpectedErr: errors.New("a DNS-1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character")},
+		{
+			Name: "Returns error when name contains upper case letter",
+			RepositoryFn: func() *automock.RuntimeRepository {
+				repo := &automock.RuntimeRepository{}
+				return repo
+			},
+			UIDServiceFn: func() *automock.UIDService {
+				svc := &automock.UIDService{}
+				return svc
+			},
+			Input:       model.RuntimeInput{Name: "upperCase"},
+			ExpectedErr: errors.New("a DNS-1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character"),
+		},
+		{
 			Name: "Returns error when runtime creation failed",
 			RepositoryFn: func() *automock.RuntimeRepository {
 				repo := &automock.RuntimeRepository{}
@@ -86,7 +111,11 @@ func TestService_Create(t *testing.T) {
 
 			// then
 			assert.IsType(t, "string", result)
-			assert.Equal(t, testCase.ExpectedErr, err)
+			if err == nil {
+				require.Nil(t, testCase.ExpectedErr)
+			} else {
+				assert.Contains(t, err.Error(), testCase.ExpectedErr.Error())
+			}
 
 			repo.AssertExpectations(t)
 			idSvc.AssertExpectations(t)
@@ -100,7 +129,7 @@ func TestService_Update(t *testing.T) {
 
 	desc := "Lorem ipsum"
 	modelInput := model.RuntimeInput{
-		Name: "Bar",
+		Name: "bar",
 	}
 
 	inputRuntimeModel := mock.MatchedBy(func(rtm *model.Runtime) bool {
@@ -135,6 +164,24 @@ func TestService_Update(t *testing.T) {
 			InputID:            "foo",
 			Input:              modelInput,
 			ExpectedErrMessage: "",
+		},
+		{
+			Name: "Returns error when name is empty",
+			RepositoryFn: func() *automock.RuntimeRepository {
+				repo := &automock.RuntimeRepository{}
+				return repo
+			},
+			Input:              model.RuntimeInput{Name: ""},
+			ExpectedErrMessage: "a DNS-1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character",
+		},
+		{
+			Name: "Returns error when name contains upper case letter",
+			RepositoryFn: func() *automock.RuntimeRepository {
+				repo := &automock.RuntimeRepository{}
+				return repo
+			},
+			Input:              model.RuntimeInput{Name: "upperCase"},
+			ExpectedErrMessage: "a DNS-1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character",
 		},
 		{
 			Name: "Returns error when application update failed",

--- a/components/director/internal/model/application.go
+++ b/components/director/internal/model/application.go
@@ -106,6 +106,7 @@ func (i *ApplicationInput) ToApplication(id, tenant string) *Application {
 	}
 }
 
-func (i *ApplicationInput) ValidateInput() []string {
+//returns array of error messages, if returns nil model is correct
+func (i *ApplicationInput) Validate() []string {
 	return validation.NameIsDNSSubdomain(i.Name, false)
 }

--- a/components/director/internal/model/application.go
+++ b/components/director/internal/model/application.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"fmt"
+	"github.com/pkg/errors"
 	"time"
 
 	"k8s.io/apimachinery/pkg/api/validation"
@@ -106,7 +107,9 @@ func (i *ApplicationInput) ToApplication(id, tenant string) *Application {
 	}
 }
 
-//returns array of error messages, if returns nil model is correct
-func (i *ApplicationInput) Validate() []string {
-	return validation.NameIsDNSSubdomain(i.Name, false)
+func (i *ApplicationInput) Validate() error {
+	if errorMgs := validation.NameIsDNSSubdomain(i.Name, false); errorMgs != nil {
+		return errors.Errorf("%v", errorMgs)
+	}
+	return nil
 }

--- a/components/director/internal/model/application.go
+++ b/components/director/internal/model/application.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"time"
 
+	"k8s.io/apimachinery/pkg/api/validation"
+
 	"github.com/kyma-incubator/compass/components/director/pkg/pagination"
 	"github.com/kyma-incubator/compass/components/director/pkg/strings"
 )
@@ -102,4 +104,8 @@ func (i *ApplicationInput) ToApplication(id, tenant string) *Application {
 		Labels:         i.Labels,
 		HealthCheckURL: i.HealthCheckURL,
 	}
+}
+
+func (i *ApplicationInput) ValidateInput() []string {
+	return validation.NameIsDNSSubdomain(i.Name, false)
 }

--- a/components/director/internal/model/application.go
+++ b/components/director/internal/model/application.go
@@ -2,8 +2,9 @@ package model
 
 import (
 	"fmt"
-	"github.com/pkg/errors"
 	"time"
+
+	"github.com/pkg/errors"
 
 	"k8s.io/apimachinery/pkg/api/validation"
 

--- a/components/director/internal/model/application_test.go
+++ b/components/director/internal/model/application_test.go
@@ -236,11 +236,11 @@ func TestApplicationInput_ValidateInput(t *testing.T) {
 	for i, testCase := range testCases {
 		t.Run(fmt.Sprintf("%d: %s", i, testCase.Name), func(t *testing.T) {
 			//WHEN
-			errorMsg := testCase.Input.ValidateInput()
+			errorMsg := testCase.Input.Validate()
 
 			//THEN
 			if testCase.ExpectedErrMsg != nil {
-				require.Equal(t, 1, len(errorMsg))
+				require.Len(t, errorMsg, 1)
 				assert.Contains(t, errorMsg[0], testCase.ExpectedErrMsg[0])
 			} else {
 				assert.Nil(t, errorMsg)

--- a/components/director/internal/model/application_test.go
+++ b/components/director/internal/model/application_test.go
@@ -245,7 +245,6 @@ func TestApplicationInput_ValidateInput(t *testing.T) {
 			} else {
 				assert.Nil(t, errorMsg)
 			}
-
 		})
 	}
 }

--- a/components/director/internal/model/application_test.go
+++ b/components/director/internal/model/application_test.go
@@ -2,6 +2,7 @@ package model_test
 
 import (
 	"fmt"
+	"github.com/pkg/errors"
 	"testing"
 
 	"github.com/kyma-incubator/compass/components/director/internal/model"
@@ -205,45 +206,44 @@ func TestApplicationInput_ToApplication(t *testing.T) {
 
 func TestApplicationInput_ValidateInput(t *testing.T) {
 	//GIVEN
-	validationErrorMsg := []string{"a DNS-1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character"}
+	testError := errors.New("a DNS-1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character")
 	testCases := []struct {
-		Name           string
-		Input          model.ApplicationInput
-		ExpectedErrMsg []string
+		Name        string
+		Input       model.ApplicationInput
+		ExpectedErr error
 	}{
 		{
-			Name:           "Correct Application name",
-			Input:          model.ApplicationInput{Name: "correct-name.yeah"},
-			ExpectedErrMsg: nil,
+			Name:        "Correct Application name",
+			Input:       model.ApplicationInput{Name: "correct-name.yeah"},
+			ExpectedErr: nil,
 		},
 		{
-			Name:           "Returns errors when Application name is empty",
-			Input:          model.ApplicationInput{Name: ""},
-			ExpectedErrMsg: validationErrorMsg,
+			Name:        "Returns errors when Application name is empty",
+			Input:       model.ApplicationInput{Name: ""},
+			ExpectedErr: testError,
 		},
 		{
-			Name:           "Returns errors when Application name contains UpperCase letter",
-			Input:          model.ApplicationInput{Name: "Not-correct-name.yeah"},
-			ExpectedErrMsg: validationErrorMsg,
+			Name:        "Returns errors when Application name contains UpperCase letter",
+			Input:       model.ApplicationInput{Name: "Not-correct-name.yeah"},
+			ExpectedErr: testError,
 		},
 		{
-			Name:           "Returns errors when Application name contains special not allowed character",
-			Input:          model.ApplicationInput{Name: "not-correct-n@me.yeah"},
-			ExpectedErrMsg: validationErrorMsg,
+			Name:        "Returns errors when Application name contains special not allowed character",
+			Input:       model.ApplicationInput{Name: "not-correct-n@me.yeah"},
+			ExpectedErr: testError,
 		},
 	}
 
 	for i, testCase := range testCases {
 		t.Run(fmt.Sprintf("%d: %s", i, testCase.Name), func(t *testing.T) {
 			//WHEN
-			errorMsg := testCase.Input.Validate()
+			err := testCase.Input.Validate()
 
 			//THEN
-			if testCase.ExpectedErrMsg != nil {
-				require.Len(t, errorMsg, 1)
-				assert.Contains(t, errorMsg[0], testCase.ExpectedErrMsg[0])
+			if err != nil {
+				assert.Contains(t, err.Error(), testCase.ExpectedErr.Error())
 			} else {
-				assert.Nil(t, errorMsg)
+				assert.Nil(t, testCase.ExpectedErr)
 			}
 		})
 	}

--- a/components/director/internal/model/application_test.go
+++ b/components/director/internal/model/application_test.go
@@ -202,3 +202,50 @@ func TestApplicationInput_ToApplication(t *testing.T) {
 		})
 	}
 }
+
+func TestApplicationInput_ValidateInput(t *testing.T) {
+	//GIVEN
+	validationErrorMsg := []string{"a DNS-1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character"}
+	testCases := []struct {
+		Name           string
+		Input          model.ApplicationInput
+		ExpectedErrMsg []string
+	}{
+		{
+			Name:           "Correct Application name",
+			Input:          model.ApplicationInput{Name: "correct-name.yeah"},
+			ExpectedErrMsg: nil,
+		},
+		{
+			Name:           "Returns errors when Application name is empty",
+			Input:          model.ApplicationInput{Name: ""},
+			ExpectedErrMsg: validationErrorMsg,
+		},
+		{
+			Name:           "Returns errors when Application name contains UpperCase letter",
+			Input:          model.ApplicationInput{Name: "Not-correct-name.yeah"},
+			ExpectedErrMsg: validationErrorMsg,
+		},
+		{
+			Name:           "Returns errors when Application name contains special not allowed character",
+			Input:          model.ApplicationInput{Name: "not-correct-n@me.yeah"},
+			ExpectedErrMsg: validationErrorMsg,
+		},
+	}
+
+	for i, testCase := range testCases {
+		t.Run(fmt.Sprintf("%d: %s", i, testCase.Name), func(t *testing.T) {
+			//WHEN
+			errorMsg := testCase.Input.ValidateInput()
+
+			//THEN
+			if testCase.ExpectedErrMsg != nil {
+				require.Equal(t, 1, len(errorMsg))
+				assert.Contains(t, errorMsg[0], testCase.ExpectedErrMsg[0])
+			} else {
+				assert.Nil(t, errorMsg)
+			}
+
+		})
+	}
+}

--- a/components/director/internal/model/application_test.go
+++ b/components/director/internal/model/application_test.go
@@ -2,8 +2,9 @@ package model_test
 
 import (
 	"fmt"
-	"github.com/pkg/errors"
 	"testing"
+
+	"github.com/pkg/errors"
 
 	"github.com/kyma-incubator/compass/components/director/internal/model"
 	"github.com/stretchr/testify/assert"
@@ -243,7 +244,7 @@ func TestApplicationInput_ValidateInput(t *testing.T) {
 			if err != nil {
 				assert.Contains(t, err.Error(), testCase.ExpectedErr.Error())
 			} else {
-				assert.Nil(t, testCase.ExpectedErr)
+				assert.NoError(t, testCase.ExpectedErr)
 			}
 		})
 	}

--- a/components/director/internal/model/runtime.go
+++ b/components/director/internal/model/runtime.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"time"
 
+	"k8s.io/apimachinery/pkg/api/validation"
+
 	"github.com/kyma-incubator/compass/components/director/pkg/strings"
 
 	"github.com/kyma-incubator/compass/components/director/pkg/pagination"
@@ -92,6 +94,10 @@ func (i *RuntimeInput) ToRuntime(id string, tenant string) *Runtime {
 		AgentAuth:   &Auth{},
 		Status:      &RuntimeStatus{},
 	}
+}
+
+func (i *RuntimeInput) ValidateInput() []string {
+	return validation.NameIsDNSSubdomain(i.Name, false)
 }
 
 type RuntimePage struct {

--- a/components/director/internal/model/runtime.go
+++ b/components/director/internal/model/runtime.go
@@ -96,7 +96,8 @@ func (i *RuntimeInput) ToRuntime(id string, tenant string) *Runtime {
 	}
 }
 
-func (i *RuntimeInput) ValidateInput() []string {
+//returns array of error messages, if returns nil model is correct
+func (i *RuntimeInput) Validate() []string {
 	return validation.NameIsDNSSubdomain(i.Name, false)
 }
 

--- a/components/director/internal/model/runtime.go
+++ b/components/director/internal/model/runtime.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"fmt"
+	"github.com/pkg/errors"
 	"time"
 
 	"k8s.io/apimachinery/pkg/api/validation"
@@ -96,9 +97,11 @@ func (i *RuntimeInput) ToRuntime(id string, tenant string) *Runtime {
 	}
 }
 
-//returns array of error messages, if returns nil model is correct
-func (i *RuntimeInput) Validate() []string {
-	return validation.NameIsDNSSubdomain(i.Name, false)
+func (i *RuntimeInput) Validate() error {
+	if errorMgs := validation.NameIsDNSSubdomain(i.Name, false); errorMgs != nil {
+		return errors.Errorf("%v", errorMgs)
+	}
+	return nil
 }
 
 type RuntimePage struct {

--- a/components/director/internal/model/runtime.go
+++ b/components/director/internal/model/runtime.go
@@ -2,8 +2,9 @@ package model
 
 import (
 	"fmt"
-	"github.com/pkg/errors"
 	"time"
+
+	"github.com/pkg/errors"
 
 	"k8s.io/apimachinery/pkg/api/validation"
 

--- a/components/director/internal/model/runtime_test.go
+++ b/components/director/internal/model/runtime_test.go
@@ -234,11 +234,11 @@ func TestRuntimeInput_ValidateInput(t *testing.T) {
 	for i, testCase := range testCases {
 		t.Run(fmt.Sprintf("%d: %s", i, testCase.Name), func(t *testing.T) {
 			//WHEN
-			errorMsg := testCase.Input.ValidateInput()
+			errorMsg := testCase.Input.Validate()
 
 			//THEN
 			if testCase.ExpectedErrMsg != nil {
-				require.Equal(t, 1, len(errorMsg))
+				require.Len(t, errorMsg, 1)
 				assert.Contains(t, errorMsg[0], testCase.ExpectedErrMsg[0])
 			} else {
 				assert.Nil(t, errorMsg)

--- a/components/director/internal/model/runtime_test.go
+++ b/components/director/internal/model/runtime_test.go
@@ -2,6 +2,7 @@ package model_test
 
 import (
 	"fmt"
+	"github.com/pkg/errors"
 	"testing"
 
 	"github.com/kyma-incubator/compass/components/director/internal/model"
@@ -203,45 +204,44 @@ func TestRuntimeInput_ToRuntime(t *testing.T) {
 
 func TestRuntimeInput_ValidateInput(t *testing.T) {
 	//GIVEN
-	validationErrorMsg := []string{"a DNS-1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character"}
+	validationErrorMsg := errors.New("a DNS-1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character")
 	testCases := []struct {
-		Name           string
-		Input          model.RuntimeInput
-		ExpectedErrMsg []string
+		Name        string
+		Input       model.RuntimeInput
+		ExpectedErr error
 	}{
 		{
-			Name:           "Correct Runtime name",
-			Input:          model.RuntimeInput{Name: "correct-name.yeah"},
-			ExpectedErrMsg: nil,
+			Name:        "Correct Runtime name",
+			Input:       model.RuntimeInput{Name: "correct-name.yeah"},
+			ExpectedErr: nil,
 		},
 		{
-			Name:           "Returns errors when Runtime name is empty",
-			Input:          model.RuntimeInput{Name: ""},
-			ExpectedErrMsg: validationErrorMsg,
+			Name:        "Returns errors when Runtime name is empty",
+			Input:       model.RuntimeInput{Name: ""},
+			ExpectedErr: validationErrorMsg,
 		},
 		{
-			Name:           "Returns errors when Runtime name contains UpperCase letter",
-			Input:          model.RuntimeInput{Name: "Not-correct-name.yeah"},
-			ExpectedErrMsg: validationErrorMsg,
+			Name:        "Returns errors when Runtime name contains UpperCase letter",
+			Input:       model.RuntimeInput{Name: "Not-correct-name.yeah"},
+			ExpectedErr: validationErrorMsg,
 		},
 		{
-			Name:           "Returns errors when Runtime name contains special not allowed character",
-			Input:          model.RuntimeInput{Name: "not-correct-n@me.yeah"},
-			ExpectedErrMsg: validationErrorMsg,
+			Name:        "Returns errors when Runtime name contains special not allowed character",
+			Input:       model.RuntimeInput{Name: "not-correct-n@me.yeah"},
+			ExpectedErr: validationErrorMsg,
 		},
 	}
 
 	for i, testCase := range testCases {
 		t.Run(fmt.Sprintf("%d: %s", i, testCase.Name), func(t *testing.T) {
 			//WHEN
-			errorMsg := testCase.Input.Validate()
+			err := testCase.Input.Validate()
 
 			//THEN
-			if testCase.ExpectedErrMsg != nil {
-				require.Len(t, errorMsg, 1)
-				assert.Contains(t, errorMsg[0], testCase.ExpectedErrMsg[0])
+			if err != nil {
+				assert.Contains(t, err.Error(), testCase.ExpectedErr.Error())
 			} else {
-				assert.Nil(t, errorMsg)
+				assert.Nil(t, testCase.ExpectedErr)
 			}
 		})
 	}

--- a/components/director/internal/model/runtime_test.go
+++ b/components/director/internal/model/runtime_test.go
@@ -200,3 +200,49 @@ func TestRuntimeInput_ToRuntime(t *testing.T) {
 		})
 	}
 }
+
+func TestRuntimeInput_ValidateInput(t *testing.T) {
+	//GIVEN
+	validationErrorMsg := []string{"a DNS-1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character"}
+	testCases := []struct {
+		Name           string
+		Input          model.RuntimeInput
+		ExpectedErrMsg []string
+	}{
+		{
+			Name:           "Correct Runtime name",
+			Input:          model.RuntimeInput{Name: "correct-name.yeah"},
+			ExpectedErrMsg: nil,
+		},
+		{
+			Name:           "Returns errors when Runtime name is empty",
+			Input:          model.RuntimeInput{Name: ""},
+			ExpectedErrMsg: validationErrorMsg,
+		},
+		{
+			Name:           "Returns errors when Runtime name contains UpperCase letter",
+			Input:          model.RuntimeInput{Name: "Not-correct-name.yeah"},
+			ExpectedErrMsg: validationErrorMsg,
+		},
+		{
+			Name:           "Returns errors when Runtime name contains special not allowed character",
+			Input:          model.RuntimeInput{Name: "not-correct-n@me.yeah"},
+			ExpectedErrMsg: validationErrorMsg,
+		},
+	}
+
+	for i, testCase := range testCases {
+		t.Run(fmt.Sprintf("%d: %s", i, testCase.Name), func(t *testing.T) {
+			//WHEN
+			errorMsg := testCase.Input.ValidateInput()
+
+			//THEN
+			if testCase.ExpectedErrMsg != nil {
+				require.Equal(t, 1, len(errorMsg))
+				assert.Contains(t, errorMsg[0], testCase.ExpectedErrMsg[0])
+			} else {
+				assert.Nil(t, errorMsg)
+			}
+		})
+	}
+}

--- a/components/director/internal/model/runtime_test.go
+++ b/components/director/internal/model/runtime_test.go
@@ -2,8 +2,9 @@ package model_test
 
 import (
 	"fmt"
-	"github.com/pkg/errors"
 	"testing"
+
+	"github.com/pkg/errors"
 
 	"github.com/kyma-incubator/compass/components/director/internal/model"
 	"github.com/stretchr/testify/assert"
@@ -204,7 +205,7 @@ func TestRuntimeInput_ToRuntime(t *testing.T) {
 
 func TestRuntimeInput_ValidateInput(t *testing.T) {
 	//GIVEN
-	validationErrorMsg := errors.New("a DNS-1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character")
+	testError := errors.New("a DNS-1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character")
 	testCases := []struct {
 		Name        string
 		Input       model.RuntimeInput
@@ -218,17 +219,17 @@ func TestRuntimeInput_ValidateInput(t *testing.T) {
 		{
 			Name:        "Returns errors when Runtime name is empty",
 			Input:       model.RuntimeInput{Name: ""},
-			ExpectedErr: validationErrorMsg,
+			ExpectedErr: testError,
 		},
 		{
 			Name:        "Returns errors when Runtime name contains UpperCase letter",
 			Input:       model.RuntimeInput{Name: "Not-correct-name.yeah"},
-			ExpectedErr: validationErrorMsg,
+			ExpectedErr: testError,
 		},
 		{
 			Name:        "Returns errors when Runtime name contains special not allowed character",
 			Input:       model.RuntimeInput{Name: "not-correct-n@me.yeah"},
-			ExpectedErr: validationErrorMsg,
+			ExpectedErr: testError,
 		},
 	}
 
@@ -241,7 +242,7 @@ func TestRuntimeInput_ValidateInput(t *testing.T) {
 			if err != nil {
 				assert.Contains(t, err.Error(), testCase.ExpectedErr.Error())
 			} else {
-				assert.Nil(t, testCase.ExpectedErr)
+				assert.NoError(t, testCase.ExpectedErr)
 			}
 		})
 	}

--- a/tests/end-to-end/director/application_api_test.go
+++ b/tests/end-to-end/director/application_api_test.go
@@ -405,8 +405,7 @@ func TestUpdateApplication(t *testing.T) {
 func TestCreateUpdateApplicationWithDuplicatedNamesWithinTenant(t *testing.T) {
 	// GIVEN
 	ctx := context.Background()
-	in := generateSampleApplicationInput("app")
-	in.Name = "application-1"
+	in := generateSampleApplicationInput("first")
 	appInputGQL, err := tc.graphqlizer.ApplicationInputToGQL(in)
 	require.NoError(t, err)
 	createReq := gcli.NewRequest(
@@ -427,8 +426,6 @@ func TestCreateUpdateApplicationWithDuplicatedNamesWithinTenant(t *testing.T) {
 
 	//Create second application with first application name
 	//GIVEN
-	in = generateSampleApplicationInput("app")
-	in.Name = firstApp.Name
 	appInputGQL, err = tc.graphqlizer.ApplicationInputToGQL(in)
 	require.NoError(t, err)
 	createReq = gcli.NewRequest(
@@ -447,8 +444,7 @@ func TestCreateUpdateApplicationWithDuplicatedNamesWithinTenant(t *testing.T) {
 
 	//Create second application with unique name
 	//GIVEN
-	in = generateSampleApplicationInput("app")
-	in.Name = "application-2"
+	in.Name = "second"
 	appInputGQL, err = tc.graphqlizer.ApplicationInputToGQL(in)
 	require.NoError(t, err)
 	createReq = gcli.NewRequest(
@@ -468,7 +464,6 @@ func TestCreateUpdateApplicationWithDuplicatedNamesWithinTenant(t *testing.T) {
 
 	// Try to update second app with name from first app
 	//GIVEN
-	in = generateSampleApplicationInput("app")
 	in.Name = firstApp.Name
 	appInputGQL, err = tc.graphqlizer.ApplicationInputToGQL(in)
 	require.NoError(t, err)

--- a/tests/end-to-end/director/runtime_api_test.go
+++ b/tests/end-to-end/director/runtime_api_test.go
@@ -39,25 +39,6 @@ func TestRuntimeCreateUpdateAndDelete(t *testing.T) {
 	assertRuntime(t, givenInput, actualRuntime)
 	assert.NotNil(t, actualRuntime.AgentAuth)
 
-	// update runtime
-	givenInput.Description = ptrString("modified-runtime-1-description")
-	runtimeInGQL, err = tc.graphqlizer.RuntimeInputToGQL(givenInput)
-	require.NoError(t, err)
-
-	// WHEN
-	updateReq := gcli.NewRequest(
-		fmt.Sprintf(`mutation{ 
-			result: updateRuntime(id: "%s", in: %s) {
-					%s
-				}
-			}`, actualRuntime.ID, runtimeInGQL, tc.gqlFieldsProvider.ForRuntime()))
-	saveQueryInExamples(t, updateReq.Query(), "update runtime")
-	err = tc.RunQuery(ctx, updateReq, &actualRuntime)
-
-	//THEN
-	require.NoError(t, err)
-	assert.Equal(t, *givenInput.Description, *actualRuntime.Description)
-
 	// add Label
 	actualLabel := graphql.Label{}
 
@@ -102,6 +83,87 @@ func TestRuntimeCreateUpdateAndDelete(t *testing.T) {
 	//THEN
 	require.NoError(t, err)
 
+	// add agent auth
+	// GIVEN
+	in := generateSampleApplicationInput("app")
+
+	appInputGQL, err := tc.graphqlizer.ApplicationInputToGQL(in)
+	require.NoError(t, err)
+	createAppReq := gcli.NewRequest(
+		fmt.Sprintf(`mutation {
+  				result: createApplication(in: %s) {
+    					%s
+					}
+				}`, appInputGQL, tc.gqlFieldsProvider.ForApplication()))
+	actualApp := ApplicationExt{}
+
+	//WHEN
+	err = tc.RunQuery(ctx, createAppReq, &actualApp)
+
+	//THEN
+	require.NoError(t, err)
+	require.NotEmpty(t, actualApp.ID)
+	defer deleteApplication(t, actualApp.ID)
+
+	// set Auth
+	// GIVEN
+	authIn := graphql.AuthInput{
+		Credential: &graphql.CredentialDataInput{
+			Basic: &graphql.BasicCredentialDataInput{
+				Username: "x-men",
+				Password: "secret",
+			}}}
+	actualRuntimeAuth := graphql.RuntimeAuth{}
+
+	authInStr, err := tc.graphqlizer.AuthInputToGQL(&authIn)
+	require.NoError(t, err)
+	setAuthReq := gcli.NewRequest(
+		fmt.Sprintf(`mutation {
+			result: setAPIAuth(apiID: "%s", runtimeID: "%s", in: %s) {
+					%s
+				}
+			}`, actualApp.Apis.Data[0].ID, actualRuntime.ID, authInStr, tc.gqlFieldsProvider.ForRuntimeAuth()))
+
+	//WHEN
+	err = tc.RunQuery(ctx, setAuthReq, &actualRuntimeAuth)
+
+	//THEN
+	require.NoError(t, err)
+	require.NotNil(t, actualRuntimeAuth.Auth)
+	assert.Equal(t, actualRuntime.ID, actualRuntimeAuth.RuntimeID)
+	actualBasic, ok := actualRuntimeAuth.Auth.Credential.(*graphql.BasicCredentialData)
+	require.True(t, ok)
+	assert.Equal(t, "x-men", actualBasic.Username)
+	assert.Equal(t, "secret", actualBasic.Password)
+
+	// update runtime, check if only simple values are updated
+	//GIVEN
+	givenInput.Name = "updated-name"
+	givenInput.Description = ptrString("updated-description")
+	givenInput.Labels = &graphql.Labels{
+		"key": {"values", "aabbcc"},
+	}
+	runtimeInGQL, err = tc.graphqlizer.RuntimeInputToGQL(givenInput)
+	require.NoError(t, err)
+	actualRuntime = graphql.Runtime{ID: actualRuntime.ID}
+	updateRuntimeReq := gcli.NewRequest(
+		fmt.Sprintf(`mutation {
+				result: updateRuntime(id: "%s", in: %s) {
+					%s
+				}
+		}
+		`, actualRuntime.ID, runtimeInGQL, tc.gqlFieldsProvider.ForRuntime()))
+
+	//WHEN
+	err = tc.RunQuery(ctx, updateRuntimeReq, &actualRuntime)
+
+	//THEN
+	require.NoError(t, err)
+	assert.Equal(t, givenInput.Name, actualRuntime.Name)
+	assert.Equal(t, *givenInput.Description, *actualRuntime.Description)
+	assert.Equal(t, *givenInput.Labels, actualRuntime.Labels)
+	assert.NotNil(t, actualRuntime.AgentAuth)
+
 	// delete runtime
 
 	// WHEN
@@ -111,6 +173,111 @@ func TestRuntimeCreateUpdateAndDelete(t *testing.T) {
 
 	//THEN
 	require.NoError(t, err)
+}
+
+func TestRuntimeCreateUpdateDuplicatedNames(t *testing.T) {
+	// GIVEN
+	ctx := context.Background()
+	firstRuntimeName := "unique-name-1"
+	givenInput := graphql.RuntimeInput{
+		Name:        firstRuntimeName,
+		Description: ptrString("runtime-1-description"),
+		Labels:      &graphql.Labels{"ggg": []string{"hhh"}},
+	}
+	runtimeInGQL, err := tc.graphqlizer.RuntimeInputToGQL(givenInput)
+	require.NoError(t, err)
+	firstRuntime := graphql.Runtime{}
+	createReq := gcli.NewRequest(
+		fmt.Sprintf(`mutation {
+			result: createRuntime(in: %s) {
+					%s
+				}
+			}`, runtimeInGQL, tc.gqlFieldsProvider.ForRuntime()))
+	// WHEN
+	err = tc.RunQuery(ctx, createReq, &firstRuntime)
+
+	//THEN
+	require.NoError(t, err)
+	require.NotEmpty(t, firstRuntime.ID)
+	assertRuntime(t, givenInput, firstRuntime)
+	assert.NotNil(t, firstRuntime.AgentAuth)
+	defer deleteRuntime(t, firstRuntime.ID)
+
+	// try to create second runtime with first runtime name
+	//GIVEN
+	givenInput = graphql.RuntimeInput{
+		Name:        firstRuntimeName,
+		Description: ptrString("runtime-1-description"),
+		Labels:      &graphql.Labels{"ggg": []string{"hhh"}},
+	}
+	runtimeInGQL, err = tc.graphqlizer.RuntimeInputToGQL(givenInput)
+	require.NoError(t, err)
+	createReq = gcli.NewRequest(
+		fmt.Sprintf(`mutation {
+			result: createRuntime(in: %s) {
+					%s
+				}
+			}`, runtimeInGQL, tc.gqlFieldsProvider.ForRuntime()))
+	saveQueryInExamples(t, createReq.Query(), "create runtime")
+
+	// WHEN
+	err = tc.RunQuery(ctx, createReq, nil)
+
+	//THEN
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Runtime name is not unique within tenant")
+
+	// create second runtime
+	//GIVEN
+	secondRuntimeName := "unique-name-2"
+	givenInput = graphql.RuntimeInput{
+		Name:        secondRuntimeName,
+		Description: ptrString("runtime-1-description"),
+		Labels:      &graphql.Labels{"ggg": []string{"hhh"}},
+	}
+	runtimeInGQL, err = tc.graphqlizer.RuntimeInputToGQL(givenInput)
+	require.NoError(t, err)
+	secondRuntime := graphql.Runtime{}
+	createReq = gcli.NewRequest(
+		fmt.Sprintf(`mutation {
+			result: createRuntime(in: %s) {
+					%s
+				}
+			}`, runtimeInGQL, tc.gqlFieldsProvider.ForRuntime()))
+
+	// WHEN
+	err = tc.RunQuery(ctx, createReq, &secondRuntime)
+
+	//THEN
+	require.NoError(t, err)
+	require.NotEmpty(t, secondRuntime.ID)
+	assertRuntime(t, givenInput, secondRuntime)
+	assert.NotNil(t, secondRuntime.AgentAuth)
+	defer deleteRuntime(t, secondRuntime.ID)
+
+	//Update first runtime with second runtime name, failed
+
+	//GIVEN
+	givenInput = graphql.RuntimeInput{
+		Name:        secondRuntimeName,
+		Description: ptrString("runtime-1-description"),
+		Labels:      &graphql.Labels{"ggg": []string{"hhh"}},
+	}
+	runtimeInGQL, err = tc.graphqlizer.RuntimeInputToGQL(givenInput)
+	require.NoError(t, err)
+	createReq = gcli.NewRequest(
+		fmt.Sprintf(`mutation {
+			result: updateRuntime(id: "%s", in :%s) {
+					%s
+				}
+			}`, firstRuntime.ID, runtimeInGQL, tc.gqlFieldsProvider.ForRuntime()))
+
+	// WHEN
+	err = tc.RunQuery(ctx, createReq, &secondRuntime)
+
+	//THEN
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Runtime name is not unique within tenant")
 }
 
 func TestSetAndDeleteAPIAuth(t *testing.T) {
@@ -184,6 +351,7 @@ func TestSetAndDeleteAPIAuth(t *testing.T) {
 	require.True(t, ok)
 	assert.Equal(t, "x-men", actualBasic.Username)
 	assert.Equal(t, "secret", actualBasic.Password)
+
 	// delete Auth
 	delAuthReq := gcli.NewRequest(
 		fmt.Sprintf(`mutation {
@@ -193,7 +361,6 @@ func TestSetAndDeleteAPIAuth(t *testing.T) {
 			}`, actualApp.Apis.Data[0].ID, actualRuntime.ID, tc.gqlFieldsProvider.ForRuntimeAuth()))
 	err = tc.RunQuery(ctx, delAuthReq, nil)
 	require.NoError(t, err)
-
 }
 
 func TestQueryRuntimes(t *testing.T) {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Add validation on application and runtime name when creating or updating. Name has to be in accordance with [Kubernetes Naming Convention](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names)
- Add validation that name of application or runtime is unique.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
See #135 