### PR TITLE
Add a PoC of running Kyma Environment Broker locally in KinD

### DIFF
--- a/components/kyma-environment-broker/Makefile
+++ b/components/kyma-environment-broker/Makefile
@@ -50,3 +50,19 @@ testing-with-database-network:
 
 clean-up:
 	@docker network rm $(TESTING_DB_NETWORK) || true
+
+run-local:
+	kind create cluster --name compass --config config/kind/cluster.yaml
+	kubectl apply -f https://projectcontour.io/quickstart/contour.yaml
+	kubectl patch daemonsets -n projectcontour envoy -p '{"spec":{"template":{"spec":{"nodeSelector":{"ingress-ready":"true"},"tolerations":[{"key":"node-role.kubernetes.io/master","operator":"Equal","effect":"NoSchedule"}]}}}}'
+	while [[ `kubectl get pods -n projectcontour -l app=envoy -o 'jsonpath={..status.conditions[?(@.type=="Ready")].status}'` != "True" ]]; do \
+  		echo "Waiting for envoy pod" && sleep 2;\
+	done;
+	ko apply -f config
+	while [[ `kubectl get pods -n compass-system -l app=postgresql -o 'jsonpath={..status.conditions[?(@.type=="Ready")].status}'` != "True" ]]; do \
+  		echo "Waiting for postgresql pod" && sleep 2;\
+	done;
+	if [ -a config/kind/database.sql ]; \
+	then \
+		cat config/kind/database.sql | kubectl -n compass-system exec -i compass-postgresql-0 -- psql 'postgresql://postgres:KCRXNu2d1g@localhost/broker' ;\
+	fi \

--- a/components/kyma-environment-broker/config/100-namespace.yaml
+++ b/components/kyma-environment-broker/config/100-namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: compass-system

