### PR TITLE
Revert changes in expected status for deprovision call in e2e test

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -55,7 +55,7 @@ global:
         version: "PR-565"
       e2e_provisioning:
         dir:
-        version: "PR-1009"
+        version: "PR-1018"
       connectivity_adapter:
         dir:
         version: "PR-984"

--- a/tests/e2e/provisioning/pkg/client/broker/broker_client.go
+++ b/tests/e2e/provisioning/pkg/client/broker/broker_client.go
@@ -118,7 +118,7 @@ func (c *Client) DeprovisionRuntime() (string, error) {
 	response := provisionResponse{}
 	c.log.Infof("Deprovisioning Runtime [ID: %s, NAME: %s]", c.instanceID, c.clusterName)
 	err := wait.Poll(time.Second, time.Second*5, func() (bool, error) {
-		err := c.executeRequest(http.MethodDelete, deprovisionURL, http.StatusGone, nil, &response)
+		err := c.executeRequest(http.MethodDelete, deprovisionURL, http.StatusOK, nil, &response)
 		if err != nil {
 			c.log.Warn(errors.Wrap(err, "while executing request").Error())
 			return false, nil


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Changed back expected status from `410 GONE` (which is returned when instance does not exists) to `200 OK` which is returned when instance is deleted as a result of deprovision call
**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
#1009 
