### PR TITLE
Avoid indexing of log payloads

### DIFF
--- a/components/kyma-environment-broker/internal/process/provisioning/lms_cert_step.go
+++ b/components/kyma-environment-broker/internal/process/provisioning/lms_cert_step.go
@@ -159,6 +159,8 @@ func (s *lmsCertStep) Run(operation internal.ProvisioningOperation, logger logru
 
 	operation.InputCreator.AppendOverrides("logging", []*gqlschema.ConfigEntryInput{
 		{Key: "fluent-bit.conf.Output.forward.enabled", Value: "true"},
+		{Key: "fluent-bit.conf.Output.forward.Match", Value: "kube.*"},
+
 		{Key: "fluent-bit.backend.forward.host", Value: fmt.Sprintf("forward.%s", tenantInfo.DNS)},
 		{Key: "fluent-bit.backend.forward.port", Value: "8443"},
 		{Key: "fluent-bit.backend.forward.tls.enabled", Value: "true"},
@@ -168,6 +170,9 @@ func (s *lmsCertStep) Run(operation internal.ProvisioningOperation, logger logru
 		{Key: "fluent-bit.backend.forward.tls.ca", Value: base64.StdEncoding.EncodeToString([]byte(caCert))},
 		{Key: "fluent-bit.backend.forward.tls.cert", Value: base64.StdEncoding.EncodeToString([]byte(signedCert))},
 		{Key: "fluent-bit.backend.forward.tls.key", Value: base64.StdEncoding.EncodeToString(pKey)},
+
+		//kubernetes filter should not parse the document to avoid indexing on LMS side
+		{Key: "fluent-bit.conf.Filter.Kubernetes.Merge_Log", Value: "Off"},
 
 		{Key: "fluent-bit.conf.extra", Value: fmt.Sprintf(`
 [FILTER]

--- a/components/kyma-environment-broker/internal/process/provisioning/lms_cert_step.go
+++ b/components/kyma-environment-broker/internal/process/provisioning/lms_cert_step.go
@@ -173,6 +173,8 @@ func (s *lmsCertStep) Run(operation internal.ProvisioningOperation, logger logru
 
 		//kubernetes filter should not parse the document to avoid indexing on LMS side
 		{Key: "fluent-bit.conf.Filter.Kubernetes.Merge_Log", Value: "Off"},
+		//input should not conatain dex logs as it contains sensitive data
+		{Key: "fluent-bit.conf.Input.Kubernetes.Exclude_Path", Value: "/var/log/containers/*_dex-*.log"},
 
 		{Key: "fluent-bit.conf.extra", Value: fmt.Sprintf(`
 [FILTER]


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Having the Merge_Log option on for the kubernetes filter will cause indexing of the log message by elasticsearch. As every log has a different format, that will not work
Furthermore the output was defined for all inputs, it must be only for the kube.* input and it needs to exclude logs from dex

Changes proposed in this pull request:

- Set Merge_Log option for filter to Off
- Set proper match for output plugin
- Exclude dex logs

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
