### PR TITLE
Allow to update only basic application attributes

### DIFF
--- a/components/director/internal/domain/application/automock/application_converter.go
+++ b/components/director/internal/domain/application/automock/application_converter.go
@@ -11,15 +11,15 @@ type ApplicationConverter struct {
 	mock.Mock
 }
 
-// InputFromGraphQL provides a mock function with given fields: in
-func (_m *ApplicationConverter) InputFromGraphQL(in graphql.ApplicationInput) model.ApplicationInput {
+// CreateInputFromGraphQL provides a mock function with given fields: in
+func (_m *ApplicationConverter) CreateInputFromGraphQL(in graphql.ApplicationCreateInput) model.ApplicationCreateInput {
 	ret := _m.Called(in)
 
-	var r0 model.ApplicationInput
-	if rf, ok := ret.Get(0).(func(graphql.ApplicationInput) model.ApplicationInput); ok {
+	var r0 model.ApplicationCreateInput
+	if rf, ok := ret.Get(0).(func(graphql.ApplicationCreateInput) model.ApplicationCreateInput); ok {
 		r0 = rf(in)
 	} else {
-		r0 = ret.Get(0).(model.ApplicationInput)
+		r0 = ret.Get(0).(model.ApplicationCreateInput)
 	}
 
 	return r0
@@ -52,6 +52,20 @@ func (_m *ApplicationConverter) ToGraphQL(in *model.Application) *graphql.Applic
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*graphql.Application)
 		}
+	}
+
+	return r0
+}
+
+// UpdateInputFromGraphQL provides a mock function with given fields: in
+func (_m *ApplicationConverter) UpdateInputFromGraphQL(in graphql.ApplicationUpdateInput) model.ApplicationUpdateInput {
+	ret := _m.Called(in)
+
+	var r0 model.ApplicationUpdateInput
+	if rf, ok := ret.Get(0).(func(graphql.ApplicationUpdateInput) model.ApplicationUpdateInput); ok {
+		r0 = rf(in)
+	} else {
+		r0 = ret.Get(0).(model.ApplicationUpdateInput)
 	}
 
 	return r0

--- a/components/director/internal/domain/application/automock/application_service.go
+++ b/components/director/internal/domain/application/automock/application_service.go
@@ -14,18 +14,18 @@ type ApplicationService struct {
 }
 
 // Create provides a mock function with given fields: ctx, in
-func (_m *ApplicationService) Create(ctx context.Context, in model.ApplicationInput) (string, error) {
+func (_m *ApplicationService) Create(ctx context.Context, in model.ApplicationCreateInput) (string, error) {
 	ret := _m.Called(ctx, in)
 
 	var r0 string
-	if rf, ok := ret.Get(0).(func(context.Context, model.ApplicationInput) string); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, model.ApplicationCreateInput) string); ok {
 		r0 = rf(ctx, in)
 	} else {
 		r0 = ret.Get(0).(string)
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, model.ApplicationInput) error); ok {
+	if rf, ok := ret.Get(1).(func(context.Context, model.ApplicationCreateInput) error); ok {
 		r1 = rf(ctx, in)
 	} else {
 		r1 = ret.Error(1)
@@ -192,11 +192,11 @@ func (_m *ApplicationService) SetLabel(ctx context.Context, label *model.LabelIn
 }
 
 // Update provides a mock function with given fields: ctx, id, in
-func (_m *ApplicationService) Update(ctx context.Context, id string, in model.ApplicationInput) error {
+func (_m *ApplicationService) Update(ctx context.Context, id string, in model.ApplicationUpdateInput) error {
 	ret := _m.Called(ctx, id, in)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, model.ApplicationInput) error); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, string, model.ApplicationUpdateInput) error); ok {
 		r0 = rf(ctx, id, in)
 	} else {
 		r0 = ret.Error(0)

--- a/components/director/internal/domain/application/converter.go
+++ b/components/director/internal/domain/application/converter.go
@@ -83,13 +83,13 @@ func (c *converter) MultipleToGraphQL(in []*model.Application) []*graphql.Applic
 	return runtimes
 }
 
