### PR TITLE
Add retries to Graphql client

### DIFF
--- a/chart/compass/templates/test.yaml
+++ b/chart/compass/templates/test.yaml
@@ -29,7 +29,7 @@ spec:
           args: ["-c", "./wait-for-director.sh; /director.test -test.v; exit_code=$?; pkill -INT pilot-agent; sleep 4; exit $exit_code;"]
           env:
           - name: DIRECTOR_URL
-            value: "http://compass-director.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.global.director.port }}/"
+            value: "http://compass-director.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.global.director.port }}"
           - name: ALL_SCOPES
             value: "runtime:write application:write label_definition:write integration_system:write application:read runtime:read label_definition:read integration_system:read health_checks:read"
     restartPolicy: Never

--- a/chart/compass/templates/test.yaml
+++ b/chart/compass/templates/test.yaml
@@ -26,10 +26,10 @@ spec:
           image: {{ .Values.global.images.containerRegistry.path }}/{{ .Values.global.images.tests.e2e.dir }}compass-end-to-end-test:{{ .Values.global.images.tests.e2e.version }}
           imagePullPolicy: IfNotPresent
           command: ["/bin/sh"]
-          args: ["-c", "sleep 10; /director.test -test.v; exit_code=$?; pkill -INT pilot-agent; sleep 4; exit $exit_code;"]
+          args: ["-c", "./wait-for-director.sh; /director.test -test.v; exit_code=$?; pkill -INT pilot-agent; sleep 4; exit $exit_code;"]
           env:
-          - name: DIRECTOR_GRAPHQL_API
-            value: "http://compass-director.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.global.director.port }}/graphql"
+          - name: DIRECTOR_URL
+            value: "http://compass-director.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.global.director.port }}/"
           - name: ALL_SCOPES
             value: "runtime:write application:write label_definition:write integration_system:write application:read runtime:read label_definition:read integration_system:read health_checks:read"
     restartPolicy: Never

--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -31,7 +31,7 @@ global:
     tests:
       e2e:
         dir: pr/
-        version: "PR-357"
+        version: "PR-384"
       connector:
         dir: pr/
         version: "PR-357"

--- a/tests/end-to-end/Dockerfile
+++ b/tests/end-to-end/Dockerfile
@@ -12,6 +12,7 @@ FROM alpine:3.10
 
 LABEL source=git@github.com:kyma-incubator/compass.git
 
+COPY --from=builder /go/src/github.com/kyma-incubator/compass/tests/end-to-end/wait-for-director.sh .
 COPY --from=builder /go/src/github.com/kyma-incubator/compass/tests/end-to-end/director.test .
 COPY --from=builder /go/src/github.com/kyma-incubator/compass/tests/end-to-end/licenses ./licenses
 

--- a/tests/end-to-end/Gopkg.lock
+++ b/tests/end-to-end/Gopkg.lock
@@ -256,6 +256,7 @@
     "github.com/kyma-incubator/compass/components/director/pkg/graphql",
     "github.com/machinebox/graphql",
     "github.com/pkg/errors",
+    "github.com/sirupsen/logrus",
     "github.com/stretchr/testify/assert",
     "github.com/stretchr/testify/require",
     "golang.org/x/tools/cmd/goimports",

--- a/tests/end-to-end/Gopkg.lock
+++ b/tests/end-to-end/Gopkg.lock
@@ -45,6 +45,14 @@
   version = "v1.0.2"
 
 [[projects]]
+  digest = "1:7c51a593e7593dbbaec61e209bdd04095995362834e4399aaa5a9227c25bb403"
+  name = "github.com/avast/retry-go"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "101acd3290b786bf437607d874596e3996484d8d"
+  version = "v2.4.1"
+
+[[projects]]
   digest = "1:ffe9824d294da03b391f44e1ae8281281b4afc1bdaa9588c9097785e3af10cec"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
