### PR TITLE
Update CLI usage parameters in installation script

### DIFF
--- a/installation/cmd/run.sh
+++ b/installation/cmd/run.sh
@@ -12,7 +12,7 @@ COMPASS_HELM_RELEASE_NAMESPACE="compass-system"
 INSTALLER_CR_PATH="${ROOT_PATH}"/installation/resources/installer-cr-kyma-diet.yaml
 
 kyma provision minikube
-kyma install -o $INSTALLER_CR_PATH --release "${KYMA_RELEASE}"
+kyma install -o $INSTALLER_CR_PATH --source "${KYMA_RELEASE}"
 
 #Get Tiller tls client certificates
 kubectl get -n kyma-installer secret helm-secret -o jsonpath="{.data['global\.helm\.ca\.crt']}" | base64 --decode > "$(helm home)/ca.pem"
@@ -26,3 +26,4 @@ helm install --set=global.minikubeIP=${MINIKUBE_IP} --set=global.isLocalEnv=true
 # TODO: Remove it after next CLI release
 echo "Adding Compass entries to /etc/hosts..."
 sudo sh -c 'echo "\n$(minikube ip) compass-gateway.kyma.local compass.kyma.local compass-mf.kyma.local" >> /etc/hosts'
+

--- a/installation/cmd/run.sh
+++ b/installation/cmd/run.sh
@@ -4,7 +4,7 @@ set -o errexit
 
 ROOT_PATH=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/../..
 
-defaultRelease="master"
+defaultRelease="latest"
 KYMA_RELEASE=${1:-$defaultRelease}
 COMPASS_HELM_RELEASE_NAME="compass"
 COMPASS_HELM_RELEASE_NAMESPACE="compass-system"


### PR DESCRIPTION
Kyma CLI has been updated recently. The `--release` flag has been dropped. Use `--source` to provide the version. Failed job: https://status.build.kyma-project.io/view/gcs/kyma-prow-logs/logs/post-master-compass-integration/1168466850607009792