### PR TITLE
Change tiller.yaml download url to less error-prone

### DIFF
--- a/components/provisioner/internal/installation/release/downloader.go
+++ b/components/provisioner/internal/installation/release/downloader.go
@@ -25,7 +25,7 @@ const (
 
 	releaseFetchURL   = "https://api.github.com/repos/kyma-project/kyma/releases"
 	installerYAMLName = "kyma-installer-cluster.yaml"
-	tillerFormat      = "https://raw.githubusercontent.com/kyma-project/kyma/release-%s/installation/resources/tiller.yaml"
+	tillerFormat      = "https://raw.githubusercontent.com/kyma-project/kyma/%s/installation/resources/tiller.yaml"
 )
 
 func NewArtifactsDownloader(repository Repository, latestReleases int, includePreReleases bool, client *http.Client, log *logrus.Entry) *artifactsDownloader {
@@ -201,5 +201,5 @@ func getLatestReleases(releases []model.GithubRelease, latestReleases int) []mod
 }
 
 func buildTillerURL(releaseName string) string {
-	return fmt.Sprintf(tillerFormat, releaseName[:3])
+	return fmt.Sprintf(tillerFormat, releaseName)
 }


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Fixing a bug which was blocking Kyma 1.10 from installing - in current implementation truncating to first 3 characters from `release.Name` resulted in fetching tiller.yaml for Kyma `1.1` instead of `1.10`


Changes proposed in this pull request:

- Changed url pointing to tiller.yaml file
- ...
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
#861 