### PR TITLE
Use unique names for Event Hubs namespace and resource group

### DIFF
--- a/components/kyma-environment-broker/internal/hyperscaler/azure/client.go
+++ b/components/kyma-environment-broker/internal/hyperscaler/azure/client.go
@@ -51,16 +51,17 @@ func (nc *AzureClient) CreateNamespace(ctx context.Context, azureCfg *Config, gr
 }
 
 func (nc *AzureClient) CheckNamespaceAvailability(ctx context.Context, name string) (bool, error) {
-	//TODO Validate name string
+	if name == "" {
+		return false, errors.New("Name cannot be empty")
+	}
 	res, err := nc.eventhubNamespaceClient.CheckNameAvailability(ctx, eventhub.CheckNameAvailabilityParameter{Name: &name})
 	if err != nil {
 		return false, errors.Wrapf(err, "Failed to check Event Hubs namespace availability with name: %s", name)
 	}
 	if res.NameAvailable == nil {
 		return false, errors.Errorf("Failed to check Event Hubs namespace availability with name: %s. Received no response using Azure client.", name)
-	} else {
-		return *res.NameAvailable, nil
 	}
+	return *res.NameAvailable, nil
 }
 
 func (nc *AzureClient) createAndWait(ctx context.Context, resourceGroupName string, namespaceName string, parameters eventhub.EHNamespace) (result eventhub.EHNamespace, err error) {

--- a/components/kyma-environment-broker/internal/hyperscaler/azure/client.go
+++ b/components/kyma-environment-broker/internal/hyperscaler/azure/client.go
@@ -74,19 +74,19 @@ func (nc *AzureClient) CheckResourceGroupAvailability(ctx context.Context, name 
 	}
 	group, err := nc.resourcegroupClient.CheckExistence(ctx, name)
 	if err != nil {
-		return false, errors.Wrapf(err, "Failed to check Azure resource group availability with name: %s. Error " +
+		return false, errors.Wrapf(err, "Failed to check Azure resource group availability with name: %s. Error "+
 			"while using Azure client.", name)
 	}
-	switch group.StatusCode{
+	switch group.StatusCode {
 	case 404:
 		available = true
 	case 204:
 		available = false
 	default:
-		return false, errors.Errorf("Failed to check Azure resource group availability with name: %s." +
+		return false, errors.Errorf("Failed to check Azure resource group availability with name: %s."+
 			" Unexpected API response code %d", name, group.StatusCode)
 	}
-	return available , nil
+	return available, nil
 }
 
 func (nc *AzureClient) NamespaceExists(ctx context.Context, resourceGroupName string, namespaceName string, tags Tags) (bool, error) {
@@ -102,28 +102,28 @@ func (nc *AzureClient) NamespaceExists(ctx context.Context, resourceGroupName st
 	if err != nil {
 		return false, errors.Wrapf(err, "Failed to check Azure Event Hubs namespace availability with name: %s.", namespaceName)
 	}
-	if ! exists {
+	if !exists {
 		return false, nil
 	}
 
 	res, err := nc.eventhubNamespaceClient.ListByResourceGroup(ctx, resourceGroupName)
 	if err != nil {
-		return false, errors.Errorf("Failed to check Event Hubs namespace availability with name: %s in resource" +
+		return false, errors.Errorf("Failed to check Event Hubs namespace availability with name: %s in resource"+
 			"group %s. Error while using Azure client. %v", namespaceName, resourceGroupName, err)
 	}
 	if res.Response().StatusCode != 200 && res.Response().StatusCode != 201 {
-		return false, errors.Errorf("Failed to check Event Hubs namespace availability with name: %s in resource" +
+		return false, errors.Errorf("Failed to check Event Hubs namespace availability with name: %s in resource"+
 			"group %s. Unexpected API response code. Expected 2XX but received %d", namespaceName, resourceGroupName,
 			res.Response().StatusCode)
 	}
 	for res.NotDone() {
 		namespaces := res.Values()
-		for _, ns := range namespaces{
+		for _, ns := range namespaces {
 			exists = matchWithTags(namespaceName, tags, *ns.Name, ns.Tags)
 		}
 		err := res.NextWithContext(ctx)
 		if err != nil {
-			return false, errors.Errorf("Failed to check Event Hubs namespace availability with name: %s in resource" +
+			return false, errors.Errorf("Failed to check Event Hubs namespace availability with name: %s in resource"+
 				"group %s. Error while listing namespaces. %v", namespaceName, resourceGroupName, err)
 		}
 	}
@@ -139,18 +139,18 @@ func (nc *AzureClient) ResourceGroupExists(ctx context.Context, name string, tag
 	if err != nil {
 		return false, errors.Wrapf(err, "Failed to check Azure resource group availability with name: %s.", name)
 	}
-	if ! exists {
+	if !exists {
 		return false, nil
 	}
 	// Now we are safe to assume resource group exists, so any errors returned are not related to resource group not
 	// existing
 	group, err := nc.resourcegroupClient.Get(ctx, name)
 	if err != nil {
-		return false, errors.Wrapf(err, "Failed to check Azure resource group availability with name: %s. Error " +
+		return false, errors.Wrapf(err, "Failed to check Azure resource group availability with name: %s. Error "+
 			"while using Azure client.", name)
 	}
 	if group.StatusCode != 200 {
-		return false, errors.Errorf("Failed to check Azure resource group availability with name: %s." +
+		return false, errors.Errorf("Failed to check Azure resource group availability with name: %s."+
 			" Unexpected API response code. Expected 2XX but received %d", name, group.StatusCode)
 	}
 	return matchWithTags(name, tags, *group.Name, group.Tags), nil

--- a/components/kyma-environment-broker/internal/hyperscaler/azure/client.go
+++ b/components/kyma-environment-broker/internal/hyperscaler/azure/client.go
@@ -97,12 +97,12 @@ func (nc *AzureClient) NamespaceExists(ctx context.Context, resourceGroupName st
 	if resourceGroupName == "" {
 		return false, errors.New("Resource group name cannot be empty")
 	}
-	exists, err := nc.CheckResourceGroupAvailability(ctx, resourceGroupName)
+	available, err := nc.CheckResourceGroupAvailability(ctx, resourceGroupName)
 
 	if err != nil {
 		return false, errors.Wrapf(err, "Failed to check Azure Event Hubs namespace availability with name: %s.", namespaceName)
 	}
-	if !exists {
+	if available {
 		return false, nil
 	}
 
@@ -135,11 +135,11 @@ func (nc *AzureClient) ResourceGroupExists(ctx context.Context, name string, tag
 		return false, errors.New("Resource group name cannot be empty")
 	}
 	// Will not return an error if resource group does not exist
-	exists, err := nc.CheckResourceGroupAvailability(ctx, name)
+	available, err := nc.CheckResourceGroupAvailability(ctx, name)
 	if err != nil {
 		return false, errors.Wrapf(err, "Failed to check Azure resource group availability with name: %s.", name)
 	}
-	if !exists {
+	if available {
 		return false, nil
 	}
 	// Now we are safe to assume resource group exists, so any errors returned are not related to resource group not

--- a/components/kyma-environment-broker/internal/hyperscaler/azure/provider.go
+++ b/components/kyma-environment-broker/internal/hyperscaler/azure/provider.go
@@ -10,6 +10,7 @@ import (
 )
 
 type HyperscalerProvider interface {
+	// GetClient returns a client for interacting with Azure
 	GetClient(config *Config) (AzureInterface, error)
 }
 

--- a/components/kyma-environment-broker/internal/process/provisioning/event_hub_step.go
+++ b/components/kyma-environment-broker/internal/process/provisioning/event_hub_step.go
@@ -6,6 +6,11 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/services/eventhub/mgmt/2017-04-01/eventhub"
+	"github.com/google/uuid"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+
 	"github.com/kyma-incubator/compass/components/kyma-environment-broker/internal"
 	"github.com/kyma-incubator/compass/components/kyma-environment-broker/internal/hyperscaler"
 	"github.com/kyma-incubator/compass/components/kyma-environment-broker/internal/hyperscaler/azure"
@@ -13,11 +18,6 @@ import (
 	"github.com/kyma-incubator/compass/components/kyma-environment-broker/internal/ptr"
 	"github.com/kyma-incubator/compass/components/kyma-environment-broker/internal/storage"
 	"github.com/kyma-incubator/compass/components/provisioner/pkg/gqlschema"
-
-	"github.com/Azure/azure-sdk-for-go/services/eventhub/mgmt/2017-04-01/eventhub"
-	"github.com/google/uuid"
-	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 )
 
 const (

--- a/components/kyma-environment-broker/internal/process/provisioning/event_hub_step.go
+++ b/components/kyma-environment-broker/internal/process/provisioning/event_hub_step.go
@@ -139,22 +139,22 @@ func (p *ProvisionAzureEventHubStep) Run(operation internal.ProvisioningOperatio
 	return operation, 0, nil
 }
 
-func (p *ProvisionAzureEventHubStep) resourcesExist( resourcesName string, tags azure.Tags, azureClient azure.AzureInterface) (bool, error) {
+func (p *ProvisionAzureEventHubStep) resourcesExist(resourcesName string, tags azure.Tags, azureClient azure.AzureInterface) (bool, error) {
 	exists, err := azureClient.ResourceGroupExists(p.context, resourcesName, tags)
 	if err != nil {
-		return false, errors.Wrapf(err,"Can't check Azure resource group %s.", resourcesName)
+		return false, errors.Wrapf(err, "Can't check Azure resource group %s.", resourcesName)
 	}
 	// we are using the same name for resource group and namespace name
 	if exists {
 		exists, err = azureClient.NamespaceExists(p.context, resourcesName, resourcesName, tags)
 		if err != nil {
-			return false,errors.Wrapf(err, "Can't check Azure Event Hubs namespace %s.", resourcesName)
+			return false, errors.Wrapf(err, "Can't check Azure Event Hubs namespace %s.", resourcesName)
 		}
 	}
 	return exists, nil
 }
 
-func (p *ProvisionAzureEventHubStep) createEHResources( azureClient azure.AzureInterface, azureCfg *azure.Config, tags azure.Tags, log logrus.FieldLogger) (string, error) {
+func (p *ProvisionAzureEventHubStep) createEHResources(azureClient azure.AzureInterface, azureCfg *azure.Config, tags azure.Tags, log logrus.FieldLogger) (string, error) {
 	uniqueName, err := p.getUniqueNSName(azureClient, log)
 	if err != nil {
 		return "", errors.Errorf("Can't find a unique name for Event "+
@@ -165,7 +165,7 @@ func (p *ProvisionAzureEventHubStep) createEHResources( azureClient azure.AzureI
 	groupName := uniqueName
 	if _, err = azureClient.CreateResourceGroup(p.context, azureCfg, groupName, tags); err != nil {
 		// retrying might solve the issue while communicating with azure, e.g. network problems etc
-		return "", errors.Errorf( "Failed to create Azure Resource Group [%s] with error: %v", groupName, err)
+		return "", errors.Errorf("Failed to create Azure Resource Group [%s] with error: %v", groupName, err)
 	}
 	log.Info("created Azure Resource Group [%s]", groupName)
 

--- a/components/kyma-environment-broker/internal/process/provisioning/event_hub_step_test.go
+++ b/components/kyma-environment-broker/internal/process/provisioning/event_hub_step_test.go
@@ -276,7 +276,7 @@ func Test_StepsUnhappyPath(t *testing.T) {
 					context.Background(),
 				)
 			},
-			wantRepeatOperation: false,
+			wantRepeatOperation: true,
 		},
 	}
 	for _, tt := range tests {

--- a/components/kyma-environment-broker/internal/process/provisioning/event_hub_step_test.go
+++ b/components/kyma-environment-broker/internal/process/provisioning/event_hub_step_test.go
@@ -76,6 +76,14 @@ func (nc *FakeNamespaceClient) CheckNamespaceAvailability(ctx context.Context, n
 	return nc.uniqueNamespace, nil
 }
 
+func (nc *FakeNamespaceClient) NamespaceExists(ctx context.Context, resourceGroupName string, namespaceName string, tags azure.Tags) (bool, error) {
+	return false, nil
+}
+
+func (nc *FakeNamespaceClient) ResourceGroupExists(ctx context.Context, name string, tags azure.Tags) (bool, error) {
+	return false, nil
+}
+
 func NewFakeNamespaceClientCreationError() azure.AzureInterface {
 	return &FakeNamespaceClient{
 		persistEventhubsNamespaceError: fmt.Errorf("error while creating namespace"),

--- a/components/kyma-environment-broker/internal/process/provisioning/event_hub_step_test.go
+++ b/components/kyma-environment-broker/internal/process/provisioning/event_hub_step_test.go
@@ -83,7 +83,7 @@ func (nc *FakeNamespaceClient) NamespaceExists(ctx context.Context, resourceGrou
 func (nc *FakeNamespaceClient) ResourceGroupExists(ctx context.Context, name string, tags azure.Tags) (bool, error) {
 	return false, nil
 }
-func (nc *FakeNamespaceClient)  CheckResourceGroupAvailability(ctx context.Context, name string) (bool, error) {
+func (nc *FakeNamespaceClient) CheckResourceGroupAvailability(ctx context.Context, name string) (bool, error) {
 	return true, nil
 }
 

--- a/components/kyma-environment-broker/internal/process/provisioning/event_hub_step_test.go
+++ b/components/kyma-environment-broker/internal/process/provisioning/event_hub_step_test.go
@@ -83,6 +83,9 @@ func (nc *FakeNamespaceClient) NamespaceExists(ctx context.Context, resourceGrou
 func (nc *FakeNamespaceClient) ResourceGroupExists(ctx context.Context, name string, tags azure.Tags) (bool, error) {
 	return false, nil
 }
+func (nc *FakeNamespaceClient)  CheckResourceGroupAvailability(ctx context.Context, name string) (bool, error) {
+	return true, nil
+}
 
 func NewFakeNamespaceClientCreationError() azure.AzureInterface {
 	return &FakeNamespaceClient{

--- a/components/kyma-environment-broker/internal/process/provisioning/event_hub_step_test.go
+++ b/components/kyma-environment-broker/internal/process/provisioning/event_hub_step_test.go
@@ -8,13 +8,10 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/eventhub/mgmt/2017-04-01/eventhub"
 	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2019-05-01/resources"
-	"github.com/kyma-project/kyma/components/kyma-operator/pkg/apis/installer/v1alpha1"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-
-	"github.com/kyma-incubator/compass/components/provisioner/pkg/gqlschema"
 
 	"github.com/kyma-incubator/compass/components/kyma-environment-broker/internal"
 	"github.com/kyma-incubator/compass/components/kyma-environment-broker/internal/broker"
@@ -25,6 +22,8 @@ import (
 	inputAutomock "github.com/kyma-incubator/compass/components/kyma-environment-broker/internal/process/provisioning/input/automock"
 	"github.com/kyma-incubator/compass/components/kyma-environment-broker/internal/ptr"
 	"github.com/kyma-incubator/compass/components/kyma-environment-broker/internal/storage"
+	"github.com/kyma-incubator/compass/components/provisioner/pkg/gqlschema"
+	"github.com/kyma-project/kyma/components/kyma-operator/pkg/apis/installer/v1alpha1"
 )
 
 const (


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

Azure Event Hubs namespace names are globally unique. So we need to make sure that we're using
a unique namespace name each time we're provisioning a Kyma runtime.

- Use a unique name for Azure Event Hubs namespace and resource group