### PR TITLE
Add labels to runtime from KEB

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -48,7 +48,7 @@ global:
       version: "PR-5318"
     kyma_environment_broker:
       dir:
-      version: "PR-830"
+      version: "PR-842"
     tests:
       director:
         dir:

--- a/components/kyma-environment-broker/Gopkg.lock
+++ b/components/kyma-environment-broker/Gopkg.lock
@@ -350,7 +350,7 @@
   version = "v1.0.2"
 
 [[projects]]
-  digest = "1:7ac5e3b0541b473878fab1ff89ba035ed5b62ebe2e082e63cdf0be117de55f11"
+  digest = "1:ea808d89112be5076fa384bcbbe497a6320ef22e98d98715fc0a0f208b56b2da"
   name = "github.com/kyma-incubator/compass"
   packages = [
     "components/director/internal/model",
@@ -363,7 +363,7 @@
     "tests/provisioner-tests/test/testkit/graphql",
   ]
   pruneopts = "UT"
-  revision = "dc5e1435a3b74406b75faf19a51347985e2c43ad"
+  revision = "ad250cc742673ef5b628cc806841182bafe9750a"
 
 [[projects]]
   digest = "1:bde204c6c8dd5169cd05ed5aa9a1e027bc8d2cdd172c5e80b971cb4e14b55e3c"

--- a/components/kyma-environment-broker/Gopkg.toml
+++ b/components/kyma-environment-broker/Gopkg.toml
@@ -46,7 +46,7 @@
   version = "1.4.2"
 
 [[constraint]]
-  revision = "dc5e1435a3b74406b75faf19a51347985e2c43ad"
+  revision = "ad250cc742673ef5b628cc806841182bafe9750a"
   name = "github.com/kyma-incubator/compass"
 
 [[constraint]]

--- a/components/kyma-environment-broker/internal/broker/builder.go
+++ b/components/kyma-environment-broker/internal/broker/builder.go
@@ -13,7 +13,8 @@ import (
 )
 
 const (
-	labelKeyPrefix              = "broker/"
+	brokerKeyPrefix             = "broker_"
+	globalKeyPrefix             = "global_"
 	serviceManagerComponentName = "service-manager-proxy"
 )
 