--- a/components/kyma-environment-broker/config/150-pg.yaml
+++ b/components/kyma-environment-broker/config/150-pg.yaml
@@ -1,0 +1,265 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: compass-postgresql
+  namespace: compass-system
+  labels:
+    app: postgresql
+type: Opaque
+data:
+  postgresql-director-db-name: "cG9zdGdyZXM=" # broker
+  postgresql-director-username: "cG9zdGdyZXM=" # postgresql
+  postgresql-director-password: "S0NSWE51MmQxZw==" #KCRXNu2d1g
+  postgresql-provisioner-db-name: "cHJvdmlzaW9uZXI=" # provisioner
+  postgresql-provisioner-username: "cG9zdGdyZXM=" # postgres
+  postgresql-provisioner-password: "S0NSWE51MmQxZw==" #KCRXNu2d1g
+  postgresql-broker-db-name: "YnJva2Vy" # broker
+  postgresql-broker-username: "cG9zdGdyZXM=" # postgres
+  postgresql-broker-password: "S0NSWE51MmQxZw==" #KCRXNu2d1g
+  postgresql-serviceName: "Y29tcGFzcy1wb3N0Z3Jlc3Fs" # compass-postgresql
+  postgresql-servicePort: "NTQzMg==" # 5432
+  postgresql-sslMode: "ZGlzYWJsZQ==" # disable
+  postgresql-username: "cG9zdGdyZXM=" # postgres
+  postgresql-password: "M1EwS3RpMzZ4Ng==" # 3Q0Kti36x6
+  postgresql-directorDatabaseName: "cG9zdGdyZXM=" # postgres
+  postgresql-provisionerDatabaseName: "cHJvdmlzaW9uZXI=" # provisioner
+  postgresql-brokerDatabaseName: "YnJva2Vy" # broker
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: compass-postgresql-db-init
+  namespace: compass-system
+data:
+  init-director-db.sql: |
+    CREATE DATABASE postgres;
+  init-provisioner-db.sql: |
+    CREATE DATABASE provisioner;
+  init-broker-db.sql: |
+    CREATE DATABASE broker;
+---
+# Source: compass/charts/postgresql/templates/svc-headless.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: compass-postgresql-headless
+  namespace: compass-system
+  labels:
+    app: postgresql
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - name: postgresql
+      port: 5432
+      targetPort: postgresql
+  selector:
+    app: postgresql
+---
+# Source: compass/charts/postgresql/templates/svc.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: compass-postgresql
+  namespace: compass-system
+  labels:
+    app: postgresql
+spec:
+  type: ClusterIP
+  ports:
+    - name: postgresql
+      port: 5432
+      targetPort: postgresql
+  selector:
+    app: postgresql
+    role: master
+
+---
+# Source: compass/charts/postgresql/templates/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: compass-postgresql
+  namespace: compass-system
+  labels:
+    app: postgresql
+spec:
+  serviceName: compass-postgresql-headless
+  replicas: 1
+  updateStrategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: postgresql
+      role: master
+  template:
+    metadata:
+      name: compass-postgresql
+      labels:
+        app: postgresql
+        role: master
+    spec:
+      securityContext:
+        fsGroup: 1001
+      initContainers:
+        - name: init-chmod-data
+          image: docker.io/bitnami/minideb:stretch
+          imagePullPolicy: "Always"
+          resources:
+            requests:
+              cpu: 250m
+              memory: 256Mi
+
+          command:
+            - sh
+            - -c
+            - |
+              mkdir -p /bitnami/postgresql/data
+              chmod 700 /bitnami/postgresql/data
+              find /bitnami/postgresql -mindepth 1 -maxdepth 1 -not -name ".snapshot" -not -name "lost+found" | \
+                xargs chown -R 1001:1001
+          securityContext:
+            runAsUser: 0
+          volumeMounts:
+            - name: data
+              mountPath: /bitnami/postgresql
+              subPath:
+      containers:
+        - name: compass-postgresql
+          image: docker.io/bitnami/postgresql:11.4.0-debian-9-r12
+          imagePullPolicy: "IfNotPresent"
+          resources:
+            requests:
+              cpu: 250m
+              memory: 256Mi
+
+          securityContext:
+            runAsUser: 1001
+          env:
+            - name: BITNAMI_DEBUG
+              value: "false"
+            - name: POSTGRESQL_PORT_NUMBER
+              value: "5432"
+            - name: PGDATA
+              value: "/bitnami/postgresql/data"
+            - name: POSTGRES_USER
+              value: "postgres"
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: compass-postgresql
+                  key: postgresql-director-password
+          ports:
+            - name: postgresql
+              containerPort: 5432
+          livenessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - exec pg_isready -U "postgres" -h 127.0.0.1 -p 5432
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            timeoutSeconds: 5
+            successThreshold: 1
+            failureThreshold: 6
+          readinessProbe:
+            exec:
+              command:
+                - sh
+                - -c
+                - |
+                  pg_isready -U "postgres" -h 127.0.0.1 -p 5432
+                  [ -f /opt/bitnami/postgresql/tmp/.initialized ]
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+            successThreshold: 1
+            failureThreshold: 6
+          volumeMounts:
+            - name: custom-init-scripts
+              mountPath: /docker-entrypoint-initdb.d/
+            - name: data
+              mountPath: /bitnami/postgresql
+              subPath:
+      volumes:
+        - name: custom-init-scripts
+          configMap:
+            name: compass-postgresql-db-init
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes:
+          - "ReadWriteOnce"
+        resources:
+          requests:
+            storage: "8Gi"
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: compass-migration-broker
+  namespace: compass-system
+  labels:
+    app: compass
+    release: compass
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "1"
+    "helm.sh/hook-delete-policy": before-hook-creation
+spec:
+  template:
+    metadata:
+      labels:
+        app: compass
+        release: compass
+    spec:
+      restartPolicy: Never
+      shareProcessNamespace: true
+      containers:
+
+        - name: migrator
+          image: eu.gcr.io/kyma-project/incubator/compass-schema-migrator:PR-1134
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: DB_USER
+              valueFrom:
+                secretKeyRef:
+                  name: compass-postgresql
+                  key: postgresql-broker-username
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: compass-postgresql
+                  key: postgresql-broker-password
+            - name: DB_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: compass-postgresql
+                  key: postgresql-serviceName
+            - name: DB_PORT
+              valueFrom:
+                secretKeyRef:
+                  name: compass-postgresql
+                  key: postgresql-servicePort
+            - name: DB_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: compass-postgresql
+                  key: postgresql-broker-db-name
+            - name: DB_SSL
+              valueFrom:
+                secretKeyRef:
+                  name: compass-postgresql
+                  key: postgresql-sslMode
+            - name: MIGRATION_PATH
+              value: "kyma-environment-broker"
+            - name: DIRECTION
+              value: "up"
+
+          command:
+            - "/bin/bash"
+          args:
+            - "-c"
+            - "sleep 20; ./run.sh; exit_code=$?; echo '# KILLING PILOT-AGENT #'; pkill -INT cloud_sql_proxy; curl -XPOST http://127.0.0.1:15020/quitquitquit; sleep 5; exit $exit_code;"

