### PR TITLE
Use logger from the initialisation call

### DIFF
--- a/components/kyma-environment-broker/cmd/broker/main.go
+++ b/components/kyma-environment-broker/cmd/broker/main.go
@@ -173,7 +173,7 @@ func main() {
 	avsDel := avs.NewDelegator(cfg.Avs, db.Operations())
 	externalEvalAssistant := avs.NewExternalEvalAssistant(cfg.Avs)
 	internalEvalAssistant := avs.NewInternalEvalAssistant(cfg.Avs)
-	externalEvalCreator := provisioning.NewExternalEvalCreator(cfg.Avs, avsDel, cfg.Avs.Disabled, externalEvalAssistant)
+	externalEvalCreator := provisioning.NewExternalEvalCreator(avsDel, cfg.Avs.Disabled, externalEvalAssistant)
 
 	bundleBuilder := ias.NewBundleBuilder(httpClient, cfg.IAS)
 	iasTypeSetter := provisioning.NewIASType(bundleBuilder, cfg.IAS.Disabled)
@@ -198,7 +198,7 @@ func main() {
 		},
 		{
 			weight:   1,
-			step:     provisioning.NewInternalEvaluationStep(cfg.Avs, avsDel, internalEvalAssistant),
+			step:     provisioning.NewInternalEvaluationStep(avsDel, internalEvalAssistant),
 			disabled: cfg.Avs.Disabled,
 		},
 		{

--- a/components/kyma-environment-broker/internal/process/provisioning/external_eval.go
+++ b/components/kyma-environment-broker/internal/process/provisioning/external_eval.go
@@ -11,23 +11,21 @@ import (
 type ExternalEvalCreator struct {
 	delegator *avs.Delegator
 	assistant *avs.ExternalEvalAssistant
-	logger    logrus.FieldLogger
 	disabled  bool
 }
 
-func NewExternalEvalCreator(config avs.Config, delegator *avs.Delegator, disabled bool, assistant *avs.ExternalEvalAssistant) *ExternalEvalCreator {
+func NewExternalEvalCreator(delegator *avs.Delegator, disabled bool, assistant *avs.ExternalEvalAssistant) *ExternalEvalCreator {
 	return &ExternalEvalCreator{
 		delegator: delegator,
 		assistant: assistant,
-		logger:    logrus.New(),
 		disabled:  disabled,
 	}
 }
 
-func (eec *ExternalEvalCreator) createEval(operation internal.ProvisioningOperation, url string) (internal.ProvisioningOperation, time.Duration, error) {
+func (eec *ExternalEvalCreator) createEval(operation internal.ProvisioningOperation, url string, logger logrus.FieldLogger) (internal.ProvisioningOperation, time.Duration, error) {
 	if eec.disabled {
 		return operation, 0, nil
 	} else {
-		return eec.delegator.CreateEvaluation(eec.logger, operation, eec.assistant, url)
+		return eec.delegator.CreateEvaluation(logger, operation, eec.assistant, url)
 	}
 }

--- a/components/kyma-environment-broker/internal/process/provisioning/initialisation.go
+++ b/components/kyma-environment-broker/internal/process/provisioning/initialisation.go
@@ -182,7 +182,7 @@ func (s *InitialisationStep) handleDashboardURL(instance *internal.Instance, log
 
 func (s *InitialisationStep) launchPostActions(operation internal.ProvisioningOperation, instance *internal.Instance, log logrus.FieldLogger, msg string) (internal.ProvisioningOperation, time.Duration, error) {
 	// action #1
-	operation, repeat, err := s.externalEvalCreator.createEval(operation, instance.DashboardURL)
+	operation, repeat, err := s.externalEvalCreator.createEval(operation, instance.DashboardURL, log)
 	if err != nil || repeat != 0 {
 		return operation, repeat, nil
 	}

--- a/components/kyma-environment-broker/internal/process/provisioning/initialisation_test.go
+++ b/components/kyma-environment-broker/internal/process/provisioning/initialisation_test.go
@@ -61,7 +61,7 @@ func TestInitialisationStep_Run(t *testing.T) {
 	avsConfig := avsConfig(mockOauthServer, mockAvsServer)
 	avsDel := avs.NewDelegator(avsConfig, memoryStorage.Operations())
 	externalEvalAssistant := avs.NewExternalEvalAssistant(avsConfig)
-	externalEvalCreator := NewExternalEvalCreator(avsConfig, avsDel, false, externalEvalAssistant)
+	externalEvalCreator := NewExternalEvalCreator(avsDel, false, externalEvalAssistant)
 	iasType := NewIASType(nil, true)
 
 	step := NewInitialisationStep(memoryStorage.Operations(), memoryStorage.Instances(), provisionerClient, directorClient, nil, externalEvalCreator, iasType, time.Hour)

--- a/components/kyma-environment-broker/internal/process/provisioning/internal_eval.go
+++ b/components/kyma-environment-broker/internal/process/provisioning/internal_eval.go
@@ -14,7 +14,7 @@ type InternalEvaluationStep struct {
 	iec       *avs.InternalEvalAssistant
 }
 
-func NewInternalEvaluationStep(avsConfig avs.Config, delegator *avs.Delegator, assistant *avs.InternalEvalAssistant) *InternalEvaluationStep {
+func NewInternalEvaluationStep(delegator *avs.Delegator, assistant *avs.InternalEvalAssistant) *InternalEvaluationStep {
 	return &InternalEvaluationStep{
 		delegator: delegator,
 		iec:       assistant,
@@ -22,7 +22,7 @@ func NewInternalEvaluationStep(avsConfig avs.Config, delegator *avs.Delegator, a
 }
 
 func (ies *InternalEvaluationStep) Name() string {
-	return "AVS_Configuration_Step"
+	return "AVS_Create_Internal_Eval_Step"
 }
 
 func (ies *InternalEvaluationStep) Run(operation internal.ProvisioningOperation, logger logrus.FieldLogger) (internal.ProvisioningOperation, time.Duration, error) {

--- a/components/kyma-environment-broker/internal/process/provisioning/internal_eval_test.go
+++ b/components/kyma-environment-broker/internal/process/provisioning/internal_eval_test.go
@@ -35,7 +35,7 @@ func TestInternalEvaluationStep_Run(t *testing.T) {
 	avsConfig := avsConfig(mockOauthServer, mockAvsServer)
 	avsDel := avs.NewDelegator(avsConfig, memoryStorage.Operations())
 	internalEvalAssistant := avs.NewInternalEvalAssistant(avsConfig)
-	ies := NewInternalEvaluationStep(avsConfig, avsDel, internalEvalAssistant)
+	ies := NewInternalEvaluationStep(avsDel, internalEvalAssistant)
 
 	// when
 	logger := log.WithFields(logrus.Fields{"step": "TEST"})


### PR DESCRIPTION
- and Minor cleanup: remove unused params and rename internal eval step