### PR TITLE
Converter graphql <-> REST types 

### DIFF
--- a/components/connectivity-adapter/internal/appregistry/service/converter.go
+++ b/components/connectivity-adapter/internal/appregistry/service/converter.go
@@ -1,9 +1,17 @@
 package service
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/kyma-incubator/compass/components/connectivity-adapter/internal/appregistry/model"
 	"github.com/kyma-incubator/compass/components/director/pkg/graphql"
-	"github.com/kyma-incubator/compass/tests/director/pkg/ptr"
+)
+
+const (
+	prefixUnmappedFields          = "compatibility_unmapped_fields_" // TODO
+	unmappedFieldIdentifier       = prefixUnmappedFields + "identifier"
+	unmappedFieldShortDescription = prefixUnmappedFields + "shortDescription"
 )
 
 type converter struct{}
@@ -12,35 +20,434 @@ func NewConverter() *converter {
 	return &converter{}
 }
 
+/*
+type Converter interface {
+	DetailsToGraphQLInput(in model.ServiceDetails) (graphql.ApplicationRegisterInput, error)
+	GraphQLToDetailsModel(in graphql.ApplicationExt) (model.ServiceDetails, error)
+	GraphQLToModel(in graphql.ApplicationExt) (model.Service, error)
+}
+*/
+
 func (c *converter) DetailsToGraphQLInput(in model.ServiceDetails) (graphql.ApplicationRegisterInput, error) {
-	// This is just a temporary fixture for testing purposes
-	// TODO: Replace with production-grade implementation
-	return graphql.ApplicationRegisterInput{
-		Name:           "wordpress",
-		ProviderName:   ptr.String("provider name"),
-		Description:    ptr.String("my first wordpress application"),
-		HealthCheckURL: ptr.String("http://mywordpress.com/health"),
-		Labels: &graphql.Labels{
-			"group":     []interface{}{"production", "experimental"},
-			"scenarios": []interface{}{"DEFAULT"},
-		},
-	}, nil
+
+	outLabels := graphql.Labels{}
+
+	out := graphql.ApplicationRegisterInput{
+		Name:         in.Name,
+		Description:  ptrStringOrNilForEmpty(in.Description),
+		ProviderName: ptrStringOrNilForEmpty(in.Provider),
+	}
+
+	if in.ShortDescription != "" {
+		outLabels[unmappedFieldShortDescription] = in.ShortDescription
+	}
+	if in.Identifier != "" {
+		outLabels[unmappedFieldIdentifier] = in.Identifier
+	}
+	if in.Api != nil {
+
+		outApi := &graphql.APIDefinitionInput{
+			TargetURL: in.Api.TargetUrl,
+		}
+
+		if in.Api.ApiType != "" {
+			if outApi.Spec == nil {
+				outApi.Spec = &graphql.APISpecInput{}
+			}
+			if strings.ToLower(in.Api.ApiType) == "odata" {
+				outApi.Spec.Type = graphql.APISpecTypeOdata
+				outApi.Spec.Format = graphql.SpecFormatJSON // this field is required
+			} else {
+				outApi.Spec.Type = graphql.APISpecTypeOpenAPI // quite brave assumption that it will be OpenAPI
+				outApi.Spec.Format = graphql.SpecFormatJSON
+			}
+		}
+
+		if in.Api.Credentials != nil {
+			outApi.DefaultAuth = &graphql.AuthInput{
+				Credential: &graphql.CredentialDataInput{},
+			}
+			if in.Api.Credentials.BasicWithCSRF != nil {
+				// TODO not mapped: in.Api.Credentials.BasicWithCSRF.CSRFInfo
+				outApi.DefaultAuth.Credential.Basic = &graphql.BasicCredentialDataInput{
+					Username: in.Api.Credentials.BasicWithCSRF.Username,
+					Password: in.Api.Credentials.BasicWithCSRF.Password,
+				}
+			}
+
+			if in.Api.Credentials.OauthWithCSRF != nil {
+				// TODO not mapped: in.Api.Credentials.OauthWithCSRF.CSRFInfo
+				outApi.DefaultAuth.Credential.Oauth = &graphql.OAuthCredentialDataInput{
+					ClientID:     in.Api.Credentials.OauthWithCSRF.ClientID,
+					ClientSecret: in.Api.Credentials.OauthWithCSRF.ClientSecret,
+					URL:          in.Api.Credentials.OauthWithCSRF.URL,
+				}
+			}
+
+			if in.Api.Credentials.CertificateGenWithCSRF != nil {
+				// TODO not supported
+			}
+		}
+
+		// old way of providing request headers
+		if in.Api.Headers != nil {
+			if outApi.DefaultAuth == nil {
+				outApi.DefaultAuth = &graphql.AuthInput{}
+			}
+			h := (graphql.HttpHeaders)(*in.Api.Headers)
+			outApi.DefaultAuth.AdditionalHeaders = &h
+		}
+
+		// old way of providing request headers
+		if in.Api.QueryParameters != nil {
+			if outApi.DefaultAuth == nil {
+				outApi.DefaultAuth = &graphql.AuthInput{}
+			}
+			q := (graphql.QueryParams)(*in.Api.QueryParameters)
+			outApi.DefaultAuth.AdditionalQueryParams = &q
+		}
+
+		// new way
+		if in.Api.RequestParameters != nil {
+			if outApi.DefaultAuth == nil {
+				outApi.DefaultAuth = &graphql.AuthInput{}
+			}
+			if in.Api.RequestParameters.Headers != nil {
+				h := (graphql.HttpHeaders)(*in.Api.RequestParameters.Headers)
+				outApi.DefaultAuth.AdditionalHeaders = &h
+			}
+			if in.Api.RequestParameters.QueryParameters != nil {
+				q := (graphql.QueryParams)(*in.Api.RequestParameters.QueryParameters)
+				outApi.DefaultAuth.AdditionalQueryParams = &q
+			}
+		}
+
+		if in.Api.Spec != nil {
+			if outApi.Spec == nil {
+				outApi.Spec = &graphql.APISpecInput{}
+			}
+			c := graphql.CLOB(string(in.Api.Spec))
+			outApi.Spec.Data = &c
+			if outApi.Spec.Type == "" {
+				outApi.Spec.Type = graphql.APISpecTypeOpenAPI
+			}
+			if outApi.Spec.Format == "" {
+				outApi.Spec.Format = graphql.SpecFormatJSON
+			}
+		}
+
+		if in.Api.SpecificationUrl != "" {
+			if outApi.Spec == nil {
+				outApi.Spec = &graphql.APISpecInput{}
+			}
+			outApi.Spec.FetchRequest = &graphql.FetchRequestInput{
+				URL: in.Api.SpecificationUrl,
+			}
+
+			if in.Api.SpecificationCredentials != nil || in.Api.SpecificationRequestParameters != nil {
+				outApi.Spec.FetchRequest.Auth = &graphql.AuthInput{}
+			}
+
+			if in.Api.SpecificationCredentials != nil {
+				if in.Api.SpecificationCredentials.Oauth != nil {
+					inOauth := in.Api.SpecificationCredentials.Oauth
+					outApi.Spec.FetchRequest.Auth.Credential = &graphql.CredentialDataInput{
+						Oauth: &graphql.OAuthCredentialDataInput{
+							URL:          inOauth.URL,
+							ClientID:     inOauth.ClientID,
+							ClientSecret: inOauth.ClientSecret,
+						},
+					}
+				}
+				if in.Api.SpecificationCredentials.Basic != nil {
+					inBasic := in.Api.SpecificationCredentials.Basic
+					outApi.Spec.FetchRequest.Auth.Credential = &graphql.CredentialDataInput{
+						Basic: &graphql.BasicCredentialDataInput{
+							Username: inBasic.Username,
+							Password: inBasic.Password,
+						},
+					}
+				}
+			}
+		}
+
+		if in.Api.SpecificationRequestParameters != nil {
+			if in.Api.SpecificationRequestParameters.Headers != nil {
+				h := (graphql.HttpHeaders)(*in.Api.SpecificationRequestParameters.Headers)
+				outApi.Spec.FetchRequest.Auth.AdditionalHeaders = &h
+			}
+			if in.Api.SpecificationRequestParameters.QueryParameters != nil {
+				q := (graphql.QueryParams)(*in.Api.SpecificationRequestParameters.QueryParameters)
+				outApi.Spec.FetchRequest.Auth.AdditionalQueryParams = &q
+			}
+		}
+		out.APIDefinitions = []*graphql.APIDefinitionInput{outApi}
+
+	}
+
+	if in.Events != nil && in.Events.Spec != nil {
+		out.EventDefinitions = []*graphql.EventDefinitionInput{
+			{
+				Spec: &graphql.EventSpecInput{
+					Data: ptrClob(graphql.CLOB(in.Events.Spec)),
+				},
+			},
+		}
+	}
+
+	if in.Documentation != nil {
+		// TODO later
+	}
+
+	if in.Labels != nil && *in.Labels != nil {
+		for k, v := range *in.Labels {
+			outLabels[k] = v
+		}
+	}
+
+	out.Labels = getLabelsOrNil(outLabels)
+	return out, nil
 }
 
 func (c *converter) GraphQLToDetailsModel(in graphql.ApplicationExt) (model.ServiceDetails, error) {
-	// This is just a temporary fixture for testing purposes
-	// TODO: Replace with production-grade implementation
+	// TODO
+	out := model.ServiceDetails{
+		Name: in.Name,
+	}
+	if in.ProviderName != nil {
+		out.Provider = *in.ProviderName
+	}
 
-	return model.ServiceDetails{
-		Name:     "foo",
-		Provider: "test",
-		Labels: &map[string]string{
-			"foo": "bar",
-		},
-	}, nil
+	if in.Description != nil {
+		out.Description = *in.Description
+	}
+
+	outLabels := make(map[string]string)
+	for k, v := range in.Labels {
+		asString, ok := v.(string)
+		if ok && !strings.HasPrefix(k, prefixUnmappedFields) {
+			outLabels[k] = asString
+		}
+	}
+	if len(outLabels) > 0 {
+		out.Labels = &outLabels
+	}
+
+	out.Identifier = c.getUnmappedFromLabel(in.Labels, "identifier")
+
+	out.ShortDescription = c.getUnmappedFromLabel(in.Labels, "shortDescription")
+
+	// TODO out.Events
+	// TODO out.Api
+	// TODO out.Documentation
+
+	if in.EventDefinitions.TotalCount != len(in.EventDefinitions.Data) {
+		return model.ServiceDetails{}, fmt.Errorf("expected all event definitions [%d], got [%d]", in.EventDefinitions.TotalCount, len(in.EventDefinitions.Data))
+	}
+
+	if len(in.EventDefinitions.Data) > 1 {
+		return model.ServiceDetails{}, fmt.Errorf("only one event definition is supported, but got [%d]", in.EventDefinitions.TotalCount)
+	}
+
+	// Event Definition
+	if len(in.EventDefinitions.Data) == 1 {
+		inDef := in.EventDefinitions.Data[0]
+		// TODO fetch requests
+		if inDef != nil && inDef.Spec != nil && inDef.Spec.Data != nil {
+
+			out.Events = &model.Events{
+				Spec: []byte(string(*inDef.Spec.Data)),
+			}
+		}
+
+	}
+
+	if in.APIDefinitions.TotalCount != len(in.APIDefinitions.Data) {
+		return model.ServiceDetails{}, fmt.Errorf("expected all api definitinons [%d], got [%d]", in.APIDefinitions.TotalCount, len(in.APIDefinitions.Data))
+	}
+
+	if len(in.APIDefinitions.Data) > 1 {
+		return model.ServiceDetails{}, fmt.Errorf("only one api definition is supported, but got [%d]", len(in.APIDefinitions.Data))
+	}
+
+	// API Definitions
+	if len(in.APIDefinitions.Data) == 1 {
+		inDef := in.APIDefinitions.Data[0]
+		out.Api = &model.API{
+			TargetUrl: inDef.TargetURL,
+		}
+
+		if inDef.Spec != nil {
+			out.Api.ApiType = string(inDef.Spec.Type) // TODO we have enums, they have strings, OMG
+		}
+
+		if inDef.DefaultAuth != nil && inDef.DefaultAuth.Credential != nil {
+			if out.Api.Credentials == nil {
+				out.Api.Credentials = &model.CredentialsWithCSRF{}
+			}
+			switch actual := inDef.DefaultAuth.Credential.(type) {
+			case graphql.BasicCredentialData:
+				out.Api.Credentials.BasicWithCSRF = &model.BasicAuthWithCSRF{
+					BasicAuth: model.BasicAuth{
+						Username: actual.Username,
+						Password: actual.Password,
+					},
+				}
+			case graphql.OAuthCredentialData:
+				out.Api.Credentials.OauthWithCSRF = &model.OauthWithCSRF{
+					Oauth: model.Oauth{
+						URL:          actual.URL,
+						ClientID:     actual.ClientID,
+						ClientSecret: actual.ClientSecret,
+					},
+				}
+			}
+		}
+
+		if inDef.DefaultAuth != nil && inDef.DefaultAuth.AdditionalHeaders != nil {
+			in := *inDef.DefaultAuth.AdditionalHeaders
+			out.Api.Headers = &map[string][]string{}
+			if out.Api.RequestParameters == nil {
+				out.Api.RequestParameters = &model.RequestParameters{}
+			}
+			if out.Api.RequestParameters.Headers == nil {
+				out.Api.RequestParameters.Headers = &map[string][]string{}
+			}
+
+			for k, v := range in {
+				(*out.Api.Headers)[k] = v
+				(*out.Api.RequestParameters.Headers)[k] = v
+			}
+		}
+
+		if inDef.DefaultAuth != nil && inDef.DefaultAuth.AdditionalQueryParams != nil {
+			in := *inDef.DefaultAuth.AdditionalQueryParams
+			out.Api.QueryParameters = &map[string][]string{}
+			if out.Api.RequestParameters == nil {
+				out.Api.RequestParameters = &model.RequestParameters{}
+			}
+
+			if out.Api.RequestParameters.QueryParameters == nil {
+				out.Api.RequestParameters.QueryParameters = &map[string][]string{}
+			}
+
+			for k, v := range in {
+				(*out.Api.QueryParameters)[k] = v
+				(*out.Api.RequestParameters.QueryParameters)[k] = v
+			}
+		}
+
+		if inDef.Spec != nil && inDef.Spec.FetchRequest != nil {
+			out.Api.SpecificationUrl = inDef.Spec.FetchRequest.URL
+			if inDef.Spec.FetchRequest.Auth != nil {
+				if inDef.Spec.FetchRequest.Auth.AdditionalQueryParams != nil || inDef.Spec.FetchRequest.Auth.AdditionalHeaders != nil {
+					out.Api.SpecificationRequestParameters = &model.RequestParameters{}
+				}
+
+				if inDef.Spec.FetchRequest.Auth.AdditionalQueryParams != nil {
+					asMap := ((map[string][]string)(*inDef.Spec.FetchRequest.Auth.AdditionalQueryParams))
+					out.Api.SpecificationRequestParameters.QueryParameters = &asMap
+				}
+
+				if inDef.Spec.FetchRequest.Auth.AdditionalHeaders != nil {
+					asMap := ((map[string][]string)(*inDef.Spec.FetchRequest.Auth.AdditionalHeaders))
+					out.Api.SpecificationRequestParameters.Headers = &asMap
+				}
+
+				basic, isBasic := (inDef.Spec.FetchRequest.Auth.Credential).(graphql.BasicCredentialData)
+				oauth, isOauth := (inDef.Spec.FetchRequest.Auth.Credential).(graphql.OAuthCredentialData)
+				outCred := &model.Credentials{}
+				if isOauth || isBasic {
+					if isBasic {
+						outCred.Basic = &model.BasicAuth{
+							Username: basic.Username,
+							Password: basic.Password,
+						}
+					}
+					if isOauth {
+						outCred.Oauth = &model.Oauth{
+							URL:               oauth.URL,
+							ClientID:          oauth.ClientID,
+							ClientSecret:      oauth.ClientSecret,
+							RequestParameters: nil, // TODO not supported
+						}
+					}
+					out.Api.SpecificationCredentials = outCred
+				}
+
+			}
+
+		}
+
+	}
+
+	if in.Documents.TotalCount != len(in.Documents.Data) {
+		return model.ServiceDetails{}, fmt.Errorf("expected all documents [%d], got [%d]", in.Documents.TotalCount, len(in.Documents.Data))
+	}
+
+	if len(in.Documents.Data) > 1 {
+		return model.ServiceDetails{}, fmt.Errorf("only one Documentation for Application is supported, but got [%d]", len(in.Documents.Data))
+	}
+
+	// TODO docs
+	return out, nil
 
 }
 
