### PR TITLE
Fix Runtime Agent naming across docs

### DIFF
--- a/docs/compass/02-01-components.md
+++ b/docs/compass/02-01-components.md
@@ -23,7 +23,7 @@ Runtime is a system to which you can apply configuration provided by Compass. Yo
 
 ## Runtime Agent
 
-Runtime Agent is an integral part of every Runtime and it fetches the latest configuration from Compass. In the future releases, Runtime Agent will:
+Runtime Agent is an integral part of every Runtime and it fetches the latest configuration from Compass. In the future releases, the Runtime Agent will:
 - Provide Runtime specific information that will be displayed in the Compass UI, such as Runtime UI URL
 - Provide Compass with Runtime configuration, such as Event Gateway URL, that should be passed to an Application
 - Send Runtime health checks to Compass

--- a/docs/runtime-agent/runtime-agent-contract.md
+++ b/docs/runtime-agent/runtime-agent-contract.md
@@ -2,14 +2,14 @@
 
 ## Overview
 
-This document describes contract between Management Plane and Runtime Agent. Main responsibilities of the Runtime Agent are:
+This document describes the contract between the Management Plane and the Runtime Agent. The main responsibilities of the Runtime Agent are:
 - [Establishing trusted connection](#establishing-trusted-connection)
 - [Renewing trusted connection](#renewing-trusted-connection)
 - [Configuring the Runtime](#configuring-the-runtime)
 
 ## Establishing trusted connection
 
-Runtime Agent automates the process of [establishing trusted connection](../archive/establishing-trusted-connection.md#establishing-trusted-connection) between Runtime and Management Plane. To initially trigger the process the Runtime Provisioner configures the Runtime Agent providing it the required parameters to establish the trusted connection between Management Plane and the Runtime. The Runtime Agent configuration in its minimal scope requires setting up the form of the initial secured connection to the Connector. Currently, Runtime Provisioner sets up on the Runtime a resource that holds the one-time token to enable the pairing. Runtime Agent triggered by the creation of the resource performs the pairing process and in the end, the trusted connection between the Runtime and the Management Plane is established. At this point further communication between Runtime Agent and Management Plane, and Application and Runtime is possible.
+Runtime Agent automates the process of [establishing trusted connection](../archive/establishing-trusted-connection.md#establishing-trusted-connection) between the Runtime and the Management Plane. To initially trigger the process the Runtime Provisioner configures the Runtime Agent providing it with the required parameters to establish the trusted connection between the Management Plane and the Runtime. The Runtime Agent configuration in its minimal scope requires setting up the form of the initial secured connection to the Connector. Currently, Runtime Provisioner sets up on the Runtime a resource that holds the one-time token to enable the pairing. Runtime Agent triggered by the creation of the resource performs the pairing process and, in the end, the trusted connection between the Runtime and the Management Plane is established. At this point, further communication between the Runtime Agent and the Management Plane, and Application and the Runtime is possible.
 
 ## Renewing trusted connection
 
@@ -23,9 +23,9 @@ In Kyma Runtime, during Runtime configuration, Application's Packages are integr
 
 Runtime Agent periodically requests for the configuration of its Runtime from the Management Plane. Changes in the configuration for the Runtime are applied by the Runtime Agent on the Runtime.
 
-To fetch the Runtime configuration the Runtime Agent calls `applicationsForRuntime(runtimeId: ID!, first: Int = 100, after: PageCursor)` query offered by Director. The response for the query contains a page with list of Applications assigned for the Runtime and info about next page. Each Application will contain only credentials that are valid for the runtime that called the query. Each Runtime Agent can fetch the configurations for Runtimes that belong to its tenant, there is no validation if the Runtime Agent is fetching the configuration for the runtime on which it runs.
+To fetch the Runtime configuration, Runtime Agent calls `applicationsForRuntime(runtimeId: ID!, first: Int = 100, after: PageCursor)` query offered by the Director. The response for the query contains a page with the list of Applications assigned for the Runtime and info about the next page. Each Application will contain only credentials that are valid for the Runtime that called the query. Each Runtime Agent can fetch the configurations for Runtimes that belong to its tenant, there is no validation if the Runtime Agent is fetching the configuration for the Runtime on which it runs.
 
-Runtime Agent reports back to the Director the Runtime specific LabelDefinitions that represent runtime configuration together with their values.
+Runtime Agent reports back to the Director the Runtime-specific LabelDefinitions that represent Runtime configuration together with their values.
 
 Runtime specific LabelDefinitions:
 


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Unify Runtime Agent naming across the whole documentation (`the Runtime Agent`)
- Fix related language mistakes

**Related PR**
See also [#7749](https://github.com/kyma-project/kyma/pull/7749)