### PR TITLE
Add guards to enable external management of secrets

### DIFF
--- a/chart/compass/charts/gateway/templates/gateway-certs-mtls.yaml
+++ b/chart/compass/charts/gateway/templates/gateway-certs-mtls.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.gateway.enabled }}
+{{- if and (.Values.gateway.enabled) (eq .Values.gateway.manageCerts true) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/chart/compass/charts/gateway/templates/gateway-certs.yaml
+++ b/chart/compass/charts/gateway/templates/gateway-certs.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.gateway.enabled }}
+{{- if and (.Values.gateway.enabled) (eq .Values.gateway.manageCerts true) }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/chart/compass/charts/gateway/values.yaml
+++ b/chart/compass/charts/gateway/values.yaml
@@ -7,3 +7,4 @@ deployment:
 
 gateway:
   enabled: true
+  manageCerts: true

--- a/chart/compass/charts/kyma-environment-broker/templates/secrets.yaml
+++ b/chart/compass/charts/kyma-environment-broker/templates/secrets.yaml
@@ -1,3 +1,4 @@
+{{- if eq .Values.manageSecrets true }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -24,3 +25,4 @@ data:
   url: {{ .Values.serviceManger.url | b64enc | quote }}
   username: {{ .Values.serviceManger.username | b64enc | quote }}
   password: {{ .Values.serviceManger.password | b64enc | quote }}
+{{- end }}

--- a/chart/compass/charts/kyma-environment-broker/values.yaml
+++ b/chart/compass/charts/kyma-environment-broker/values.yaml
@@ -9,6 +9,7 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 host: "kyma-env-broker"
+manageSecrets: true
 
 broker:
   port: "8080"

--- a/chart/compass/charts/provisioner/templates/gardener-creds-secret.yaml
+++ b/chart/compass/charts/provisioner/templates/gardener-creds-secret.yaml
@@ -1,3 +1,4 @@
+{{- if eq .Values.gardener.manageSecrets true }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -9,4 +10,4 @@ metadata:
 type: Opaque
 data:
   kubeconfig: {{ .Values.gardener.kubeconfig }}
-
+{{- end }}

--- a/chart/compass/charts/provisioner/values.yaml
+++ b/chart/compass/charts/provisioner/values.yaml
@@ -13,7 +13,8 @@ gardener:
   project: "" # Gardener project connected to SA
   kubeconfigPath: "/gardener/kubeconfig/kubeconfig"
   kubeconfig: "" # Base64 encoded Gardener SA key
-  secretName: "gardener-crednetials"
+  secretName: "gardener-credentials"
+  manageSecrets: true
 
 provisioner: "gardener"
 

--- a/chart/compass/templates/managed-postgresql-secret.yaml
+++ b/chart/compass/templates/managed-postgresql-secret.yaml
@@ -1,4 +1,4 @@
-{{if eq .Values.global.database.embedded.enabled false}}
+{{if and (eq .Values.global.database.embedded.enabled false) (eq .Values.global.database.manageSecrets true) }}
 apiVersion: v1
 kind: Secret
 type: Opaque

--- a/chart/compass/templates/tenant-fetcher-secret.yaml
+++ b/chart/compass/templates/tenant-fetcher-secret.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.global.tenantFetcher.enabled true }}
+{{- if and (eq .Values.global.tenantFetcher.enabled true) (eq .Values.global.tenantFetcher.manageSecrets true) }}
 apiVersion: v1
 kind: Secret
 type: Opaque

--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -132,7 +132,7 @@ global:
       host: adapter-gateway
     mtls:
       host: adapter-gateway-mtls
-  
+
   rewriteFilters:
     workloadLabel: oathkeeper
     tokenDataHeader: "Connector-Token"
@@ -149,6 +149,7 @@ global:
       namespace: compass-system
 
   database:
+    manageSecrets: true
     embedded:
       enabled: true
       directorDBName: "postgres"
@@ -197,6 +198,7 @@ global:
 
   tenantFetcher:
     enabled: false
+    manageSecrets: true
     providerName: "compass"
     schedule: "*/5 * * * *"
     oauth:


### PR DESCRIPTION
**Description**
Add possibility to manage compass secrets, and istio gateway certificates externally, i.e. outside of the helm charts.

Changes proposed in this pull request:

- Toggle deployment of certificate secrets
- Toggle deployment of KEB Service Manager credentials
- Toggle deployment of KEB user/password credentials
- Toggle deployment of Gardener kubeconfig
- Toggle deployment of Google Cloud SQL credentials
- Toggle deployment of tenant fetcher job credentials

**Related issue(s)**
N/A
