### PR TITLE
Fix nil pointer in e2e-test

### DIFF
--- a/tests/e2e/provisioning/internal/director/client.go
+++ b/tests/e2e/provisioning/internal/director/client.go
@@ -129,7 +129,7 @@ func (dc *Client) setToken() error {
 }
 
 func (dc *Client) getIDFromRuntime(response *graphql.RuntimePageExt) (string, error) {
-	if response.Data == nil || len(response.Data) == 0 {
+	if response.Data == nil || response.Data[0] == nil {
 		return "", errors.New("got empty data from director response")
 	}
 	if len(response.Data) > 1 {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Fixed nil pointer in e2e-test:
```
Start of logs from container "tests" in pod "oct-tp-testsuite-e2e-azure-cleanup-e2e-provisioning-azure-cleanup-0" in status "Failed"
  Starting e2e-provisioning cleanup test on Azure. Waiting 20s for api server...
  time="2020-04-17T19:20:07Z" level=info msg="using instance ID 4730e0eb-c4fd-4ab8-9fba-016450ef99cb"
  time="2020-04-17T19:20:08Z" level=info msg="Cleaning up..."
  time="2020-04-17T19:20:08Z" level=info msg="removing secret e2e-runtime-config-azure"
  time="2020-04-17T19:20:08Z" level=warning msg="secret not found"
  time="2020-04-17T19:20:08Z" level=info msg="removing config map e2e-runtime-config-azure"
  time="2020-04-17T19:20:08Z" level=info msg="Create request to director service" service=director_client
  time="2020-04-17T19:20:08Z" level=info msg="Send request to director" service=director_client
  time="2020-04-17T19:20:08Z" level=info msg="Getting authorization token for credentials to access Director from endpoint: https://oauth2.mps.dev.kyma.cloud.sap/oauth2/token"
  time="2020-04-17T19:20:08Z" level=error msg="Successfully unmarshal response oauth token for accessing Director"
  time="2020-04-17T19:20:08Z" level=info msg=">> variables: map[]"
  time="2020-04-17T19:20:08Z" level=info msg=">> query: query {\n\tresult: runtimes(filter: { key: \"broker_instance_id\" query: \"\\\"4730e0eb-c4fd-4ab8-9fba-016450ef99cb\\\"\" }) {\n    data {\n      id\n\t}\n}\n}"
  time="2020-04-17T19:20:08Z" level=info msg=">> headers: map[Accept:[application/json; charset=utf-8] Authorization:[Bearer p3SUE7XHsy8TqNk4etRXQeq_lC3N3hfrIPJ19IQgq4A.yjskMftWZie3APvnWirys3ZeSgKUvgHxrk_s6MNPlMY] Content-Type:[application/json; charset=utf-8] Tenant:[3e64ebae-38b5-46a0-b1ed-9ccee153a0ae]]"
  time="2020-04-17T19:20:08Z" level=info msg="<< {\"data\":{\"result\":{\"data\":[{\"id\":\"4a88f0ab-c737-46a8-837a-c72064ae52dc\"}]}}}"
  time="2020-04-17T19:20:08Z" level=info msg="Extract the RuntimeID from the response" service=director_client
  --- FAIL: Test_E2E_Provisioning (2.98s)
  panic: runtime error: invalid memory address or nil pointer dereference [recovered]
  	panic: runtime error: invalid memory address or nil pointer dereference
  [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x110c23b]
  
  goroutine 7 [running]:
  testing.tRunner.func1(0xc00052a800)
  	/usr/local/go/src/testing/testing.go:874 +0x3a3
  panic(0x1221240, 0x205ae60)
  	/usr/local/go/src/runtime/panic.go:679 +0x1b2
  github.com/kyma-incubator/compass/tests/e2e/provisioning/pkg/client/runtime.(*Client).newRuntimeClient(0xc0003028c0, 0x0, 0x0, 0x0, 0x0)
  	/go/src/github.com/kyma-incubator/compass/tests/e2e/provisioning/pkg/client/runtime/runtime_client.go:81 +0x6b
  github.com/kyma-incubator/compass/tests/e2e/provisioning/pkg/client/runtime.(*Client).EnsureUAAInstanceRemoved(0xc0003028c0, 0xc00052a800, 0x0)
  	/go/src/github.com/kyma-incubator/compass/tests/e2e/provisioning/pkg/client/runtime/runtime_client.go:64 +0x2f
  github.com/kyma-incubator/compass/tests/e2e/provisioning/test.(*Suite).Cleanup(0xc000302960)
  	/go/src/github.com/kyma-incubator/compass/tests/e2e/provisioning/test/test_suite.go:144 +0xdb
  github.com/kyma-incubator/compass/tests/e2e/provisioning/test.Test_E2E_Provisioning(0xc00052a800)
  	/go/src/github.com/kyma-incubator/compass/tests/e2e/provisioning/test/e2e_provisioning_test.go:16 +0xa4d
  testing.tRunner(0xc00052a800, 0x1428c40)
  	/usr/local/go/src/testing/testing.go:909 +0xc9
  created by testing.(*T).Run
```


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