--- a/components/kyma-environment-broker/config/200-configmap.yaml
+++ b/components/kyma-environment-broker/config/200-configmap.yaml
@@ -1,0 +1,59 @@
+apiVersion: v1
+data:
+  additionalRuntimeComponents.yaml: |-
+    components:
+      - name: service-manager-proxy
+        namespace: kyma-system
+      - name: uaa-activator
+        namespace: kyma-system
+      - name: compass-runtime-agent
+        namespace: compass-system
+      - name: knative-eventing-kafka
+        namespace: knative-eventing
+      - name: "prometheus-config-updater"
+        namespace: "kyma-system"
+        source:
+          url: "https://storage.googleapis.com/kyma-mps-dev-artifacts/prometheus-config-updater.zip"
+      - name: "avs-bridge"
+        namespace: "kyma-system"
+        source:
+          url: "https://storage.googleapis.com/kyma-mps-dev-artifacts/avs-bridge-noparent-1.1.0.tgz"
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/instance: compass
+    app.kubernetes.io/name: kyma-environment-broker
+  name: compass-kyma-environment-broker
+  namespace: compass-system
+---
+apiVersion: v1
+data:
+  console.managementPlane.url: https://compass-gateway.mps.dev.kyma.cloud.sap/runtime/director/graphql
+kind: ConfigMap
+metadata:
+  labels:
+    component: core
+    provisioning-runtime-override: "true"
+  name: core-overrides
+  namespace: compass-system
+---
+apiVersion: v1
+data:
+  global.enableAPIPackages: "true"
+kind: ConfigMap
+metadata:
+  labels:
+    provisioning-runtime-override: "true"
+  name: global-overrides
+  namespace: compass-system
+---
+apiVersion: v1
+data:
+  managementPlane.url: https://compass-gateway.mps.dev.kyma.cloud.sap/runtime/director/graphql
+kind: ConfigMap
+metadata:
+  labels:
+    component: compass-runtime-agent
+    provisioning-runtime-override: "true"
+  name: compass-runtime-agent-overrides
+  namespace: compass-system

--- a/components/kyma-environment-broker/config/300-rbac.yaml
+++ b/components/kyma-environment-broker/config/300-rbac.yaml
@@ -1,0 +1,46 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: compass-kyma-environment-broker
+  namespace: compass-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app: kyma-environment-broker
+    release: compass
+  name: compass-kyma-environment-broker
+  namespace: compass-system
+rules:
+- apiGroups:
+  - '*'
+  resources:
+  - secrets
+  verbs:
+  - list
+  - get
+- apiGroups:
+  - '*'
+  resources:
+  - configmaps
+  verbs:
+  - list
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app: kyma-environment-broker
+    release: compass
+  name: compass-kyma-environment-broker
+  namespace: compass-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: compass-kyma-environment-broker
+subjects:
+- kind: ServiceAccount
+  name: compass-kyma-environment-broker
+  namespace: compass-system

