### PR TITLE
Postgres secret should be generated only on install

### DIFF
--- a/chart/compass/charts/postgresql/templates/secrets.yaml
+++ b/chart/compass/charts/postgresql/templates/secrets.yaml
@@ -9,6 +9,9 @@ metadata:
     chart: {{ template "postgresql.chart" . }}
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
+  annotations:
+    "helm.sh/hook": "pre-install"
+    "helm.sh/hook-delete-policy": "before-hook-creation"
 type: Opaque
 data:
   postgresql-username: {{ include "postgresql.username" . | b64enc | quote }}

--- a/chart/compass/charts/postgresql/templates/secrets.yaml
+++ b/chart/compass/charts/postgresql/templates/secrets.yaml
@@ -10,8 +10,8 @@ metadata:
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
   annotations:
-    "helm.sh/hook": "pre-install"
-    "helm.sh/hook-delete-policy": "before-hook-creation"
+    "helm.sh/hook": "pre-install" # Modified
+    "helm.sh/hook-delete-policy": "before-hook-creation" # Modified
 type: Opaque
 data:
   postgresql-username: {{ include "postgresql.username" . | b64enc | quote }}


### PR DESCRIPTION
Currently, when we upgrade compass chart, new password for Postgress will be generated and saved into `compass-postgresql` . This new password is not populated to Postgres, but schema migrator tries to use it and fails.
In this PR, I mark the secret to be created only on installation, so on upgrade, it should not be changed.
This is only a quick fix because it still has some drawbacks:
- what will happen if we want to update previously mentioned secret, for example, to use new user to connect to DB? Probably it will be ignored
- Director is not restarted when the secret is changed, but it is also no so easy to do it, because the method described [here](https://github.com/helm/helm/blob/master/docs/charts_tips_and_tricks.md#automatically-roll-deployments-when-configmaps-or-secrets-change) probably won't work, because the secret is defined in another sub chart.