### PR TITLE
Add unmarshall method to CSRFToken creditential request auth

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -10,7 +10,7 @@ global:
       version: "PR-99"
     director:
       dir: pr/
-      version: "PR-190"
+      version: "PR-212"
     gateway:
       dir: pr/
       version: "PR-100"

--- a/components/director/pkg/graphql/auth.go
+++ b/components/director/pkg/graphql/auth.go
@@ -27,3 +27,28 @@ func (a *Auth) UnmarshalJSON(data []byte) error {
 
 	return nil
 }
+
+func (csrf *CSRFTokenCredentialRequestAuth) UnmarshalJSON(data []byte) error {
+	type Alias CSRFTokenCredentialRequestAuth
+
+	aux := &struct {
+		*Alias
+		Credential struct {
+			*BasicCredentialData
+			*OAuthCredentialData
+		} `json:"credential"`
+	}{
+		Alias: (*Alias)(csrf),
+	}
+
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	if aux.Credential.BasicCredentialData != nil {
+		csrf.Credential = aux.Credential.BasicCredentialData
+	} else {
+		csrf.Credential = aux.Credential.OAuthCredentialData
+	}
+
+	return nil
+}

--- a/components/director/pkg/graphql/auth.go
+++ b/components/director/pkg/graphql/auth.go
@@ -12,6 +12,7 @@ type credential struct {
 // UnmarshalJSON is used only by integration tests, we have to help graphql client to deal with Credential field
 func (a *Auth) UnmarshalJSON(data []byte) error {
 	type Alias Auth
+
 	aux := &struct {
 		*Alias
 		Credential credential `json:"credential"`
@@ -49,7 +50,6 @@ func (csrf *CSRFTokenCredentialRequestAuth) UnmarshalJSON(data []byte) error {
 func retrieveCredential(umarshaledCredential credential) CredentialData {
 	if umarshaledCredential.BasicCredentialData != nil {
 		return umarshaledCredential.BasicCredentialData
-	} else {
-		return umarshaledCredential.OAuthCredentialData
 	}
+	return umarshaledCredential.OAuthCredentialData
 }

--- a/components/director/pkg/graphql/auth_test.go
+++ b/components/director/pkg/graphql/auth_test.go
@@ -59,3 +59,58 @@ func TestUnmarshalOAuth(t *testing.T) {
 	assert.Equal(t, "client-id", oauth.ClientID)
 	assert.Equal(t, "client-secret", oauth.ClientSecret)
 }
+
+
+func TestUnmarshalCSRFBasicAuth(t *testing.T) {
+	// GIVEN
+	a := &CSRFTokenCredentialRequestAuth{}
+	// WHEN
+	err := a.UnmarshalJSON([]byte(`{
+		"credential": {
+			"username": "aaa",
+			"password": "bbb"
+		},
+		"additionalHeaders": {
+			"scopes": ["read", "write"]
+		}
+	}`))
+	// THEN
+	require.NoError(t, err)
+	require.NotNil(t, a.AdditionalHeaders)
+	scopes := (*a.AdditionalHeaders)["scopes"]
+	assert.Len(t, scopes, 2)
+	assert.Contains(t, scopes, "read")
+	assert.Contains(t, scopes, "write")
+	basic, ok := a.Credential.(*BasicCredentialData)
+	require.True(t, ok)
+	assert.Equal(t, "aaa", basic.Username)
+	assert.Equal(t, "bbb", basic.Password)
+}
+
+func TestUnmarshalCSRFOAuth(t *testing.T) {
+	// GIVEN
+	a := &CSRFTokenCredentialRequestAuth{}
+	// WHEN
+	err := a.UnmarshalJSON([]byte(`{
+  		"credential": {
+			"url":"oauth.url",
+			"clientId": "client-id",
+			"clientSecret":"client-secret"
+		},
+		"additionalHeaders": {
+			"scopes": ["read", "write"]
+		}
+	}`))
+	// THEN
+	require.NoError(t, err)
+	require.NotNil(t, a.AdditionalHeaders)
+	scopes := (*a.AdditionalHeaders)["scopes"]
+	assert.Len(t, scopes, 2)
+	assert.Contains(t, scopes, "read")
+	assert.Contains(t, scopes, "write")
+	oauth, ok := a.Credential.(*OAuthCredentialData)
+	require.True(t, ok)
+	assert.Equal(t, "oauth.url", oauth.URL)
+	assert.Equal(t, "client-id", oauth.ClientID)
+	assert.Equal(t, "client-secret", oauth.ClientSecret)
+}


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- fix unmarshalling in `CSRFTokenCredentialRequestAuth`

**Related issue(s)**
See #207 