### PR TITLE
Provide istio overrides to stabilize tests

### DIFF
--- a/installation/cmd/run.sh
+++ b/installation/cmd/run.sh
@@ -11,9 +11,10 @@ COMPASS_HELM_RELEASE_NAMESPACE="compass-system"
 
 INSTALLER_CR_PATH="${ROOT_PATH}"/installation/resources/installer-cr-kyma-diet.yaml
 OVERRIDES_COMPASS_GATEWAY="${ROOT_PATH}"/installation/resources/installer-overrides-compass-gateway.yaml
+ISTIO_OVERRIDES="${ROOT_PATH}"/installation/resources/installer-overrides-istio.yaml
 
 kyma provision minikube
-kyma install -o $INSTALLER_CR_PATH  -o $OVERRIDES_COMPASS_GATEWAY --source "${KYMA_RELEASE}"
+kyma install -o $INSTALLER_CR_PATH  -o $OVERRIDES_COMPASS_GATEWAY -o -o $ISTIO_OVERRIDES --source "${KYMA_RELEASE}"
 
 #Get Tiller tls client certificates
 kubectl get -n kyma-installer secret helm-secret -o jsonpath="{.data['global\.helm\.ca\.crt']}" | base64 --decode > "$(helm home)/ca.pem"

--- a/installation/cmd/run.sh
+++ b/installation/cmd/run.sh
@@ -14,7 +14,7 @@ OVERRIDES_COMPASS_GATEWAY="${ROOT_PATH}"/installation/resources/installer-overri
 ISTIO_OVERRIDES="${ROOT_PATH}"/installation/resources/installer-overrides-istio.yaml
 
 kyma provision minikube
-kyma install -o $INSTALLER_CR_PATH  -o $OVERRIDES_COMPASS_GATEWAY -o -o $ISTIO_OVERRIDES --source "${KYMA_RELEASE}"
+kyma install -o $INSTALLER_CR_PATH  -o $OVERRIDES_COMPASS_GATEWAY -o $ISTIO_OVERRIDES --source "${KYMA_RELEASE}"
 
 #Get Tiller tls client certificates
 kubectl get -n kyma-installer secret helm-secret -o jsonpath="{.data['global\.helm\.ca\.crt']}" | base64 --decode > "$(helm home)/ca.pem"

--- a/installation/resources/installer-overrides-istio.yaml
+++ b/installation/resources/installer-overrides-istio.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: istio-overrides
+  namespace: kyma-installer
+  labels:
+    installer: overrides
+    component: istio
+data:
+  global.proxy.resources.requests.cpu: 20m
+  global.proxy.resources.requests.memory: 32Mi
+  global.proxy.resources.limits.cpu: 100m
+  global.proxy.resources.limits.memory: 128Mi
+


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

Default istio-proxy configuration for minikube:
```
      proxy:
        resources:
          requests:
            cpu: 10m
            memory: 10Mi
          limits:
            cpu: 100m
            memory: 50Mi
```
Default istio-proxy config for cluster:
```
        resources:
          limits:
            cpu: 200m
            memory: 128Mi
          requests:
            cpu: 20m
            memory: 32Mi
```
I copied values from cluster config, the only `limit.cpu` is set to `100` instead of `200m`, last 4 executions on Prow succeeded. 


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
