### PR TITLE
Correct azure region in broker plans

### DIFF
--- a/components/kyma-environment-broker/internal/broker/plans.go
+++ b/components/kyma-environment-broker/internal/broker/plans.go
@@ -13,7 +13,7 @@ const (
 
 func AzureRegions() []string {
 	return []string{
-		"eastus2",
+		"westus2",
 		"westeurope",
 	}
 }

--- a/components/kyma-environment-broker/internal/broker/plans_test.go
+++ b/components/kyma-environment-broker/internal/broker/plans_test.go
@@ -47,7 +47,7 @@ func TestSchemaGenerator(t *testing.T) {
 		},
 			"region": {
 			"type": "string",
-			"enum": [ "eastus2", "westeurope" ]
+			"enum": [ "westus2", "westeurope" ]
 		},
 			"zone": {
 			"type": "string"


### PR DESCRIPTION
i see that we are referring eastus2 azure region in plans,. this seems like a typo.