@@ -240,8 +241,8 @@ func (b *InputBuilder) applyTemporaryCustomization(in *gqlschema.ProvisionRuntim
 
 func (b *InputBuilder) applyRuntimeLabels(in *gqlschema.ProvisionRuntimeInput) error {
 	in.RuntimeInput.Labels = &gqlschema.Labels{
-		labelKeyPrefix + "instance_id":    []string{b.instanceID},
-		labelKeyPrefix + "sub_account_id": []string{b.ersCtx.SubAccountID},
+		brokerKeyPrefix + "instance_id":   []string{b.instanceID},
+		globalKeyPrefix + "subaccount_id": []string{b.ersCtx.SubAccountID},
 	}
 
 	return nil

--- a/components/kyma-environment-broker/internal/broker/builder.go
+++ b/components/kyma-environment-broker/internal/broker/builder.go
@@ -12,7 +12,10 @@ import (
 	"github.com/pkg/errors"
 )
 
-const serviceManagerComponentName = "service-manager-proxy"
+const (
+	labelKeyPrefix              = "broker/"
+	serviceManagerComponentName = "service-manager-proxy"
+)
 
 //go:generate mockery -name=OptionalComponentService -output=automock -outpkg=automock -case=underscore
 //go:generate mockery -name=InputBuilderForPlan -output=automock -outpkg=automock -case=underscore
@@ -36,6 +39,7 @@ type (
 		SetProvisioningParameters(params internal.ProvisioningParametersDTO) ConcreteInputBuilder
 		SetERSContext(ersCtx internal.ERSContext) ConcreteInputBuilder
 		SetProvisioningConfig(brokerConfig ProvisioningConfig) ConcreteInputBuilder
+		SetInstanceID(instanceID string) ConcreteInputBuilder
 		Build() (gqlschema.ProvisionRuntimeInput, error)
 	}
 
@@ -87,6 +91,7 @@ func (f *InputBuilderFactory) ForPlan(planID string) (ConcreteInputBuilder, bool
 
 type InputBuilder struct {
 	planID                    string
+	instanceID                string
 	kymaVersion               string
 	serviceManager            internal.ServiceManagerOverride
 	hyperscalerInputProvider  HyperscalerInputProvider
@@ -111,6 +116,11 @@ func (b *InputBuilder) SetERSContext(ersCtx internal.ERSContext) ConcreteInputBu
 
 func (b *InputBuilder) SetProvisioningConfig(brokerConfig ProvisioningConfig) ConcreteInputBuilder {
 	b.provisioningConfig = brokerConfig
+	return b
+}
+
+func (b *InputBuilder) SetInstanceID(instanceID string) ConcreteInputBuilder {
+	b.instanceID = instanceID
 	return b
 }
 
@@ -228,6 +238,15 @@ func (b *InputBuilder) applyTemporaryCustomization(in *gqlschema.ProvisionRuntim
 	return nil
 }
 
+func (b *InputBuilder) applyRuntimeLabels(in *gqlschema.ProvisionRuntimeInput) error {
+	in.RuntimeInput.Labels = &gqlschema.Labels{
+		labelKeyPrefix + "instance_id":    []string{b.instanceID},
+		labelKeyPrefix + "sub_account_id": []string{b.ersCtx.SubAccountID},
+	}
+
+	return nil
+}
+
 func (b *InputBuilder) initInput() gqlschema.ProvisionRuntimeInput {
 	return gqlschema.ProvisionRuntimeInput{
 		RuntimeInput:  &gqlschema.RuntimeInput{},
@@ -266,6 +285,10 @@ func (b *InputBuilder) Build() (gqlschema.ProvisionRuntimeInput, error) {
 		{
 			name:    "applying temporary customization",
 			execute: b.applyTemporaryCustomization,
+		},
+		{
+			name:    "applying labels to runtime",
+			execute: b.applyRuntimeLabels,
 		},
 	} {
 		if err := step.execute(&input); err != nil {

--- a/components/kyma-environment-broker/internal/broker/builder_test.go
+++ b/components/kyma-environment-broker/internal/broker/builder_test.go
@@ -21,6 +21,7 @@ func TestInputBuilderFactoryForAzurePlan(t *testing.T) {
 		mappedComponentList = mapToGQLComponentConfigurationInput(inputComponentList)
 		toDisableComponents = []string{"kiali"}
 		smOverrides         = internal.ServiceManagerEntryDTO{URL: "http://sm-pico-bello-url.com"}
+		fixID               = "fix-id"
 	)
 
 	optComponentsSvc := &automock.OptionalComponentService{}
@@ -43,18 +44,24 @@ func TestInputBuilderFactoryForAzurePlan(t *testing.T) {
 		}).
 		SetERSContext(internal.ERSContext{
 			ServiceManager: smOverrides,
+			SubAccountID:   fixID,
 		}).
 		SetProvisioningConfig(ProvisioningConfig{
 			AzureSecretName: "azure-secret",
 		}).
+		SetInstanceID(fixID).
 		Build()
 
 	// then
 	require.NoError(t, err)
+	assert.EqualValues(t, mappedComponentList, input.KymaConfig.Components)
 	assert.Equal(t, "azure-cluster", input.RuntimeInput.Name)
 	assert.Equal(t, "azure", input.ClusterConfig.GardenerConfig.Provider)
 	assert.Equal(t, "azure-secret", input.ClusterConfig.GardenerConfig.TargetSecret)
-	assert.EqualValues(t, mappedComponentList, input.KymaConfig.Components)
+	assert.Equal(t, &gqlschema.Labels{
+		labelKeyPrefix + "instance_id":    []string{fixID},
+		labelKeyPrefix + "sub_account_id": []string{fixID},
+	}, input.RuntimeInput.Labels)
 
 	assertServiceManagerOverrides(t, input.KymaConfig.Components, smOverrides)
 }

--- a/components/kyma-environment-broker/internal/broker/builder_test.go
+++ b/components/kyma-environment-broker/internal/broker/builder_test.go
@@ -59,8 +59,8 @@ func TestInputBuilderFactoryForAzurePlan(t *testing.T) {
 	assert.Equal(t, "azure", input.ClusterConfig.GardenerConfig.Provider)
 	assert.Equal(t, "azure-secret", input.ClusterConfig.GardenerConfig.TargetSecret)
 	assert.Equal(t, &gqlschema.Labels{
-		labelKeyPrefix + "instance_id":    []string{fixID},
-		labelKeyPrefix + "sub_account_id": []string{fixID},
+		brokerKeyPrefix + "instance_id":   []string{fixID},
+		globalKeyPrefix + "subaccount_id": []string{fixID},
 	}, input.RuntimeInput.Labels)
 
 	assertServiceManagerOverrides(t, input.KymaConfig.Components, smOverrides)

--- a/components/kyma-environment-broker/internal/broker/instance_create.go
+++ b/components/kyma-environment-broker/internal/broker/instance_create.go
@@ -87,11 +87,11 @@ func (b *ProvisionEndpoint) Provision(ctx context.Context, instanceID string, de
 	if !found {
 		return domain.ProvisionedServiceSpec{}, apiresponses.NewFailureResponseBuilder(err, http.StatusBadRequest, fmt.Sprintf("The plan ID not known, instanceID %s, planID: %s", instanceID, details.PlanID))
 	}
-
 	inputBuilder.
 		SetERSContext(ersContext).
 		SetProvisioningParameters(parameters).
-		SetProvisioningConfig(b.provisioningCfg)
+		SetProvisioningConfig(b.provisioningCfg).
+		SetInstanceID(instanceID)
 
 	input, err := inputBuilder.Build()
 	if err != nil {

--- a/components/kyma-environment-broker/internal/broker/instance_create_integration_test.go
+++ b/components/kyma-environment-broker/internal/broker/instance_create_integration_test.go
@@ -39,6 +39,7 @@ func TestBrokerProvisioningScenario(t *testing.T) {
 		serviceID       = "47c9dcbf-ff30-448e-ab36-d3bad66ba281"
 		planID          = "4deee563-e5ec-4731-b9b1-53b42d855f0c"
 		globalAccountID = "e8f7ec0a-0cd6-41f0-905d-5d1efa9fb6c4"
+		subAccountID    = "e8f7ec0a-0cd6-41f0-905d-5d1efa9fb666"
 	)
 
 	var (
@@ -93,7 +94,7 @@ func TestBrokerProvisioningScenario(t *testing.T) {
 		ServiceID:     serviceID,
 		PlanID:        planID,
 		RawParameters: json.RawMessage(fmt.Sprintf(`{"name": "%s"}`, clusterName)),
-		RawContext:    json.RawMessage(fmt.Sprintf(`{"globalaccount_id": "%s"}`, globalAccountID)),
+		RawContext:    json.RawMessage(fmt.Sprintf(`{"globalaccount_id": "%s", "subaccount_id": "%s"}`, globalAccountID, subAccountID)),
 	}, true)
 
 	// then

--- a/components/kyma-environment-broker/internal/broker/instance_create_test.go
+++ b/components/kyma-environment-broker/internal/broker/instance_create_test.go
@@ -93,6 +93,10 @@ func (c *ConcreteInputBuilderFake) SetProvisioningConfig(brokerConfig broker.Pro
 	return c
 }
 
+func (c *ConcreteInputBuilderFake) SetInstanceID(instanceID string) broker.ConcreteInputBuilder {
+	return c
+}
+
 func (c *ConcreteInputBuilderFake) Build() (schema.ProvisionRuntimeInput, error) {
 	return c.input, nil
 }

--- a/components/kyma-environment-broker/internal/broker/testdata/TestBrokerProvisioningScenario.golden.graphql
+++ b/components/kyma-environment-broker/internal/broker/testdata/TestBrokerProvisioningScenario.golden.graphql
@@ -148,10 +148,6 @@
               {
                 key: "loki.enabled",
                 value: "false",
-              }
-              {
-                key: "fluent-bit.conf.Output.loki.enabled",
-                value: "false",
               } 
             ] 
           }

--- a/components/kyma-environment-broker/internal/broker/testdata/TestBrokerProvisioningScenario.golden.graphql
+++ b/components/kyma-environment-broker/internal/broker/testdata/TestBrokerProvisioningScenario.golden.graphql
@@ -2,8 +2,8 @@
       	runtimeInput: {
 		name: "cluster-testing",
 		labels: {
-			broker/instance_id: ["inst-id"],
-			broker/sub_account_id: ["e8f7ec0a-0cd6-41f0-905d-5d1efa9fb666"],
+			broker_instance_id: ["inst-id"],
+			global_subaccount_id: ["e8f7ec0a-0cd6-41f0-905d-5d1efa9fb666"],
 	},
 	},
 		clusterConfig: {

--- a/components/kyma-environment-broker/internal/broker/testdata/TestBrokerProvisioningScenario.golden.graphql
+++ b/components/kyma-environment-broker/internal/broker/testdata/TestBrokerProvisioningScenario.golden.graphql
@@ -1,99 +1,103 @@
 {
-      runtimeInput: {
-        name: "cluster-testing"
-      }
+      	runtimeInput: {
+		name: "cluster-testing",
+		labels: {
+			broker/instance_id: ["inst-id"],
+			broker/sub_account_id: ["e8f7ec0a-0cd6-41f0-905d-5d1efa9fb666"],
+	},
+	},
 		clusterConfig: {
 		gardenerConfig: {
-		kubernetesVersion: "1.15.4"
-		nodeCount: 3
-		volumeSizeGB: 50
-		machineType: "Standard_D2_v3"
-		region: "westeurope"
-		provider: "azure"
-		diskType: "Standard_LRS"
-		seed: "az-eu3"
-		targetSecret: ""
-		workerCidr: "10.250.0.0/19"
-        autoScalerMin: 2
-        autoScalerMax: 4
-        maxSurge: 4
-		maxUnavailable: 1
+		kubernetesVersion: "1.15.4",
+		nodeCount: 3,
+		volumeSizeGB: 50,
+		machineType: "Standard_D2_v3",
+		region: "westeurope",
+		provider: "azure",
+		diskType: "Standard_LRS",
+		seed: "az-eu3",
+		targetSecret: "",
+		workerCidr: "10.250.0.0/19",
+        autoScalerMin: 2,
+        autoScalerMax: 4,
+        maxSurge: 4,
+		maxUnavailable: 1,
 		providerSpecificConfig: {
-			azureConfig: { vnetCidr: "10.250.0.0/19" }
+			azureConfig: { vnetCidr: "10.250.0.0/19" },
 
         }
-	}
-	}
+	},
+	},
 		kymaConfig: {
-		version: "1.9.0"
+		version: "1.9.0",
         components: [
           {
-            component: "cluster-essentials"
-            namespace: "kyma-system" 
+            component: "cluster-essentials",
+            namespace: "kyma-system",
           }
           {
-            component: "testing"
-            namespace: "kyma-system" 
+            component: "testing",
+            namespace: "kyma-system",
           }
           {
-            component: "istio-init"
-            namespace: "istio-system" 
+            component: "istio-init",
+            namespace: "istio-system",
           }
           {
-            component: "istio"
-            namespace: "istio-system" 
+            component: "istio",
+            namespace: "istio-system",
           }
           {
-            component: "xip-patch"
-            namespace: "kyma-installer" 
+            component: "xip-patch",
+            namespace: "kyma-installer",
           }
           {
-            component: "istio-kyma-patch"
-            namespace: "istio-system" 
+            component: "istio-kyma-patch",
+            namespace: "istio-system",
           }
           {
-            component: "knative-serving-init"
-            namespace: "knative-serving" 
+            component: "knative-serving-init",
+            namespace: "knative-serving",
           }
           {
-            component: "knative-serving"
-            namespace: "knative-serving" 
+            component: "knative-serving",
+            namespace: "knative-serving",
           }
           {
-            component: "knative-eventing"
-            namespace: "knative-eventing" 
+            component: "knative-eventing",
+            namespace: "knative-eventing",
           }
           {
-            component: "dex"
-            namespace: "kyma-system" 
+            component: "dex",
+            namespace: "kyma-system",
           }
           {
-            component: "ory"
-            namespace: "kyma-system" 
+            component: "ory",
+            namespace: "kyma-system",
           }
           {
-            component: "api-gateway"
-            namespace: "kyma-system" 
+            component: "api-gateway",
+            namespace: "kyma-system",
           }
           {
-            component: "service-catalog"
-            namespace: "kyma-system" 
+            component: "service-catalog",
+            namespace: "kyma-system",
           }
           {
-            component: "service-catalog-addons"
-            namespace: "kyma-system" 
+            component: "service-catalog-addons",
+            namespace: "kyma-system",
           }
           {
-            component: "helm-broker"
-            namespace: "kyma-system" 
+            component: "helm-broker",
+            namespace: "kyma-system",
           }
           {
-            component: "nats-streaming"
-            namespace: "natss" 
+            component: "nats-streaming",
+            namespace: "natss",
           }
           {
-            component: "rafter"
-            namespace: "kyma-system" 
+            component: "rafter",
+            namespace: "kyma-system",
           }
           {
             component: "core"
@@ -102,73 +106,77 @@
               {
                 key: "console.managementPlane.url"
                 value: "https://compass-gateway-auth-oauth.kyma.local/director/graphql"
-              } 
-            ] 
+              }
+            ]
           }
           {
-            component: "knative-provisioner-natss"
-            namespace: "knative-eventing" 
+            component: "knative-provisioner-natss",
+            namespace: "knative-eventing",
           }
           {
-            component: "event-bus"
-            namespace: "kyma-system" 
+            component: "event-bus",
+            namespace: "kyma-system",
           }
           {
-            component: "event-sources"
-            namespace: "kyma-system" 
+            component: "event-sources",
+            namespace: "kyma-system",
           }
           {
-            component: "application-connector-ingress"
-            namespace: "kyma-system" 
+            component: "application-connector-ingress",
+            namespace: "kyma-system",
           }
           {
-            component: "application-connector-helper"
-            namespace: "kyma-integration" 
+            component: "application-connector-helper",
+            namespace: "kyma-integration",
           }
           {
-            component: "application-connector"
-            namespace: "kyma-integration" 
+            component: "application-connector",
+            namespace: "kyma-integration",
           }
           {
-            component: "backup-init"
-            namespace: "kyma-system" 
+            component: "backup-init",
+            namespace: "kyma-system",
           }
           {
-            component: "backup"
-            namespace: "kyma-system" 
+            component: "backup",
+            namespace: "kyma-system",
           }
           {
-            component: "logging"
-            namespace: "kyma-system"
+            component: "logging",
+            namespace: "kyma-system",
             configuration: [
               {
-                key: "loki.enabled"
-                value: "false"
+                key: "loki.enabled",
+                value: "false",
+              }
+              {
+                key: "fluent-bit.conf.Output.loki.enabled",
+                value: "false",
               } 
             ] 
           }
           {
-            component: "service-manager-proxy"
-            namespace: "kyma-system"
+            component: "service-manager-proxy",
+            namespace: "kyma-system",
             configuration: [
               {
-                key: "config.sm.url"
-                value: "sm-url"
+                key: "config.sm.url",
+                value: "sm-url",
               }
               {
-                key: "sm.user"
-                value: "sm-user"
+                key: "sm.user",
+                value: "sm-user",
               }
               {
-                key: "sm.password"
-                value: "sm-pass"
-                secret: true
+                key: "sm.password",
+                value: "sm-pass",
+                secret: true,
               } 
             ] 
           }
           {
-            component: "uaa-activator"
-            namespace: "kyma-system" 
+            component: "uaa-activator",
+            namespace: "kyma-system",
           }
           {
             component: "compass-runtime-agent"
@@ -177,9 +185,9 @@
               {
                 key: "managementPlane.url"
                 value: "https://compass-gateway-auth-oauth.kyma.local/director/graphql"
-              } 
-            ] 
+              }
+            ]
           } 
         ]         
+	},
 	}
