### PR TITLE
Remove redundant scopes from config.yaml

### DIFF
--- a/chart/compass/charts/director/config.yaml
+++ b/chart/compass/charts/director/config.yaml
@@ -11,8 +11,6 @@ graphql:
     healthChecks: ["health_checks:read"]
     integrationSystem: ["integration_system:read"]
     integrationSystems: ["integration_system:read"]
-    api: ["application:read"]
-    eventAPI: ["application:read"]
 
   mutation:
     createApplication: ["application:write"]

--- a/components/director/examples/add-api/add-api.graphql
+++ b/components/director/examples/add-api/add-api.graphql
@@ -2,7 +2,11 @@
 mutation {
   result: addAPI(
     applicationID: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
-    in: { name: "new-api-name", targetURL: "new-api-url" }
+    in: {
+      name: "new-api-name"
+      targetURL: "new-api-url"
+      spec: { type: OPEN_API, format: JSON, fetchRequest: { url: "foo.bar" } }
+    }
   ) {
     id
     name


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Remove `api` and `eventapi` scopes


**Related issue(s)**

