### PR TITLE
Change setting labels for runtime from arrays to strings

### DIFF
--- a/components/kyma-environment-broker/internal/process/provisioning/create_runtime_test.go
+++ b/components/kyma-environment-broker/internal/process/provisioning/create_runtime_test.go
@@ -51,8 +51,8 @@ func TestCreateRuntimeStep_Run(t *testing.T) {
 			Name:        "dummy",
 			Description: nil,
 			Labels: &gqlschema.Labels{
-				"broker_instance_id":   []string{instanceID},
-				"global_subaccount_id": []string{subAccountID},
+				"broker_instance_id":   instanceID,
+				"global_subaccount_id": subAccountID,
 			},
 		},
 		ClusterConfig: &gqlschema.ClusterConfigInput{

--- a/components/kyma-environment-broker/internal/process/provisioning/input/input.go
+++ b/components/kyma-environment-broker/internal/process/provisioning/input/input.go
@@ -67,8 +67,8 @@ func (r *RuntimeInput) SetRuntimeLabels(instanceID, subAccountID string) interna
 	defer r.mutex.Unlock("SetRuntimeLabels")
 
 	r.input.RuntimeInput.Labels = &gqlschema.Labels{
-		brokerKeyPrefix + "instance_id":   []string{instanceID},
-		globalKeyPrefix + "subaccount_id": []string{subAccountID},
+		brokerKeyPrefix + "instance_id":   instanceID,
+		globalKeyPrefix + "subaccount_id": subAccountID,
 	}
 
 	return r

--- a/components/kyma-environment-broker/internal/process/provisioning/input/input_test.go
+++ b/components/kyma-environment-broker/internal/process/provisioning/input/input_test.go
@@ -139,8 +139,8 @@ func TestInputBuilderFactoryForAzurePlan(t *testing.T) {
 	assert.Equal(t, "azure-secret", input.ClusterConfig.GardenerConfig.TargetSecret)
 	assert.EqualValues(t, mappedComponentList, input.KymaConfig.Components)
 	assert.Equal(t, &gqlschema.Labels{
-		brokerKeyPrefix + "instance_id":   []string{fixID},
-		globalKeyPrefix + "subaccount_id": []string{fixID},
+		brokerKeyPrefix + "instance_id":   fixID,
+		globalKeyPrefix + "subaccount_id": fixID,
 	}, input.RuntimeInput.Labels)
 
 	assertOverrides(t, "keb", input.KymaConfig.Components, kebOverrides)


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Changed `broker_instance_id` and `global_subaccount_id` from arrays to strings
- ...
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