--- a/components/kyma-environment-broker/config/400-secrets.yaml
+++ b/components/kyma-environment-broker/config/400-secrets.yaml
@@ -1,0 +1,90 @@
+apiVersion: v1
+data:
+  # value is password
+  broker-password: cGFzc3dvcmQ=
+kind: Secret
+metadata:
+  labels:
+    app.kubernetes.io/name: kyma-environment-broker
+  name: compass-kyma-environment-broker
+  namespace: compass-system
+type: Opaque
+---
+apiVersion: v1
+data:
+  password: cGFzc3dvcmQ= #password
+  url: aHR0cDovL3N2Yy1tYW5hZ2VyLmNvbXBhc3Mtc3lzdGVtLnN2Yy5jbHVzdGVyLmxvY2FsOjMwMDAK #http://svc-manager.compass-system.svc.cluster.local:3000
+  username: dXNlcm5hbWU= #username
+kind: Secret
+metadata:
+  labels:
+    app.kubernetes.io/name: kyma-environment-broker
+  name: service-manager-creds
+  namespace: compass-system
+type: Opaque
+---
+apiVersion: v1
+data:
+  token: cGFzc3dvcmQ= #password
+kind: Secret
+metadata:
+  labels:
+    app.kubernetes.io/name: kyma-environment-broker
+  name: lms-creds
+  namespace: compass-system
+type: Opaque
+---
+apiVersion: v1
+data:
+  kubeconfig: cGFzc3dvcmQ= # replace with a valid kubecfg base64 e.g. cat ~/.kube/config | base64
+kind: Secret
+metadata:
+  labels:
+    app: provisioner
+    release: compass
+  name: gardener-credentials
+  namespace: compass-system
+type: Opaque
+---
+apiVersion: v1
+data:
+  credentials.json: cGFzc3dvcmQ= # replace with a valid credentials.json file for cloudsql
+kind: Secret
+metadata:
+  name: cloudsql-instance-credentials
+  namespace: compass-system
+type: Opaque
+---
+apiVersion: v1
+data:
+  apiEndpoint: aHR0cHM6Ly9hdmFpbGFiaWxpdHkuZXhhbXBsZS5jb20= #  https://availability.example.com
+  apiKey: a2V5 # key
+  clientId: MTIzNDU2Nzg= #12345679
+  externalTesterAccessId: MTIzNDU2Nzg= #12345679
+  groupId: MTIzNDU2Nzg= #12345679
+  internalTesterAccessId: MTIzNDU2Nzg= #12345679
+  oauthPassword: cGFzc3dvcmQ= #password
+  oauthTokenEndpoint: aHR0cHM6Ly9vYXV0aC5leGFtcGxlLmNvbQ== #https://oauth.example.com
+  oauthUserName: dXNlcm5hbWU= #username
+kind: Secret
+metadata:
+  labels:
+    app.kubernetes.io/instance: compass
+    app.kubernetes.io/managed-by: Tiller
+    app.kubernetes.io/name: kyma-environment-broker
+    app.kubernetes.io/version: 0.1.0
+    helm.sh/chart: kyma-environment-broker-0.1.0
+  name: avs-creds
+  namespace: compass-system
+type: Opaque
+---
+apiVersion: v1
+data:
+  client_id: MTIzNDU2Nzg= #12345679
+  client_secret: cGFzc3dvcmQ= #password
+  tokens_endpoint: aHR0cHM6Ly9vYXV0aC5leGFtcGxlLmNvbQ== #https://oauth.example.com
+kind: Secret
+metadata:
+  name: compass-kyma-environment-broker-credentials
+  namespace: compass-system
+type: Opaque

--- a/components/kyma-environment-broker/config/500-service.yaml
+++ b/components/kyma-environment-broker/config/500-service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/name: kyma-environment-broker
+  name: compass-kyma-environment-broker
+  namespace: compass-system
+spec:
+  type: ClusterIP
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: http
+  selector:
+    app.kubernetes.io/instance: compass
+    app.kubernetes.io/name: kyma-environment-broker

--- a/components/kyma-environment-broker/config/550-echo.yaml
+++ b/components/kyma-environment-broker/config/550-echo.yaml
@@ -1,0 +1,64 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: echoserver
+  namespace: compass-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: echoserver
+  template:
+    metadata:
+      labels:
+        app: echoserver
+    spec:
+      containers:
+        - image: mendhak/http-https-echo
+          imagePullPolicy: Always
+          name: echoserver
+          ports:
+            - containerPort: 80
+            - containerPort: 443
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: compass-provisioner
+  namespace: compass-system
+spec:
+  ports:
+    - port: 80
+      targetPort: 80
+      protocol: TCP
+      name: http
+  selector:
+    app: echoserver
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: compass-director
+  namespace: compass-system
+spec:
+  ports:
+    - port: 80
+      targetPort: 80
+      protocol: TCP
+      name: http
+  selector:
+    app: echoserver
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: lms
+  namespace: compass-system
+spec:
+  ports:
+    - port: 80
+      targetPort: 80
+      protocol: TCP
+      name: http
+  selector:
+    app: echoserver