@@ -241,6 +249,7 @@
   analyzer-version = 1
   input-imports = [
     "github.com/Masterminds/sprig",
+    "github.com/avast/retry-go",
     "github.com/dgrijalva/jwt-go",
     "github.com/google/uuid",
     "github.com/kisielk/errcheck",

--- a/tests/end-to-end/README.md
+++ b/tests/end-to-end/README.md
@@ -10,7 +10,7 @@ The E2E binary allows to override some configuration parameters. You can specify
 | ENV                         | Default                         | Description                                       |
 |-----------------------------|---------------------------------|---------------------------------------------------|
 | ALL_SCOPES                  | ""                              | string with all scopes (permissions) separated by semicolon, which will be used in requests |
-| DIRECTOR_GRAPHQL_API        | "http://127.0.0.1:3000/graphql" | director graphql API URL                          |
+| DIRECTOR_URL                | 127.0.0.1:3000                  | The address and port for the Director                           |
 
 To run Director tests with running director and connector, execute:
 ```

--- a/tests/end-to-end/director/gqlclient.go
+++ b/tests/end-to-end/director/gqlclient.go
@@ -12,13 +12,15 @@ import (
 
 func newAuthorizedGraphQLClient(bearerToken string) *gcli.Client {
 	authorizedClient := newAuthorizedHTTPClient(bearerToken)
-	return gcli.NewClient(getDirectorURL(), gcli.WithHTTPClient(authorizedClient))
+	return gcli.NewClient(getDirectorGraphqlURL(), gcli.WithHTTPClient(authorizedClient))
 }
 
-func getDirectorURL() string {
-	url := os.Getenv("DIRECTOR_GRAPHQL_API")
+func getDirectorGraphqlURL() string {
+	url := os.Getenv("DIRECTOR_URL")
 	if url == "" {
 		url = "http://127.0.0.1:3000/graphql"
+	} else {
+		url = url + "/graphql"
 	}
 	return url
 }

--- a/tests/end-to-end/director/testctx.go
+++ b/tests/end-to-end/director/testctx.go
@@ -64,7 +64,9 @@ func (tc *testContext) RunOperation(ctx context.Context, req *gcli.Request, resp
 		return tc.cli.Run(ctx, req, &m)
 	}, retry.Attempts(5), retry.Delay(time.Second), retry.OnRetry(func(n uint, err error) {
 		fmt.Printf("Retrying attempted %d time, got error: %v\n", n, err)
-	}), retry.LastErrorOnly(true))
+	}), retry.LastErrorOnly(true), retry.RetryIf(func(err error) bool {
+		return strings.Contains(err.Error(), "connection refused")
+	}))
 
 	return err
 }

--- a/tests/end-to-end/director/testctx.go
+++ b/tests/end-to-end/director/testctx.go
@@ -68,7 +68,7 @@ func (tc *testContext) RunOperation(ctx context.Context, req *gcli.Request, resp
 
 func (tc *testContext) withRetryOnConnectionRefused(risky func() error) error {
 	return retry.Do(risky, retry.Attempts(7), retry.Delay(time.Second), retry.OnRetry(func(n uint, err error) {
-		logrus.Warnf("[testContext] OnRetry: attempts: %d, error: %v\n", n, err)
+		logrus.WithField("component","testContext").Warnf("OnRetry: attempts: %d, error: %v", n, err)
 
 	}), retry.LastErrorOnly(true), retry.RetryIf(func(err error) bool {
 		return strings.Contains(err.Error(), "connection refused")

--- a/tests/end-to-end/director/testctx.go
+++ b/tests/end-to-end/director/testctx.go
@@ -68,7 +68,7 @@ func (tc *testContext) RunOperation(ctx context.Context, req *gcli.Request, resp
 
 func (tc *testContext) withRetryOnConnectionRefused(risky func() error) error {
 	return retry.Do(risky, retry.Attempts(7), retry.Delay(time.Second), retry.OnRetry(func(n uint, err error) {
-		logrus.WithField("component","testContext").Warnf("OnRetry: attempts: %d, error: %v", n, err)
+		logrus.WithField("component", "testContext").Warnf("OnRetry: attempts: %d, error: %v", n, err)
 
 	}), retry.LastErrorOnly(true), retry.RetryIf(func(err error) bool {
 		return strings.Contains(err.Error(), "connection refused")

--- a/tests/end-to-end/director/testctx.go
+++ b/tests/end-to-end/director/testctx.go
@@ -62,9 +62,9 @@ func (tc *testContext) RunOperation(ctx context.Context, req *gcli.Request, resp
 
 	err := retry.Do(func() error {
 		return tc.cli.Run(ctx, req, &m)
-	}, retry.Attempts(10), retry.Delay(time.Second), retry.OnRetry(func(n uint, err error) {
+	}, retry.Attempts(5), retry.Delay(time.Second), retry.OnRetry(func(n uint, err error) {
 		fmt.Printf("Retrying attempted %d time, got error: %v\n", n, err)
-	}))
+	}), retry.LastErrorOnly(true))
 
 	return err
 }

--- a/tests/end-to-end/gen-examples.sh
+++ b/tests/end-to-end/gen-examples.sh
@@ -97,14 +97,14 @@ docker run --name ${DIRECTOR_CONTAINER} -d --rm --network=${NETWORK} \
 
 cd "${SCRIPT_DIR}"
 
-env DIRECTOR_URL="http://localhost:${APP_PORT}" ./wait-for-director.sh
+export DIRECTOR_URL="http://${DIRECTOR_URL}:${APP_PORT}"
+./wait-for-director.sh
 
 echo -e "${GREEN}Removing previous GraphQL examples...${NC}"
 rm -f "${LOCAL_ROOT_PATH}/examples/"*
 
 echo -e "${GREEN}Running Director tests with generating examples...${NC}"
 go test -c "${SCRIPT_DIR}/director/" -tags no_token_test
-DIRECTOR_GRAPHQL_API="http://${DIRECTOR_URL}:${APP_PORT}/graphql" \
 ALL_SCOPES="runtime:write application:write label_definition:write integration_system:write application:read runtime:read label_definition:read integration_system:read health_checks:read" \
 ./director.test
 

--- a/tests/end-to-end/gen-examples.sh
+++ b/tests/end-to-end/gen-examples.sh
@@ -97,29 +97,7 @@ docker run --name ${DIRECTOR_CONTAINER} -d --rm --network=${NETWORK} \
 
 cd "${SCRIPT_DIR}"
 
-# wait for Director to be up and running
-
-echo -e "${GREEN}Checking if Director is up...${NC}"
-directorIsUp=false
-set +e
-for i in {1..10}; do
-    curl --fail "http://${DIRECTOR_URL}:${APP_PORT}/healthz" -H 'tenant: 49b179ea-9839-4608-afbe-1e934908f38a'
-    res=$?
-
-    if [[ ${res} == 0 ]]; then
-        directorIsUp=true
-        break
-    fi
-    sleep 1
-done
-set -e
-
-echo ""
-
-if [[ "$directorIsUp" == false ]]; then
-    echo -e "${RED}Cannot access Director API${NC}"
-    exit 1
-fi
+env DIRECTOR_URL="http://localhost:${APP_PORT}" ./wait-for-director.sh
 
 echo -e "${GREEN}Removing previous GraphQL examples...${NC}"
 rm -f "${LOCAL_ROOT_PATH}/examples/"*

--- a/tests/end-to-end/wait-for-director.sh
+++ b/tests/end-to-end/wait-for-director.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
 # wait for Director to be up and running
 

--- a/tests/end-to-end/wait-for-director.sh
+++ b/tests/end-to-end/wait-for-director.sh
@@ -1,11 +1,10 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 
 # wait for Director to be up and running
 
 echo -e "Checking if Director is up..."
 
-if [ -z "$DIRECTOR_URL" ]
-then
+if [[ -z "$DIRECTOR_URL" ]]; then
       echo "\$DIRECTOR_URL is empty"
       exit 1
 fi

--- a/tests/end-to-end/wait-for-director.sh
+++ b/tests/end-to-end/wait-for-director.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+# wait for Director to be up and running
+
+echo -e "Checking if Director is up..."
+
+if [ -z "$DIRECTOR_URL" ]
+then
+      echo "\$DIRECTOR_URL is empty"
+      exit 1
+fi
+
+directorIsUp=false
+set +e
+for i in {1..10}; do
+    curl --fail "${DIRECTOR_URL}/healthz"
+    res=$?
+
+    if [[ ${res} == 0 ]]; then
+        directorIsUp=true
+        break
+    fi
+    sleep 1
+done
+set -e

--- a/tests/end-to-end/wait-for-director.sh
+++ b/tests/end-to-end/wait-for-director.sh
@@ -23,3 +23,8 @@ for i in {1..10}; do
     sleep 1
 done
 set -e
+
+if [[ "$directorIsUp" == false ]]; then
+    echo -e "Cannot access Director API"
+    exit 1
+fi


### PR DESCRIPTION
In this PR we are trying to address `connection refused` error.
According to [this discussion](https://serverfault.com/a/725263) , this error occurs in 2 cases:
- no process does listen on the given port
- a port is blocked by the firewall 

I was able to reproduce this problem by executing compass integration tests multiple times (with setting `count` to ClusterTestSuite). 
The communication problem is not caused by Director Pod, but rather by a testing pod. Testing pod has a sidecar injected, we have to wait until it is fully functional and we can make calls from it.
In Kyma, there is a pattern to run tests in the following way:

```
 - sleep 10; /director.test -test.v; exit_code=$?; pkill -INT pilot-agent;
   sleep 4; exit $exit_code;
```
As you can see, at the beginning there is sleep for 10 seconds, to give Istio time to make Pod fully functional. Unfortunately, sometimes 10 seconds is not enough.
In this PR, I added retries for GraphQL calls, when `connection refused` occurs.
I executed 100 times Compass tests:
```
Testing Pod 23
time="2019-10-16T07:25:30Z" level=warning msg="[testContext] OnRetry: attempts: 0, error: Post http://compass-director.compass-system.svc.cluster.local:3000/graphql: dial tcp 10.11.247.46:3000: connect: connection refused\n"
time="2019-10-16T07:25:31Z" level=warning msg="[testContext] OnRetry: attempts: 1, error: Post http://compass-director.compass-system.svc.cluster.local:3000/graphql: dial tcp 10.11.247.46:3000: connect: connection refused\n"

Testing Pod 46
time="2019-10-16T07:40:17Z" level=warning msg="[testContext] OnRetry: attempts: 0, error: Post http://compass-director.compass-system.svc.cluster.local:3000/graphql: dial tcp 10.11.247.46:3000: connect: connection refused\n"
```
As you can see, retries were used 2 times and thanks to that all 100 test executions passed.
If I reduce sleep time to 5 seconds before starting test, retries are more frequent:
```
Pod 0
time="2019-10-16T08:16:29Z" level=warning msg="[testContext] OnRetry: attempts: 0, error: Post http://compass-director.compass-system.svc.cluster.local:3000/graphql: dial tcp 10.11.247.46:3000: connect: connection refused\n"
Pod 1
time="2019-10-16T08:17:04Z" level=warning msg="[testContext] OnRetry: attempts: 0, error: Post http://compass-director.compass-system.svc.cluster.local:3000/graphql: dial tcp 10.11.247.46:3000: connect: connection refused\n"
time="2019-10-16T08:17:05Z" level=warning msg="[testContext] OnRetry: attempts: 1, error: Post http://compass-director.compass-system.svc.cluster.local:3000/graphql: dial tcp 10.11.247.46:3000: connect: connection refused\n"
Pod 2
time="2019-10-16T08:17:42Z" level=warning msg="[testContext] OnRetry: attempts: 0, error: Post http://compass-director.compass-system.svc.cluster.local:3000/graphql: dial tcp 10.11.247.46:3000: connect: connection refused\n"
Pod 3
time="2019-10-16T08:18:14Z" level=warning msg="[testContext] OnRetry: attempts: 0, error: Post http://compass-director.compass-system.svc.cluster.local:3000/graphql: dial tcp 10.11.247.46:3000: connect: connection refused\n"
Pod 4
time="2019-10-16T08:18:52Z" level=warning msg="[testContext] OnRetry: attempts: 0, error: Post http://compass-director.compass-system.svc.cluster.local:3000/graphql: dial tcp 10.11.247.46:3000: connect: connection refused\n"
Pod 5
Pod 6
Pod 7
Pod 8
time="2019-10-16T08:21:06Z" level=warning msg="[testContext] OnRetry: attempts: 0, error: Post http://compass-director.compass-system.svc.cluster.local:3000/graphql: dial tcp 10.11.247.46:3000: connect: connection refused\n"
Pod 9
time="2019-10-16T08:21:40Z" level=warning msg="[testContext] OnRetry: attempts: 0, error: Post http://compass-director.compass-system.svc.cluster.local:3000/graphql: dial tcp 10.11.247.46:3000: connect: connection refused\n"
time="2019-10-16T08:21:41Z" level=warning msg="[testContext] OnRetry: attempts: 1, error: Post http://compass-director.compass-system.svc.cluster.local:3000/graphql: dial tcp 10.11.247.46:3000: connect: connection refused\n"
Pod 10
Pod 11
Pod 12
time="2019-10-16T08:23:25Z" level=warning msg="[testContext] OnRetry: attempts: 0, error: Post http://compass-director.compass-system.svc.cluster.local:3000/graphql: dial tcp 10.11.247.46:3000: connect: connection refused\n"
Pod 13
time="2019-10-16T08:24:03Z" level=warning msg="[testContext] OnRetry: attempts: 0, error: Post http://compass-director.compass-system.svc.cluster.local:3000/graphql: dial tcp 10.11.247.46:3000: connect: connection refused\n"
Pod 14
Pod 15
time="2019-10-16T08:25:15Z" level=warning msg="[testContext] OnRetry: attempts: 0, error: Post http://compass-director.compass-system.svc.cluster.local:3000/graphql: dial tcp 10.11.247.46:3000: connect: connection refused\n"
Pod 16
time="2019-10-16T08:25:48Z" level=warning msg="[testContext] OnRetry: attempts: 0, error: Post http://compass-director.compass-system.svc.cluster.local:3000/graphql: dial tcp 10.11.247.46:3000: connect: connection refused\n"
Pod 17
time="2019-10-16T08:26:22Z" level=warning msg="[testContext] OnRetry: attempts: 0, error: Post http://compass-director.compass-system.svc.cluster.local:3000/graphql: dial tcp 10.11.247.46:3000: connect: connection refused\n"
Pod 18
Pod 19
time="2019-10-16T08:27:26Z" level=warning msg="[testContext] OnRetry: attempts: 0, error: Post http://compass-director.compass-system.svc.cluster.local:3000/graphql: dial tcp 10.11.247.46:3000: connect: connection refused\n"
```