+// GET /v1/metadata/services
 func (c *converter) GraphQLToModel(in graphql.ApplicationExt) (model.Service, error) {
-	panic("not implemented")
+	out := model.Service{
+		Name: in.Name,
+		ID:   in.ID,
+	}
+
+	if in.ProviderName != nil {
+		out.Provider = *in.ProviderName
+	}
+
+	if in.Description != nil {
+		out.Description = *in.Description
+	}
+
+	outLabels := make(map[string]string)
+	for k, v := range in.Labels {
+		asString, ok := v.(string)
+		if ok && !strings.HasPrefix(k, prefixUnmappedFields) {
+			outLabels[k] = asString
+		}
+	}
+	if len(outLabels) > 0 {
+		out.Labels = &outLabels
+	}
+
+	out.Identifier = c.getUnmappedFromLabel(in.Labels, "identifier")
+
+	return out, nil
+}
+
+func (c *converter) getUnmappedFromLabel(labels graphql.Labels, field string) string {
+	val := labels[prefixUnmappedFields+field]
+	asString, ok := val.(string)
+	if ok {
+		return asString
+	}
+	return ""
+}
+
+func getLabelsOrNil(in graphql.Labels) *graphql.Labels {
+	if len(in) == 0 {
+		return nil
+	}
+	return &in
+}
+
+func ptrStringOrNilForEmpty(s string) *string {
+	if s == "" {
+		return nil
+	}
+	return &s
+}
+
+func ptrClob(in graphql.CLOB) *graphql.CLOB {
+	return &in
 }

