### PR TITLE
Add retries for operation calls in KEB

### DIFF
--- a/components/kyma-environment-broker/Gopkg.lock
+++ b/components/kyma-environment-broker/Gopkg.lock
@@ -856,7 +856,7 @@
   version = "v0.17.1"
 
 [[projects]]
-  digest = "1:e0ce2f07c93aa1fdfcc220a8dbe183a28bfa4fdb4f893301795f1f1ac3a3bc63"
+  digest = "1:c2001b25ae19e1af3389e8f824cc537449084b1d29be4e94cb2c16c98796501f"
   name = "k8s.io/client-go"
   packages = [
     "discovery",

--- a/components/kyma-environment-broker/internal/storage/driver/postsql/instance.go
+++ b/components/kyma-environment-broker/internal/storage/driver/postsql/instance.go
@@ -27,7 +27,7 @@ func (s *Instance) GetByID(instanceID string) (*internal.Instance, error) {
 	err := wait.PollImmediate(defaultRetryInterval, defaultRetryTimeout, func() (bool, error) {
 		instance, lastErr = sess.GetInstanceByID(instanceID)
 		if lastErr != nil {
-			if lastErr.Code() == dberr.CodeNotFound {
+			if dberr.IsNotFound(lastErr) {
 				return false, dberr.NotFound("Instance with id %s not exist", instanceID)
 			}
 			log.Warn(errors.Wrapf(lastErr, "while getting instance by ID %s", instanceID).Error())
@@ -64,7 +64,7 @@ func (s *Instance) Update(instance internal.Instance) error {
 	err := wait.PollImmediate(defaultRetryInterval, defaultRetryTimeout, func() (bool, error) {
 		lastErr = sess.UpdateInstance(instance)
 		if lastErr != nil {
-			if lastErr.Code() == dberr.CodeNotFound {
+			if dberr.IsNotFound(lastErr) {
 				return false, dberr.NotFound("Instance with id %s not exist", instance.InstanceID)
 			}
 			log.Warn(errors.Wrapf(lastErr, "while updating instance ID %s", instance.InstanceID).Error())

--- a/components/kyma-environment-broker/internal/storage/driver/postsql/instance.go
+++ b/components/kyma-environment-broker/internal/storage/driver/postsql/instance.go
@@ -22,20 +22,23 @@ func NewInstance(sess dbsession.Factory) *Instance {
 // TODO: Wrap retries in single method WithRetries
 func (s *Instance) GetByID(instanceID string) (*internal.Instance, error) {
 	sess := s.NewReadSession()
-	instance := &internal.Instance{}
-	err := wait.Poll(defaultRetryInterval, defaultRetryTimeout, func() (bool, error) {
-		inst, err := sess.GetInstanceByID(instanceID)
-		if err != nil {
-			if err.Code() == dberr.CodeNotFound {
+	instance := internal.Instance{}
+	var lastErr dberr.Error
+	err := wait.PollImmediate(defaultRetryInterval, defaultRetryTimeout, func() (bool, error) {
+		instance, lastErr = sess.GetInstanceByID(instanceID)
+		if lastErr != nil {
+			if lastErr.Code() == dberr.CodeNotFound {
 				return false, dberr.NotFound("Instance with id %s not exist", instanceID)
 			}
-			log.Warn(errors.Wrapf(err, "while getting instance by ID %s", instanceID).Error())
+			log.Warn(errors.Wrapf(lastErr, "while getting instance by ID %s", instanceID).Error())
 			return false, nil
 		}
-		instance = &inst
 		return true, nil
 	})
-	return instance, err
+	if err != nil {
+		return nil, lastErr
+	}
+	return &instance, nil
 }
 
 func (s *Instance) Insert(instance internal.Instance) error {
@@ -45,7 +48,7 @@ func (s *Instance) Insert(instance internal.Instance) error {
 	}
 
 	sess := s.NewWriteSession()
-	return wait.Poll(defaultRetryInterval, defaultRetryTimeout, func() (bool, error) {
+	return wait.PollImmediate(defaultRetryInterval, defaultRetryTimeout, func() (bool, error) {
 		err := sess.InsertInstance(instance)
 		if err != nil {
 			log.Warn(errors.Wrapf(err, "while saving instance ID %s", instance.InstanceID).Error())
@@ -57,15 +60,20 @@ func (s *Instance) Insert(instance internal.Instance) error {
 
 func (s *Instance) Update(instance internal.Instance) error {
 	sess := s.NewWriteSession()
-	return wait.Poll(defaultRetryInterval, defaultRetryTimeout, func() (bool, error) {
-		err := sess.UpdateInstance(instance)
-		if err != nil {
-			if err.Code() == dberr.CodeNotFound {
+	var lastErr dberr.Error
+	err := wait.PollImmediate(defaultRetryInterval, defaultRetryTimeout, func() (bool, error) {
+		lastErr = sess.UpdateInstance(instance)
+		if lastErr != nil {
+			if lastErr.Code() == dberr.CodeNotFound {
 				return false, dberr.NotFound("Instance with id %s not exist", instance.InstanceID)
 			}
-			log.Warn(errors.Wrapf(err, "while updating instance ID %s", instance.InstanceID).Error())
+			log.Warn(errors.Wrapf(lastErr, "while updating instance ID %s", instance.InstanceID).Error())
 			return false, nil
 		}
 		return true, nil
 	})
+	if err != nil {
+		return lastErr
+	}
+	return nil
 }

--- a/components/kyma-environment-broker/internal/storage/driver/postsql/operation.go
+++ b/components/kyma-environment-broker/internal/storage/driver/postsql/operation.go
@@ -5,6 +5,9 @@ import (
 	"fmt"
 	"time"
 
+	log "github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/util/wait"
+
 	"github.com/kyma-incubator/compass/components/kyma-environment-broker/internal"
 	"github.com/kyma-incubator/compass/components/kyma-environment-broker/internal/storage/dberr"
 	"github.com/kyma-incubator/compass/components/kyma-environment-broker/internal/storage/dbsession"
@@ -30,19 +33,35 @@ func (s *operations) InsertProvisioningOperation(operation internal.Provisioning
 	if err != nil {
 		return errors.Wrapf(err, "while inserting provisioning operation (id: %s)", operation.ID)
 	}
-
-	return session.InsertOperation(dto)
+	var lastErr error
+	_ = wait.PollImmediate(defaultRetryInterval, defaultRetryTimeout, func() (bool, error) {
+		lastErr = session.InsertOperation(dto)
+		if lastErr != nil {
+			log.Warn(errors.Wrap(err, "while insert operation"))
+			return false, nil
+		}
+		return true, nil
+	})
+	return lastErr
 }
 
 // GetProvisioningOperationByID fetches the ProvisioningOperation by given ID, returns error if not found
 func (s *operations) GetProvisioningOperationByID(operationID string) (*internal.ProvisioningOperation, error) {
 	session := s.NewReadSession()
-	dto, dbErr := session.GetOperationByID(operationID)
-	if dbErr != nil {
-		return nil, errors.Wrapf(dbErr, "while reading Operation from the storage")
+	operation := dbsession.OperationDTO{}
+	err := wait.PollImmediate(defaultRetryInterval, defaultRetryTimeout, func() (bool, error) {
+		dto, dbErr := session.GetOperationByID(operationID)
+		if dbErr != nil {
+			log.Warn(errors.Wrapf(dbErr, "while reading Operation from the storage"))
+			return false, nil
+		}
+		operation = dto
+		return true, nil
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "while getting operation by ID")
 	}
-
-	ret, err := toProvisioningOperation(&dto)
+	ret, err := toProvisioningOperation(&operation)
 	if err != nil {
 		return nil, errors.Wrapf(err, "while converting DTO to Operation")
 	}
@@ -53,15 +72,24 @@ func (s *operations) GetProvisioningOperationByID(operationID string) (*internal
 // GetProvisioningOperationByInstanceID fetches the ProvisioningOperation by given instanceID, returns error if not found
 func (s *operations) GetProvisioningOperationByInstanceID(instanceID string) (*internal.ProvisioningOperation, error) {
 	session := s.NewReadSession()
-	dto, dbErr := session.GetOperationByInstanceID(instanceID)
-	if dbErr != nil {
-		if dbErr.Code() == dberr.CodeNotFound {
-			return nil, dberr.NotFound("operation does not exist")
+	operation := dbsession.OperationDTO{}
+	var lastErr dberr.Error
+	err := wait.PollImmediate(defaultRetryInterval, defaultRetryTimeout, func() (bool, error) {
+		operation, lastErr = session.GetOperationByInstanceID(instanceID)
+		if lastErr != nil {
+			if lastErr.Code() == dberr.CodeNotFound {
+				lastErr = dberr.NotFound("operation does not exist")
+				return false, lastErr
+			}
+			log.Warn(errors.Wrapf(lastErr, "while reading Operation from the storage").Error())
+			return false, nil
 		}
-		return nil, errors.Wrapf(dbErr, "while reading Operation from the storage")
+		return true, nil
+	})
+	if err != nil {
+		return nil, lastErr
 	}
-
-	ret, err := toProvisioningOperation(&dto)
+	ret, err := toProvisioningOperation(&operation)
 	if err != nil {
 		return nil, errors.Wrapf(err, "while converting DTO to Operation")
 	}
@@ -78,38 +106,63 @@ func (s *operations) UpdateProvisioningOperation(op internal.ProvisioningOperati
 		return nil, errors.Wrapf(err, "while converting Operation to DTO")
 	}
 
-	dErr := session.UpdateOperation(dto)
-	if dErr != nil && dErr.Code() == dberr.CodeNotFound {
-		_, err := s.NewReadSession().GetOperationByID(op.ID)
-		if err != nil {
-			return nil, errors.Wrapf(err, "while getting Operation")
-		}
+	var lastErr error
+	err = wait.PollImmediate(defaultRetryInterval, defaultRetryTimeout, func() (bool, error) {
+		dErr := session.UpdateOperation(dto)
+		if dErr != nil && dErr.Code() == dberr.CodeNotFound {
+			_, lastErr = s.NewReadSession().GetOperationByID(op.ID)
+			if lastErr != nil {
+				log.Warn(errors.Wrapf(lastErr, "while getting Operation").Error())
+				return false, nil
+			}
 
-		// the operation exists but the version is different
-		return nil, dberr.Conflict("operation update conflict, operation ID: %s", op.ID)
-	}
+			// the operation exists but the version is different
+			lastErr = dberr.Conflict("operation update conflict, operation ID: %s", op.ID)
+			log.Warn(lastErr.Error())
+			return false, lastErr
+		}
+		return true, nil
+	})
 	op.Version = op.Version + 1
-	return &op, err
+	return &op, lastErr
 }
 
 // GetOperation returns Operation with given ID. Returns an error if the operation does not exists.
 func (s *operations) GetOperation(operationID string) (*internal.Operation, error) {
 	session := s.NewReadSession()
-	dto, err := session.GetOperationByID(operationID)
+	operation := dbsession.OperationDTO{}
+	err := wait.PollImmediate(defaultRetryInterval, defaultRetryTimeout, func() (bool, error) {
+		dto, err := session.GetOperationByID(operationID)
+		if err != nil {
+			log.Warn(errors.Wrapf(err, "while reading Operation from the storage").Error())
+			return false, nil
+		}
+		operation = dto
+		return true, nil
+	})
 	if err != nil {
-		return nil, errors.Wrapf(err, "while reading Operation from the storage")
+		return nil, err
 	}
-	op := toOperation(&dto)
+	op := toOperation(&operation)
 	return &op, nil
 }
 
 func (s *operations) GetOperationsInProgressByType(operationType dbsession.OperationType) ([]internal.Operation, error) {
 	session := s.NewReadSession()
-	dto, err := session.GetOperationsInProgressByType(operationType)
+	operations := make([]dbsession.OperationDTO, 0)
+	err := wait.PollImmediate(defaultRetryInterval, defaultRetryTimeout, func() (bool, error) {
+		dto, err := session.GetOperationsInProgressByType(operationType)
+		if err != nil {
+			log.Warn(errors.Wrapf(err, "while getting Operations from the storage").Error())
+			return false, nil
+		}
+		operations = dto
+		return true, nil
+	})
 	if err != nil {
-		return nil, errors.Wrapf(err, "while getting Operations from the storage")
+		return nil, err
 	}
-	return toOperations(dto), nil
+	return toOperations(operations), nil
 }
 
 func toOperation(op *dbsession.OperationDTO) internal.Operation {

--- a/components/kyma-environment-broker/internal/storage/storage.go
+++ b/components/kyma-environment-broker/internal/storage/storage.go
@@ -7,7 +7,6 @@ import (
 	"github.com/kyma-incubator/compass/components/kyma-environment-broker/internal/storage/postsql"
 )
 
-//go:generate mockery -name=Instances -output=automock -outpkg=automock -case=underscore
 type BrokerStorage interface {
 	Instances() Instances
 	Operations() Operations


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Added retries for operation calls in KEB
- Fixed retries in instance calls to return database error
- Changed Poll -> PollImmediate (0.5s faster)

It's a workaround for this issue: https://github.com/kyma-incubator/compass/issues/998

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
https://github.com/kyma-incubator/compass/issues/998