-}

--- a/components/kyma-environment-broker/internal/broker/testdata/TestBrokerProvisioningScenario.golden.graphql
+++ b/components/kyma-environment-broker/internal/broker/testdata/TestBrokerProvisioningScenario.golden.graphql
@@ -33,113 +33,113 @@
         components: [
           {
             component: "cluster-essentials",
-            namespace: "kyma-system",
+            namespace: "kyma-system", 
           }
           {
             component: "testing",
-            namespace: "kyma-system",
+            namespace: "kyma-system", 
           }
           {
             component: "istio-init",
-            namespace: "istio-system",
+            namespace: "istio-system", 
           }
           {
             component: "istio",
-            namespace: "istio-system",
+            namespace: "istio-system", 
           }
           {
             component: "xip-patch",
-            namespace: "kyma-installer",
+            namespace: "kyma-installer", 
           }
           {
             component: "istio-kyma-patch",
-            namespace: "istio-system",
+            namespace: "istio-system", 
           }
           {
             component: "knative-serving-init",
-            namespace: "knative-serving",
+            namespace: "knative-serving", 
           }
           {
             component: "knative-serving",
-            namespace: "knative-serving",
+            namespace: "knative-serving", 
           }
           {
             component: "knative-eventing",
-            namespace: "knative-eventing",
+            namespace: "knative-eventing", 
           }
           {
             component: "dex",
-            namespace: "kyma-system",
+            namespace: "kyma-system", 
           }
           {
             component: "ory",
-            namespace: "kyma-system",
+            namespace: "kyma-system", 
           }
           {
             component: "api-gateway",
-            namespace: "kyma-system",
+            namespace: "kyma-system", 
           }
           {
             component: "service-catalog",
-            namespace: "kyma-system",
+            namespace: "kyma-system", 
           }
           {
             component: "service-catalog-addons",
-            namespace: "kyma-system",
+            namespace: "kyma-system", 
           }
           {
             component: "helm-broker",
-            namespace: "kyma-system",
+            namespace: "kyma-system", 
           }
           {
             component: "nats-streaming",
-            namespace: "natss",
+            namespace: "natss", 
           }
           {
             component: "rafter",
-            namespace: "kyma-system",
+            namespace: "kyma-system", 
           }
           {
-            component: "core"
-            namespace: "kyma-system"
+            component: "core",
+            namespace: "kyma-system",
             configuration: [
               {
-                key: "console.managementPlane.url"
-                value: "https://compass-gateway-auth-oauth.kyma.local/director/graphql"
-              }
-            ]
+                key: "console.managementPlane.url",
+                value: "https://compass-gateway-auth-oauth.kyma.local/director/graphql",
+              } 
+            ] 
           }
           {
             component: "knative-provisioner-natss",
-            namespace: "knative-eventing",
+            namespace: "knative-eventing", 
           }
           {
             component: "event-bus",
-            namespace: "kyma-system",
+            namespace: "kyma-system", 
           }
           {
             component: "event-sources",
-            namespace: "kyma-system",
+            namespace: "kyma-system", 
           }
           {
             component: "application-connector-ingress",
-            namespace: "kyma-system",
+            namespace: "kyma-system", 
           }
           {
             component: "application-connector-helper",
-            namespace: "kyma-integration",
+            namespace: "kyma-integration", 
           }
           {
             component: "application-connector",
-            namespace: "kyma-integration",
+            namespace: "kyma-integration", 
           }
           {
             component: "backup-init",
-            namespace: "kyma-system",
+            namespace: "kyma-system", 
           }
           {
             component: "backup",
-            namespace: "kyma-system",
+            namespace: "kyma-system", 
           }
           {
             component: "logging",
@@ -176,17 +176,17 @@
           }
           {
             component: "uaa-activator",
-            namespace: "kyma-system",
+            namespace: "kyma-system", 
           }
           {
-            component: "compass-runtime-agent"
-            namespace: "compass-system"
+            component: "compass-runtime-agent",
+            namespace: "compass-system",
             configuration: [
               {
-                key: "managementPlane.url"
-                value: "https://compass-gateway-auth-oauth.kyma.local/director/graphql"
-              }
-            ]
+                key: "managementPlane.url",
+                value: "https://compass-gateway-auth-oauth.kyma.local/director/graphql",
+              } 
+            ] 
           } 
         ]         
 	},

