### PR TITLE
Propagate artifacts environment variables in compass pipelines

### DIFF
--- a/components/provisioner/go.mod
+++ b/components/provisioner/go.mod
@@ -3,31 +3,16 @@ module github.com/kyma-incubator/compass/components/provisioner
 go 1.13
 
 require (
-	contrib.go.opencensus.io/exporter/ocagent v0.4.12 // indirect
 	github.com/99designs/gqlgen v0.9.3
-	github.com/Azure/azure-pipeline-go v0.2.2 // indirect
 	github.com/Masterminds/sprig v2.22.0+incompatible
 	github.com/Microsoft/hcsshim v0.8.7 // indirect
-	github.com/NYTimes/gziphandler v1.1.1 // indirect
-	github.com/coreos/bbolt v1.3.3 // indirect
-	github.com/coreos/go-semver v0.3.0 // indirect
-	github.com/docker/spdystream v0.0.0-20181023171402-6480d4af844c // indirect
-	github.com/gardener/external-dns-management v0.0.0-20190722114702-f6b12f6e4b43 // indirect
 	github.com/gardener/gardener v0.33.7
-	github.com/go-ini/ini v1.46.0 // indirect
-	github.com/gobuffalo/logger v1.0.1 // indirect
-	github.com/gobuffalo/packd v0.3.0 // indirect
 	github.com/gocraft/dbr/v2 v2.6.3
-	github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6 // indirect
-	github.com/golang/snappy v0.0.1 // indirect
 	github.com/google/uuid v1.1.1
 	github.com/gorilla/mux v1.7.3
-	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 // indirect
-	github.com/grpc-ecosystem/go-grpc-middleware v1.1.0 // indirect
 	github.com/hashicorp/hil v0.0.0-20190212132231-97b3a9cdfa93 // indirect
 	github.com/hashicorp/terraform v0.12.16
 	github.com/json-iterator/go v1.1.8 // indirect
-	github.com/karrick/godirwalk v1.10.12 // indirect
 	github.com/kubernetes/client-go v11.0.0+incompatible
 	github.com/kyma-incubator/compass/components/director v0.0.0-20200123101435-9cd00b2924b8
 	github.com/kyma-incubator/hydroform v0.0.0-20191217171037-affe7099c3b9
@@ -36,8 +21,6 @@ require (
 	github.com/lib/pq v1.2.0
 	github.com/machinebox/graphql v0.2.3-0.20181106130121-3a9253180225
 	github.com/matryer/is v1.2.0 // indirect
-	github.com/mattn/go-ieproxy v0.0.0-20190805055040-f9202b1cfdeb // indirect
-	github.com/munnerz/goautoneg v0.0.0-20190414153302-2ae31c8b6b30 // indirect
 	github.com/onsi/ginkgo v1.10.1 // indirect
 	github.com/onsi/gomega v1.7.0 // indirect
 	github.com/pkg/errors v0.8.1
@@ -45,24 +28,18 @@ require (
 	github.com/stretchr/testify v1.4.0
 	github.com/terraform-providers/terraform-provider-openstack v1.20.0 // indirect
 	github.com/testcontainers/testcontainers-go v0.0.8
-	github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5 // indirect
-	github.com/ugorji/go/codec v1.1.7 // indirect
-	github.com/ulikunitz/xz v0.5.6 // indirect
 	github.com/vektah/gqlparser v1.2.0
 	github.com/vrischmann/envconfig v1.2.0
-	github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2 // indirect
 	golang.org/x/time v0.0.0-20190921001708-c4c64cad1fd0 // indirect
 	google.golang.org/appengine v1.6.4 // indirect
 	google.golang.org/genproto v0.0.0-20190927181202-20e1ac93f88c // indirect
 	google.golang.org/grpc v1.24.0 // indirect
-	gopkg.in/ini.v1 v1.44.0 // indirect
 	gotest.tools v2.2.0+incompatible
 	k8s.io/api v0.15.8-beta.1
 	k8s.io/apiextensions-apiserver v0.0.0-20190918201827-3de75813f604
 	k8s.io/apimachinery v0.15.8-beta.1
 	k8s.io/client-go v11.0.1-0.20190409021438-1a26190bd76a+incompatible // tag kubernetes-1.15.6
 	k8s.io/kube-openapi v0.0.0-20191107075043-30be4d16710a // indirect
-	k8s.io/utils v0.0.0-20190712204705-3dccf664f023 // indirect
 	sigs.k8s.io/controller-runtime v0.3.0
 )
 

--- a/components/provisioner/go.mod
+++ b/components/provisioner/go.mod
@@ -3,16 +3,31 @@ module github.com/kyma-incubator/compass/components/provisioner
 go 1.13
 
 require (
+	contrib.go.opencensus.io/exporter/ocagent v0.4.12 // indirect
 	github.com/99designs/gqlgen v0.9.3
+	github.com/Azure/azure-pipeline-go v0.2.2 // indirect
 	github.com/Masterminds/sprig v2.22.0+incompatible
 	github.com/Microsoft/hcsshim v0.8.7 // indirect
+	github.com/NYTimes/gziphandler v1.1.1 // indirect
+	github.com/coreos/bbolt v1.3.3 // indirect
+	github.com/coreos/go-semver v0.3.0 // indirect
+	github.com/docker/spdystream v0.0.0-20181023171402-6480d4af844c // indirect
+	github.com/gardener/external-dns-management v0.0.0-20190722114702-f6b12f6e4b43 // indirect
 	github.com/gardener/gardener v0.33.7
+	github.com/go-ini/ini v1.46.0 // indirect
+	github.com/gobuffalo/logger v1.0.1 // indirect
+	github.com/gobuffalo/packd v0.3.0 // indirect
 	github.com/gocraft/dbr/v2 v2.6.3
+	github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6 // indirect
+	github.com/golang/snappy v0.0.1 // indirect
 	github.com/google/uuid v1.1.1
 	github.com/gorilla/mux v1.7.3
+	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 // indirect
+	github.com/grpc-ecosystem/go-grpc-middleware v1.1.0 // indirect
 	github.com/hashicorp/hil v0.0.0-20190212132231-97b3a9cdfa93 // indirect
 	github.com/hashicorp/terraform v0.12.16
 	github.com/json-iterator/go v1.1.8 // indirect
+	github.com/karrick/godirwalk v1.10.12 // indirect
 	github.com/kubernetes/client-go v11.0.0+incompatible
 	github.com/kyma-incubator/compass/components/director v0.0.0-20200123101435-9cd00b2924b8
 	github.com/kyma-incubator/hydroform v0.0.0-20191217171037-affe7099c3b9
@@ -21,6 +36,8 @@ require (
 	github.com/lib/pq v1.2.0
 	github.com/machinebox/graphql v0.2.3-0.20181106130121-3a9253180225
 	github.com/matryer/is v1.2.0 // indirect
+	github.com/mattn/go-ieproxy v0.0.0-20190805055040-f9202b1cfdeb // indirect
+	github.com/munnerz/goautoneg v0.0.0-20190414153302-2ae31c8b6b30 // indirect
 	github.com/onsi/ginkgo v1.10.1 // indirect
 	github.com/onsi/gomega v1.7.0 // indirect
 	github.com/pkg/errors v0.8.1
@@ -28,18 +45,24 @@ require (
 	github.com/stretchr/testify v1.4.0
 	github.com/terraform-providers/terraform-provider-openstack v1.20.0 // indirect
 	github.com/testcontainers/testcontainers-go v0.0.8
+	github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5 // indirect
+	github.com/ugorji/go/codec v1.1.7 // indirect
+	github.com/ulikunitz/xz v0.5.6 // indirect
 	github.com/vektah/gqlparser v1.2.0
 	github.com/vrischmann/envconfig v1.2.0
+	github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2 // indirect
 	golang.org/x/time v0.0.0-20190921001708-c4c64cad1fd0 // indirect
 	google.golang.org/appengine v1.6.4 // indirect
 	google.golang.org/genproto v0.0.0-20190927181202-20e1ac93f88c // indirect
 	google.golang.org/grpc v1.24.0 // indirect
+	gopkg.in/ini.v1 v1.44.0 // indirect
 	gotest.tools v2.2.0+incompatible
 	k8s.io/api v0.15.8-beta.1
 	k8s.io/apiextensions-apiserver v0.0.0-20190918201827-3de75813f604
 	k8s.io/apimachinery v0.15.8-beta.1
 	k8s.io/client-go v11.0.1-0.20190409021438-1a26190bd76a+incompatible // tag kubernetes-1.15.6
 	k8s.io/kube-openapi v0.0.0-20191107075043-30be4d16710a // indirect
+	k8s.io/utils v0.0.0-20190712204705-3dccf664f023 // indirect
 	sigs.k8s.io/controller-runtime v0.3.0
 )
 

--- a/installation/scripts/prow/deploy-and-test.sh
+++ b/installation/scripts/prow/deploy-and-test.sh
@@ -13,4 +13,4 @@ export ARTIFACTS="/var/log/prow_artifacts"
 sudo mkdir -p "${ARTIFACTS}"
 
 sudo ${INSTALLATION_DIR}/cmd/run.sh
-sudo ${INSTALLATION_DIR}/scripts/testing.sh
+sudo ARTIFACTS=${ARTIFACTS} ${INSTALLATION_DIR}/scripts/testing.sh

--- a/installation/scripts/testing.sh
+++ b/installation/scripts/testing.sh
@@ -26,12 +26,6 @@ matchNames=$(cat <<-END
     matchNames:
       - name: compass-director-api
         namespace: compass-system
-      - name: compass-director-gateway-integration
-        namespace: kyma-system
-      - name: compass-connector-tests
-        namespace: compass-system
-      - name: connectivity-adapter
-        namespace: compass-system
 END
 )
 

--- a/installation/scripts/testing.sh
+++ b/installation/scripts/testing.sh
@@ -5,6 +5,7 @@ source ${ROOT_PATH}/kyma-scripts/testing-common.sh
 
 readonly TMP_DIR=$(mktemp -d)
 
+echo "ARTIFACTS: ${ARTIFACTS}"
 readonly JUNIT_REPORT_PATH="${ARTIFACTS:-${TMP_DIR}}/junit_compass_octopus-test-suite.xml"
 
 suiteName="testsuite-all"

--- a/installation/scripts/testing.sh
+++ b/installation/scripts/testing.sh
@@ -102,6 +102,10 @@ echo "ClusterTestSuite details:"
 kubectl get cts ${suiteName} -oyaml
 
 echo "Generate JUnit test summary (${JUNIT_REPORT_PATH})"
+
+set -e
+set -o pipefail
+
 kyma test status "${suiteName}" -ojunit | sed 's/ (executions: [0-9]*)"/"/g' > "${JUNIT_REPORT_PATH}"
 
 

--- a/installation/scripts/testing.sh
+++ b/installation/scripts/testing.sh
@@ -102,7 +102,6 @@ echo "ClusterTestSuite details:"
 kubectl get cts ${suiteName} -oyaml
 
 echo "Generate JUnit test summary (${JUNIT_REPORT_PATH})"
-
 kyma test status "${suiteName}" -ojunit | sed 's/ (executions: [0-9]*)"/"/g' > "${JUNIT_REPORT_PATH}"
 
 

--- a/installation/scripts/testing.sh
+++ b/installation/scripts/testing.sh
@@ -26,6 +26,12 @@ matchNames=$(cat <<-END
     matchNames:
       - name: compass-director-api
         namespace: compass-system
+      - name: compass-director-gateway-integration
+        namespace: kyma-system
+      - name: compass-connector-tests
+        namespace: compass-system
+      - name: connectivity-adapter
+        namespace: compass-system
 END
 )
 
@@ -96,9 +102,6 @@ echo "ClusterTestSuite details:"
 kubectl get cts ${suiteName} -oyaml
 
 echo "Generate JUnit test summary (${JUNIT_REPORT_PATH})"
-
-set -e
-set -o pipefail
 
 kyma test status "${suiteName}" -ojunit | sed 's/ (executions: [0-9]*)"/"/g' > "${JUNIT_REPORT_PATH}"
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Job should publish test results in artifacts dir (https://gcsweb.build.kyma-project.io/gcs/kyma-prow-logs/pr-logs/pull/kyma-incubator_compass/926/pre-master-compass-integration/1236975273400864768/artifacts/prow_artifacts/), then it is used by Testgrid. Unfortunately, because we execute `testing.sh` script with `sudo` privileges, `ARTIFACTS` env was not propagated correctly.
- ...
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
