### PR TITLE
KEB: use 3x n1-standard-4 worker nodes by default for GCP

### DIFF
--- a/components/kyma-environment-broker/internal/process/provisioning/create_runtime_test.go
+++ b/components/kyma-environment-broker/internal/process/provisioning/create_runtime_test.go
@@ -64,7 +64,7 @@ func TestCreateRuntimeStep_Run(t *testing.T) {
 				Region:            "europe-west4-a",
 				Provider:          "gcp",
 				WorkerCidr:        "10.250.0.0/19",
-				AutoScalerMin:     2,
+				AutoScalerMin:     3,
 				AutoScalerMax:     4,
 				MaxSurge:          4,
 				MaxUnavailable:    1,

--- a/components/kyma-environment-broker/internal/provider/gcp_provider.go
+++ b/components/kyma-environment-broker/internal/provider/gcp_provider.go
@@ -17,7 +17,7 @@ func (p *GcpInput) Defaults() *gqlschema.ClusterConfigInput {
 			Region:            "europe-west4",
 			Provider:          "gcp",
 			WorkerCidr:        "10.250.0.0/19",
-			AutoScalerMin:     2,
+			AutoScalerMin:     3,
 			AutoScalerMax:     4,
 			MaxSurge:          4,
 			MaxUnavailable:    1,


### PR DESCRIPTION
**Description**
2 is not enough :)

**Changes proposed in this pull request:**
- Add 1 to 2, that makes 3

**Related issue(s)**
