### PR TITLE
Split e2e-provisioning test into two steps

### DIFF
--- a/chart/compass/charts/kyma-environment-broker/templates/tests/e2e-provisioning-azure.yaml
+++ b/chart/compass/charts/kyma-environment-broker/templates/tests/e2e-provisioning-azure.yaml
@@ -18,8 +18,6 @@ spec:
               value: "3h"
             - name: APP_DEPROVISION_TIMEOUT
               value: "1h"
-            - name: APP_CONFIG_MAP_NAME
-              value: "e2e-runtime-config"
             - name: APP_SKIP_CERT_VERIFICATION
               value: "true"
             - name: APP_TENANT_ID
@@ -49,8 +47,10 @@ spec:
               value: "uaa-issuer"
             - name: APP_RUNTIME_UUA_INSTANCE_NAMESPACE
               value: "kyma-system"
-            - name: APP_RUNTIME_CONFIG_NAME
+            - name: APP_CONFIG_NAME
               value: "{{ .Values.e2e.azure.configName }}"
+            - name: APP_DEPLOY_NAMESPACE
+              value: "compass-system"
             - name: APP_DIRECTOR_URL
               value: "https://{{ .Values.global.gateway.tls.secure.oauth.host }}.{{ .Values.global.ingress.domainName }}/director/graphql"
             - name: APP_DIRECTOR_NAMESPACE
@@ -81,8 +81,6 @@ spec:
               value: "3h"
             - name: APP_DEPROVISION_TIMEOUT
               value: "1h"
-            - name: APP_CONFIG_MAP_NAME
-              value: "e2e-runtime-config"
             - name: APP_SKIP_CERT_VERIFICATION
               value: "true"
             - name: APP_TENANT_ID
@@ -108,13 +106,10 @@ spec:
               value: "uaa-issuer"
             - name: APP_RUNTIME_UUA_INSTANCE_NAMESPACE
               value: "kyma-system"
-            - name: APP_RUNTIME_CONFIG_NAME
+            - name: APP_CONFIG_NAME
               value: "{{ .Values.e2e.azure.configName }}"
-            - name: APP_INSTANCE_ID
-              valueFrom:
-                configMapKeyRef:
-                  name: "{{ .Values.e2e.azure.configName }}"
-                  key: instanceID
+            - name: APP_DEPLOY_NAMESPACE
+              value: "compass-system"
             - name: APP_DIRECTOR_URL
               value: "https://{{ .Values.global.gateway.tls.secure.oauth.host }}.{{ .Values.global.ingress.domainName }}/director/graphql"
             - name: APP_DIRECTOR_NAMESPACE

--- a/chart/compass/charts/kyma-environment-broker/templates/tests/e2e-provisioning-azure.yaml
+++ b/chart/compass/charts/kyma-environment-broker/templates/tests/e2e-provisioning-azure.yaml
@@ -49,8 +49,8 @@ spec:
               value: "uaa-issuer"
             - name: APP_RUNTIME_UUA_INSTANCE_NAMESPACE
               value: "kyma-system"
-            - name: APP_RUNTIME_KUBECONFIG_SECRET_NAME
-              value: "e2e-runtime-kubeconfig"
+            - name: APP_RUNTIME_CONFIG_NAME
+              value: "{{ .Values.e2e.azure.configName }}"
             - name: APP_DIRECTOR_URL
               value: "https://{{ .Values.global.gateway.tls.secure.oauth.host }}.{{ .Values.global.ingress.domainName }}/director/graphql"
             - name: APP_DIRECTOR_NAMESPACE
@@ -66,7 +66,7 @@ kind: TestDefinition
 metadata:
   name: e2e-provisioning-azure-cleanup
   labels:
-{{ include "kyma-env-broker.labels" . | indent 4 }}
+  {{ include "kyma-env-broker.labels" . | indent 4 }}
 spec:
   disableConcurrency: false
   template:
@@ -108,8 +108,13 @@ spec:
               value: "uaa-issuer"
             - name: APP_RUNTIME_UUA_INSTANCE_NAMESPACE
               value: "kyma-system"
-            - name: APP_RUNTIME_KUBECONFIG_SECRET_NAME
-              value: "e2e-runtime-kubeconfig"
+            - name: APP_RUNTIME_CONFIG_NAME
+              value: "{{ .Values.e2e.azure.configName }}"
+            - name: APP_INSTANCE_ID
+              valueFrom:
+                configMapKeyRef:
+                  name: "{{ .Values.e2e.azure.configName }}"
+                  key: instanceID
             - name: APP_DIRECTOR_URL
               value: "https://{{ .Values.global.gateway.tls.secure.oauth.host }}.{{ .Values.global.ingress.domainName }}/director/graphql"
             - name: APP_DIRECTOR_NAMESPACE

--- a/chart/compass/charts/kyma-environment-broker/templates/tests/e2e-provisioning-azure.yaml
+++ b/chart/compass/charts/kyma-environment-broker/templates/tests/e2e-provisioning-azure.yaml
@@ -1,0 +1,120 @@
+apiVersion: "testing.kyma-project.io/v1alpha1"
+kind: TestDefinition
+metadata:
+  name: e2e-provisioning-azure
+  labels:
+  {{ include "kyma-env-broker.labels" . | indent 4 }}
+spec:
+  disableConcurrency: false
+  template:
+    spec:
+      serviceAccountName: e2e-provisioning
+      containers:
+        - name: tests
+          image: {{ .Values.global.images.containerRegistry.path }}/{{ .Values.global.images.tests.e2e_provisioning.dir }}e2e-provisioning-test:{{ .Values.global.images.tests.e2e_provisioning.version }}
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: APP_PROVISION_TIMEOUT
+              value: "3h"
+            - name: APP_DEPROVISION_TIMEOUT
+              value: "1h"
+            - name: APP_CONFIG_MAP_NAME
+              value: "e2e-runtime-config"
+            - name: APP_SKIP_CERT_VERIFICATION
+              value: "true"
+            - name: APP_TENANT_ID
+              value: "{{ .Values.global.defaultTenant }}"
+            - name: APP_DUMMY_TEST
+              # For now it is set to `true`, because if anyone set global.provisioning.enabled to `true`
+              # then this test will be executed on the pre-master-compass-integration job with the rest of the acceptance tests.
+              # With the Dummy test, we won't block the pipelines.
+              # In future we can make that test useful for pre-master jobs.
+              value: "true"
+            - name: APP_CLEANUP_PHASE
+              value: "false"
+            - name: APP_BROKER_URL
+              value: 'https://{{ .Values.host }}.{{ .Values.global.ingress.domainName }}'
+            - name: APP_BROKER_PROVISION_GCP
+              value: "false"
+            - name: APP_BROKER_AUTH_USERNAME
+              value: "{{ .Values.broker.username }}"
+            - name: APP_BROKER_AUTH_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "kyma-env-broker.fullname" . }}
+                  key: broker-password
+            - name: APP_RUNTIME_PROVISIONER_URL
+              value: "{{ .Values.provisioner.URL }}"
+            - name: APP_RUNTIME_UUA_INSTANCE_NAME
+              value: "uaa-issuer"
+            - name: APP_RUNTIME_UUA_INSTANCE_NAMESPACE
+              value: "kyma-system"
+            - name: APP_RUNTIME_KUBECONFIG_SECRET_NAME
+              value: "e2e-runtime-kubeconfig"
+            - name: APP_DIRECTOR_URL
+              value: "https://{{ .Values.global.gateway.tls.secure.oauth.host }}.{{ .Values.global.ingress.domainName }}/director/graphql"
+            - name: APP_DIRECTOR_NAMESPACE
+              value: "compass-system"
+            - name: APP_DIRECTOR_OAUTH_CREDENTIALS_SECRET_NAME
+              value: "{{ .Values.global.kyma_environment_broker.secrets.integrationSystemCredentials.name }}"
+          command: ["/bin/sh"]
+          args: ["-c", "echo 'Starting e2e-provisioning test on Azure. Waiting 20s for api server...'; sleep 20; ./test.test; exit_code=$?; curl -XPOST http://127.0.0.1:15020/quitquitquit; sleep 4; exit $exit_code;"]
+
+---
+apiVersion: "testing.kyma-project.io/v1alpha1"
+kind: TestDefinition
+metadata:
+  name: e2e-provisioning-azure-cleanup
+  labels:
+{{ include "kyma-env-broker.labels" . | indent 4 }}
+spec:
+  disableConcurrency: false
+  template:
+    spec:
+      serviceAccountName: e2e-provisioning
+      containers:
+        - name: tests
+          image: {{ .Values.global.images.containerRegistry.path }}/{{ .Values.global.images.tests.e2e_provisioning.dir }}e2e-provisioning-test:{{ .Values.global.images.tests.e2e_provisioning.version }}
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: APP_PROVISION_TIMEOUT
+              value: "3h"
+            - name: APP_DEPROVISION_TIMEOUT
+              value: "1h"
+            - name: APP_CONFIG_MAP_NAME
+              value: "e2e-runtime-config"
+            - name: APP_SKIP_CERT_VERIFICATION
+              value: "true"
+            - name: APP_TENANT_ID
+              value: "{{ .Values.global.defaultTenant }}"
+            - name: APP_DUMMY_TEST
+              value: "true"
+            - name: APP_CLEANUP_PHASE
+              value: "true"
+            - name: APP_BROKER_URL
+              value: 'https://{{ .Values.host }}.{{ .Values.global.ingress.domainName }}'
+            - name: APP_BROKER_PROVISION_GCP
+              value: "false"
+            - name: APP_BROKER_AUTH_USERNAME
+              value: "{{ .Values.broker.username }}"
+            - name: APP_BROKER_AUTH_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "kyma-env-broker.fullname" . }}
+                  key: broker-password
+            - name: APP_RUNTIME_PROVISIONER_URL
+              value: "{{ .Values.provisioner.URL }}"
+            - name: APP_RUNTIME_UUA_INSTANCE_NAME
+              value: "uaa-issuer"
+            - name: APP_RUNTIME_UUA_INSTANCE_NAMESPACE
+              value: "kyma-system"
+            - name: APP_RUNTIME_KUBECONFIG_SECRET_NAME
+              value: "e2e-runtime-kubeconfig"
+            - name: APP_DIRECTOR_URL
+              value: "https://{{ .Values.global.gateway.tls.secure.oauth.host }}.{{ .Values.global.ingress.domainName }}/director/graphql"
+            - name: APP_DIRECTOR_NAMESPACE
+              value: "compass-system"
+            - name: APP_DIRECTOR_OAUTH_CREDENTIALS_SECRET_NAME
+              value: "{{ .Values.global.kyma_environment_broker.secrets.integrationSystemCredentials.name }}"
+          command: ["/bin/sh"]
+          args: ["-c", "echo 'Starting e2e-provisioning cleanup test on Azure. Waiting 20s for api server...'; sleep 20; ./test.test; exit_code=$?; curl -XPOST http://127.0.0.1:15020/quitquitquit; sleep 4; exit $exit_code;"]

