### PR TITLE
Override unmarshaling for Cluster Config

### DIFF
--- a/components/provisioner/internal/util/pointers.go
+++ b/components/provisioner/internal/util/pointers.go
@@ -6,6 +6,10 @@ func StringPtr(str string) *string {
 	return &str
 }
 
+func IntPtr(val int) *int {
+	return &val
+}
+
 func BoolPtr(b bool) *bool {
 	return &b
 }

--- a/components/provisioner/pkg/gqlschema/cluster_config.go
+++ b/components/provisioner/pkg/gqlschema/cluster_config.go
@@ -1,0 +1,136 @@
+package gqlschema
+
+import (
+	"bytes"
+	"encoding/json"
+)
+
+// UnmarshalJSON is used to handle unmarshalling ClusterConfig interface properly
+func (a *RuntimeConfig) UnmarshalJSON(data []byte) error {
+	err := a.unmarshalGardener(data)
+	if err != nil {
+		return a.unmarshalGCP(data)
+	}
+
+	return nil
+}
+
+func (a *RuntimeConfig) unmarshalGardener(data []byte) error {
+	type Alias RuntimeConfig
+
+	tempGardener := &struct {
+		*Alias
+		ClusterConfig *GardenerConfig `json:"clusterConfig"`
+	}{
+		Alias: (*Alias)(a),
+	}
+
+	decoder := newDecoder(data)
+	if err := decoder.Decode(&tempGardener); err != nil {
+		return err
+	}
+
+	a.ClusterConfig = tempGardener.ClusterConfig
+
+	return nil
+}
+
+func (a *RuntimeConfig) unmarshalGCP(data []byte) error {
+	type Alias RuntimeConfig
+
+	tempGCP := &struct {
+		*Alias
+		ClusterConfig *GCPConfig `json:"clusterConfig"`
+	}{
+		Alias: (*Alias)(a),
+	}
+
+	decoder := newDecoder(data)
+	if err := decoder.Decode(&tempGCP); err != nil {
+		return err
+	}
+
+	a.ClusterConfig = tempGCP.ClusterConfig
+
+	return nil
+}
+
+// UnmarshalJSON is used to handle unmarshalling ProviderSpecificConfig interface properly
+func (g *GardenerConfig) UnmarshalJSON(data []byte) error {
+	err := g.unmarshalAzure(data)
+	if err != nil {
+		err := g.unmarshalGCP(data)
+		if err != nil {
+			return g.unmarshalAWS(data)
+		}
+		return nil
+	}
+
+	return nil
+}
+
+func (g *GardenerConfig) unmarshalAzure(data []byte) error {
+	type Alias GardenerConfig
+
+	temp := &struct {
+		*Alias
+		ProviderSpecificConfig *AzureProviderConfig `json:"providerSpecificConfig"`
+	}{
+		Alias: (*Alias)(g),
+	}
+
+	decoder := newDecoder(data)
+	if err := decoder.Decode(&temp); err != nil {
+		return err
+	}
+
+	g.ProviderSpecificConfig = temp.ProviderSpecificConfig
+
+	return nil
+}
+
+func (g *GardenerConfig) unmarshalGCP(data []byte) error {
+	type Alias GardenerConfig
+
+	temp := &struct {
+		*Alias
+		ProviderSpecificConfig *GCPProviderConfig `json:"providerSpecificConfig"`
+	}{
+		Alias: (*Alias)(g),
+	}
+
+	decoder := newDecoder(data)
+	if err := decoder.Decode(&temp); err != nil {
+		return err
+	}
+
+	g.ProviderSpecificConfig = temp.ProviderSpecificConfig
+
+	return nil
+}
+
+func (g *GardenerConfig) unmarshalAWS(data []byte) error {
+	type Alias GardenerConfig
+
+	temp := &struct {
+		*Alias
+		ProviderSpecificConfig *AWSProviderConfig `json:"providerSpecificConfig"`
+	}{
+		Alias: (*Alias)(g),
+	}
+
+	decoder := newDecoder(data)
+	if err := decoder.Decode(&temp); err != nil {
+		return err
+	}
+
+	g.ProviderSpecificConfig = temp.ProviderSpecificConfig
+
+	return nil
+}
+
+func newDecoder(data []byte) *json.Decoder {
+	decoder := json.NewDecoder(bytes.NewBuffer(data))
+	decoder.DisallowUnknownFields()
+	return decoder
+}

