### PR TITLE
Scenario Details View (no longer) crashes with minified react error

### DIFF
--- a/chart/compass/charts/cockpit/values.yaml
+++ b/chart/compass/charts/cockpit/values.yaml
@@ -2,8 +2,8 @@ images:
   containerRegistry:
     path: eu.gcr.io/kyma-project
   ui:
-    dir: pr/
-    version: PR-1400
+    dir:
+    version: dc2e9b07
 
 ui:
   host: compass

--- a/chart/compass/charts/cockpit/values.yaml
+++ b/chart/compass/charts/cockpit/values.yaml
@@ -2,8 +2,8 @@ images:
   containerRegistry:
     path: eu.gcr.io/kyma-project
   ui:
-    dir:
-    version: 649d3869
+    dir: pr/
+    version: PR-1400
 
 ui:
   host: compass


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Change GenericList's default to named import in ScenarioRuntimes and ScenarioApplications

**Related issue(s)**
[Console](https://github.com/kyma-project/console/pull/1400)
[Kyma](https://github.com/kyma-project/kyma/pull/6297)