--- a/chart/compass/charts/kyma-environment-broker/templates/tests/e2e-provisioning-gcp.yaml
+++ b/chart/compass/charts/kyma-environment-broker/templates/tests/e2e-provisioning-gcp.yaml
@@ -49,8 +49,8 @@ spec:
               value: "uaa-issuer"
             - name: APP_RUNTIME_UUA_INSTANCE_NAMESPACE
               value: "kyma-system"
-            - name: APP_RUNTIME_KUBECONFIG_SECRET_NAME
-              value: "e2e-runtime-kubeconfig"
+            - name: APP_RUNTIME_CONFIG_NAME
+              value: "{{ .Values.e2e.gcp.configName }}"
             - name: APP_DIRECTOR_URL
               value: "https://{{ .Values.global.gateway.tls.secure.oauth.host }}.{{ .Values.global.ingress.domainName }}/director/graphql"
             - name: APP_DIRECTOR_NAMESPACE
@@ -86,7 +86,7 @@ spec:
               value: "true"
             - name: APP_TENANT_ID
               value: "{{ .Values.global.defaultTenant }}"
-            - name: APP_DUMMY_TEST}
+            - name: APP_DUMMY_TEST
               value: "false"
             - name: APP_CLEANUP_PHASE
               value: "true"
@@ -107,8 +107,13 @@ spec:
               value: "uaa-issuer"
             - name: APP_RUNTIME_UUA_INSTANCE_NAMESPACE
               value: "kyma-system"
-            - name: APP_RUNTIME_KUBECONFIG_SECRET_NAME
-              value: "e2e-runtime-kubeconfig"
+            - name: APP_RUNTIME_CONFIG_NAME
+              value: "{{ .Values.e2e.gcp.configName }}"
+            - name: APP_INSTANCE_ID
+              valueFrom:
+                configMapKeyRef:
+                  name: "{{ .Values.e2e.gcp.configName }}"
+                  key: instanceID
             - name: APP_DIRECTOR_URL
               value: "https://{{ .Values.global.gateway.tls.secure.oauth.host }}.{{ .Values.global.ingress.domainName }}/director/graphql"
             - name: APP_DIRECTOR_NAMESPACE

--- a/chart/compass/charts/kyma-environment-broker/templates/tests/e2e-provisioning-gcp.yaml
+++ b/chart/compass/charts/kyma-environment-broker/templates/tests/e2e-provisioning-gcp.yaml
@@ -27,7 +27,7 @@ spec:
               # then this test will be executed on the pre-master-compass-integration job with the rest of the acceptance tests.
               # With the Dummy test, we won't block the pipelines.
               # In future we can make that test useful for pre-master jobs.
-              value: "false"
+              value: "true"
             - name: APP_CLEANUP_PHASE
               value: "false"
             - name: APP_BROKER_URL
@@ -85,7 +85,7 @@ spec:
             - name: APP_TENANT_ID
               value: "{{ .Values.global.defaultTenant }}"
             - name: APP_DUMMY_TEST
-              value: "false"
+              value: "true"
             - name: APP_CLEANUP_PHASE
               value: "true"
             - name: APP_BROKER_URL

--- a/chart/compass/charts/kyma-environment-broker/templates/tests/e2e-provisioning-gcp.yaml
+++ b/chart/compass/charts/kyma-environment-broker/templates/tests/e2e-provisioning-gcp.yaml
@@ -1,45 +1,3 @@
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: e2e-provisioning
-  namespace: {{ .Release.Namespace }}
-  labels:
-{{ include "kyma-env-broker.labels" . | indent 4 }}
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: e2e-provisioning
-  namespace: {{ .Release.Namespace }}
-  labels:
-{{ include "kyma-env-broker.labels" . | indent 4 }}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: e2e-provisioning
-subjects:
-  - kind: ServiceAccount
-    name: e2e-provisioning
-    namespace: {{ .Release.Namespace }}
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: e2e-provisioning
-  namespace: {{ .Release.Namespace }}
-  labels:
-{{ include "kyma-env-broker.labels" . | indent 4 }}
-rules:
-  - apiGroups: ["*"]
-    resources: ["secrets"]
-    verbs: ["get"]
-  - apiGroups: ["*"]
-    resources: ["pods", "pods/log"]
-    verbs: ["get", "list"]
-  - apiGroups: ["testing.kyma-project.io"]
-    resources: ["clustertestsuites", "testdefinitions"]
-    verbs: ["*"]
----
 apiVersion: "testing.kyma-project.io/v1alpha1"
 kind: TestDefinition
 metadata:
@@ -60,16 +18,20 @@ spec:
               value: "3h"
             - name: APP_DEPROVISION_TIMEOUT
               value: "1h"
+            - name: APP_CONFIG_MAP_NAME
+              value: "e2e-runtime-config"
             - name: APP_SKIP_CERT_VERIFICATION
               value: "true"
             - name: APP_TENANT_ID
               value: "{{ .Values.global.defaultTenant }}"
             - name: APP_DUMMY_TEST
-              # For now it is set to `true`, because if anyone set global.provisioning.enabled to `true` 
+              # For now it is set to `true`, because if anyone set global.provisioning.enabled to `true`
               # then this test will be executed on the pre-master-compass-integration job with the rest of the acceptance tests.
               # With the Dummy test, we won't block the pipelines.
               # In future we can make that test useful for pre-master jobs.
-              value: "true"
+              value: "false"
+            - name: APP_CLEANUP_PHASE
+              value: "false"
             - name: APP_BROKER_URL
               value: 'https://{{ .Values.host }}.{{ .Values.global.ingress.domainName }}'
             - name: APP_BROKER_PROVISION_GCP
@@ -87,6 +49,8 @@ spec:
               value: "uaa-issuer"
             - name: APP_RUNTIME_UUA_INSTANCE_NAMESPACE
               value: "kyma-system"
+            - name: APP_RUNTIME_KUBECONFIG_SECRET_NAME
+              value: "e2e-runtime-kubeconfig"
             - name: APP_DIRECTOR_URL
               value: "https://{{ .Values.global.gateway.tls.secure.oauth.host }}.{{ .Values.global.ingress.domainName }}/director/graphql"
             - name: APP_DIRECTOR_NAMESPACE
@@ -99,9 +63,9 @@ spec:
 apiVersion: "testing.kyma-project.io/v1alpha1"
 kind: TestDefinition
 metadata:
-  name: e2e-provisioning-azure
+  name: e2e-provisioning-cleanup
   labels:
-{{ include "kyma-env-broker.labels" . | indent 4 }}
+  {{ include "kyma-env-broker.labels" . | indent 4 }}
 spec:
   disableConcurrency: false
   template:
@@ -116,16 +80,20 @@ spec:
               value: "3h"
             - name: APP_DEPROVISION_TIMEOUT
               value: "1h"
+            - name: APP_CONFIG_MAP_NAME
+              value: "e2e-runtime-config"
             - name: APP_SKIP_CERT_VERIFICATION
               value: "true"
             - name: APP_TENANT_ID
               value: "{{ .Values.global.defaultTenant }}"
-            - name: APP_DUMMY_TEST
+            - name: APP_DUMMY_TEST}
+              value: "false"
+            - name: APP_CLEANUP_PHASE
               value: "true"
             - name: APP_BROKER_URL
               value: 'https://{{ .Values.host }}.{{ .Values.global.ingress.domainName }}'
             - name: APP_BROKER_PROVISION_GCP
-              value: "false"
+              value: "true"
             - name: APP_BROKER_AUTH_USERNAME
               value: "{{ .Values.broker.username }}"
             - name: APP_BROKER_AUTH_PASSWORD
@@ -139,6 +107,8 @@ spec:
               value: "uaa-issuer"
             - name: APP_RUNTIME_UUA_INSTANCE_NAMESPACE
               value: "kyma-system"
+            - name: APP_RUNTIME_KUBECONFIG_SECRET_NAME
+              value: "e2e-runtime-kubeconfig"
             - name: APP_DIRECTOR_URL
               value: "https://{{ .Values.global.gateway.tls.secure.oauth.host }}.{{ .Values.global.ingress.domainName }}/director/graphql"
             - name: APP_DIRECTOR_NAMESPACE
@@ -146,4 +116,4 @@ spec:
             - name: APP_DIRECTOR_OAUTH_CREDENTIALS_SECRET_NAME
               value: "{{ .Values.global.kyma_environment_broker.secrets.integrationSystemCredentials.name }}"
           command: ["/bin/sh"]
-          args: ["-c", "echo 'Starting e2e-provisioning test on Azure. Waiting 20s for api server...'; sleep 20; ./test.test; exit_code=$?; curl -XPOST http://127.0.0.1:15020/quitquitquit; sleep 4; exit $exit_code;"]
+          args: ["-c", "echo 'Starting e2e-provisioning cleanup test on GCP. Waiting 20s for api server...'; sleep 20; ./test.test; exit_code=$?; curl -XPOST http://127.0.0.1:15020/quitquitquit; sleep 4; exit $exit_code;"]

--- a/chart/compass/charts/kyma-environment-broker/templates/tests/e2e-provisioning-gcp.yaml
+++ b/chart/compass/charts/kyma-environment-broker/templates/tests/e2e-provisioning-gcp.yaml
@@ -18,8 +18,6 @@ spec:
               value: "3h"
             - name: APP_DEPROVISION_TIMEOUT
               value: "1h"
-            - name: APP_CONFIG_MAP_NAME
-              value: "e2e-runtime-config"
             - name: APP_SKIP_CERT_VERIFICATION
               value: "true"
             - name: APP_TENANT_ID
@@ -49,8 +47,10 @@ spec:
               value: "uaa-issuer"
             - name: APP_RUNTIME_UUA_INSTANCE_NAMESPACE
               value: "kyma-system"
-            - name: APP_RUNTIME_CONFIG_NAME
+            - name: APP_CONFIG_NAME
               value: "{{ .Values.e2e.gcp.configName }}"
+            - name: APP_DEPLOY_NAMESPACE
+              value: "compass-system"
             - name: APP_DIRECTOR_URL
               value: "https://{{ .Values.global.gateway.tls.secure.oauth.host }}.{{ .Values.global.ingress.domainName }}/director/graphql"
             - name: APP_DIRECTOR_NAMESPACE
@@ -80,8 +80,6 @@ spec:
               value: "3h"
             - name: APP_DEPROVISION_TIMEOUT
               value: "1h"
