### PR TITLE
A hotfix to remove creating separate Gardener credential secret for H…

### DIFF
--- a/chart/compass/charts/kyma-environment-broker/templates/secrets.yaml
+++ b/chart/compass/charts/kyma-environment-broker/templates/secrets.yaml
@@ -26,15 +26,4 @@ data:
   username: {{ .Values.serviceManager.username | b64enc | quote }}
   password: {{ .Values.serviceManager.password | b64enc | quote }}
 {{- end }}
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: {{ .Values.gardener.secretName }}
-  namespace: {{ .Release.Namespace }}
-  labels:
-    app: {{ .Chart.Name }}
-    release: {{ .Release.Name }}
-type: Opaque
-data:
-  kubeconfig: {{ .Values.gardener.kubeconfig }}
+

--- a/chart/compass/charts/kyma-environment-broker/values.yaml
+++ b/chart/compass/charts/kyma-environment-broker/values.yaml
@@ -54,9 +54,8 @@ kymaVersion: "1.10.0"
 enablePlans: "azure,gcp"
 
 gardener:
-  project: "" # Gardener project connected to SA
+  project: "kyma-dev" # Gardener project connected to SA for HAP credentials lookup
   kubeconfigPath: "/gardener/kubeconfig/kubeconfig"
-  kubeconfig: "" # Base64 encoded Gardener SA key
   secretName: "gardener-credentials"
 
 # It is used to provide own creds for Service Manager instead of using the one provided by external system


### PR DESCRIPTION
After merging PR for HAP I noticed that we do not need to create a separate secret for Gardner kubeconfig since it should be already present in the environement, created by Provisioner. Even worse it is possible that this additional secret in KEB when will override the valid one. So this PR is to remove this redundancy