### PR TITLE
Update provisioning documentation with custom component sourceURL info

### DIFF
--- a/docs/provisioner/01-01-provisioner-overview.md
+++ b/docs/provisioner/01-01-provisioner-overview.md
@@ -11,7 +11,7 @@ It allows you to provision the clusters in the following ways:
     * Microsoft Azure
     * Amazon Web Services (AWS).
     
-During the operation of provisioning, you can pass a list of Kyma components you want installed on the provisioned Runtime with their custom configuration, as well as a custom Runtime configuration. 
+During the operation of provisioning, you can pass a list of Kyma components you want installed on the provisioned Runtime with their custom configuration, as well as a custom Runtime configuration. To install a customized version of a given component, you can also provide an [external URL as the installation source](https://kyma-project.io/docs/#configuration-install-components-from-user-defined-ur-ls) for the component. See the [provisioning tutorial](08-02-provisioning-gardener.md) for more details.
     
 Note that the operations of provisioning and deprovisioning are asynchronous. The operation of provisioning returns the Runtime Operation Status containing the Runtime ID and the operation ID. The operation of deprovisioning returns the operation ID. You can use the operation ID to [check the Runtime Operation Status](08-03-runtime-operation-status.md) and the Runtime ID to [check the Runtime Status](08-04-runtime-status.md).
 

--- a/docs/provisioner/08-02-provisioning-gardener.md
+++ b/docs/provisioner/08-02-provisioning-gardener.md
@@ -88,7 +88,7 @@ This tutorial shows how to provision clusters with Kyma Runtimes on Google Cloud
     
      > **NOTE:** The Runtime Agent component (`compass-runtime-agent`) in the Kyma configuration is mandatory and the order of the components matters.
                                                                           
-   ```graphql
+     ```graphql
       mutation {
         provisionRuntime(
           config: {
@@ -129,6 +129,7 @@ This tutorial shows how to provision clusters with Kyma Runtimes on Google Cloud
                       secret: {true|false} # Specifies if the property is confidential
                     }
                   ]
+                  sourceURL: "{CUSTOM_COMPONENT_SOURCE_URL}"
                 }
               ]
               configuration: [
@@ -158,7 +159,7 @@ This tutorial shows how to provision clusters with Kyma Runtimes on Google Cloud
             }
           }
         }
-   ``` 
+      ``` 
     
   </details>
 
@@ -179,7 +180,7 @@ This tutorial shows how to provision clusters with Kyma Runtimes on Google Cloud
   
      > **NOTE:** The Runtime Agent component (`compass-runtime-agent`) in the Kyma configuration is mandatory and the order of the components matters.
                                                                           
-   ```graphql
+      ```graphql
       mutation {
         provisionRuntime(
           config: {
@@ -220,6 +221,7 @@ This tutorial shows how to provision clusters with Kyma Runtimes on Google Cloud
                       secret: {true|false} # Specifies if the property is confidential
                     }
                   ]
+                  sourceURL: "{CUSTOM_COMPONENT_SOURCE_URL}"
                 }
               ]
               configuration: [
@@ -249,7 +251,7 @@ This tutorial shows how to provision clusters with Kyma Runtimes on Google Cloud
           }
         }
       }
-   ```
+      ```
     
   </details>
   
@@ -270,7 +272,7 @@ This tutorial shows how to provision clusters with Kyma Runtimes on Google Cloud
   
      > **NOTE:** The Runtime Agent component (`compass-runtime-agent`) in the Kyma configuration is mandatory and the order of the components matters.
                                                                           
-   ```graphql
+      ```graphql
       mutation {
         provisionRuntime(
           config: {
@@ -318,6 +320,7 @@ This tutorial shows how to provision clusters with Kyma Runtimes on Google Cloud
                       secret: {true|false} # Specifies if the property is confidential
                     }
                   ]
+                  sourceURL: "{CUSTOM_COMPONENT_SOURCE_URL}"
                 }
               ]
               configuration: [
@@ -347,7 +350,7 @@ This tutorial shows how to provision clusters with Kyma Runtimes on Google Cloud
           }
         }
       }
-   ```
+      ```
   </details>
     
 </div>

--- a/docs/provisioner/08-04-runtime-status.md
+++ b/docs/provisioner/08-04-runtime-status.md
@@ -31,11 +31,13 @@ query { runtimeStatus(id: "{RUNTIME_ID}") {
       kymaConfig {
         version  components {
           component
-          namespace configuration {
+          namespace 
+          configuration {
             key
             value
             secret
           }
+          sourceURL
         }
         configuration {
           key value secret


### PR DESCRIPTION
**Description**

With the recent addition to Kyma Installer, there is now a possibility to define the URL Source of a component to be installed. Following this change, such functionality has also been added to the Runtime Provisioner. 

Changes proposed in this pull request:

- Update documentation on provisioning with information on the custom component source URL.

**Related issue(s)**
See #942 

**Related PR(s)**
See #1046 