### PR TITLE
Fix overrides CM in KEB

### DIFF
--- a/chart/compass/charts/kyma-environment-broker/templates/provisioning-runtime-overrides.yaml
+++ b/chart/compass/charts/kyma-environment-broker/templates/provisioning-runtime-overrides.yaml
@@ -31,5 +31,4 @@ metadata:
   labels:
     provisioning-runtime-override: "true"
 data:
-  # Can be remove when the compass will be enabled by default in Kyma. (after 1.12)
-  global.enableAPIPackages: "true"
+  global.disableLegacyConnectivity: "true"

--- a/docs/kyma-environment-broker/03-06-runtime-overrides.md
+++ b/docs/kyma-environment-broker/03-06-runtime-overrides.md
@@ -16,7 +16,7 @@ See the examples:
       name: global-overrides
       namespace: compass-system
     data:
-      global.enableAPIPackages: "true"
+      global.disableLegacyConnectivity: "true"
     ```  
 
 - Secret with overrides for the `core` component:


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Fix overrides CM in KEB

The problem is that in KEB we are sending the override but in master-91a18c32 version the override name was changed from `enableAPIPackages` to `disableLegacyConnectivity` (https://github.com/kyma-project/kyma/pull/7769)