--- a/components/kyma-environment-broker/config/600-deployment.yaml
+++ b/components/kyma-environment-broker/config/600-deployment.yaml
@@ -1,0 +1,213 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/name: kyma-environment-broker
+    app.kubernetes.io/version: 0.1.0
+  name: compass-kyma-environment-broker
+  namespace: compass-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: compass
+      app.kubernetes.io/name: kyma-environment-broker
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/instance: compass
+        app.kubernetes.io/name: kyma-environment-broker
+    spec:
+      containers:
+      - env:
+        - name: APP_BROKER_ENABLE_PLANS
+          value: azure,gcp
+        - name: APP_PROVISIONING_URL
+          value: http://compass-provisioner.compass-system.svc.cluster.local/graphql
+        - name: APP_PORT
+          value: "8080"
+        - name: APP_AUTH_USERNAME
+          value: broker
+        - name: APP_AUTH_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: broker-password
+              name: compass-kyma-environment-broker
+        - name: APP_DIRECTOR_NAMESPACE
+          value: compass-system
+        - name: APP_DIRECTOR_DEFAULT_TENANT
+          value: tenant9ccee153a0ae
+        - name: APP_DIRECTOR_URL
+          value: http://compass-director.compass-system.svc.cluster.local
+        - name: APP_DIRECTOR_OAUTH_CREDENTIALS_SECRET_NAME
+          value: compass-kyma-environment-broker-credentials
+        - name: APP_DIRECTOR_SKIP_CERT_VERIFICATION
+          value: "true"
+        - name: APP_LMS_URL
+          value: https://lms.compass-system.svc.cluster.local
+        - name: APP_LMS_CLUSTER_TYPE
+          value: single-node
+        - name: APP_LMS_ENVIRONMENT
+          value: dev
+        - name: APP_LMS_SAML_TENANT
+          value: kymatest.accounts400.ondemand.com
+        - name: APP_LMS_DISABLED
+          value: "true"
+        - name: APP_LMS_TOKEN
+          valueFrom:
+            secretKeyRef:
+              key: token
+              name: lms-creds
+        - name: APP_DATABASE_USER
+          valueFrom:
+            secretKeyRef:
+              key: postgresql-broker-username
+              name: compass-postgresql
+        - name: APP_DATABASE_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: postgresql-broker-password
+              name: compass-postgresql
+        - name: APP_DATABASE_HOST
+          valueFrom:
+            secretKeyRef:
+              key: postgresql-serviceName
+              name: compass-postgresql
+        - name: APP_DATABASE_PORT
+          valueFrom:
+            secretKeyRef:
+              key: postgresql-servicePort
+              name: compass-postgresql
+        - name: APP_DATABASE_NAME
+          valueFrom:
+            secretKeyRef:
+              key: postgresql-broker-db-name
+              name: compass-postgresql
+        - name: APP_DATABASE_SSL
+          valueFrom:
+            secretKeyRef:
+              key: postgresql-sslMode
+              name: compass-postgresql
+        - name: APP_SERVICE_MANAGER_OVERRIDE_MODE
+          value: WhenNotSentInRequest
+        - name: APP_SERVICE_MANAGER_URL
+          valueFrom:
+            secretKeyRef:
+              key: url
+              name: service-manager-creds
+        - name: APP_SERVICE_MANAGER_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: service-manager-creds
+        - name: APP_SERVICE_MANAGER_USERNAME
+          valueFrom:
+            secretKeyRef:
+              key: username
+              name: service-manager-creds
+        - name: APP_AVS_OAUTH_TOKEN_ENDPOINT
+          valueFrom:
+            secretKeyRef:
+              key: oauthTokenEndpoint
+              name: avs-creds
+        - name: APP_AVS_OAUTH_USERNAME
+          valueFrom:
+            secretKeyRef:
+              key: oauthUserName
+              name: avs-creds
+        - name: APP_AVS_OAUTH_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: oauthPassword
+              name: avs-creds
+        - name: APP_AVS_API_ENDPOINT
+          valueFrom:
+            secretKeyRef:
+              key: apiEndpoint
+              name: avs-creds
+        - name: APP_AVS_OAUTH_CLIENT_ID
+          valueFrom:
+            secretKeyRef:
+              key: clientId
+              name: avs-creds
+        - name: APP_AVS_API_KEY
+          valueFrom:
+            secretKeyRef:
+              key: apiKey
+              name: avs-creds
+        - name: APP_AVS_INTERNAL_TESTER_ACCESS_ID
+          valueFrom:
+            secretKeyRef:
+              key: internalTesterAccessId
+              name: avs-creds
+        - name: APP_AVS_EXTERNAL_TESTER_ACCESS_ID
+          valueFrom:
+            secretKeyRef:
+              key: externalTesterAccessId
+              name: avs-creds
+        - name: APP_AVS_GROUP_ID
+          valueFrom:
+            secretKeyRef:
+              key: groupId
+              name: avs-creds
+        - name: APP_KYMA_VERSION
+          value: 1.11.0-rc2
+        - name: APP_ENABLE_ON_DEMAND_VERSION
+          value: "true"
+        - name: APP_MANAGED_RUNTIME_COMPONENTS_YAML_FILE_PATH
+          value: /config/additionalRuntimeComponents.yaml
+        - name: APP_GARDENER_PROJECT
+          value: kyma-dev
+        - name: APP_GARDENER_KUBECONFIG_PATH
+          value: /gardener/kubeconfig/kubeconfig
+        image: github.com/kyma-incubator/compass/components/kyma-environment-broker/cmd/broker
+        imagePullPolicy: IfNotPresent
+        name: kyma-environment-broker
+        ports:
+        - containerPort: 8080
+          name: http
+          protocol: TCP
+        volumeMounts:
+        - mountPath: /gardener/kubeconfig
+          name: gardener-kubeconfig
+          readOnly: true
+        - mountPath: /config
+          name: config-volume
+#        - mountPath: /secrets/cloudsql-instance-credentials
+#          name: cloudsql-instance-credentials
+#          readOnly: true
+#      - command:
+#        - /cloud_sql_proxy
+#        - -instances=sap-ti-dx-kyma-mps-dev:europe-west1:kyma-mps-dev-f720=tcp:5432
+#        - -credential_file=/secrets/cloudsql-instance-credentials/credentials.json
+#        image: gcr.io/cloudsql-docker/gce-proxy:1.16
+#        imagePullPolicy: IfNotPresent
+#        name: cloudsql-proxy
+#        resources: {}
+#        securityContext:
+#          runAsUser: 2000
+#        volumeMounts:
+#        - mountPath: /secrets/cloudsql-instance-credentials
+#          name: cloudsql-instance-credentials
+#          readOnly: true
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext:
+        runAsUser: 2000
+      serviceAccount: compass-kyma-environment-broker
+      serviceAccountName: compass-kyma-environment-broker
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - configMap:
+          defaultMode: 420
+          name: compass-kyma-environment-broker
+        name: config-volume
+#      - name: cloudsql-instance-credentials
+#        secret:
+#          defaultMode: 420
+#          secretName: cloudsql-instance-credentials
+      - name: gardener-kubeconfig
+        secret:
+          defaultMode: 420
+          secretName: gardener-credentials

