### PR TITLE
Move default auth management to packages

### DIFF
--- a/chart/compass/charts/cockpit/values.yaml
+++ b/chart/compass/charts/cockpit/values.yaml
@@ -3,7 +3,7 @@ images:
     path: eu.gcr.io/kyma-project
   ui:
     dir:
-    version: 2066dd35
+    version: 1851b75b
 
 ui:
   host: compass


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- personal data no longer stored in session storage
- default auth manageable on API packages


