### PR TITLE
Add status port environment variable to KEB deployment

### DIFF
--- a/chart/compass/charts/kyma-environment-broker/templates/deployment.yaml
+++ b/chart/compass/charts/kyma-environment-broker/templates/deployment.yaml
@@ -46,6 +46,8 @@ spec:
               value: "{{ .Values.provisioner.URL }}"
             - name: APP_PORT
               value: "{{ .Values.broker.port }}"
+            - name: APP_STATUS_PORT
+              value: "{{ .Values.broker.statusPort }}"
             - name: APP_AUTH_USERNAME
               value: "{{ .Values.broker.username }}"
             - name: APP_AUTH_PASSWORD


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Without this env variable in deployment, KEB would always take default value as `statusPort`:
https://github.com/kyma-incubator/compass/blob/5ccfdc022569076d111f79f2b7f134fb032e9328/components/kyma-environment-broker/cmd/broker/main.go#L61

Changes proposed in this pull request:

- Added `APP_STATUS_PORT` environment variable to KEB deployment
- ...
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