--- a/components/kyma-environment-broker/config/700-ingress.yaml
+++ b/components/kyma-environment-broker/config/700-ingress.yaml
@@ -1,0 +1,15 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: broker-ingress
+  namespace: compass-system
+  annotations:
+    ingress.kubernetes.io/rewrite-target: /
+spec:
+  rules:
+    - http:
+        paths:
+          - path: /v2
+            backend:
+              serviceName: compass-kyma-environment-broker
+              servicePort: 80

--- a/components/kyma-environment-broker/config/kind/cluster.yaml
+++ b/components/kyma-environment-broker/config/kind/cluster.yaml
@@ -1,0 +1,23 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+# the control plane node config
+- role: control-plane
+  image: kindest/node:v1.16.4@sha256:b91a2c2317a000f3a783489dfb755064177dbc3a0b2f4147d50f04825d016f55
+  kubeadmConfigPatches:
+    - |
+      kind: InitConfiguration
+      nodeRegistration:
+        kubeletExtraArgs:
+          node-labels: "ingress-ready=true"
+          authorization-mode: "AlwaysAllow"
+  extraPortMappings:
+    - containerPort: 80
+      hostPort: 80
+      protocol: TCP
+    - containerPort: 443
+      hostPort: 443
+      protocol: TCP
+  # one worker
+- role: worker
+  image: kindest/node:v1.16.4@sha256:b91a2c2317a000f3a783489dfb755064177dbc3a0b2f4147d50f04825d016f55


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
For faster feedback cycle, a new make target is added that uses KinD and ko
to build and deploy Kyma Environment Broker.

Simply run 'make run-local' and then you can send requests to localhost:80.

* Adds a make target run-local
* Installs a KinD cluster with contour ingress controller
* Adds working manifests with a ko ready version of KEB deployment
* Installs an echo server with a set of services for KEB dependencies
* If exists, loads the database from a database.sql file in config/kind directory