### PR TITLE
add curl binary to compass e2e tests Docker image

### DIFF
--- a/tests/end-to-end/Dockerfile
+++ b/tests/end-to-end/Dockerfile
@@ -11,6 +11,8 @@ RUN CGO_ENABLED=0 go test -c ./director && \
 
 FROM alpine:3.10
 
+RUN apk add --no-cache curl
+
 LABEL source=git@github.com:kyma-incubator/compass.git
 
 COPY --from=builder /go/src/github.com/kyma-incubator/compass/tests/end-to-end/wait-for-director.sh .


### PR DESCRIPTION
**Description**
Add `curl` binary to compass end-to-end tests Docker image
This is necessary in order to run our tests in Azure environment - See https://github.com/kyma-project/kyma/issues/4719

Changes proposed in this pull request:
- Add `curl` binary to compass end-to-end tests Docker image

**Related issue(s)**
See also: https://github.com/kyma-project/kyma/issues/4719