-            - name: APP_CONFIG_MAP_NAME
-              value: "e2e-runtime-config"
             - name: APP_SKIP_CERT_VERIFICATION
               value: "true"
             - name: APP_TENANT_ID
@@ -107,13 +105,10 @@ spec:
               value: "uaa-issuer"
             - name: APP_RUNTIME_UUA_INSTANCE_NAMESPACE
               value: "kyma-system"
-            - name: APP_RUNTIME_CONFIG_NAME
+            - name: APP_CONFIG_NAME
               value: "{{ .Values.e2e.gcp.configName }}"
-            - name: APP_INSTANCE_ID
-              valueFrom:
-                configMapKeyRef:
-                  name: "{{ .Values.e2e.gcp.configName }}"
-                  key: instanceID
+            - name: APP_DEPLOY_NAMESPACE
+              value: "compass-system"
             - name: APP_DIRECTOR_URL
               value: "https://{{ .Values.global.gateway.tls.secure.oauth.host }}.{{ .Values.global.ingress.domainName }}/director/graphql"
             - name: APP_DIRECTOR_NAMESPACE

--- a/chart/compass/charts/kyma-environment-broker/templates/tests/rbac.yaml
+++ b/chart/compass/charts/kyma-environment-broker/templates/tests/rbac.yaml
@@ -32,7 +32,7 @@ metadata:
 rules:
   - apiGroups: ["*"]
     resources: ["secrets", "configmaps"]
-    verbs: ["get", "create", "delete"]
+    verbs: ["get", "create", "update", "delete"]
   - apiGroups: ["*"]
     resources: ["pods", "pods/log"]
     verbs: ["get", "list"]

--- a/chart/compass/charts/kyma-environment-broker/templates/tests/rbac.yaml
+++ b/chart/compass/charts/kyma-environment-broker/templates/tests/rbac.yaml
@@ -31,8 +31,8 @@ metadata:
   {{ include "kyma-env-broker.labels" . | indent 4 }}
 rules:
   - apiGroups: ["*"]
-    resources: ["secrets"]
-    verbs: ["get"]
+    resources: ["secrets", "configmaps"]
+    verbs: ["get", "create", "delete"]
   - apiGroups: ["*"]
     resources: ["pods", "pods/log"]
     verbs: ["get", "list"]

--- a/chart/compass/charts/kyma-environment-broker/templates/tests/rbac.yaml
+++ b/chart/compass/charts/kyma-environment-broker/templates/tests/rbac.yaml
@@ -1,0 +1,41 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: e2e-provisioning
+  namespace: {{ .Release.Namespace }}
+  labels:
+  {{ include "kyma-env-broker.labels" . | indent 4 }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: e2e-provisioning
+  namespace: {{ .Release.Namespace }}
+  labels:
+  {{ include "kyma-env-broker.labels" . | indent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: e2e-provisioning
+subjects:
+  - kind: ServiceAccount
+    name: e2e-provisioning
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: e2e-provisioning
+  namespace: {{ .Release.Namespace }}
+  labels:
+  {{ include "kyma-env-broker.labels" . | indent 4 }}
+rules:
+  - apiGroups: ["*"]
+    resources: ["secrets"]
+    verbs: ["get"]
+  - apiGroups: ["*"]
+    resources: ["pods", "pods/log"]
+    verbs: ["get", "list"]
+  - apiGroups: ["testing.kyma-project.io"]
+    resources: ["clustertestsuites", "testdefinitions"]
+    verbs: ["*"]

--- a/chart/compass/charts/kyma-environment-broker/values.yaml
+++ b/chart/compass/charts/kyma-environment-broker/values.yaml
@@ -78,3 +78,9 @@ lms:
   environment: "dev"
   samlTenant: "TBD"
   disabled: false
+
+e2e:
+  azure:
+    configName: "e2e-runtime-config-azure"
+  gcp:
+    configName: "e2e-runtime-config-gcp"

--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -55,7 +55,7 @@ global:
         version: "PR-1046"
       e2e_provisioning:
         dir:
-        version: "PR-1018"
+        version: "PR-1139"
       connectivity_adapter:
         dir:
         version: "PR-984"

--- a/tests/e2e/provisioning/README.md
+++ b/tests/e2e/provisioning/README.md
@@ -19,9 +19,10 @@ You must also have the Kyma Environment Broker [configured](https://github.com/k
 The provisioning end-to-end test contains a broker client implementation which mocks Registry. It is an external dependency that calls the broker in the regular scenario. The test is divided into two phases:
 
 1. Provisioning
-During the provisioning phase, the test executes the following steps:
+
+    During the provisioning phase, the test executes the following steps:
     
-    a. Sends a call to KEB to provision a Runtime. KEB creates an operation and sends a request to the Runtime Provisioner. Wait until the operation is successful. It takes about 30 minutes on GCP and a few hours on Azure. You can configure the timeout using the environment variable. 
+    a. Sends a call to KEB to provision a Runtime. KEB creates an operation and sends a request to the Runtime Provisioner. The test waits until the operation is successful. It takes about 30 minutes on GCP and a few hours on Azure. You can configure the timeout using the environment variable. 
     
     b. Creates a ConfigMap with **instanceId** specified.
     

--- a/tests/e2e/provisioning/README.md
+++ b/tests/e2e/provisioning/README.md
@@ -34,7 +34,7 @@ The provisioning end-to-end test contains a broker client implementation which m
 
 2. Cleanup
 
-    The cleanup logic is executed at the end of the end-to-end test or when the provisioning phase fails. It consists of the following steps:
+    The cleanup logic is executed at the end of the end-to-end test or when the provisioning phase fails. During this phase, the test executes the following steps:
     
     a. Gets **instanceId** from the ConfigMap.
     

--- a/tests/e2e/provisioning/README.md
+++ b/tests/e2e/provisioning/README.md
@@ -20,33 +20,33 @@ The provisioning end-to-end test contains a broker client implementation which m
 
 1. Provisioning:
     
-    a. Send a call to KEB to provision a Runtime. KEB creates an operation and sends a request to Runtime Provisioner. Wait until the operation is successful. It takes about 30 minutes on GCP and a few hours on Azure. You can configure the timeout using the environment variable. 
+    a. Sends a call to KEB to provision a Runtime. KEB creates an operation and sends a request to the Runtime Provisioner. Wait until the operation is successful. It takes about 30 minutes on GCP and a few hours on Azure. You can configure the timeout using the environment variable. 
     
-    b. Creates a config map with `instanceId` specified.
+    b. Creates a ConfigMap with **instanceId** specified.
     
-    c. Fetch the DashboardURL from KEB. To do so, the Runtime must be successfully provisioned and registered in the Director.
+    c. Fetches the DashboardURL from KEB. To do so, the Runtime must be successfully provisioned and registered in the Director.
     
-    d. Updates config map with `dashboardUrl` field.
+    d. Updates the ConfigMap with **dashboardUrl** field.
     
-    e. Creates a secret with a kubeconfig of the provisioned runtime.
+    e. Creates a Secret with a kubeconfig of the provisioned Runtime.
     
-    f. Ensure that the DashboardURL redirects you to the UUA login page. It means that the Kyma Runtime is accessible.
+    f. Ensures that the DashboardURL redirects to the UUA login page. It means that the Kyma Runtime is accessible.
 
 2. Cleanup
 
-    The cleanup logic is executed at the end of the e2e test or if the provisioning phase failed. It consists of the following steps:
+    The cleanup logic is executed at the end of the end-to-end test or when the provisioning phase fails. It consists of the following steps:
     
-    a. Get `instanceId` from the config map.
+    a. Gets **instanceId** from the ConfigMap.
     
-    b. Remove the test's secret and config map.
+    b. Removes the test's Secret and ConfigMap.
     
-    c. Fetch the Runtime kubeconfig from Provisioner and use it to clean resources which block the cluster from deprovisioning.
+    c. Fetches the Runtime kubeconfig from the Runtime Provisioner and uses it to clean resources which block the cluster from deprovisioning.
     
-    d. Send a request to deprovision the Runtime to KEB. The request is passed to Runtime Provisioner which deprovisions the Runtime.
+    d. Sends a request to deprovision the Runtime to KEB. The request is passed to the Runtime Provisioner which deprovisions the Runtime.
     
-    e. Wait until the deprovisioning is successful. It takes about 20 minutes to complete. You can configure the timeout using the environment variable.
+    e. Waits until the deprovisioning is successful. It takes about 20 minutes to complete. You can configure the timeout using the environment variable.
 
-Between the above steps you can execute your own test directly on the provisioned runtime, using a kubeconfig fetched from the Provisioner.
+Between the end-to-end test phases, you can execute your own test directly on the provisioned Runtime. To do so, use a kubeconfig stored in a Secret created in the provisioning phase. 
 
 ## Configuration
 
@@ -69,6 +69,6 @@ You can configure the test execution by using the following environment variable
 | **APP_DIRECTOR_OAUTH_CREDENTIALS_SECRET_NAME** | Specifies the name of the Secret created by the Integration System. | `compass-kyma-environment-broker-credentials` |
 | **APP_SKIP_CERT_VERIFICATION** | Specifies whether TLS checks the presented certificates. | `false` |
 | **APP_DUMMY_TEST** | Specifies if test should success without any action. | `false` |
-| **APP_CLEANUP_PHASE** | Specifies if test is executed in the cleanup phase. | `false` |
-| **APP_CONFIG_NAME** | Specifies the name of the config map and secret, created in the test. | `false` |
-| **APP_DEPLOY_NAME** | Specifies the namespace of the config map and secret, created in the test. | `false` |
+| **APP_CLEANUP_PHASE** | Specifies if the test executes the cleanup phase. | `false` |
+| **APP_CONFIG_NAME** | Specifies the name of the ConfigMap and Secret created in the test. | `e2e-runtime-config` |
+| **APP_DEPLOY_NAMESPACE** | Specifies the Namespace of the ConfigMap and Secret created in the test. | `compass-system` |

--- a/tests/e2e/provisioning/README.md
+++ b/tests/e2e/provisioning/README.md
@@ -19,21 +19,21 @@ You must also have the Kyma Environment Broker [configured](https://github.com/k
 The provisioning end-to-end test contains a broker client implementation which mocks Registry. It is an external dependency that calls the broker in the regular scenario. The test is divided into two phases:
 
 1. Provisioning:
-    - Send the a call to KEB to provision a Runtime. KEB creates an operation and sends a request to Runtime Provisioner. Wait until the operation is successful. It takes about 30 minutes on GCP and a few hours on Azure. You can configure the timeout using the environment variable. 
-    - Creates a config map with `instanceId` specified.
-    - Fetch the DashboardURL from KEB. To do so, the Runtime must be successfully provisioned and registered in the Director.
-    - Updates config map with `dashboardUrl` field.
-    - Creates a secret with a kubeconfig of the provisioned runtime.
-    - Ensure that the DashboardURL redirects you to the UUA login page. It means that the Kyma Runtime is accessible.
+    a) Send a call to KEB to provision a Runtime. KEB creates an operation and sends a request to Runtime Provisioner. Wait until the operation is successful. It takes about 30 minutes on GCP and a few hours on Azure. You can configure the timeout using the environment variable. 
+    b) Creates a config map with `instanceId` specified.
+    c) Fetch the DashboardURL from KEB. To do so, the Runtime must be successfully provisioned and registered in the Director.
+    d) Updates config map with `dashboardUrl` field.
+    e) Creates a secret with a kubeconfig of the provisioned runtime.
+    f) Ensure that the DashboardURL redirects you to the UUA login page. It means that the Kyma Runtime is accessible.
 
 2. Cleaning up
 
     The cleanup logic is executed at the end of the e2e test or if the provisioning phase failed. It consists of the following steps:
