### PR TITLE
Bump base images to alpine-3.11.3

### DIFF
--- a/components/connectivity-adapter/Dockerfile
+++ b/components/connectivity-adapter/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13.5-alpine3.10 as builder
+FROM golang:1.13.8-alpine3.11 as builder
 
 ENV BASE_APP_DIR /go/src/github.com/kyma-incubator/compass/components/connectivity-adapter
 WORKDIR ${BASE_APP_DIR}
@@ -15,7 +15,7 @@ COPY . ${BASE_APP_DIR}
 RUN go build -v -o main ./cmd/main.go
 RUN mkdir /app && mv ./main /app/main && mv ./licenses /app/licenses
 
-FROM alpine:3.10
+FROM alpine:3.11.3
 LABEL source = git@github.com:kyma-incubator/compass.git
 WORKDIR /app
 

--- a/components/connector/Dockerfile
+++ b/components/connector/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.12.5-alpine3.9 as builder
+FROM golang:1.13.8-alpine3.11 as builder
 
 ENV BASE_APP_DIR /go/src/github.com/kyma-incubator/compass/components/connector
 WORKDIR ${BASE_APP_DIR}
@@ -21,7 +21,7 @@ COPY ./licenses ${BASE_APP_DIR}/licenses
 RUN go build -v -o main .
 RUN mkdir /app && mv ./main /app/main && mv ./licenses /app/licenses
 
-FROM alpine:3.10
+FROM alpine:3.11.3
 LABEL source = git@github.com:kyma-incubator/compass.git
 WORKDIR /app
 

--- a/components/director/Dockerfile
+++ b/components/director/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13.5-alpine3.10 as builder
+FROM golang:1.13.8-alpine3.11 as builder
 
 ENV BASE_APP_DIR /go/src/github.com/kyma-incubator/compass/components/director
 WORKDIR ${BASE_APP_DIR}
@@ -21,7 +21,7 @@ RUN mkdir /app && mv ./director /app/director \
   && mv ./tenantloader /app/tenantloader \
   && mv ./licenses /app/licenses
 
-FROM alpine:3.10
+FROM alpine:3.11.3
 LABEL source = git@github.com:kyma-incubator/compass.git
 WORKDIR /app
 

--- a/components/gateway/Dockerfile
+++ b/components/gateway/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.12.5-alpine3.9 as builder
+FROM golang:1.13.8-alpine3.11 as builder
 
 ENV BASE_APP_DIR /go/src/github.com/kyma-incubator/compass/components/gateway
 WORKDIR ${BASE_APP_DIR}
@@ -20,7 +20,7 @@ COPY ./licenses ${BASE_APP_DIR}/licenses
 RUN go build -v -o main ./cmd/main.go
 RUN mkdir /app && mv ./main /app/main && mv ./licenses /app/licenses
 
-FROM alpine:3.10
+FROM alpine:3.11.3
 LABEL source = git@github.com:kyma-incubator/compass.git
 WORKDIR /app
 

--- a/components/healthchecker/Dockerfile
+++ b/components/healthchecker/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.12.5-alpine3.9 as builder
+FROM golang:1.13.8-alpine3.11 as builder
 
 ENV BASE_APP_DIR /go/src/github.com/kyma-incubator/compass/components/healthchecker
 WORKDIR ${BASE_APP_DIR}
@@ -18,7 +18,7 @@ COPY ./licenses ${BASE_APP_DIR}/licenses
 RUN go build -v -o main .
 RUN mkdir /app && mv ./main /app/main && mv ./licenses /app/licenses
 
-FROM alpine:3.10
+FROM alpine:3.11.3
 LABEL source = git@github.com:kyma-incubator/compass.git
 WORKDIR /app
 

--- a/components/kyma-environment-broker/Dockerfile
+++ b/components/kyma-environment-broker/Dockerfile
@@ -1,5 +1,5 @@
 # Build image
-FROM golang:1.13-alpine AS build
+FROM golang:1.13.8-alpine3.11 AS build
 
 WORKDIR /go/src/github.com/kyma-incubator/compass/components/kyma-environment-broker
 

--- a/components/provisioner/Dockerfile
+++ b/components/provisioner/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13.1-alpine3.10 as builder
+FROM golang:1.13.8-alpine3.11 as builder
 
 ENV BASE_APP_DIR /go/src/github.com/kyma-incubator/compass/components/provisioner
 WORKDIR ${BASE_APP_DIR}
@@ -35,7 +35,7 @@ RUN go build -v -o main ./cmd/
 RUN mkdir /app && mv ./main /app/main && mv ./licenses /app/licenses
 RUN wget https://github.com/kyma-incubator/terraform-provider-gardener/releases/download/v0.0.3/terraform-provider-gardener-linux-amd64
 
-FROM alpine:3.10
+FROM alpine:3.11.3
 LABEL source = git@github.com:kyma-incubator/compass.git
 # Hydroform needs write permissions
 RUN mkdir /app && chmod 777 /app

--- a/components/schema-migrator/Dockerfile
+++ b/components/schema-migrator/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.10
+FROM alpine:3.11.3
 
 ARG MIGRATE_VER=4.5.0
 


### PR DESCRIPTION
**Description**

Bump eliminates security issue with openssl lib being to old

Changes proposed in this pull request:

- updated golang and alpine images
- ...
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