--- a/components/provisioner/pkg/gqlschema/cluster_config_test.go
+++ b/components/provisioner/pkg/gqlschema/cluster_config_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestRuntimeConfig_UnmarshalJSON(t *testing.T) {
 
-	gcpCluster := GCPConfig{
+	gcpClusterConfig := GCPConfig{
 		Name:              util.StringPtr("name"),
 		ProjectName:       util.StringPtr("project"),
 		KubernetesVersion: util.StringPtr("1.17"),
@@ -80,7 +80,7 @@ func TestRuntimeConfig_UnmarshalJSON(t *testing.T) {
 		{
 			description: "GCP cluster",
 			runtimeCfg: RuntimeConfig{
-				ClusterConfig: &gcpCluster,
+				ClusterConfig: &gcpClusterConfig,
 				KymaConfig:    &KymaConfig{Version: util.StringPtr("my favourite")},
 				Kubeconfig:    util.StringPtr("kubeconfig"),
 			},

--- a/components/provisioner/pkg/gqlschema/cluster_config_test.go
+++ b/components/provisioner/pkg/gqlschema/cluster_config_test.go
@@ -3,10 +3,11 @@ package gqlschema
 import (
 	"bytes"
 	"encoding/json"
+	"testing"
+
 	"github.com/kyma-incubator/compass/components/provisioner/internal/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func TestRuntimeConfig_UnmarshalJSON(t *testing.T) {

--- a/components/provisioner/pkg/gqlschema/cluster_config_test.go
+++ b/components/provisioner/pkg/gqlschema/cluster_config_test.go
@@ -1,0 +1,110 @@
+package gqlschema
+
+import (
+	"bytes"
+	"encoding/json"
+	"github.com/kyma-incubator/compass/components/provisioner/internal/util"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestRuntimeConfig_UnmarshalJSON(t *testing.T) {
+
+	gcpCluster := GCPConfig{
+		Name:              util.StringPtr("name"),
+		ProjectName:       util.StringPtr("project"),
+		KubernetesVersion: util.StringPtr("1.17"),
+		NumberOfNodes:     util.IntPtr(3),
+		BootDiskSizeGb:    util.IntPtr(50),
+		MachineType:       util.StringPtr("machine"),
+		Region:            util.StringPtr("region"),
+		Zone:              util.StringPtr("zone"),
+	}
+
+	gardenerClusterConfig := GardenerConfig{
+		Name:              util.StringPtr("name"),
+		KubernetesVersion: util.StringPtr("1.16"),
+		NodeCount:         util.IntPtr(3),
+		VolumeSizeGb:      util.IntPtr(50),
+		MachineType:       util.StringPtr("machine"),
+		Region:            util.StringPtr("region"),
+		Provider:          util.StringPtr("provider"),
+		Seed:              util.StringPtr("seed"),
+		TargetSecret:      util.StringPtr("secret"),
+		DiskType:          util.StringPtr("disk"),
+		WorkerCidr:        util.StringPtr("10.10.10.10/25"),
+		AutoScalerMin:     util.IntPtr(1),
+		AutoScalerMax:     util.IntPtr(4),
+		MaxSurge:          util.IntPtr(25),
+		MaxUnavailable:    util.IntPtr(2),
+	}
+	azureProviderCfg := &AzureProviderConfig{VnetCidr: util.StringPtr("10.10.11.11/25")}
+	gcpProviderCfg := &GCPProviderConfig{Zone: util.StringPtr("zone")}
+	awsProviderCfg := &AWSProviderConfig{
+		Zone:         util.StringPtr("aws zone"),
+		VpcCidr:      util.StringPtr("10.10.10.11/25"),
+		PublicCidr:   util.StringPtr("10.10.10.12/25"),
+		InternalCidr: util.StringPtr("10.10.10.13/25"),
+	}
+
+	for _, testCase := range []struct {
+		description string
+		runtimeCfg  RuntimeConfig
+	}{
+		{
+			description: "gardener cluster with Azure",
+			runtimeCfg: RuntimeConfig{
+				ClusterConfig: newGardenerClusterCfg(gardenerClusterConfig, azureProviderCfg),
+				KymaConfig:    &KymaConfig{Version: util.StringPtr("my favourite")},
+				Kubeconfig:    util.StringPtr("kubeconfig"),
+			},
+		},
+		{
+			description: "gardener cluster with GCP",
+			runtimeCfg: RuntimeConfig{
+				ClusterConfig: newGardenerClusterCfg(gardenerClusterConfig, gcpProviderCfg),
+				KymaConfig:    &KymaConfig{Version: util.StringPtr("my favourite")},
+				Kubeconfig:    util.StringPtr("kubeconfig"),
+			},
+		},
+		{
+			description: "gardener cluster with AWS",
+			runtimeCfg: RuntimeConfig{
+				ClusterConfig: newGardenerClusterCfg(gardenerClusterConfig, awsProviderCfg),
+				KymaConfig:    &KymaConfig{Version: util.StringPtr("my favourite")},
+				Kubeconfig:    util.StringPtr("kubeconfig"),
+			},
+		},
+		{
+			description: "GCP cluster",
+			runtimeCfg: RuntimeConfig{
+				ClusterConfig: &gcpCluster,
+				KymaConfig:    &KymaConfig{Version: util.StringPtr("my favourite")},
+				Kubeconfig:    util.StringPtr("kubeconfig"),
+			},
+		},
+	} {
+		t.Run(testCase.description, func(t *testing.T) {
+			// given
+			marshalled, err := json.Marshal(testCase.runtimeCfg)
+			require.NoError(t, err)
+
+			var unmarshalledConfig RuntimeConfig
+
+			// when
+			err = json.NewDecoder(bytes.NewBuffer(marshalled)).Decode(&unmarshalledConfig)
+			require.NoError(t, err)
+
+			// then
+			assert.Equal(t, testCase.runtimeCfg, unmarshalledConfig)
+		})
+	}
+
+}
+
+func newGardenerClusterCfg(gardenerCfg GardenerConfig, providerCfg ProviderSpecificConfig) ClusterConfig {
+	gardenerCfg.ProviderSpecificConfig = providerCfg
+
+	return &gardenerCfg
+}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Go graphql client is unmarshaling responses to structs but to properly handle unmarshaling of interfaces into the generated structs the `UnmarshalJSON` needs to be overridden.

This behavior would make it easier to unmarshal responses from the Provisioner with Go.

Changes proposed in this pull request:

- Override unmarshaling of `RuntimeConfig` to properly handle `ClusterConfig`, and `ProviderSpecificConfig` interfaces

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