-    - Get `instanceId` from the config map.
-    - Remove the test's secret and config map.
-    - Fetch the Runtime kubeconfig from Provisioner and use it to clean resources which block the cluster from deprovisioning.
-    - Send a request to deprovision the Runtime to KEB. The request is passed to Runtime Provisioner which deprovisions the Runtime.
-    - Wait until the deprovisioning is successful. It takes about 20 minutes to complete. You can configure the timeout using the environment variable.
+    a) Get `instanceId` from the config map.
+    b) Remove the test's secret and config map.
+    c) Fetch the Runtime kubeconfig from Provisioner and use it to clean resources which block the cluster from deprovisioning.
+    d) Send a request to deprovision the Runtime to KEB. The request is passed to Runtime Provisioner which deprovisions the Runtime.
+    e) Wait until the deprovisioning is successful. It takes about 20 minutes to complete. You can configure the timeout using the environment variable.
 
 Between the above steps you can execute your own test directly on the provisioned runtime, using a kubeconfig fetched from the Provisioner.
 

--- a/tests/e2e/provisioning/README.md
+++ b/tests/e2e/provisioning/README.md
@@ -18,7 +18,8 @@ You must also have the Kyma Environment Broker [configured](https://github.com/k
 
 The provisioning end-to-end test contains a broker client implementation which mocks Registry. It is an external dependency that calls the broker in the regular scenario. The test is divided into two phases:
 
-1. Provisioning:
+1. Provisioning
+During the provisioning phase, the test executes the following steps:
     
     a. Sends a call to KEB to provision a Runtime. KEB creates an operation and sends a request to the Runtime Provisioner. Wait until the operation is successful. It takes about 30 minutes on GCP and a few hours on Azure. You can configure the timeout using the environment variable. 
     

--- a/tests/e2e/provisioning/README.md
+++ b/tests/e2e/provisioning/README.md
@@ -32,7 +32,7 @@ The provisioning end-to-end test contains a broker client implementation which m
     
     f. Ensure that the DashboardURL redirects you to the UUA login page. It means that the Kyma Runtime is accessible.
 
-2. Cleaning up
+2. Cleanup
 
     The cleanup logic is executed at the end of the e2e test or if the provisioning phase failed. It consists of the following steps:
     

--- a/tests/e2e/provisioning/README.md
+++ b/tests/e2e/provisioning/README.md
@@ -19,21 +19,32 @@ You must also have the Kyma Environment Broker [configured](https://github.com/k
 The provisioning end-to-end test contains a broker client implementation which mocks Registry. It is an external dependency that calls the broker in the regular scenario. The test is divided into two phases:
 
 1. Provisioning:
-    a) Send a call to KEB to provision a Runtime. KEB creates an operation and sends a request to Runtime Provisioner. Wait until the operation is successful. It takes about 30 minutes on GCP and a few hours on Azure. You can configure the timeout using the environment variable. 
-    b) Creates a config map with `instanceId` specified.
-    c) Fetch the DashboardURL from KEB. To do so, the Runtime must be successfully provisioned and registered in the Director.
-    d) Updates config map with `dashboardUrl` field.
-    e) Creates a secret with a kubeconfig of the provisioned runtime.
-    f) Ensure that the DashboardURL redirects you to the UUA login page. It means that the Kyma Runtime is accessible.
+    
+    a. Send a call to KEB to provision a Runtime. KEB creates an operation and sends a request to Runtime Provisioner. Wait until the operation is successful. It takes about 30 minutes on GCP and a few hours on Azure. You can configure the timeout using the environment variable. 
+    
+    b. Creates a config map with `instanceId` specified.
+    
+    c. Fetch the DashboardURL from KEB. To do so, the Runtime must be successfully provisioned and registered in the Director.
+    
+    d. Updates config map with `dashboardUrl` field.
+    
+    e. Creates a secret with a kubeconfig of the provisioned runtime.
+    
+    f. Ensure that the DashboardURL redirects you to the UUA login page. It means that the Kyma Runtime is accessible.
 
 2. Cleaning up
 
     The cleanup logic is executed at the end of the e2e test or if the provisioning phase failed. It consists of the following steps:
-    a) Get `instanceId` from the config map.
-    b) Remove the test's secret and config map.
-    c) Fetch the Runtime kubeconfig from Provisioner and use it to clean resources which block the cluster from deprovisioning.
-    d) Send a request to deprovision the Runtime to KEB. The request is passed to Runtime Provisioner which deprovisions the Runtime.
-    e) Wait until the deprovisioning is successful. It takes about 20 minutes to complete. You can configure the timeout using the environment variable.
+    
+    a. Get `instanceId` from the config map.
+    
+    b. Remove the test's secret and config map.
+    
+    c. Fetch the Runtime kubeconfig from Provisioner and use it to clean resources which block the cluster from deprovisioning.
+    
+    d. Send a request to deprovision the Runtime to KEB. The request is passed to Runtime Provisioner which deprovisions the Runtime.
+    
+    e. Wait until the deprovisioning is successful. It takes about 20 minutes to complete. You can configure the timeout using the environment variable.
 
 Between the above steps you can execute your own test directly on the provisioned runtime, using a kubeconfig fetched from the Provisioner.
 