--- a/components/connectivity-adapter/internal/appregistry/service/converter_test.go
+++ b/components/connectivity-adapter/internal/appregistry/service/converter_test.go
@@ -1,0 +1,856 @@
+package service
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/kyma-incubator/compass/components/connectivity-adapter/internal/appregistry/model"
+	"github.com/kyma-incubator/compass/components/director/pkg/graphql"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConversionServiceDetailsToApplicationRegisterInput(t *testing.T) {
+
+	type testCase struct {
+		given    model.ServiceDetails
+		expected graphql.ApplicationRegisterInput
+	}
+	// GIVEN
+	sut := NewConverter()
+	// WHEN
+
+	for name, tc := range map[string]testCase{
+		"minimal number of fields set": {
+			given: model.ServiceDetails{
+				Name:        "serviceName",
+				Description: "description",
+			},
+			expected: graphql.ApplicationRegisterInput{
+				Name:        "serviceName",
+				Description: ptrStringOrNilForEmpty("description"),
+			},
+		},
+		"labels": {
+			given: model.ServiceDetails{
+				Labels: &map[string]string{"some-label": "some-value"},
+			},
+			expected: graphql.ApplicationRegisterInput{
+				Labels: getLabelsOrNil(map[string]interface{}{"some-label": "some-value"}),
+			},
+		},
+		"labels and our custom labels": {
+			given: model.ServiceDetails{
+				Labels:     &map[string]string{"some-label": "some-value"},
+				Identifier: "identifier",
+			},
+			expected: graphql.ApplicationRegisterInput{
+				Labels: getLabelsOrNil(map[string]interface{}{
+					"some-label":            "some-value",
+					unmappedFieldIdentifier: "identifier"}),
+			},
+		},
+		"only our custom labels": {
+			given: model.ServiceDetails{
+				Identifier: "identifier",
+			},
+			expected: graphql.ApplicationRegisterInput{
+				Labels: getLabelsOrNil(map[string]interface{}{unmappedFieldIdentifier: "identifier"}),
+			},
+		},
+		"all basic attributes provided": {
+			given: model.ServiceDetails{
+				Identifier:       "identifier",
+				Name:             "name",
+				Description:      "description",
+				Provider:         "provider",
+				ShortDescription: "shortDescription",
+			},
+			expected: graphql.ApplicationRegisterInput{
+				Name:         "name",
+				Description:  ptrStringOrNilForEmpty("description"),
+				ProviderName: ptrStringOrNilForEmpty("provider"),
+				Labels: getLabelsOrNil(map[string]interface{}{
+					unmappedFieldIdentifier:       "identifier",
+					unmappedFieldShortDescription: "shortDescription",
+				}),
+			},
+		},
+		"API with only URL provided": {
+			given: model.ServiceDetails{
+				Api: &model.API{
+					TargetUrl: "http://target.url",
+				},
+			},
+			expected: graphql.ApplicationRegisterInput{
+				APIDefinitions: []*graphql.APIDefinitionInput{
+					{
+						// TODO what about name?
+						TargetURL: "http://target.url",
+					},
+				},
+			},
+		},
+		"ODATA API provided": {
+			given: model.ServiceDetails{
+				Api: &model.API{
+					TargetUrl: "http://target.url",
+					ApiType:   "ODATA",
+				},
+			},
+			expected: graphql.ApplicationRegisterInput{
+				APIDefinitions: []*graphql.APIDefinitionInput{
+					{TargetURL: "http://target.url",
+						Spec: &graphql.APISpecInput{
+							Type:   graphql.APISpecTypeOdata,
+							Format: graphql.SpecFormatJSON,
+						}},
+				},
+			},
+		},
+
+		"API other than ODATA provided": {
+			given: model.ServiceDetails{
+				Api: &model.API{
+					ApiType: "anything else",
+				},
+			},
+			expected: graphql.ApplicationRegisterInput{
+				APIDefinitions: []*graphql.APIDefinitionInput{
+					{
+						Spec: &graphql.APISpecInput{
+							Type:   graphql.APISpecTypeOpenAPI,
+							Format: graphql.SpecFormatJSON,
+						},
+					},
+				},
+			},
+		},
+
+		"API with directly spec provided": {
+			given: model.ServiceDetails{
+				Api: &model.API{
+					Spec: json.RawMessage(`openapi: "3.0.0"`),
+				},
+			},
+			expected: graphql.ApplicationRegisterInput{
+				APIDefinitions: []*graphql.APIDefinitionInput{
+					{
+						Spec: &graphql.APISpecInput{
+							Data:   ptrClob(graphql.CLOB(`openapi: "3.0.0"`)),
+							Type:   graphql.APISpecTypeOpenAPI,
+							Format: graphql.SpecFormatJSON,
+						},
+					},
+				},
+			},
+		},
+
+		"API with query params and headers stored in old fields": {
+			given: model.ServiceDetails{
+				Api: &model.API{
+					QueryParameters: &map[string][]string{
+						"q1": {"a", "b"},
+						"q2": {"c", "d"},
+					},
+					Headers: &map[string][]string{
+						"h1": {"e", "f"},
+						"h2": {"g", "h"},
+					},
+				},
+			},
+			expected: graphql.ApplicationRegisterInput{
+				APIDefinitions: []*graphql.APIDefinitionInput{
+					{
+						DefaultAuth: &graphql.AuthInput{
+							AdditionalQueryParams: &graphql.QueryParams{
+								"q1": {"a", "b"},
+								"q2": {"c", "d"},
+							},
+							AdditionalHeaders: &graphql.HttpHeaders{
+								"h1": {"e", "f"},
+								"h2": {"g", "h"},
+							},
+						},
+					},
+				},
+			},
+		},
+		"API with query params and headers stored in the new fields": {
+			given: model.ServiceDetails{
+				Api: &model.API{
+					RequestParameters: &model.RequestParameters{
+						QueryParameters: &map[string][]string{
+							"q1": {"a", "b"},
+							"q2": {"c", "d"},
+						},
+						Headers: &map[string][]string{
+							"h1": {"e", "f"},
+							"h2": {"g", "h"},
+						},
+					},
+				},
+			},
+			expected: graphql.ApplicationRegisterInput{
+				APIDefinitions: []*graphql.APIDefinitionInput{
+					{
+						DefaultAuth: &graphql.AuthInput{
+							AdditionalQueryParams: &graphql.QueryParams{
+								"q1": {"a", "b"},
+								"q2": {"c", "d"},
+							},
+							AdditionalHeaders: &graphql.HttpHeaders{
+								"h1": {"e", "f"},
+								"h2": {"g", "h"},
+							},
+						},
+					},
+				},
+			},
+		},
+		"API with query params and headers stored in old and new fields": {
+			given: model.ServiceDetails{
+				Api: &model.API{
+					RequestParameters: &model.RequestParameters{
+						QueryParameters: &map[string][]string{
+							"new": {"new"},
+						},
+						Headers: &map[string][]string{
+							"new": {"new"},
+						}},
+					QueryParameters: &map[string][]string{
+						"old": {"old"},
+					},
+					Headers: &map[string][]string{
+						"old": {"old"},
+					},
+				},
+			},
+			expected: graphql.ApplicationRegisterInput{
+				APIDefinitions: []*graphql.APIDefinitionInput{
+					{
+						DefaultAuth: &graphql.AuthInput{
+							AdditionalQueryParams: &graphql.QueryParams{
+								"new": {"new"},
+							},
+							AdditionalHeaders: &graphql.HttpHeaders{
+								"new": {"new"},
+							},
+						},
+					},
+				},
+			},
+		},
+		"API protected with basic": {
+			given: model.ServiceDetails{
+				Api: &model.API{
+					Credentials: &model.CredentialsWithCSRF{
+						BasicWithCSRF: &model.BasicAuthWithCSRF{
+							BasicAuth: model.BasicAuth{
+								Username: "user",
+								Password: "password",
+							},
+						},
+					},
+				},
+			},
+			expected: graphql.ApplicationRegisterInput{
+				APIDefinitions: []*graphql.APIDefinitionInput{
+					{
+						DefaultAuth: &graphql.AuthInput{
+							Credential: &graphql.CredentialDataInput{
+								Basic: &graphql.BasicCredentialDataInput{
+									Username: "user",
+									Password: "password",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"API protected with oauth": {
+			given: model.ServiceDetails{
+				Api: &model.API{
+					Credentials: &model.CredentialsWithCSRF{
+						OauthWithCSRF: &model.OauthWithCSRF{
+							Oauth: model.Oauth{
+								ClientID:     "client_id",
+								ClientSecret: "client_secret",
+								URL:          "http://oauth.url",
+								RequestParameters: &model.RequestParameters{ // TODO this field is not mapped at all
+									QueryParameters: &map[string][]string{
+										"q1": {"a", "b"},
+										"q2": {"c", "d"},
+									},
+									Headers: &map[string][]string{
+										"h1": {"e", "f"},
+										"h2": {"g", "h"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: graphql.ApplicationRegisterInput{
+				APIDefinitions: []*graphql.APIDefinitionInput{
+					{
+						DefaultAuth: &graphql.AuthInput{
+							Credential: &graphql.CredentialDataInput{
+								Oauth: &graphql.OAuthCredentialDataInput{
+									URL:          "http://oauth.url",
+									ClientID:     "client_id",
+									ClientSecret: "client_secret",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"API protected with certificate": {
+			// TODO this is not mapped
+		},
+		//
+		"API specification mapped to fetch request": {
+			given: model.ServiceDetails{
+				Api: &model.API{
+					SpecificationUrl: "http://specification.url",
+				},
+			},
+			expected: graphql.ApplicationRegisterInput{
+				APIDefinitions: []*graphql.APIDefinitionInput{
+					{
+						Spec: &graphql.APISpecInput{
+							FetchRequest: &graphql.FetchRequestInput{
+								URL: "http://specification.url",
+							},
+						},
+					},
+				},
+			},
+		},
+		"API specification with basic to fetch request": {
+			given: model.ServiceDetails{
+				Api: &model.API{
+					SpecificationUrl: "http://specification.url",
+					SpecificationCredentials: &model.Credentials{
+						Basic: &model.BasicAuth{
+							Username: "username",
+							Password: "password",
+						},
+					},
+				},
+			},
+			expected: graphql.ApplicationRegisterInput{
+				APIDefinitions: []*graphql.APIDefinitionInput{
+					{
+						Spec: &graphql.APISpecInput{
+							FetchRequest: &graphql.FetchRequestInput{
+								URL: "http://specification.url",
+								Auth: &graphql.AuthInput{
+									Credential: &graphql.CredentialDataInput{
+										Basic: &graphql.BasicCredentialDataInput{
+											Username: "username",
+											Password: "password",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"API specification with oauth to fetch request": {
+			given: model.ServiceDetails{
+				Api: &model.API{
+					SpecificationUrl: "http://specification.url",
+					SpecificationCredentials: &model.Credentials{
+						Oauth: &model.Oauth{
+							URL:               "http://oauth.url",
+							ClientID:          "client_id",
+							ClientSecret:      "client_secret",
+							RequestParameters: nil, // TODO not supported
+						},
+					},
+				},
+			},
+			expected: graphql.ApplicationRegisterInput{
+				APIDefinitions: []*graphql.APIDefinitionInput{
+					{
+						Spec: &graphql.APISpecInput{
+							FetchRequest: &graphql.FetchRequestInput{
+								URL: "http://specification.url",
+								Auth: &graphql.AuthInput{
+									Credential: &graphql.CredentialDataInput{
+										Oauth: &graphql.OAuthCredentialDataInput{
+											URL:          "http://oauth.url",
+											ClientID:     "client_id",
+											ClientSecret: "client_secret",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"API specification with request parameters": {
+			given: model.ServiceDetails{
+				Api: &model.API{
+					SpecificationUrl: "http://specification.url",
+					SpecificationRequestParameters: &model.RequestParameters{
+						QueryParameters: &map[string][]string{
+							"q1": {"a", "b"},
+							"q2": {"c", "d"},
+						},
+						Headers: &map[string][]string{
+							"h1": {"e", "f"},
+							"h2": {"g", "h"},
+						},
+					},
+				},
+			},
+			expected: graphql.ApplicationRegisterInput{
+				APIDefinitions: []*graphql.APIDefinitionInput{
+					{
+						Spec: &graphql.APISpecInput{
+							FetchRequest: &graphql.FetchRequestInput{
+								URL: "http://specification.url",
+								Auth: &graphql.AuthInput{
+									AdditionalQueryParams: &graphql.QueryParams{
+										"q1": {"a", "b"},
+										"q2": {"c", "d"},
+									},
+									AdditionalHeaders: &graphql.HttpHeaders{
+										"h1": {"e", "f"},
+										"h2": {"g", "h"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"event": {
+			given: model.ServiceDetails{
+				Events: &model.Events{
+					Spec: json.RawMessage(`asyncapi: "1.2.0"`),
+				},
+			},
+			expected: graphql.ApplicationRegisterInput{
+				EventDefinitions: []*graphql.EventDefinitionInput{
+					{
+						//TODO what about name
+						Spec: &graphql.EventSpecInput{
+							Data: ptrClob(graphql.CLOB(`asyncapi: "1.2.0"`)),
+						},
+					},
+				},
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			actual, err := sut.DetailsToGraphQLInput(tc.given)
+
+			// THEN
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, actual)
+		})
+	}
+}
+
+func TestConversionApplicationExtToServiceDetails(t *testing.T) {
+	// GIVEN
+	type testCase struct {
+		given    graphql.ApplicationExt
+		expected model.ServiceDetails
+	}
+	sut := NewConverter()
+	// WHEN
+
+	for name, tc := range map[string]testCase{
+		"simple attributes": {
+			given: graphql.ApplicationExt{
+				Application: graphql.Application{
+					ID:          "id",
+					Name:        "name",
+					Description: ptrStringOrNilForEmpty("description"),
+					//TODO IntegrationSystemID
+					ProviderName: ptrStringOrNilForEmpty("providerName"),
+				},
+			},
+			expected: model.ServiceDetails{
+				Name:        "name",
+				Description: "description",
+				Provider:    "providerName",
+			},
+		},
+		"custom mapping labels": {
+			given: graphql.ApplicationExt{
+				Labels: graphql.Labels{
+					unmappedFieldIdentifier:       "identifier",
+					unmappedFieldShortDescription: "short description",
+				},
+			},
+			expected: model.ServiceDetails{
+				Identifier:       "identifier",
+				ShortDescription: "short description",
+			},
+		},
+		"labels": {
+			given: graphql.ApplicationExt{
+				Labels: graphql.Labels{
+					"label-a": "a",
+					"label-b": "b",
+				},
+			},
+			expected: model.ServiceDetails{
+				Labels: &map[string]string{
+					"label-a": "a",
+					"label-b": "b",
+				},
+			},
+		},
+		"simple API": {
+			given: graphql.ApplicationExt{
+				APIDefinitions: graphql.APIDefinitionPageExt{
+					APIDefinitionPage: fixPageWithTotalCountOne(),
+					Data: []*graphql.APIDefinitionExt{
+						{
+							APIDefinition: graphql.APIDefinition{
+								TargetURL: "http://target.url",
+							},
+						},
+					},
+				},
+			},
+			expected: model.ServiceDetails{
+				Api: &model.API{
+					TargetUrl: "http://target.url",
+				},
+			},
+		},
+		"simple API with additional headers and query params": {
+			given: graphql.ApplicationExt{
+				APIDefinitions: graphql.APIDefinitionPageExt{
+					APIDefinitionPage: fixPageWithTotalCountOne(),
+					Data: []*graphql.APIDefinitionExt{
+						{
+							APIDefinition: graphql.APIDefinition{
+								TargetURL: "http://target.url",
+								DefaultAuth: &graphql.Auth{
+									AdditionalQueryParams: &graphql.QueryParams{
+										"q1": []string{"a", "b"},
+										"q2": []string{"c", "d"},
+									},
+									AdditionalHeaders: &graphql.HttpHeaders{
+										"h1": []string{"e", "f"},
+										"h2": []string{"g", "h"},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: model.ServiceDetails{
+				Api: &model.API{
+					TargetUrl: "http://target.url",
+					Headers: &map[string][]string{
+						"h1": {"e", "f"},
+						"h2": {"g", "h"}},
+					QueryParameters: &map[string][]string{
+						"q1": {"a", "b"},
+						"q2": {"c", "d"},
+					},
+					RequestParameters: &model.RequestParameters{
+						Headers: &map[string][]string{
+							"h1": {"e", "f"},
+							"h2": {"g", "h"}},
+						QueryParameters: &map[string][]string{
+							"q1": {"a", "b"},
+							"q2": {"c", "d"},
+						},
+					},
+				},
+			},
+		},
+		"simple API with Basic Auth": {
+			given: graphql.ApplicationExt{
+				APIDefinitions: graphql.APIDefinitionPageExt{
+					APIDefinitionPage: fixPageWithTotalCountOne(),
+					Data: []*graphql.APIDefinitionExt{
+						{
+							APIDefinition: graphql.APIDefinition{
+								TargetURL: "http://target.url",
+								DefaultAuth: &graphql.Auth{
+									Credential: graphql.BasicCredentialData{
+										Username: "username",
+										Password: "password",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: model.ServiceDetails{
+				Api: &model.API{
+					TargetUrl: "http://target.url",
+					Credentials: &model.CredentialsWithCSRF{
+						BasicWithCSRF: &model.BasicAuthWithCSRF{
+							BasicAuth: model.BasicAuth{
+								Username: "username",
+								Password: "password",
+							},
+						},
+					},
+				},
+			},
+		},
+		"simple API with Oauth": {
+			given: graphql.ApplicationExt{
+				APIDefinitions: graphql.APIDefinitionPageExt{
+					APIDefinitionPage: fixPageWithTotalCountOne(),
+					Data: []*graphql.APIDefinitionExt{
+						{
+							APIDefinition: graphql.APIDefinition{
+								TargetURL: "http://target.url",
+								DefaultAuth: &graphql.Auth{
+									Credential: graphql.OAuthCredentialData{
+										URL:          "http://oauth.url",
+										ClientID:     "client_id",
+										ClientSecret: "client_secret",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: model.ServiceDetails{
+				Api: &model.API{
+					TargetUrl: "http://target.url",
+					Credentials: &model.CredentialsWithCSRF{
+						OauthWithCSRF: &model.OauthWithCSRF{
+							Oauth: model.Oauth{
+								URL:          "http://oauth.url",
+								ClientID:     "client_id",
+								ClientSecret: "client_secret",
+							},
+						},
+					},
+				},
+			},
+		},
+		"simple API with FetchRequest (query params and headers)": {
+			given: graphql.ApplicationExt{
+				APIDefinitions: graphql.APIDefinitionPageExt{
+					APIDefinitionPage: fixPageWithTotalCountOne(),
+					Data: []*graphql.APIDefinitionExt{
+						{
+							Spec: &graphql.APISpecExt{
+								FetchRequest: &graphql.FetchRequest{
+									URL: "http://apispec.url",
+									Auth: &graphql.Auth{
+										AdditionalQueryParams: &graphql.QueryParams{
+											"q1": {"a", "b"},
+											"q2": {"c", "d"},
+										},
+										AdditionalHeaders: &graphql.HttpHeaders{
+											"h1": {"e", "f"},
+											"h2": {"g", "h"},
+										},
+									},
+								},
+							},
+						}}}},
+			expected: model.ServiceDetails{
+				Api: &model.API{
+					SpecificationUrl: "http://apispec.url",
+					SpecificationRequestParameters: &model.RequestParameters{
+						Headers: &map[string][]string{
+							"h1": {"e", "f"},
+							"h2": {"g", "h"}},
+						QueryParameters: &map[string][]string{
+							"q1": {"a", "b"},
+							"q2": {"c", "d"},
+						},
+					},
+				},
+			}},
+		"simple API with Fetch Request protected with Basic Auth": {
+			given: graphql.ApplicationExt{
+				APIDefinitions: graphql.APIDefinitionPageExt{
+					APIDefinitionPage: fixPageWithTotalCountOne(),
+					Data: []*graphql.APIDefinitionExt{
+						{
+							Spec: &graphql.APISpecExt{
+								FetchRequest: &graphql.FetchRequest{
+									URL: "http://apispec.url",
+									Auth: &graphql.Auth{
+										Credential: graphql.BasicCredentialData{
+											Username: "username",
+											Password: "password",
+										},
+									},
+								},
+							},
+						}}}},
+			expected: model.ServiceDetails{
+				Api: &model.API{
+					SpecificationUrl: "http://apispec.url",
+					SpecificationCredentials: &model.Credentials{
+						Basic: &model.BasicAuth{
+							Username: "username",
+							Password: "password",
+						},
+					},
+				},
+			},
+		},
+		"simple API with Fetch Request protected with Oauth": {
+			given: graphql.ApplicationExt{
+				APIDefinitions: graphql.APIDefinitionPageExt{
+					APIDefinitionPage: fixPageWithTotalCountOne(),
+					Data: []*graphql.APIDefinitionExt{
+						{
+							Spec: &graphql.APISpecExt{
+								FetchRequest: &graphql.FetchRequest{
+									URL: "http://apispec.url",
+									Auth: &graphql.Auth{
+										Credential: graphql.OAuthCredentialData{
+											URL:          "http://oauth.url",
+											ClientID:     "client_id",
+											ClientSecret: "client_secret",
+										},
+									},
+								},
+							},
+						}}}},
+			expected: model.ServiceDetails{
+				Api: &model.API{
+					SpecificationUrl: "http://apispec.url",
+					SpecificationCredentials: &model.Credentials{
+						Oauth: &model.Oauth{
+							URL:          "http://oauth.url",
+							ClientID:     "client_id",
+							ClientSecret: "client_secret",
+						},
+					},
+				},
+			},
+		},
+		"events": {
+			given: graphql.ApplicationExt{
+				EventDefinitions: graphql.EventAPIDefinitionPageExt{
+					EventDefinitionPage: graphql.EventDefinitionPage{
+						TotalCount: 1,
+					},
+					Data: []*graphql.EventAPIDefinitionExt{
+						{
+							Spec: &graphql.EventAPISpecExt{
+								EventSpec: graphql.EventSpec{
+									Data: ptrClob(graphql.CLOB(`asyncapi: "1.2.0"`)),
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: model.ServiceDetails{
+				Events: &model.Events{
+					Spec: json.RawMessage(`asyncapi: "1.2.0"`),
+				},
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			actual, err := sut.GraphQLToDetailsModel(tc.given)
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, actual)
+		})
+	}
+	// THEN
+}
+
+func TestConvertGraphQLToModel(t *testing.T) {
+
+	t.Run("all fields provided", func(t *testing.T) {
+		// GIVEN
+		var err error
+
+		givenIn := graphql.ApplicationExt{
+			Application: graphql.Application{
+				ID:           "id",
+				Name:         "name",
+				Description:  ptrStringOrNilForEmpty("description"),
+				ProviderName: ptrStringOrNilForEmpty("providerName"),
+			},
+		}
+		givenIn.Labels, err = fixLabels()
+		givenIn.Labels[unmappedFieldIdentifier] = "identifier-dont-confuse-with-id-please"
+		require.NoError(t, err)
+
+		expectedOut := model.Service{
+			ID:          "id",
+			Name:        "name",
+			Provider:    "providerName",
+			Description: "description",
+			Identifier:  "identifier-dont-confuse-with-id-please",
+			Labels: &map[string]string{
+				"simple-label": "simple-value",
+			},
+		}
+		sut := NewConverter()
+
+		actualOut, err := sut.GraphQLToModel(givenIn)
+
+		require.NoError(t, err)
+		assert.Equal(t, expectedOut, actualOut)
+	})
+
+	t.Run("only required fields provided", func(t *testing.T) {
+		// GIVEN
+		var err error
+
+		givenIn := graphql.ApplicationExt{
+			Application: graphql.Application{
+				ID:   "id",
+				Name: "name",
+			},
+		}
+
+		expectedOut := model.Service{
+			ID:   "id",
+			Name: "name",
+		}
+		sut := NewConverter()
+
+		actualOut, err := sut.GraphQLToModel(givenIn)
+
+		require.NoError(t, err)
+		assert.Equal(t, expectedOut, actualOut)
+	})
+
+}
+
+func fixLabels() (graphql.Labels, error) {
+	l := graphql.Labels{}
+	j := `{ "ignored-group": ["production", "experimental"], "ignored-scenarios": ["DEFAULT"], "simple-label":"simple-value", "embedded":{"key":"value"} }`
+	err := json.Unmarshal(([]byte)(j), &l)
+	if err != nil {
+		return nil, err
+	}
+
+	return l, nil
+}
+
+func fixPageWithTotalCountOne() graphql.APIDefinitionPage {
+	return graphql.APIDefinitionPage{TotalCount: 1}
+}

--- a/components/connectivity-adapter/internal/appregistry/service/converter_test.go
+++ b/components/connectivity-adapter/internal/appregistry/service/converter_test.go
@@ -100,8 +100,7 @@ func TestConversionServiceDetailsToApplicationRegisterInput(t *testing.T) {
 				APIDefinitions: []*graphql.APIDefinitionInput{
 					{TargetURL: "http://target.url",
 						Spec: &graphql.APISpecInput{
-							Type:   graphql.APISpecTypeOdata,
-							Format: graphql.SpecFormatJSON,
+							Type: graphql.APISpecTypeOdata,
 						}},
 				},
 			},
@@ -117,15 +116,14 @@ func TestConversionServiceDetailsToApplicationRegisterInput(t *testing.T) {
 				APIDefinitions: []*graphql.APIDefinitionInput{
 					{
 						Spec: &graphql.APISpecInput{
-							Type:   graphql.APISpecTypeOpenAPI,
-							Format: graphql.SpecFormatJSON,
+							Type: graphql.APISpecTypeOpenAPI,
 						},
 					},
 				},
 			},
 		},
 
-		"API with directly spec provided": {
+		"API with directly spec provided in YAML": {
 			given: model.ServiceDetails{
 				Api: &model.API{
 					Spec: json.RawMessage(`openapi: "3.0.0"`),
@@ -137,7 +135,45 @@ func TestConversionServiceDetailsToApplicationRegisterInput(t *testing.T) {
 						Spec: &graphql.APISpecInput{
 							Data:   ptrClob(graphql.CLOB(`openapi: "3.0.0"`)),
 							Type:   graphql.APISpecTypeOpenAPI,
+							Format: graphql.SpecFormatYaml,
+						},
+					},
+				},
+			},
+		},
+
+		"API with directly spec provided in JSON": {
+			given: model.ServiceDetails{
+				Api: &model.API{
+					Spec: json.RawMessage(`{"spec":"v0.0.1"}`),
+				},
+			},
+			expected: graphql.ApplicationRegisterInput{
+				APIDefinitions: []*graphql.APIDefinitionInput{
+					{
+						Spec: &graphql.APISpecInput{
+							Data:   ptrClob(graphql.CLOB(`{"spec":"v0.0.1"}`)),
+							Type:   graphql.APISpecTypeOpenAPI,
 							Format: graphql.SpecFormatJSON,
+						},
+					},
+				},
+			},
+		},
+
+		"API with directly spec provided in XML": {
+			given: model.ServiceDetails{
+				Api: &model.API{
+					Spec: json.RawMessage(`<spec></spec>"`),
+				},
+			},
+			expected: graphql.ApplicationRegisterInput{
+				APIDefinitions: []*graphql.APIDefinitionInput{
+					{
+						Spec: &graphql.APISpecInput{
+							Data:   ptrClob(graphql.CLOB(`<spec></spec>"`)),
+							Type:   graphql.APISpecTypeOpenAPI,
+							Format: graphql.SpecFormatXML,
 						},
 					},
 				},
@@ -475,10 +511,9 @@ func TestConversionApplicationExtToServiceDetails(t *testing.T) {
 		"simple attributes": {
 			given: graphql.ApplicationExt{
 				Application: graphql.Application{
-					ID:          "id",
-					Name:        "name",
-					Description: ptrStringOrNilForEmpty("description"),
-					//TODO IntegrationSystemID
+					ID:           "id",
+					Name:         "name",
+					Description:  ptrStringOrNilForEmpty("description"),
 					ProviderName: ptrStringOrNilForEmpty("providerName"),
 				},
 			},

--- a/components/connectivity-adapter/internal/appregistry/service/converter_test.go
+++ b/components/connectivity-adapter/internal/appregistry/service/converter_test.go
@@ -16,9 +16,7 @@ func TestConversionServiceDetailsToApplicationRegisterInput(t *testing.T) {
 		given    model.ServiceDetails
 		expected graphql.ApplicationRegisterInput
 	}
-	// GIVEN
 	sut := NewConverter()
-	// WHEN
 
 	for name, tc := range map[string]testCase{
 		"minimal number of fields set": {
@@ -36,7 +34,7 @@ func TestConversionServiceDetailsToApplicationRegisterInput(t *testing.T) {
 				Labels: &map[string]string{"some-label": "some-value"},
 			},
 			expected: graphql.ApplicationRegisterInput{
-				Labels: getLabelsOrNil(map[string]interface{}{"some-label": "some-value"}),
+				Labels: getLabelsOrNilIfEmpty(map[string]interface{}{"some-label": "some-value"}),
 			},
 		},
 		"labels and our custom labels": {
@@ -45,7 +43,7 @@ func TestConversionServiceDetailsToApplicationRegisterInput(t *testing.T) {
 				Identifier: "identifier",
 			},
 			expected: graphql.ApplicationRegisterInput{
-				Labels: getLabelsOrNil(map[string]interface{}{
+				Labels: getLabelsOrNilIfEmpty(map[string]interface{}{
 					"some-label":            "some-value",
 					unmappedFieldIdentifier: "identifier"}),
 			},
@@ -55,7 +53,7 @@ func TestConversionServiceDetailsToApplicationRegisterInput(t *testing.T) {
 				Identifier: "identifier",
 			},
 			expected: graphql.ApplicationRegisterInput{
-				Labels: getLabelsOrNil(map[string]interface{}{unmappedFieldIdentifier: "identifier"}),
+				Labels: getLabelsOrNilIfEmpty(map[string]interface{}{unmappedFieldIdentifier: "identifier"}),
 			},
 		},
 		"all basic attributes provided": {
@@ -70,7 +68,7 @@ func TestConversionServiceDetailsToApplicationRegisterInput(t *testing.T) {
 				Name:         "name",
 				Description:  ptrStringOrNilForEmpty("description"),
 				ProviderName: ptrStringOrNilForEmpty("provider"),
-				Labels: getLabelsOrNil(map[string]interface{}{
+				Labels: getLabelsOrNilIfEmpty(map[string]interface{}{
 					unmappedFieldIdentifier:       "identifier",
 					unmappedFieldShortDescription: "shortDescription",
 				}),
@@ -331,7 +329,7 @@ func TestConversionServiceDetailsToApplicationRegisterInput(t *testing.T) {
 				},
 			},
 		},
-		"API specification with basic to fetch request": {
+		"API specification with basic auth converted to fetch request": {
 			given: model.ServiceDetails{
 				Api: &model.API{
 					SpecificationUrl: "http://specification.url",
@@ -363,7 +361,7 @@ func TestConversionServiceDetailsToApplicationRegisterInput(t *testing.T) {
 				},
 			},
 		},
-		"API specification with oauth to fetch request": {
+		"API specification with oauth converted to fetch request": {
 			given: model.ServiceDetails{
 				Api: &model.API{
 					SpecificationUrl: "http://specification.url",
@@ -398,7 +396,7 @@ func TestConversionServiceDetailsToApplicationRegisterInput(t *testing.T) {
 				},
 			},
 		},
-		"API specification with request parameters": {
+		"API specification with request parameters converted to fetch request": {
 			given: model.ServiceDetails{
 				Api: &model.API{
 					SpecificationUrl: "http://specification.url",
@@ -455,6 +453,7 @@ func TestConversionServiceDetailsToApplicationRegisterInput(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
+			// WHEN
 			actual, err := sut.DetailsToGraphQLInput(tc.given)
 
 			// THEN
@@ -465,13 +464,12 @@ func TestConversionServiceDetailsToApplicationRegisterInput(t *testing.T) {
 }
 
 func TestConversionApplicationExtToServiceDetails(t *testing.T) {
-	// GIVEN
+
 	type testCase struct {
 		given    graphql.ApplicationExt
 		expected model.ServiceDetails
 	}
 	sut := NewConverter()
-	// WHEN
 
 	for name, tc := range map[string]testCase{
 		"simple attributes": {
@@ -490,7 +488,7 @@ func TestConversionApplicationExtToServiceDetails(t *testing.T) {
 				Provider:    "providerName",
 			},
 		},
-		"custom mapping labels": {
+		"custom labels": {
 			given: graphql.ApplicationExt{
 				Labels: graphql.Labels{
 					unmappedFieldIdentifier:       "identifier",
@@ -771,12 +769,14 @@ func TestConversionApplicationExtToServiceDetails(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
+			// WHEN
 			actual, err := sut.GraphQLToDetailsModel(tc.given)
+			// THEN
 			require.NoError(t, err)
 			assert.Equal(t, tc.expected, actual)
 		})
 	}
-	// THEN
+
 }
 
 func TestConvertGraphQLToModel(t *testing.T) {
@@ -809,7 +809,9 @@ func TestConvertGraphQLToModel(t *testing.T) {
 		}
 		sut := NewConverter()
 
+		// WHEN
 		actualOut, err := sut.GraphQLToModel(givenIn)
+		// THEN
 
 		require.NoError(t, err)
 		assert.Equal(t, expectedOut, actualOut)
@@ -831,9 +833,9 @@ func TestConvertGraphQLToModel(t *testing.T) {
 			Name: "name",
 		}
 		sut := NewConverter()
-
+		// WHEN
 		actualOut, err := sut.GraphQLToModel(givenIn)
-
+		// THEN
 		require.NoError(t, err)
 		assert.Equal(t, expectedOut, actualOut)
 	})


### PR DESCRIPTION
Implemented converter Application Registry types <==> Director types. 

Not addressed in this PR:
- CSRF
- Documentation fields mapping

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
