### PR TITLE
Fix selecting EnvironmentKey for EDP

### DIFF
--- a/components/kyma-environment-broker/internal/process/provisioning/edp_registration_test.go
+++ b/components/kyma-environment-broker/internal/process/provisioning/edp_registration_test.go
@@ -8,10 +8,10 @@ import (
 
 	"github.com/kyma-incubator/compass/components/kyma-environment-broker/internal"
 	"github.com/kyma-incubator/compass/components/kyma-environment-broker/internal/edp"
+	"github.com/kyma-incubator/compass/components/kyma-environment-broker/internal/logger"
 	"github.com/kyma-incubator/compass/components/kyma-environment-broker/internal/process/provisioning/automock"
 	"github.com/kyma-incubator/compass/components/kyma-environment-broker/internal/storage"
 
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -33,7 +33,7 @@ func TestEDPRegistration_Run(t *testing.T) {
 	}).Return(nil).Once()
 	client.On("CreateMetadataTenant", edpName, edpEnvironment, edp.MetadataTenantPayload{
 		Key:   edp.MaasConsumerEnvironmentKey,
-		Value: "KUBERNETES",
+		Value: "CF",
 	}).Return(nil).Once()
 	client.On("CreateMetadataTenant", edpName, edpEnvironment, edp.MetadataTenantPayload{
 		Key:   edp.MaasConsumerRegionKey,
@@ -53,9 +53,48 @@ func TestEDPRegistration_Run(t *testing.T) {
 	// when
 	_, repeat, err := step.Run(internal.ProvisioningOperation{
 		ProvisioningParameters: `{"platform_region":"` + edpRegion + `", "ers_context":{"subaccount_id":"` + edpName + `"}}`,
-	}, logrus.New())
+	}, logger.NewLogDummy())
 
 	// then
 	assert.Equal(t, 0*time.Second, repeat)
 	assert.NoError(t, err)
+}
+
+func TestEDPRegistrationStep_selectEnvironmentKey(t *testing.T) {
+	for name, tc := range map[string]struct {
+		region   string
+		expected string
+	}{
+		"kubernetes region": {
+			region:   "k8s-as34",
+			expected: "KUBERNETES",
+		},
+		"cf region": {
+			region:   "cf-eu10",
+			expected: "CF",
+		},
+		"neo region": {
+			region:   "neo-us13",
+			expected: "NEO",
+		},
+		"default region": {
+			region:   "undefined",
+			expected: "CF",
+		},
+		"empty region": {
+			region:   "",
+			expected: "CF",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			// given
+			step := NewEDPRegistrationStep(nil, nil, edp.Config{})
+
+			// when
+			envKey := step.selectEnvironmentKey(tc.region, logger.NewLogDummy())
+
+			// then
+			assert.Equal(t, tc.expected, envKey)
+		})
+	}
 }


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- after the agreement, a new way of selecting the `MaasConsumerEnvironmentKey` parameter sent to EDP has been implemented