--- a/tests/e2e/provisioning/pkg/client/broker/broker_client.go
+++ b/tests/e2e/provisioning/pkg/client/broker/broker_client.go
@@ -118,7 +118,7 @@ func (c *Client) DeprovisionRuntime() (string, error) {
 	response := provisionResponse{}
 	c.log.Infof("Deprovisioning Runtime [ID: %s, NAME: %s]", c.instanceID, c.clusterName)
 	err := wait.Poll(time.Second, time.Second*5, func() (bool, error) {
-		err := c.executeRequest(http.MethodDelete, deprovisionURL, http.StatusOK, nil, &response)
+		err := c.executeRequest(http.MethodDelete, deprovisionURL, http.StatusAccepted, nil, &response)
 		if err != nil {
 			c.log.Warn(errors.Wrap(err, "while executing request").Error())
 			return false, nil
@@ -128,7 +128,7 @@ func (c *Client) DeprovisionRuntime() (string, error) {
 	if err != nil {
 		return "", errors.Wrap(err, "while waiting for successful deprovision call")
 	}
-	c.log.Infof("Successfully send deprovision request")
+	c.log.Infof("Successfully send deprovision request, got operation ID %s", response.Operation)
 	return response.Operation, nil
 }
 

--- a/tests/e2e/provisioning/pkg/client/runtime/runtime_client.go
+++ b/tests/e2e/provisioning/pkg/client/runtime/runtime_client.go
@@ -120,7 +120,7 @@ func (c *Client) FetchRuntimeConfig() (*string, error) {
 	if res.Result.RuntimeConfiguration != nil {
 		return res.Result.RuntimeConfiguration.Kubeconfig, nil
 	}
-	return nil, nil
+	return nil, errors.New("kubeconfig shouldn't be nil")
 }
 
 func (c *Client) writeConfigToFile(config string) (string, error) {

--- a/tests/e2e/provisioning/pkg/client/runtime/runtime_client.go
+++ b/tests/e2e/provisioning/pkg/client/runtime/runtime_client.go
@@ -8,8 +8,6 @@ import (
 	"os"
 	"time"
 
-	v1 "k8s.io/api/core/v1"
-
 	"k8s.io/client-go/kubernetes/scheme"
 
 	"github.com/kubernetes-incubator/service-catalog/pkg/apis/servicecatalog/v1beta1"
@@ -31,12 +29,9 @@ const tenantHeaderName = "tenant"
 
 type Config struct {
 	ProvisionerURL string `default:"http://compass-provisioner.compass-system.svc.cluster.local:3000/graphql"`
-	ConfigName     string `default:"e2e-runtime-config"`
 
 	UUAInstanceName      string `default:"uaa-issuer"`
 	UUAInstanceNamespace string `default:"kyma-system"`
-
-	DeployNamespace string `default:"compass-system"`
 }
 
 // Client allows to fetch runtime's config and execute the logic against it
@@ -46,124 +41,23 @@ type Client struct {
 	directorClient *director.Client
 	log            logrus.FieldLogger
 
-	configName      string
-	instanceID      string
-	tenantID        string
-	deployNamespace string
+	instanceID string
+	tenantID   string
 }
 
-func NewClient(config Config, tenantID, instanceID, configName, deployNamespace string, clientHttp http.Client, directorClient *director.Client, log logrus.FieldLogger) *Client {
+func NewClient(config Config, tenantID, instanceID string, clientHttp http.Client, directorClient *director.Client, log logrus.FieldLogger) *Client {
 	return &Client{
-		tenantID:        tenantID,
-		instanceID:      instanceID,
-		configName:      configName,
-		deployNamespace: deployNamespace,
-		config:          config,
-		httpClient:      clientHttp,
-		directorClient:  directorClient,
-		log:             log,
+		tenantID:       tenantID,
+		instanceID:     instanceID,
+		config:         config,
+		httpClient:     clientHttp,
+		directorClient: directorClient,
+		log:            log,
 	}
 }
 
 type runtimeStatusResponse struct {
 	Result schema.RuntimeStatus `json:"result"`
-}
-
-// ExposeRuntimeData creates secret and config map with data about the test
-func (c *Client) ExposeRuntimeData(dashboardURL string) error {
-	config, err := c.fetchRuntimeConfig()
-	if err != nil {
-		return errors.Wrap(err, "while fetching runtime config")
-	}
-
-	cli, err := c.newClient("")
-	c.log.Infof("creating secret %s", c.configName)
-	if err != nil {
-		return errors.Wrap(err, "while setting client config")
-	}
-	err = c.wait(func() error {
-		err = cli.Create(context.Background(), &v1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      c.configName,
-				Namespace: c.deployNamespace,
-			},
-			Data: map[string][]byte{
-				"config": []byte(*config),
-			},
-		})
-		if err != nil {
-			return err
-		}
-		return nil
-	})
-	if err != nil {
-		return errors.Wrapf(err, "while waiting for secret %s creation", c.configName)
-	}
-
-	c.log.Infof("creating config map %s", c.configName)
-	err = c.wait(func() error {
-		err = cli.Create(context.Background(), &v1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      c.configName,
-				Namespace: c.deployNamespace,
-			},
-			Data: map[string]string{
-				"dashboardURL": dashboardURL,
-				"instanceID":   c.instanceID,
-			},
-		})
-		if err != nil {
-			return err
-		}
-		return nil
-	})
-	if err != nil {
-		return errors.Wrapf(err, "while waiting for config map %s creation", c.configName)
-	}
-
-	return nil
-}
-
-// CleanupResources removes secret and config map used to store data about the test
-func (c *Client) CleanupResources() error {
-	cli, err := c.newClient("")
-	c.log.Infof("removing secret %s", c.configName)
-	if err != nil {
-		return errors.Wrap(err, "while setting client config")
-	}
-	err = c.wait(func() error {
-		err = cli.Delete(context.Background(), &v1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      c.configName,
-				Namespace: c.deployNamespace,
-			},
-		})
-		if err != nil {
-			return err
-		}
-		return nil
-	})
-
-	c.log.Infof("removing config map %s", c.configName)
-	if err != nil {
-		return errors.Wrapf(err, "while waiting for secret %s deletion", c.configName)
-	}
-	err = c.wait(func() error {
-		err = cli.Delete(context.Background(), &v1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      c.configName,
-				Namespace: c.deployNamespace,
-			},
-		})
-		if err != nil {
-			return err
-		}
-		return nil
-	})
-	if err != nil {
-		return errors.Wrapf(err, "while waiting for config map %s deletion", c.configName)
-	}
-	return nil
 }
 
 func (c *Client) EnsureUAAInstanceRemoved() error {
@@ -179,43 +73,25 @@ func (c *Client) EnsureUAAInstanceRemoved() error {
 	return nil
 }
 
-func (c *Client) wait(call func() error) error {
-	err := wait.PollImmediate(time.Second, time.Second*10, func() (bool, error) {
-		err := call()
-		if err != nil {
-			if apiErrors.IsNotFound(err) || apiErrors.IsAlreadyExists(err) {
-				return true, nil
-			}
-			c.log.Errorf("while executing request: %v", err)
-			return false, nil
-		}
-		return true, nil
-	})
-	if err != nil {
-		return errors.Wrap(err, "while waiting executing request")
-	}
-	return nil
-}
-
 func (c *Client) newRuntimeClient() (client.Client, error) {
-	response, err := c.fetchRuntimeConfig()
+	config, err := c.FetchRuntimeConfig()
 	if err != nil {
 		return nil, errors.Wrap(err, "while fetching runtime config")
 	}
-	tmpFile, err := c.writeConfigToFile(*response)
+	tmpFile, err := c.writeConfigToFile(*config)
 	if err != nil {
 		return nil, errors.Wrap(err, "while writing runtime config")
 	}
 	defer c.removeFile(tmpFile)
 
-	cli, err := c.newClient(tmpFile)
+	cli, err := newClient(tmpFile)
 	if err != nil {
 		return nil, errors.Wrap(err, "while setting client config")
 	}
 	return cli, nil
 }
 
-func (c *Client) fetchRuntimeConfig() (*string, error) {
+func (c *Client) FetchRuntimeConfig() (*string, error) {
 	runtimeID, err := c.directorClient.GetRuntimeID(c.tenantID, c.instanceID)
 	if err != nil {
 		return nil, errors.Wrapf(err, "while getting runtime id from director for instance ID %s", c.instanceID)
@@ -264,7 +140,7 @@ func (c *Client) writeConfigToFile(config string) (string, error) {
 	return runtimeConfigTmpFile.Name(), nil
 }
 
-func (c *Client) newClient(configPath string) (client.Client, error) {
+func newClient(configPath string) (client.Client, error) {
 	err := v1beta1.AddToScheme(scheme.Scheme)
 	if err != nil {
 		return nil, errors.Wrap(err, "while adding schema")

--- a/tests/e2e/provisioning/pkg/client/runtime/runtime_client.go
+++ b/tests/e2e/provisioning/pkg/client/runtime/runtime_client.go
@@ -28,7 +28,8 @@ import (
 const tenantHeaderName = "tenant"
 
 type Config struct {
-	ProvisionerURL string `default:"http://compass-provisioner.compass-system.svc.cluster.local:3000/graphql"`
+	ProvisionerURL       string `default:"http://compass-provisioner.compass-system.svc.cluster.local:3000/graphql"`
+	KubeconfigSecretName string `default:"e2e-runtime-kubeconfig"`
 
 	UUAInstanceName      string `default:"uaa-issuer"`
 	UUAInstanceNamespace string `default:"kyma-system"`

--- a/tests/e2e/provisioning/pkg/client/v1_client/configmap.go
+++ b/tests/e2e/provisioning/pkg/client/v1_client/configmap.go
@@ -1,0 +1,109 @@
+package v1_client
+
+import (
+	"context"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	v1 "k8s.io/api/core/v1"
+	apiErrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	timeout = time.Second * 10
+)
+
+type ConfigMaps interface {
+	Get(name, namespace string) (*v1.ConfigMap, error)
+	Create(configMap v1.ConfigMap) error
+	Update(configMap v1.ConfigMap) error
+	Delete(configMap v1.ConfigMap) error
+}
+
+type ConfigMapClient struct {
+	client client.Client
+	log    logrus.FieldLogger
+}
+
+func NewConfigMapClient(client client.Client, log logrus.FieldLogger) *ConfigMapClient {
+	return &ConfigMapClient{client: client, log: log}
+}
+
+func (c *ConfigMapClient) Get(name, namespace string) (*v1.ConfigMap, error) {
+	configMap := v1.ConfigMap{}
+	err := wait.PollImmediate(time.Second, timeout, func() (bool, error) {
+		err := c.client.Get(context.Background(), client.ObjectKey{Name: name, Namespace: namespace}, &configMap)
+		if err != nil {
+			if apiErrors.IsNotFound(err) {
+				return false, err
+			}
+			c.log.Errorf("while creating config map: %v", err)
+			return false, nil
+		}
+		return true, nil
+	})
+	if err != nil {
+		c.log.Errorf("while getting config map: %v", err)
+		return nil, err
+	}
+	return &configMap, nil
+}
+
+func (c *ConfigMapClient) Create(configMap v1.ConfigMap) error {
+	err := wait.PollImmediate(time.Second, timeout, func() (bool, error) {
+		err := c.client.Create(context.Background(), &configMap)
+		if err != nil {
+			if apiErrors.IsAlreadyExists(err) {
+				err = c.Update(configMap)
+				if err != nil {
+					return false, errors.Wrap(err, "while updating a config map")
+				}
+			}
+			c.log.Errorf("while creating config map: %v", err)
+			return false, nil
+		}
+		return true, nil
+	})
+	if err != nil {
+		c.log.Errorf("while creating secret: %v", err)
+		return err
+	}
+	return nil
+}
+
+func (c *ConfigMapClient) Update(configMap v1.ConfigMap) error {
+	err := wait.PollImmediate(time.Second, timeout, func() (bool, error) {
+		err := c.client.Update(context.Background(), &configMap)
+		if err != nil {
+			c.log.Errorf("while creating config map: %v", err)
+			return false, nil
+		}
+		return true, nil
+	})
+	if err != nil {
+		return errors.Wrap(err, "while waiting for secret update")
+	}
+	return nil
+}
+
+func (c *ConfigMapClient) Delete(configMap v1.ConfigMap) error {
+	err := wait.PollImmediate(time.Second, timeout, func() (bool, error) {
+		err := c.client.Delete(context.Background(), &configMap)
+		if err != nil {
+			if apiErrors.IsNotFound(err) {
+				c.log.Warn("config map not found")
+				return true, nil
+			}
+			c.log.Errorf("while creating config map: %v", err)
+			return false, nil
+		}
+		return true, nil
+	})
+	if err != nil {
+		return errors.Wrap(err, "while waiting for secret update")
+	}
+	return nil
+}

--- a/tests/e2e/provisioning/pkg/client/v1_client/configmap.go
+++ b/tests/e2e/provisioning/pkg/client/v1_client/configmap.go
@@ -68,7 +68,6 @@ func (c *ConfigMapClient) Create(configMap v1.ConfigMap) error {
 		return true, nil
 	})
 	if err != nil {
-		c.log.Errorf("while creating secret: %v", err)
 		return err
 	}
 	return nil
@@ -84,7 +83,7 @@ func (c *ConfigMapClient) Update(configMap v1.ConfigMap) error {
 		return true, nil
 	})
 	if err != nil {
-		return errors.Wrap(err, "while waiting for secret update")
+		return errors.Wrap(err, "while waiting for config map update")
 	}
 	return nil
 }
@@ -97,13 +96,13 @@ func (c *ConfigMapClient) Delete(configMap v1.ConfigMap) error {
 				c.log.Warn("config map not found")
 				return true, nil
 			}
-			c.log.Errorf("while creating config map: %v", err)
+			c.log.Errorf("while deleting config map: %v", err)
 			return false, nil
 		}
 		return true, nil
 	})
 	if err != nil {
-		return errors.Wrap(err, "while waiting for secret update")
+		return errors.Wrap(err, "while waiting for config map delete")
 	}
 	return nil
 }

--- a/tests/e2e/provisioning/pkg/client/v1_client/configmap.go
+++ b/tests/e2e/provisioning/pkg/client/v1_client/configmap.go
@@ -46,8 +46,7 @@ func (c *ConfigMapClient) Get(name, namespace string) (*v1.ConfigMap, error) {
 		return true, nil
 	})
 	if err != nil {
-		c.log.Errorf("while getting config map: %v", err)
-		return nil, err
+		return nil, errors.Wrap(err, "while getting config map")
 	}
 	return &configMap, nil
 }
@@ -61,6 +60,7 @@ func (c *ConfigMapClient) Create(configMap v1.ConfigMap) error {
 				if err != nil {
 					return false, errors.Wrap(err, "while updating a config map")
 				}
+				return true, nil
 			}
 			c.log.Errorf("while creating config map: %v", err)
 			return false, nil