-func (c *converter) InputFromGraphQL(in graphql.ApplicationInput) model.ApplicationInput {
+func (c *converter) CreateInputFromGraphQL(in graphql.ApplicationCreateInput) model.ApplicationCreateInput {
 	var labels map[string]interface{}
 	if in.Labels != nil {
 		labels = *in.Labels
 	}
 
-	return model.ApplicationInput{
+	return model.ApplicationCreateInput{
 		Name:           in.Name,
 		Description:    in.Description,
 		Labels:         labels,
@@ -98,6 +98,14 @@ func (c *converter) InputFromGraphQL(in graphql.ApplicationInput) model.Applicat
 		Documents:      c.document.MultipleInputFromGraphQL(in.Documents),
 		EventAPIs:      c.eventAPI.MultipleInputFromGraphQL(in.EventAPIs),
 		Apis:           c.api.MultipleInputFromGraphQL(in.Apis),
+	}
+}
+
+func (c *converter) UpdateInputFromGraphQL(in graphql.ApplicationUpdateInput) model.ApplicationUpdateInput {
+	return model.ApplicationUpdateInput{
+		Name:           in.Name,
+		Description:    in.Description,
+		HealthCheckURL: in.HealthCheckURL,
 	}
 }
 

--- a/components/director/internal/domain/application/converter_test.go
+++ b/components/director/internal/domain/application/converter_test.go
@@ -78,15 +78,15 @@ func TestConverter_MultipleToGraphQL(t *testing.T) {
 	assert.Equal(t, expected, res)
 }
 
-func TestConverter_InputFromGraphQL(t *testing.T) {
-	allPropsInput := fixGQLApplicationInput("foo", "Lorem ipsum")
-	allPropsExpected := fixModelApplicationInput("foo", "Lorem ipsum")
+func TestConverter_CreateInputFromGraphQL(t *testing.T) {
+	allPropsInput := fixGQLApplicationCreateInput("foo", "Lorem ipsum")
+	allPropsExpected := fixModelApplicationCreateInput("foo", "Lorem ipsum")
 
 	// given
 	testCases := []struct {
 		Name                string
-		Input               graphql.ApplicationInput
-		Expected            model.ApplicationInput
+		Input               graphql.ApplicationCreateInput
+		Expected            model.ApplicationCreateInput
 		WebhookConverterFn  func() *automock.WebhookConverter
 		DocumentConverterFn func() *automock.DocumentConverter
 		APIConverterFn      func() *automock.APIConverter
@@ -119,8 +119,8 @@ func TestConverter_InputFromGraphQL(t *testing.T) {
 		},
 		{
 			Name:     "Empty",
-			Input:    graphql.ApplicationInput{},
-			Expected: model.ApplicationInput{},
+			Input:    graphql.ApplicationCreateInput{},
+			Expected: model.ApplicationCreateInput{},
 			WebhookConverterFn: func() *automock.WebhookConverter {
 				conv := &automock.WebhookConverter{}
 				conv.On("MultipleInputFromGraphQL", []*graphql.WebhookInput(nil)).Return(nil)
@@ -153,7 +153,41 @@ func TestConverter_InputFromGraphQL(t *testing.T) {
 				testCase.EventAPIConverterFn(),
 				testCase.DocumentConverterFn(),
 			)
-			res := converter.InputFromGraphQL(testCase.Input)
+			res := converter.CreateInputFromGraphQL(testCase.Input)
+
+			// then
+			assert.Equal(t, testCase.Expected, res)
+		})
+	}
+}
+
+func TestConverter_UpdateInputFromGraphQL(t *testing.T) {
+	allPropsInput := fixGQLApplicationUpdateInput("foo", "Lorem ipsum", testURL)
+	allPropsExpected := fixModelApplicationUpdateInput("foo", "Lorem ipsum", testURL)
+
+	// given
+	testCases := []struct {
+		Name     string
+		Input    graphql.ApplicationUpdateInput
+		Expected model.ApplicationUpdateInput
+	}{
+		{
+			Name:     "All properties given",
+			Input:    allPropsInput,
+			Expected: allPropsExpected,
+		},
+		{
+			Name:     "Empty",
+			Input:    graphql.ApplicationUpdateInput{},
+			Expected: model.ApplicationUpdateInput{},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Name, func(t *testing.T) {
+			// when
+			converter := application.NewConverter(nil, nil, nil, nil)
+			res := converter.UpdateInputFromGraphQL(testCase.Input)
 
 			// then
 			assert.Equal(t, testCase.Expected, res)

--- a/components/director/internal/domain/application/fixtures_test.go
+++ b/components/director/internal/domain/application/fixtures_test.go
@@ -13,6 +13,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var (
+	testURL = "https://foo.bar"
+)
+
 func fixApplicationPage(applications []*model.Application) *model.ApplicationPage {
 	return &model.ApplicationPage{
 		Data: applications,
@@ -49,6 +53,19 @@ func fixModelApplication(id, tenant, name, description string) *model.Applicatio
 	}
 }
 
+func fixModelApplicationWithAllUpdatableFields(id, tenant, name, description, url string) *model.Application {
+	return &model.Application{
+		ID:     id,
+		Tenant: tenant,
+		Status: &model.ApplicationStatus{
+			Condition: model.ApplicationStatusConditionInitial,
+		},
+		Name:           name,
+		Description:    &description,
+		HealthCheckURL: &url,
+	}
+}
+
 func fixGQLApplication(id, name, description string) *graphql.Application {
 	return &graphql.Application{
 		ID: id,
@@ -64,7 +81,6 @@ func fixDetailedModelApplication(t *testing.T, id, tenant, name, description str
 	time, err := time.Parse(time.RFC3339, "2002-10-02T10:00:00-05:00")
 	require.NoError(t, err)
 
-	url := "https://foo.bar"
 	return &model.Application{
 		ID: id,
 		Status: &model.ApplicationStatus{
@@ -74,14 +90,13 @@ func fixDetailedModelApplication(t *testing.T, id, tenant, name, description str
 		Name:           name,
 		Description:    &description,
 		Tenant:         tenant,
-		HealthCheckURL: &url,
+		HealthCheckURL: &testURL,
 	}
 }
 
 func fixDetailedGQLApplication(t *testing.T, id, name, description string) *graphql.Application {
 	time, err := time.Parse(time.RFC3339, "2002-10-02T10:00:00-05:00")
 	require.NoError(t, err)
-	url := "https://foo.bar"
 
 	return &graphql.Application{
 		ID: id,
@@ -91,14 +106,13 @@ func fixDetailedGQLApplication(t *testing.T, id, name, description string) *grap
 		},
 		Name:           name,
 		Description:    &description,
-		HealthCheckURL: &url,
+		HealthCheckURL: &testURL,
 	}
 }
 
 func fixDetailedEntityApplication(t *testing.T, id, tenant, name, description string) *application.Entity {
 	ts, err := time.Parse(time.RFC3339, "2002-10-02T10:00:00-05:00")
 	require.NoError(t, err)
-	url := "https://foo.bar"
 
 	return &application.Entity{
 		ID:              id,
@@ -107,22 +121,20 @@ func fixDetailedEntityApplication(t *testing.T, id, tenant, name, description st
 		Description:     repo.NewValidNullableString(description),
 		StatusCondition: string(model.ApplicationStatusConditionInitial),
 		StatusTimestamp: ts,
-		HealthCheckURL:  repo.NewValidNullableString(url),
+		HealthCheckURL:  repo.NewValidNullableString(testURL),
 	}
 }
 
-func fixModelApplicationInput(name, description string) model.ApplicationInput {
-	url := "https://foo.bar"
-
+func fixModelApplicationCreateInput(name, description string) model.ApplicationCreateInput {
 	desc := "Sample"
 	kind := "test"
-	return model.ApplicationInput{
+	return model.ApplicationCreateInput{
 		Name:        name,
 		Description: &description,
 		Labels: map[string]interface{}{
 			"test": []string{"val", "val2"},
 		},
-		HealthCheckURL: &url,
+		HealthCheckURL: &testURL,
 		Webhooks: []*model.WebhookInput{
 			{URL: "webhook1.foo.bar"},
 			{URL: "webhook2.foo.bar"},
@@ -142,18 +154,25 @@ func fixModelApplicationInput(name, description string) model.ApplicationInput {
 	}
 }
 
-func fixGQLApplicationInput(name, description string) graphql.ApplicationInput {
+func fixModelApplicationUpdateInput(name, description, url string) model.ApplicationUpdateInput {
+	return model.ApplicationUpdateInput{
+		Name:           name,
+		Description:    &description,
+		HealthCheckURL: &url,
+	}
+}
+
+func fixGQLApplicationCreateInput(name, description string) graphql.ApplicationCreateInput {
 	labels := graphql.Labels{
 		"test": []string{"val", "val2"},
 	}
-	url := "https://foo.bar"
 	kind := "test"
 	desc := "Sample"
-	return graphql.ApplicationInput{
+	return graphql.ApplicationCreateInput{
 		Name:           name,
 		Description:    &description,
 		Labels:         &labels,
-		HealthCheckURL: &url,
+		HealthCheckURL: &testURL,
 		Webhooks: []*graphql.WebhookInput{
 			{URL: "webhook1.foo.bar"},
 			{URL: "webhook2.foo.bar"},
@@ -170,6 +189,14 @@ func fixGQLApplicationInput(name, description string) graphql.ApplicationInput {
 			{DisplayName: "doc1", Kind: &kind},
 			{DisplayName: "doc2", Kind: &kind},
 		},
+	}
+}
+
+func fixGQLApplicationUpdateInput(name, description, url string) graphql.ApplicationUpdateInput {
+	return graphql.ApplicationUpdateInput{
+		Name:           name,
+		Description:    &description,
+		HealthCheckURL: &url,
 	}
 }
 

--- a/components/director/internal/domain/application/resolver.go
+++ b/components/director/internal/domain/application/resolver.go
@@ -18,8 +18,8 @@ import (
 
 //go:generate mockery -name=ApplicationService -output=automock -outpkg=automock -case=underscore
 type ApplicationService interface {
-	Create(ctx context.Context, in model.ApplicationInput) (string, error)
-	Update(ctx context.Context, id string, in model.ApplicationInput) error
+	Create(ctx context.Context, in model.ApplicationCreateInput) (string, error)
+	Update(ctx context.Context, id string, in model.ApplicationUpdateInput) error
 	Get(ctx context.Context, id string) (*model.Application, error)
 	Delete(ctx context.Context, id string) error
 	List(ctx context.Context, filter []*labelfilter.LabelFilter, pageSize int, cursor string) (*model.ApplicationPage, error)
@@ -34,7 +34,8 @@ type ApplicationService interface {
 type ApplicationConverter interface {
 	ToGraphQL(in *model.Application) *graphql.Application
 	MultipleToGraphQL(in []*model.Application) []*graphql.Application
-	InputFromGraphQL(in graphql.ApplicationInput) model.ApplicationInput
+	CreateInputFromGraphQL(in graphql.ApplicationCreateInput) model.ApplicationCreateInput
+	UpdateInputFromGraphQL(in graphql.ApplicationUpdateInput) model.ApplicationUpdateInput
 }
 
 //go:generate mockery -name=APIService -output=automock -outpkg=automock -case=underscore
@@ -270,9 +271,7 @@ func (r *Resolver) ApplicationsForRuntime(ctx context.Context, runtimeID string,
 	}, nil
 }
 
-func (r *Resolver) CreateApplication(ctx context.Context, in graphql.ApplicationInput) (*graphql.Application, error) {
-	convertedIn := r.appConverter.InputFromGraphQL(in)
-
+func (r *Resolver) CreateApplication(ctx context.Context, in graphql.ApplicationCreateInput) (*graphql.Application, error) {
 	tx, err := r.transact.Begin()
 	if err != nil {
 		return nil, err
@@ -281,6 +280,7 @@ func (r *Resolver) CreateApplication(ctx context.Context, in graphql.Application
 
 	ctx = persistence.SaveToContext(ctx, tx)
 
+	convertedIn := r.appConverter.CreateInputFromGraphQL(in)
 	id, err := r.appSvc.Create(ctx, convertedIn)
 	if err != nil {
 		return nil, err
@@ -300,7 +300,7 @@ func (r *Resolver) CreateApplication(ctx context.Context, in graphql.Application
 
 	return gqlApp, nil
 }
-func (r *Resolver) UpdateApplication(ctx context.Context, id string, in graphql.ApplicationInput) (*graphql.Application, error) {
+func (r *Resolver) UpdateApplication(ctx context.Context, id string, in graphql.ApplicationUpdateInput) (*graphql.Application, error) {
 	tx, err := r.transact.Begin()
 	if err != nil {
 		return nil, err
@@ -309,7 +309,7 @@ func (r *Resolver) UpdateApplication(ctx context.Context, id string, in graphql.
 
 	ctx = persistence.SaveToContext(ctx, tx)
 
-	convertedIn := r.appConverter.InputFromGraphQL(in)
+	convertedIn := r.appConverter.UpdateInputFromGraphQL(in)
 	err = r.appSvc.Update(ctx, id, convertedIn)
 	if err != nil {
 		return nil, err

--- a/components/director/internal/domain/application/resolver_test.go
+++ b/components/director/internal/domain/application/resolver_test.go
@@ -27,11 +27,11 @@ func TestResolver_CreateApplication(t *testing.T) {
 	testErr := errors.New("Test error")
 
 	desc := "Lorem ipsum"
-	gqlInput := graphql.ApplicationInput{
+	gqlInput := graphql.ApplicationCreateInput{
 		Name:        "Foo",
 		Description: &desc,
 	}
-	modelInput := model.ApplicationInput{
+	modelInput := model.ApplicationCreateInput{
 		Name:        "Foo",
 		Description: &desc,
 	}
@@ -42,7 +42,7 @@ func TestResolver_CreateApplication(t *testing.T) {
 		TransactionerFn     func() (*persistenceautomock.PersistenceTx, *persistenceautomock.Transactioner)
 		ServiceFn           func() *automock.ApplicationService
 		ConverterFn         func() *automock.ApplicationConverter
-		Input               graphql.ApplicationInput
+		Input               graphql.ApplicationCreateInput
 		ExpectedApplication *graphql.Application
 		ExpectedErr         error
 	}{
@@ -57,7 +57,7 @@ func TestResolver_CreateApplication(t *testing.T) {
 			},
 			ConverterFn: func() *automock.ApplicationConverter {
 				conv := &automock.ApplicationConverter{}
-				conv.On("InputFromGraphQL", gqlInput).Return(modelInput).Once()
+				conv.On("CreateInputFromGraphQL", gqlInput).Return(modelInput).Once()
 				conv.On("ToGraphQL", modelApplication).Return(gqlApplication).Once()
 				return conv
 			},
@@ -76,7 +76,7 @@ func TestResolver_CreateApplication(t *testing.T) {
 			},
 			ConverterFn: func() *automock.ApplicationConverter {
 				conv := &automock.ApplicationConverter{}
-				conv.On("InputFromGraphQL", gqlInput).Return(modelInput).Once()
+				conv.On("CreateInputFromGraphQL", gqlInput).Return(modelInput).Once()
 				return conv
 			},
 			Input:               gqlInput,
@@ -93,7 +93,7 @@ func TestResolver_CreateApplication(t *testing.T) {
 			},
 			ConverterFn: func() *automock.ApplicationConverter {
 				conv := &automock.ApplicationConverter{}
-				conv.On("InputFromGraphQL", gqlInput).Return(modelInput).Once()
+				conv.On("CreateInputFromGraphQL", gqlInput).Return(modelInput).Once()
 				return conv
 			},
 			Input:               gqlInput,
@@ -111,7 +111,7 @@ func TestResolver_CreateApplication(t *testing.T) {
 			},
 			ConverterFn: func() *automock.ApplicationConverter {
 				conv := &automock.ApplicationConverter{}
-				conv.On("InputFromGraphQL", gqlInput).Return(modelInput).Once()
+				conv.On("CreateInputFromGraphQL", gqlInput).Return(modelInput).Once()
 				return conv
 			},
 			Input:               gqlInput,
@@ -150,11 +150,11 @@ func TestResolver_UpdateApplication(t *testing.T) {
 	testErr := errors.New("Test error")
 
 	desc := "Lorem ipsum"
-	gqlInput := graphql.ApplicationInput{
+	gqlInput := graphql.ApplicationUpdateInput{
 		Name:        "Foo",
 		Description: &desc,
 	}
-	modelInput := model.ApplicationInput{
+	modelInput := model.ApplicationUpdateInput{
 		Name:        "Foo",
 		Description: &desc,
 	}
@@ -168,7 +168,7 @@ func TestResolver_UpdateApplication(t *testing.T) {
 		ServiceFn           func() *automock.ApplicationService
 		ConverterFn         func() *automock.ApplicationConverter
 		ApplicationID       string
-		Input               graphql.ApplicationInput
+		Input               graphql.ApplicationUpdateInput
 		ExpectedApplication *graphql.Application
 		ExpectedErr         error
 	}{
@@ -183,7 +183,7 @@ func TestResolver_UpdateApplication(t *testing.T) {
 			},
 			ConverterFn: func() *automock.ApplicationConverter {
 				conv := &automock.ApplicationConverter{}
-				conv.On("InputFromGraphQL", gqlInput).Return(modelInput).Once()
+				conv.On("UpdateInputFromGraphQL", gqlInput).Return(modelInput).Once()
 				conv.On("ToGraphQL", modelApplication).Return(gqlApplication).Once()
 				return conv
 			},
@@ -203,7 +203,7 @@ func TestResolver_UpdateApplication(t *testing.T) {
 			},
 			ConverterFn: func() *automock.ApplicationConverter {
 				conv := &automock.ApplicationConverter{}
-				conv.On("InputFromGraphQL", gqlInput).Return(modelInput).Once()
+				conv.On("UpdateInputFromGraphQL", gqlInput).Return(modelInput).Once()
 				return conv
 			},
 			ApplicationID:       applicationID,
@@ -221,7 +221,7 @@ func TestResolver_UpdateApplication(t *testing.T) {
 			},
 			ConverterFn: func() *automock.ApplicationConverter {
 				conv := &automock.ApplicationConverter{}
-				conv.On("InputFromGraphQL", gqlInput).Return(modelInput).Once()
+				conv.On("UpdateInputFromGraphQL", gqlInput).Return(modelInput).Once()
 				return conv
 			},
 			ApplicationID:       applicationID,
@@ -240,7 +240,7 @@ func TestResolver_UpdateApplication(t *testing.T) {
 			},
 			ConverterFn: func() *automock.ApplicationConverter {
 				conv := &automock.ApplicationConverter{}
-				conv.On("InputFromGraphQL", gqlInput).Return(modelInput).Once()
+				conv.On("UpdateInputFromGraphQL", gqlInput).Return(modelInput).Once()
 				return conv
 			},
 			ApplicationID:       applicationID,

--- a/components/director/internal/domain/application/service.go
+++ b/components/director/internal/domain/application/service.go
@@ -213,7 +213,7 @@ func (s *service) Exist(ctx context.Context, id string) (bool, error) {
 	return exist, nil
 }
 
-func (s *service) Create(ctx context.Context, in model.ApplicationInput) (string, error) {
+func (s *service) Create(ctx context.Context, in model.ApplicationCreateInput) (string, error) {
 	appTenant, err := tenant.LoadFromContext(ctx)
 	if err != nil {
 		return "", err
@@ -257,13 +257,8 @@ func (s *service) Create(ctx context.Context, in model.ApplicationInput) (string
 	return id, nil
 }
 
-func (s *service) Update(ctx context.Context, id string, in model.ApplicationInput) error {
-	appTenant, err := tenant.LoadFromContext(ctx)
-	if err != nil {
-		return err
-	}
-
-	err = in.Validate()
+func (s *service) Update(ctx context.Context, id string, in model.ApplicationUpdateInput) error {
+	err := in.Validate()
 	if err != nil {
 		return err
 	}
@@ -273,33 +268,13 @@ func (s *service) Update(ctx context.Context, id string, in model.ApplicationInp
 		return errors.Wrap(err, "while getting Application")
 	}
 
-	currentStatuts := app.Status
-
-	app = in.ToApplication(currentStatuts.Timestamp, currentStatuts.Condition, app.ID, app.Tenant)
+	app.Name = in.Name
+	app.Description = in.Description
+	app.HealthCheckURL = in.HealthCheckURL
 
 	err = s.appRepo.Update(ctx, app)
 	if err != nil {
 		return errors.Wrap(err, "while updating Application")
-	}
-
-	err = s.deleteRelatedResources(ctx, app.Tenant, id)
-	if err != nil {
-		return errors.Wrap(err, "while deleting related Application resources")
-	}
-
-	err = s.labelRepo.DeleteAll(ctx, appTenant, model.ApplicationLabelableObject, id)
-	if err != nil {
-		return errors.Wrapf(err, "while deleting all labels for Application")
-	}
-
-	err = s.createRelatedResources(ctx, in, app.Tenant, app.ID)
-	if err != nil {
-		return errors.Wrap(err, "while creating related Application resources")
-	}
-
-	err = s.labelUpsertService.UpsertMultipleLabels(ctx, appTenant, model.ApplicationLabelableObject, id, in.Labels)
-	if err != nil {
-		return errors.Wrapf(err, "while creating multiple labels for Application")
 	}
 
 	return nil
@@ -413,7 +388,7 @@ func (s *service) DeleteLabel(ctx context.Context, applicationID string, key str
 	return nil
 }
 
-func (s *service) createRelatedResources(ctx context.Context, in model.ApplicationInput, tenant string, applicationID string) error {
+func (s *service) createRelatedResources(ctx context.Context, in model.ApplicationCreateInput, tenant string, applicationID string) error {
 	var err error
 	var webhooks []*model.Webhook
 	for _, item := range in.Webhooks {

--- a/components/director/internal/domain/root_resolver.go
+++ b/components/director/internal/domain/root_resolver.go
@@ -187,10 +187,10 @@ type mutationResolver struct {
 	*RootResolver
 }
 
-func (r *mutationResolver) CreateApplication(ctx context.Context, in graphql.ApplicationInput) (*graphql.Application, error) {
+func (r *mutationResolver) CreateApplication(ctx context.Context, in graphql.ApplicationCreateInput) (*graphql.Application, error) {
 	return r.app.CreateApplication(ctx, in)
 }
-func (r *mutationResolver) UpdateApplication(ctx context.Context, id string, in graphql.ApplicationInput) (*graphql.Application, error) {
+func (r *mutationResolver) UpdateApplication(ctx context.Context, id string, in graphql.ApplicationUpdateInput) (*graphql.Application, error) {
 	return r.app.UpdateApplication(ctx, id, in)
 }
 func (r *mutationResolver) DeleteApplication(ctx context.Context, id string) (*graphql.Application, error) {

--- a/components/director/internal/model/application.go
+++ b/components/director/internal/model/application.go
@@ -41,7 +41,7 @@ type ApplicationPage struct {
 	TotalCount int
 }
 
-type ApplicationInput struct {
+type ApplicationCreateInput struct {
 	Name           string
 	Description    *string
 	Labels         map[string]interface{}
@@ -52,7 +52,7 @@ type ApplicationInput struct {
 	Documents      []*DocumentInput
 }
 
-func (i *ApplicationInput) ToApplication(timestamp time.Time, condition ApplicationStatusCondition, id, tenant string) *Application {
+func (i *ApplicationCreateInput) ToApplication(timestamp time.Time, condition ApplicationStatusCondition, id, tenant string) *Application {
 	if i == nil {
 		return nil
 	}
@@ -70,13 +70,26 @@ func (i *ApplicationInput) ToApplication(timestamp time.Time, condition Applicat
 	}
 }
 
-func (i *ApplicationInput) Validate() error {
-	if errorMgs := validation.NameIsDNSSubdomain(i.Name, false); errorMgs != nil {
-		return errors.Errorf("%v", errorMgs)
+func (i *ApplicationCreateInput) Validate() error {
+	return validateApplicationName(i.Name)
+}
+
+type ApplicationUpdateInput struct {
+	Name           string
+	Description    *string
+	HealthCheckURL *string
+}
+
+func (i *ApplicationUpdateInput) Validate() error {
+	return validateApplicationName(i.Name)
+}
+
+func validateApplicationName(name string) error {
+	if errorMsg := validation.NameIsDNSSubdomain(name, false); errorMsg != nil {
+		return errors.Errorf("%v", errorMsg)
 	}
-	if len(i.Name) > applicationNameMaxLength {
-		err := errors.New("application name is too long, must be maximum 36 characters long")
-		return err
+	if len(name) > applicationNameMaxLength {
+		return errors.Errorf("application name is too long, must be maximum %d characters long", applicationNameMaxLength)
 	}
 	return nil
 }

--- a/components/director/internal/model/application_test.go
+++ b/components/director/internal/model/application_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestApplicationInput_ToApplication(t *testing.T) {
+func TestApplicationCreateInput_ToApplication(t *testing.T) {
 	// given
 	url := "https://foo.bar"
 	desc := "Sample"
@@ -20,12 +20,12 @@ func TestApplicationInput_ToApplication(t *testing.T) {
 	timestamp := time.Now()
 	testCases := []struct {
 		Name     string
-		Input    *model.ApplicationInput
+		Input    *model.ApplicationCreateInput
 		Expected *model.Application
 	}{
 		{
 			Name: "All properties given",
-			Input: &model.ApplicationInput{
+			Input: &model.ApplicationCreateInput{
 				Name:        "Foo",
 				Description: &desc,
 				Labels: map[string]interface{}{
@@ -66,37 +66,87 @@ func TestApplicationInput_ToApplication(t *testing.T) {
 	}
 }
 
-func TestApplicationInput_ValidateInput(t *testing.T) {
+func TestApplicationCreateInput_ValidateInput(t *testing.T) {
 	//GIVEN
 	testError := errors.New("a DNS-1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character")
 	testCases := []struct {
 		Name        string
-		Input       model.ApplicationInput
+		Input       model.ApplicationCreateInput
 		ExpectedErr error
 	}{
 		{
 			Name:        "Correct Application name",
-			Input:       model.ApplicationInput{Name: "correct-name.yeah"},
+			Input:       model.ApplicationCreateInput{Name: "correct-name.yeah"},
 			ExpectedErr: nil,
 		},
 		{
 			Name:        "Returns errors when Application name is empty",
-			Input:       model.ApplicationInput{Name: ""},
+			Input:       model.ApplicationCreateInput{Name: ""},
 			ExpectedErr: testError,
 		},
 		{
 			Name:        "Returns errors when Application name contains UpperCase letter",
-			Input:       model.ApplicationInput{Name: "Not-correct-name.yeah"},
+			Input:       model.ApplicationCreateInput{Name: "Not-correct-name.yeah"},
 			ExpectedErr: testError,
 		},
 		{
 			Name:        "Returns errors when Application name contains special not allowed character",
-			Input:       model.ApplicationInput{Name: "not-correct-n@me.yeah"},
+			Input:       model.ApplicationCreateInput{Name: "not-correct-n@me.yeah"},
 			ExpectedErr: testError,
 		},
 		{
 			Name:        "Returns error when Application name is too long",
-			Input:       model.ApplicationInput{Name: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
+			Input:       model.ApplicationCreateInput{Name: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
+			ExpectedErr: errors.New("application name is too long, must be maximum 36 characters long"),
+		},
+	}
+
+	for i, testCase := range testCases {
+		t.Run(fmt.Sprintf("%d: %s", i, testCase.Name), func(t *testing.T) {
+			//WHEN
+			err := testCase.Input.Validate()
+
+			//THEN
+			if err != nil {
+				assert.Contains(t, err.Error(), testCase.ExpectedErr.Error())
+			} else {
+				assert.NoError(t, testCase.ExpectedErr)
+			}
+		})
+	}
+}
+
+func TestApplicationUpdateInput_ValidateInput(t *testing.T) {
+	//GIVEN
+	testError := errors.New("a DNS-1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character")
+	testCases := []struct {
+		Name        string
+		Input       model.ApplicationUpdateInput
+		ExpectedErr error
+	}{
+		{
+			Name:        "Correct Application name",
+			Input:       model.ApplicationUpdateInput{Name: "correct-name.yeah"},
+			ExpectedErr: nil,
+		},
+		{
+			Name:        "Returns errors when Application name is empty",
+			Input:       model.ApplicationUpdateInput{Name: ""},
+			ExpectedErr: testError,
+		},
+		{
+			Name:        "Returns errors when Application name contains UpperCase letter",
+			Input:       model.ApplicationUpdateInput{Name: "Not-correct-name.yeah"},
+			ExpectedErr: testError,
+		},
+		{
+			Name:        "Returns errors when Application name contains special not allowed character",
+			Input:       model.ApplicationUpdateInput{Name: "not-correct-n@me.yeah"},
+			ExpectedErr: testError,
+		},
+		{
+			Name:        "Returns error when Application name is too long",
+			Input:       model.ApplicationUpdateInput{Name: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
 			ExpectedErr: errors.New("application name is too long, must be maximum 36 characters long"),
 		},
 	}

--- a/components/director/pkg/graphql/models_gen.go
+++ b/components/director/pkg/graphql/models_gen.go
@@ -50,7 +50,7 @@ type APISpecInput struct {
 	FetchRequest *FetchRequestInput `json:"fetchRequest"`
 }
 
-type ApplicationInput struct {
+type ApplicationCreateInput struct {
 	Name           string                     `json:"name"`
 	Description    *string                    `json:"description"`
 	Labels         *Labels                    `json:"labels"`
@@ -72,6 +72,12 @@ func (ApplicationPage) IsPageable() {}
 type ApplicationStatus struct {
 	Condition ApplicationStatusCondition `json:"condition"`
 	Timestamp Timestamp                  `json:"timestamp"`
+}
+
+type ApplicationUpdateInput struct {
+	Name           string  `json:"name"`
+	Description    *string `json:"description"`
+	HealthCheckURL *string `json:"healthCheckURL"`
 }
 
 type Auth struct {

--- a/components/director/pkg/graphql/schema.graphql
+++ b/components/director/pkg/graphql/schema.graphql
@@ -107,7 +107,7 @@ input APISpecInput {
 	fetchRequest: FetchRequestInput
 }
 
-input ApplicationInput {
+input ApplicationCreateInput {
 	name: String!
 	description: String
 	labels: Labels
@@ -116,6 +116,12 @@ input ApplicationInput {
 	apis: [APIDefinitionInput!]
 	eventAPIs: [EventAPIDefinitionInput!]
 	documents: [DocumentInput!]
+}
+
+input ApplicationUpdateInput {
+	name: String!
+	description: String
+	healthCheckURL: String
 }
 
 input AuthInput {
@@ -527,8 +533,8 @@ type Query {
 }
 
 type Mutation {
-	createApplication(in: ApplicationInput!): Application! @hasScopes(path: "graphql.mutation.createApplication")
-	updateApplication(id: ID!, in: ApplicationInput!): Application! @hasScopes(path: "graphql.mutation.updateApplication")
+	createApplication(in: ApplicationCreateInput!): Application! @hasScopes(path: "graphql.mutation.createApplication")
+	updateApplication(id: ID!, in: ApplicationUpdateInput!): Application! @hasScopes(path: "graphql.mutation.updateApplication")
 	deleteApplication(id: ID!): Application! @hasScopes(path: "graphql.mutation.deleteApplication")
 	createRuntime(in: RuntimeInput!): Runtime! @hasScopes(path: "graphql.mutation.createRuntime")
 	updateRuntime(id: ID!, in: RuntimeInput!): Runtime! @hasScopes(path: "graphql.mutation.updateRuntime")


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Separate application create and update gql types
- Remove nested objects from application update gql type

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
#142 