--- a/components/kyma-environment-broker/internal/provisioner/graphqlizer_test.go
+++ b/components/kyma-environment-broker/internal/provisioner/graphqlizer_test.go
@@ -36,24 +36,24 @@ func TestKymaConfigToGraphQLAllParametersProvided(t *testing.T) {
 		},
 	}
 	expRender := `{
-		version: "966"
+		version: "966",
         components: [
           {
-            component: "pico"
-            namespace: "bello" 
+            component: "pico",
+            namespace: "bello", 
           }
           {
-            component: "hakuna"
-            namespace: "matata"
+            component: "hakuna",
+            namespace: "matata",
             configuration: [
               {
-                key: "testing-secret-key"
-                value: "testing-secret-value"
-                secret: true
+                key: "testing-secret-key",
+                value: "testing-secret-value",
+                secret: true,
               }
               {
-                key: "testing-public-key"
-                value: "testing-public-value"
+                key: "testing-public-key",
+                value: "testing-public-value",
               } 
             ] 
           } 
@@ -77,7 +77,7 @@ func TestKymaConfigToGraphQLOnlyKymaVersion(t *testing.T) {
 		Version: "966",
 	}
 	expRender := `{
-		version: "966"         
+		version: "966",         
 	}`
 
 	sut := Graphqlizer{}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- KEB now pass 2 labels to the Provisioner on Provision runtime action:
   - broker/runtime_id
   - subaccount_id

We must decide what prefix we should use for:
- subaccount_id

My proposition is: **global/subaccount_id**

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