@@ -68,7 +68,7 @@ func (c *ConfigMapClient) Create(configMap v1.ConfigMap) error {
 		return true, nil
 	})
 	if err != nil {
-		return err
+		return errors.Wrap(err, "while creating config map")
 	}
 	return nil
 }
@@ -77,7 +77,7 @@ func (c *ConfigMapClient) Update(configMap v1.ConfigMap) error {
 	err := wait.PollImmediate(time.Second, timeout, func() (bool, error) {
 		err := c.client.Update(context.Background(), &configMap)
 		if err != nil {
-			c.log.Errorf("while creating config map: %v", err)
+			c.log.Errorf("while updating config map: %v", err)
 			return false, nil
 		}
 		return true, nil

--- a/tests/e2e/provisioning/pkg/client/v1_client/secret.go
+++ b/tests/e2e/provisioning/pkg/client/v1_client/secret.go
@@ -1,0 +1,72 @@
+package v1_client
+
+import (
+	"context"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	v1 "k8s.io/api/core/v1"
+	apiErrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type Secrets interface {
+	Create(secret v1.Secret) error
+	Delete(secret v1.Secret) error
+}
+
+type SecretClient struct {
+	client client.Client
+	log    logrus.FieldLogger
+}
+
+func NewSecretClient(client client.Client, log logrus.FieldLogger) *SecretClient {
+	return &SecretClient{client: client, log: log}
+}
+
+func (c *SecretClient) Create(secret v1.Secret) error {
+	err := wait.PollImmediate(time.Second, timeout, func() (bool, error) {
+		err := c.client.Create(context.Background(), &secret)
+		if err != nil {
+			if apiErrors.IsAlreadyExists(err) {
+				err = c.Delete(secret)
+				if err != nil {
+					return false, errors.Wrap(err, "while deleting a secret")
+				}
+				err = c.client.Create(context.Background(), &secret)
+				if err != nil {
+					return false, errors.Wrap(err, "while creating secret")
+				}
+				return true, nil
+			}
+			c.log.Errorf("while creating secret: %v", err)
+			return false, nil
+		}
+		return true, nil
+	})
+	if err != nil {
+		return errors.Wrap(err, "while waiting for secret creation")
+	}
+	return nil
+}
+
+func (c *SecretClient) Delete(secret v1.Secret) error {
+	err := wait.PollImmediate(time.Second, timeout, func() (bool, error) {
+		err := c.client.Delete(context.Background(), &secret)
+		if err != nil {
+			if apiErrors.IsNotFound(err) {
+				c.log.Warn("secret not found")
+				return true, nil
+			}
+			c.log.Errorf("while creating secret: %v", err)
+			return false, nil
+		}
+		return true, nil
+	})
+	if err != nil {
+		return errors.Wrap(err, "while waiting for secret update")
+	}
+	return nil
+}

--- a/tests/e2e/provisioning/pkg/client/v1_client/secret.go
+++ b/tests/e2e/provisioning/pkg/client/v1_client/secret.go
@@ -66,7 +66,7 @@ func (c *SecretClient) Delete(secret v1.Secret) error {
 		return true, nil
 	})
 	if err != nil {
-		return errors.Wrap(err, "while waiting for secret update")
+		return errors.Wrap(err, "while waiting for secret delete")
 	}
 	return nil
 }

--- a/tests/e2e/provisioning/test/e2e_provisioning_test.go
+++ b/tests/e2e/provisioning/test/e2e_provisioning_test.go
@@ -12,9 +12,12 @@ func Test_E2E_Provisioning(t *testing.T) {
 	if ts.IsDummyTest {
 		return
 	}
+	if ts.IsCleanupPhase {
+		ts.Cleanup()
+		return
+	}
 	operationID, err := ts.brokerClient.ProvisionRuntime()
 	require.NoError(t, err)
-	defer ts.TearDown()
 
 	err = ts.brokerClient.AwaitOperationSucceeded(operationID, ts.ProvisionTimeout)
 	require.NoError(t, err)

--- a/tests/e2e/provisioning/test/e2e_provisioning_test.go
+++ b/tests/e2e/provisioning/test/e2e_provisioning_test.go
@@ -25,7 +25,7 @@ func Test_E2E_Provisioning(t *testing.T) {
 	dashboardURL, err := ts.brokerClient.FetchDashboardURL()
 	require.NoError(t, err)
 
-	err = ts.runtimeClient.ExposeResources(dashboardURL)
+	err = ts.runtimeClient.ExposeRuntimeData(dashboardURL)
 	assert.NoError(t, err)
 
 	err = ts.dashboardChecker.AssertRedirectedToUAA(dashboardURL)

--- a/tests/e2e/provisioning/test/e2e_provisioning_test.go
+++ b/tests/e2e/provisioning/test/e2e_provisioning_test.go
@@ -16,7 +16,13 @@ func Test_E2E_Provisioning(t *testing.T) {
 		ts.Cleanup()
 		return
 	}
+	configMap := ts.testConfigMap()
+
 	operationID, err := ts.brokerClient.ProvisionRuntime()
+	require.NoError(t, err)
+
+	ts.log.Infof("Creating config map %s with test data", ts.ConfigName)
+	err = ts.configMapClient.Create(configMap)
 	require.NoError(t, err)
 
 	err = ts.brokerClient.AwaitOperationSucceeded(operationID, ts.ProvisionTimeout)
@@ -25,8 +31,18 @@ func Test_E2E_Provisioning(t *testing.T) {
 	dashboardURL, err := ts.brokerClient.FetchDashboardURL()
 	require.NoError(t, err)
 
-	err = ts.runtimeClient.ExposeRuntimeData(dashboardURL)
-	assert.NoError(t, err)
+	ts.log.Infof("Updating config map %s with dashboardUrl", ts.ConfigName)
+	configMap.Data[dashboardUrlKey] = dashboardURL
+	err = ts.configMapClient.Update(configMap)
+	require.NoError(t, err)
+
+	ts.log.Info("Fetching runtime's kubeconfig")
+	config, err := ts.runtimeClient.FetchRuntimeConfig()
+	require.NoError(t, err)
+
+	ts.log.Infof("Creating a secret %s with test data", ts.ConfigName)
+	err = ts.secretClient.Create(ts.testSecret(config))
+	require.NoError(t, err)
 
 	err = ts.dashboardChecker.AssertRedirectedToUAA(dashboardURL)
 	assert.NoError(t, err)

--- a/tests/e2e/provisioning/test/e2e_provisioning_test.go
+++ b/tests/e2e/provisioning/test/e2e_provisioning_test.go
@@ -25,6 +25,9 @@ func Test_E2E_Provisioning(t *testing.T) {
 	dashboardURL, err := ts.brokerClient.FetchDashboardURL()
 	require.NoError(t, err)
 
+	err = ts.runtimeClient.ExposeResources(dashboardURL)
+	assert.NoError(t, err)
+
 	err = ts.dashboardChecker.AssertRedirectedToUAA(dashboardURL)
 	assert.NoError(t, err)
 }

--- a/tests/e2e/provisioning/test/test_suite.go
+++ b/tests/e2e/provisioning/test/test_suite.go
@@ -31,8 +31,9 @@ type Config struct {
 
 	ProvisionTimeout   time.Duration `default:"3h"`
 	DeprovisionTimeout time.Duration `default:"1h"`
-	DummyTest          bool `default:"false"`
-	CleanupPhase       bool `default:"false"`
+	DummyTest          bool          `default:"false"`
+	CleanupPhase       bool          `default:"false"`
+	InstanceID         string        `envconfig:"optional"`
 }
 
 // Suite provides set of clients able to provision and test Kyma runtime
@@ -48,6 +49,7 @@ type Suite struct {
 	DeprovisionTimeout time.Duration
 	IsDummyTest        bool
 	IsCleanupPhase     bool
+	InstanceID         string
 }
 
 func (ts *Suite) Cleanup() {
@@ -65,6 +67,10 @@ func newTestSuite(t *testing.T) *Suite {
 
 	log := logrus.New()
 	instanceID := uuid.New().String()
+	if cfg.CleanupPhase {
+		log.Info("using instance ID %s", cfg.InstanceID)
+		instanceID = cfg.InstanceID
+	}
 
 	httpClient := newHTTPClient(cfg.SkipCertVerification)
 

--- a/tests/e2e/provisioning/test/test_suite.go
+++ b/tests/e2e/provisioning/test/test_suite.go
@@ -54,7 +54,9 @@ type Suite struct {
 
 func (ts *Suite) Cleanup() {
 	ts.log.Info("Cleaning up...")
-	err := ts.runtimeClient.EnsureUAAInstanceRemoved()
+	err := ts.runtimeClient.CleanupResources()
+	assert.NoError(ts.t, err)
+	err = ts.runtimeClient.EnsureUAAInstanceRemoved()
 	assert.NoError(ts.t, err)
 	_, err = ts.brokerClient.DeprovisionRuntime()
 	require.NoError(ts.t, err)
@@ -94,7 +96,7 @@ func newTestSuite(t *testing.T) *Suite {
 
 	directorClient := director.NewDirectorClient(oauthClient, graphQLClient, log.WithField("service", "director_client"))
 
-	runtimeClient := runtime.NewClient(cfg.Runtime, cfg.TenantID, instanceID, *httpClient, directorClient, log.WithField("service", "runtime_client"))
+	runtimeClient := runtime.NewClient(cfg.Runtime, cfg.TenantID, instanceID, cfg.Runtime.KubeconfigSecretName, *httpClient, directorClient, log.WithField("service", "runtime_client"))
 
 	dashboardChecker := runtime.NewDashboardChecker(*httpClient, log.WithField("service", "dashboard_checker"))
 
@@ -104,6 +106,7 @@ func newTestSuite(t *testing.T) *Suite {
 		dashboardChecker:   dashboardChecker,
 		brokerClient:       brokerClient,
 		runtimeClient:      runtimeClient,
+		InstanceID:         instanceID,
 		ProvisionTimeout:   cfg.ProvisionTimeout,
 		DeprovisionTimeout: cfg.DeprovisionTimeout,
 		IsDummyTest:        cfg.DummyTest,

--- a/tests/e2e/provisioning/test/test_suite.go
+++ b/tests/e2e/provisioning/test/test_suite.go
@@ -6,6 +6,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/kyma-incubator/compass/tests/e2e/provisioning/pkg/client/v1_client"
+	"github.com/pkg/errors"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/kyma-incubator/compass/tests/e2e/provisioning/internal/director"
 	"github.com/kyma-incubator/compass/tests/e2e/provisioning/internal/director/oauth"
 	"github.com/kyma-incubator/compass/tests/e2e/provisioning/pkg/client/runtime"
@@ -17,7 +22,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 	"github.com/vrischmann/envconfig"
-	k8sClient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 )
 
@@ -31,38 +36,41 @@ type Config struct {
 
 	ProvisionTimeout   time.Duration `default:"3h"`
 	DeprovisionTimeout time.Duration `default:"1h"`
-	DummyTest          bool          `default:"false"`
-	CleanupPhase       bool          `default:"false"`
-	InstanceID         string        `envconfig:"optional"`
+	ConfigName         string        `default:"e2e-runtime-config"`
+	DeployNamespace    string        `default:"compass-system"`
+
+	DummyTest    bool `default:"false"`
+	CleanupPhase bool `default:"false"`
 }
 
 // Suite provides set of clients able to provision and test Kyma runtime
 type Suite struct {
 	t *testing.T
 
-	log              logrus.FieldLogger
-	brokerClient     *broker.Client
-	runtimeClient    *runtime.Client
+	log             logrus.FieldLogger
+	brokerClient    *broker.Client
+	runtimeClient   *runtime.Client
+	secretClient    v1_client.Secrets
+	configMapClient v1_client.ConfigMaps
+
 	dashboardChecker *runtime.DashboardChecker
 
 	ProvisionTimeout   time.Duration
 	DeprovisionTimeout time.Duration
-	IsDummyTest        bool
-	IsCleanupPhase     bool
-	InstanceID         string
+
+	InstanceID      string
+	ConfigName      string
+	DeployNamespace string
+
+	IsDummyTest    bool
+	IsCleanupPhase bool
 }
 
-func (ts *Suite) Cleanup() {
-	ts.log.Info("Cleaning up...")
-	err := ts.runtimeClient.CleanupResources()
-	assert.NoError(ts.t, err)
-	err = ts.runtimeClient.EnsureUAAInstanceRemoved()
-	assert.NoError(ts.t, err)
-	operationID, err := ts.brokerClient.DeprovisionRuntime()
-	require.NoError(ts.t, err)
-	err = ts.brokerClient.AwaitOperationSucceeded(operationID, ts.DeprovisionTimeout)
-	assert.NoError(ts.t, err)
-}
+const (
+	instanceIdKey   = "instanceId"
+	dashboardUrlKey = "dashboardUrl"
+	kubeconfigKey   = "config"
+)
 
 func newTestSuite(t *testing.T) *Suite {
 	cfg := &Config{}
@@ -70,10 +78,22 @@ func newTestSuite(t *testing.T) *Suite {
 	require.NoError(t, err)
 
 	log := logrus.New()
+
+	k8sConfig, err := config.GetConfig()
+	if err != nil {
+		panic(err)
+	}
+	cli, err := client.New(k8sConfig, client.Options{})
+	secretClient := v1_client.NewSecretClient(cli, log)
+	configMapClient := v1_client.NewConfigMapClient(cli, log)
+
 	instanceID := uuid.New().String()
 	if cfg.CleanupPhase {
-		log.Infof("using instance ID %s", cfg.InstanceID)
-		instanceID = cfg.InstanceID
+		cfgMap, err := configMapClient.Get(cfg.ConfigName, cfg.DeployNamespace)
+		require.NoError(t, err)
+
+		instanceID = cfgMap.Data[instanceIdKey]
+		log.Infof("using instance ID %s", instanceID)
 	}
 
 	httpClient := newHTTPClient(cfg.SkipCertVerification)
@@ -81,12 +101,6 @@ func newTestSuite(t *testing.T) *Suite {
 	// create director client on the base of graphQL client and OAuth client
 	graphQLClient := gcli.NewClient(cfg.Director.URL, gcli.WithHTTPClient(httpClient))
 	graphQLClient.Log = func(s string) { log.Println(s) }
-
-	k8sConfig, err := config.GetConfig()
-	if err != nil {
-		panic(err)
-	}
-	cli, err := k8sClient.New(k8sConfig, k8sClient.Options{})
 
 	oauthClient := oauth.NewOauthClient(httpClient, cli, cfg.Director.OauthCredentialsSecretName, cfg.Director.Namespace)
 	err = oauthClient.WaitForCredentials()
@@ -98,21 +112,90 @@ func newTestSuite(t *testing.T) *Suite {
 
 	directorClient := director.NewDirectorClient(oauthClient, graphQLClient, log.WithField("service", "director_client"))
 
-	runtimeClient := runtime.NewClient(cfg.Runtime, cfg.TenantID, instanceID, cfg.Runtime.ConfigName, cfg.Director.Namespace, *httpClient, directorClient, log.WithField("service", "runtime_client"))
+	runtimeClient := runtime.NewClient(cfg.Runtime, cfg.TenantID, instanceID, *httpClient, directorClient, log.WithField("service", "runtime_client"))
 
 	dashboardChecker := runtime.NewDashboardChecker(*httpClient, log.WithField("service", "dashboard_checker"))
 
 	return &Suite{
-		t:                  t,
-		log:                log,
-		dashboardChecker:   dashboardChecker,
-		brokerClient:       brokerClient,
-		runtimeClient:      runtimeClient,
+		t:   t,
+		log: log,
+
+		dashboardChecker: dashboardChecker,
+		brokerClient:     brokerClient,
+		runtimeClient:    runtimeClient,
+		secretClient:     secretClient,
+		configMapClient:  configMapClient,
+
 		InstanceID:         instanceID,
 		ProvisionTimeout:   cfg.ProvisionTimeout,
 		DeprovisionTimeout: cfg.DeprovisionTimeout,
+		ConfigName:         cfg.ConfigName,
+		DeployNamespace:    cfg.DeployNamespace,
 		IsDummyTest:        cfg.DummyTest,
 		IsCleanupPhase:     cfg.CleanupPhase,
+	}
+}
+
+// Cleanup removes all data associated with the test along with runtime
+func (ts *Suite) Cleanup() {
+	ts.log.Info("Cleaning up...")
+	err := ts.cleanupResources()
+	assert.NoError(ts.t, err)
+	err = ts.runtimeClient.EnsureUAAInstanceRemoved()
+	assert.NoError(ts.t, err)
+	operationID, err := ts.brokerClient.DeprovisionRuntime()
+	require.NoError(ts.t, err)
+	err = ts.brokerClient.AwaitOperationSucceeded(operationID, ts.DeprovisionTimeout)
+	assert.NoError(ts.t, err)
+}
+
+// cleanupResources removes secret and config map used to store data about the test
+func (ts *Suite) cleanupResources() error {
+	ts.log.Infof("removing secret %s", ts.ConfigName)
+	err := ts.secretClient.Delete(v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ts.ConfigName,
+			Namespace: ts.DeployNamespace,
+		},
+	})
+	if err != nil {
+		return errors.Wrapf(err, "while waiting for secret %s deletion", ts.ConfigName)
+	}
+
+	ts.log.Infof("removing config map %s", ts.ConfigName)
+	err = ts.configMapClient.Delete(v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ts.ConfigName,
+			Namespace: ts.DeployNamespace,
+		},
+	})
+	if err != nil {
+		return errors.Wrapf(err, "while waiting for config map %s deletion", ts.ConfigName)
+	}
+	return nil
+}
+
+func (ts *Suite) testSecret(config *string) v1.Secret {
+	return v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ts.ConfigName,
+			Namespace: ts.DeployNamespace,
+		},
+		Data: map[string][]byte{
+			kubeconfigKey: []byte(*config),
+		},
+	}
+}
+
+func (ts *Suite) testConfigMap() v1.ConfigMap {
+	return v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      ts.ConfigName,
+			Namespace: ts.DeployNamespace,
+		},
+		Data: map[string]string{
+			instanceIdKey: ts.InstanceID,
+		},
 	}
 }
 

--- a/tests/e2e/provisioning/test/test_suite.go
+++ b/tests/e2e/provisioning/test/test_suite.go
@@ -58,8 +58,10 @@ func (ts *Suite) Cleanup() {
 	assert.NoError(ts.t, err)
 	err = ts.runtimeClient.EnsureUAAInstanceRemoved()
 	assert.NoError(ts.t, err)
-	_, err = ts.brokerClient.DeprovisionRuntime()
+	operationID, err := ts.brokerClient.DeprovisionRuntime()
 	require.NoError(ts.t, err)
+	err = ts.brokerClient.AwaitOperationSucceeded(operationID, ts.DeprovisionTimeout)
+	assert.NoError(ts.t, err)
 }
 
 func newTestSuite(t *testing.T) *Suite {
@@ -70,7 +72,7 @@ func newTestSuite(t *testing.T) *Suite {
 	log := logrus.New()
 	instanceID := uuid.New().String()
 	if cfg.CleanupPhase {
-		log.Info("using instance ID %s", cfg.InstanceID)
+		log.Infof("using instance ID %s", cfg.InstanceID)
 		instanceID = cfg.InstanceID
 	}
 

--- a/tests/e2e/provisioning/test/test_suite.go
+++ b/tests/e2e/provisioning/test/test_suite.go
@@ -96,7 +96,7 @@ func newTestSuite(t *testing.T) *Suite {
 
 	directorClient := director.NewDirectorClient(oauthClient, graphQLClient, log.WithField("service", "director_client"))
 
-	runtimeClient := runtime.NewClient(cfg.Runtime, cfg.TenantID, instanceID, cfg.Runtime.KubeconfigSecretName, *httpClient, directorClient, log.WithField("service", "runtime_client"))
+	runtimeClient := runtime.NewClient(cfg.Runtime, cfg.TenantID, instanceID, cfg.Runtime.ConfigName, cfg.Director.Namespace, *httpClient, directorClient, log.WithField("service", "runtime_client"))
 
 	dashboardChecker := runtime.NewDashboardChecker(*httpClient, log.WithField("service", "dashboard_checker"))
 

--- a/tests/e2e/provisioning/test/test_suite.go
+++ b/tests/e2e/provisioning/test/test_suite.go
@@ -29,9 +29,10 @@ type Config struct {
 	TenantID             string `default:"3e64ebae-38b5-46a0-b1ed-9ccee153a0ae"`
 	SkipCertVerification bool   `envconfig:"default=true"`
 
-	ProvisionTimeout   time.Duration
-	DeprovisionTimeout time.Duration
-	DummyTest          bool
+	ProvisionTimeout   time.Duration `default:"3h"`
+	DeprovisionTimeout time.Duration `default:"1h"`
+	DummyTest          bool `default:"false"`
+	CleanupPhase       bool `default:"false"`
 }
 
 // Suite provides set of clients able to provision and test Kyma runtime
@@ -46,9 +47,10 @@ type Suite struct {
 	ProvisionTimeout   time.Duration
 	DeprovisionTimeout time.Duration
 	IsDummyTest        bool
+	IsCleanupPhase     bool
 }
 
-func (ts *Suite) TearDown() {
+func (ts *Suite) Cleanup() {
 	ts.log.Info("Cleaning up...")
 	err := ts.runtimeClient.EnsureUAAInstanceRemoved()
 	assert.NoError(ts.t, err)
@@ -99,6 +101,7 @@ func newTestSuite(t *testing.T) *Suite {
 		ProvisionTimeout:   cfg.ProvisionTimeout,
 		DeprovisionTimeout: cfg.DeprovisionTimeout,
 		IsDummyTest:        cfg.DummyTest,
+		IsCleanupPhase:     cfg.CleanupPhase,
 	}
 }
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Split e2e-provisioning test on 2 phases:
   - provisioning
   - cleanup

logs from provisioning:
```
Starting e2e-provisioning test on GCP. Waiting 20s for api server...
time="2020-04-08T08:04:03Z" level=info msg="Provisioning Runtime [instanceID: 199c898a-d2ab-4650-ad0e-6417654205ea, NAME: e2e-provisioning-lywfhfhcjr]" service=broker_client
time="2020-04-08T08:04:03Z" level=info msg="Provisioning parameters: {\"service_id\":\"47c9dcbf-ff30-448e-ab36-d3bad66ba281\",\"plan_id\":\"ca6e5357-707f-4565-bbbd-b3ab732597c6\",\"organization_guid\":\"3a6ca609-4903-45f5-9575-602b0662de5e\",\"space_guid\":\"b3417ee6-25fc-43fe-92cc-d6c9659f149a\",\"context\":{\"tenant_id\":\"1eba80dd-8ff6-54ee-be4d-77944d17b10b\",\"subaccount_id\":\"39ba9a66-2c1a-4fe4-a28e-6e5db434084e\",\"globalaccount_id\":\"3e64ebae-38b5-46a0-b1ed-9ccee153a0ae\"},\"parameters\":{\"name\":\"e2e-provisioning-lywfhfhcjr\",\"components\":[]},\"maintenance_info\":{\"version\":\"0.1.0\",\"description\":\"Kyma environment broker e2e-provisioning test\"}}" service=broker_client
time="2020-04-08T08:04:04Z" level=info msg="Successfully send provision request, got operation ID 85eb72bb-4240-409e-8d2e-7b44925bfe5c" service=broker_client
time="2020-04-08T08:04:04Z" level=info msg="Creating config map e2e-runtime-config-gcp with test data"
time="2020-04-08T08:04:04Z" level=info msg="Waiting for operation at most 3h0m0s" service=broker_client
time="2020-04-08T08:09:04Z" level=info msg="Last operation status: in progress" service=broker_client
time="2020-04-08T08:14:04Z" level=info msg="Last operation status: in progress" service=broker_client
time="2020-04-08T08:19:04Z" level=info msg="Last operation status: in progress" service=broker_client
time="2020-04-08T08:24:04Z" level=info msg="Last operation status: in progress" service=broker_client
time="2020-04-08T08:29:04Z" level=info msg="Last operation status: in progress" service=broker_client
time="2020-04-08T08:34:04Z" level=info msg="Last operation status: succeeded" service=broker_client
time="2020-04-08T08:34:04Z" level=info msg="Operation succeeded!" service=broker_client
time="2020-04-08T08:34:04Z" level=info msg="Fetching the Runtime's dashboard URL" service=broker_client
time="2020-04-08T08:34:05Z" level=info msg="Successfully fetched dashboard URL: https://console.c-72f4c6b.kyma-dev.shoot.canary.k8s-hana.ondemand.com" service=broker_client
time="2020-04-08T08:34:05Z" level=info msg="Updating config map e2e-runtime-config-gcp with dashboardUrl"
time="2020-04-08T08:34:05Z" level=info msg="Fetching runtime's kubeconfig"
time="2020-04-08T08:34:05Z" level=info msg="Create request to director service" service=director_client
time="2020-04-08T08:34:05Z" level=info msg="Send request to director" service=director_client
time="2020-04-08T08:34:05Z" level=info msg="Getting authorization token for credentials to access Director from endpoint: https://oauth2.mps.dev.kyma.cloud.sap/oauth2/token"
time="2020-04-08T08:34:06Z" level=error msg="Successfully unmarshal response oauth token for accessing Director"
time="2020-04-08T08:34:06Z" level=info msg=">> variables: map[]"
time="2020-04-08T08:34:06Z" level=info msg=">> query: query {\n\tresult: runtimes(filter: { key: \"broker_instance_id\" query: \"\\\"199c898a-d2ab-4650-ad0e-6417654205ea\\\"\" }) {\n    data {\n      id\n\t}\n}\n}"
time="2020-04-08T08:34:06Z" level=info msg=">> headers: map[Accept:[application/json; charset=utf-8] Authorization:[Bearer bi_SsNePyleTRTZ5j9b_CST8t9apxjRwoXPO1ALM-kc.yYlwvaAm18iEGIaiq_rNbmzFLs0OX8gFaoeZVYBjIcQ] Content-Type:[application/json; charset=utf-8] Tenant:[3e64ebae-38b5-46a0-b1ed-9ccee153a0ae]]"
time="2020-04-08T08:34:06Z" level=info msg="<< {\"data\":{\"result\":{\"data\":[{\"id\":\"14644e6b-fbbb-4b3a-b8ac-aa97ce48f814\"}]}}}"
time="2020-04-08T08:34:06Z" level=info msg="Extract the RuntimeID from the response" service=director_client
time="2020-04-08T08:34:06Z" level=info msg="Creating a secret e2e-runtime-config-gcp with test data"
time="2020-04-08T08:34:06Z" level=info msg="Calling the dashboard URL: https://dex.c-72f4c6b.kyma-dev.shoot.canary.k8s-hana.ondemand.com/auth?client_id=console&nonce=79bf9c29&redirect_uri=https%3A%2F%2Fconsole.c-72f4c6b.kyma-dev.shoot.canary.k8s-hana.ondemand.com&response_type=id_token+token&scope=audience%3Aserver%3Aclient_id%3Akyma-client+audience%3Aserver%3Aclient_id%3Aconsole+openid+profile+email+groups&state=5a4f3d15" service=dashboard_checker
time="2020-04-08T08:34:06Z" level=info msg="Successful response from the dashboard URL" service=dashboard_checker
PASS
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100     2  100     2    0     0   2000      0 --:--:-- --:--:-- --:--:--  2000
OK%
```

logs from cleanup:
```
Starting e2e-provisioning cleanup test on GCP. Waiting 20s for api server...
time="2020-04-08T09:58:45Z" level=info msg="using instance ID 9bfde7f7-8036-450d-b41e-0d812145177e"
time="2020-04-08T09:58:46Z" level=info msg="Cleaning up..."
time="2020-04-08T09:58:46Z" level=info msg="removing secret e2e-runtime-config-gcp"
time="2020-04-08T09:58:46Z" level=warning msg="secret not found"
time="2020-04-08T09:58:46Z" level=info msg="removing config map e2e-runtime-config-gcp"
time="2020-04-08T09:58:47Z" level=info msg="Create request to director service" service=director_client
time="2020-04-08T09:58:47Z" level=info msg="Send request to director" service=director_client
time="2020-04-08T09:58:47Z" level=info msg="Getting authorization token for credentials to access Director from endpoint: https://oauth2.mps.dev.kyma.cloud.sap/oauth2/token"
time="2020-04-08T09:58:47Z" level=error msg="Successfully unmarshal response oauth token for accessing Director"
time="2020-04-08T09:58:47Z" level=info msg=">> variables: map[]"
time="2020-04-08T09:58:47Z" level=info msg=">> query: query {\n\tresult: runtimes(filter: { key: \"broker_instance_id\" query: \"\\\"9bfde7f7-8036-450d-b41e-0d812145177e\\\"\" }) {\n    data {\n      id\n\t}\n}\n}"
time="2020-04-08T09:58:47Z" level=info msg=">> headers: map[Accept:[application/json; charset=utf-8] Authorization:[Bearer taXIhaNoqj8CkV14HrZpvOwKYNyvvaU9LtDNErthZWU.e0zX_sHVLS8XiBdFuu1HRSA4EjVlOZ6B2_Gdhj5mHyA] Content-Type:[application/json; charset=utf-8] Tenant:[3e64ebae-38b5-46a0-b1ed-9ccee153a0ae]]"
time="2020-04-08T09:58:47Z" level=info msg="<< {\"data\":{\"result\":{\"data\":[{\"id\":\"8bf252c1-8fa4-4836-8b9c-b11c1a00b9f9\"}]}}}"
time="2020-04-08T09:58:47Z" level=info msg="Extract the RuntimeID from the response" service=director_client
time="2020-04-08T09:58:47Z" level=info msg="Waiting for uaa-issuer instance to be removed" service=runtime_client
time="2020-04-08T09:58:48Z" level=info msg="Successfully ensured UAA instance was removed" service=runtime_client
time="2020-04-08T09:58:48Z" level=info msg="Deprovisioning Runtime [ID: 9bfde7f7-8036-450d-b41e-0d812145177e, NAME: e2e-provisioning-dtju64uqv6]" service=broker_client
time="2020-04-08T09:58:49Z" level=info msg="Successfully send deprovision request, got operation ID d852610f-857d-4f63-b41b-5255666cd78f" service=broker_client
time="2020-04-08T09:58:49Z" level=info msg="Waiting for operation at most 1h0m0s" service=broker_client
time="2020-04-08T10:03:49Z" level=info msg="Last operation status: in progress" service=broker_client
time="2020-04-08T10:08:49Z" level=info msg="Last operation status: in progress" service=broker_client
time="2020-04-08T10:13:49Z" level=info msg="Last operation status: in progress" service=broker_client
time="2020-04-08T10:18:49Z" level=info msg="Last operation status: in progress" service=broker_client
time="2020-04-08T10:23:49Z" level=info msg="Last operation status: in progress" service=broker_client
time="2020-04-08T10:28:49Z" level=info msg="Last operation status: in progress" service=broker_client
time="2020-04-08T10:33:49Z" level=info msg="Last operation status: in progress" service=broker_client
time="2020-04-08T10:38:49Z" level=info msg="Last operation status: in progress" service=broker_client
time="2020-04-08T10:43:49Z" level=info msg="Last operation status: in progress" service=broker_client
time="2020-04-08T10:48:49Z" level=info msg="Last operation status: in progress" service=broker_client
time="2020-04-08T10:53:49Z" level=info msg="Last operation status: succeeded" service=broker_client
time="2020-04-08T10:53:49Z" level=info msg="Operation succeeded!" service=broker_client
PASS
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100     2  100     2    0     0   1000      0 --:--:-- --:--:-- --:--:--  1000
OK
```

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
