### PR TITLE
Remove seed param from azure config

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -39,7 +39,7 @@ global:
       version: "PR-5318"
     kyma_environment_broker:
       dir:
-      version: "PR-635"
+      version: "PR-668"
     tests:
       director:
         dir:

--- a/components/kyma-environment-broker/internal/broker/aws_provider.go
+++ b/components/kyma-environment-broker/internal/broker/aws_provider.go
@@ -20,7 +20,6 @@ func (p *awsInputProvider) Defaults() *gqlschema.ClusterConfigInput {
 			MachineType:       "m4.2xlarge",
 			Region:            "eu-west-1",
 			Provider:          "aws",
-			Seed:              "aws-eu1",
 			WorkerCidr:        "10.250.0.0/19",
 			AutoScalerMin:     2,
 			AutoScalerMax:     4,

--- a/components/kyma-environment-broker/internal/broker/azure_provider.go
+++ b/components/kyma-environment-broker/internal/broker/azure_provider.go
@@ -25,7 +25,6 @@ func (p *azureInputProvider) Defaults() *gqlschema.ClusterConfigInput {
 			AutoScalerMax:     4,
 			MaxSurge:          4,
 			MaxUnavailable:    1,
-			Seed:              "az-eu1",
 			ProviderSpecificConfig: &gqlschema.ProviderSpecificInput{
 				AzureConfig: &gqlschema.AzureProviderConfigInput{
 					VnetCidr: "10.250.0.0/19",

--- a/components/kyma-environment-broker/internal/broker/gcp_provider.go
+++ b/components/kyma-environment-broker/internal/broker/gcp_provider.go
@@ -25,7 +25,6 @@ func (p *gcpInputProvider) Defaults() *gqlschema.ClusterConfigInput {
 			AutoScalerMax:     4,
 			MaxSurge:          4,
 			MaxUnavailable:    1,
-			Seed:              "gcp-eu1",
 			ProviderSpecificConfig: &gqlschema.ProviderSpecificInput{
 				GcpConfig: &gqlschema.GCPProviderConfigInput{
 					Zone: "europe-west4-b",


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Remove seed param from azure config

Reason: 
The quota for az-eu1 was exceeded. What's more the seed param in the near future will not be supported by the Gardener. To benefit from auto-selected seed we need to remove it from our default config params.