### PR TITLE
Adding Przemyslaw Golicz(koala7659) as a codeowner of Compass project

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,10 +5,10 @@
 # For more details, read the following article on GitHub: https://help.github.com/articles/about-codeowners/.
 
 # These are the default owners for the whole content of the `compass` repository. The default owners are automatically added as reviewers when you open a pull request, unless different owners are specified in the file.
-* @PK85 @aszecowka @crabtree @pkosiec @kfurgol @tgorgol @akgalwas @janmedrek @Szymongib @franpog859 @Maladie @dbadura @kjaksik
+* @PK85 @aszecowka @crabtree @pkosiec @kfurgol @tgorgol @akgalwas @janmedrek @Szymongib @franpog859 @Maladie @dbadura @kjaksik @koala7659
 
 # All developers working on this repository are able to edit main values.yaml file.
-/chart/compass/values.yaml @PK85 @aszecowka @crabtree @pkosiec @kfurgol @tgorgol @akgalwas @janmedrek @Szymongib @franpog859 @Maladie @dbadura @kjaksik @mszostok @piotrmiskiewicz @polskikiel @ksputo @jasiu001
+/chart/compass/values.yaml @PK85 @aszecowka @crabtree @pkosiec @kfurgol @tgorgol @akgalwas @janmedrek @Szymongib @franpog859 @Maladie @dbadura @kjaksik @mszostok @piotrmiskiewicz @polskikiel @ksputo @jasiu001 @koala7659
 
 # All .md files
 *.md @klaudiagrz @kazydek @tomekpapiernik @bszwarc @mmitoraj @majakurcius @alexandra-simeonova

--- a/OWNERS
+++ b/OWNERS
@@ -14,6 +14,7 @@ filters:
      - franpog859 
      - Maladie 
      - KarolJaksik
+     - koala7659
   '\.md$|/docs/|^milv\.config\.yaml$':
     approvers:
       - documentation-approvers


### PR DESCRIPTION
Adding Przemyslaw Golicz(koala7659) as a code owner of Compass project.

This change is only in scope of CODEOWNERS and OWNERS files and should not affect any functionality or test results