### PR TITLE
Build Compass components with Go 1.14

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -15,28 +15,28 @@ global:
       path: eu.gcr.io/kyma-project/incubator
     connector:
       dir:
-      version: "PR-1162"
+      version: "PR-1270"
     connectivity_adapter:
       dir:
-      version: "PR-1208"
+      version: "PR-1270"
     pairing_adapter:
       dir:
-      version: "PR-1156"
+      version: "PR-1270"
     director:
       dir:
-      version: "PR-1222"
+      version: "PR-1270"
     gateway:
       dir:
-      version: "PR-1217"
+      version: "PR-1270"
     healthchecker:
       dir: pr/
       version: "PR-357"
     schema_migrator:
       dir:
-      version: "PR-1222"
+      version: "PR-1270"
     provisioner:
       dir:
-      version: "PR-1222"
+      version: "PR-1270"
     certs_setup_job:
       containerRegistry:
         path: eu.gcr.io/kyma-project
@@ -44,29 +44,29 @@ global:
       version: "PR-5318"
     kyma_environment_broker:
       dir:
-      version: "PR-1196"
+      version: "PR-1270"
     external_services_mock:
       dir:
-      version: "PR-1250"
+      version: "PR-1270"
     metris:
       dir:
-      version: "PR-1241"
+      version: "PR-1270"
     tests:
       director:
         dir:
-        version: "PR-1250"
+        version: "PR-1270"
       connector:
         dir:
-        version: "PR-1156"
+        version: "PR-1270"
       provisioner:
         dir:
-        version: "PR-1252"
+        version: "PR-1270"
       e2e_provisioning:
         dir:
-        version: "PR-1226"
+        version: "PR-1270"
       connectivity_adapter:
         dir:
-        version: "PR-1156"
+        version: "PR-1270"
   isLocalEnv: false
   oauth2:
     host: oauth2

--- a/components/connectivity-adapter/Dockerfile
+++ b/components/connectivity-adapter/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13.8-alpine3.11 as builder
+FROM golang:1.14.2-alpine3.11 as builder
 
 ENV BASE_APP_DIR /go/src/github.com/kyma-incubator/compass/components/connectivity-adapter
 WORKDIR ${BASE_APP_DIR}

--- a/components/connectivity-adapter/Makefile
+++ b/components/connectivity-adapter/Makefile
@@ -1,7 +1,7 @@
 APP_NAME = connectivity-adapter
 APP_PATH = components/connectivity-adapter
 ENTRYPOINT = cmd/main.go
-BUILDPACK = eu.gcr.io/kyma-project/test-infra/buildpack-golang-toolbox:v20190913-65b55d1
+BUILDPACK = eu.gcr.io/kyma-project/test-infra/buildpack-golang-toolbox:v20200423-1d9d6590
 SCRIPTS_DIR = $(realpath $(shell pwd)/../..)/scripts
 
 include $(SCRIPTS_DIR)/generic_make_go.mk

--- a/components/connector/Dockerfile
+++ b/components/connector/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13.8-alpine3.11 as builder
+FROM golang:1.14.2-alpine3.11 as builder
 
 ENV BASE_APP_DIR /go/src/github.com/kyma-incubator/compass/components/connector
 WORKDIR ${BASE_APP_DIR}

--- a/components/connector/Makefile
+++ b/components/connector/Makefile
@@ -1,7 +1,7 @@
 APP_NAME = compass-connector
 APP_PATH = components/connector
 ENTRYPOINT = cmd/main.go
-BUILDPACK = eu.gcr.io/kyma-project/test-infra/buildpack-golang-toolbox:v20190913-65b55d1
+BUILDPACK = eu.gcr.io/kyma-project/test-infra/buildpack-golang-toolbox:v20200423-1d9d6590
 SCRIPTS_DIR = $(realpath $(shell pwd)/../..)/scripts
 
 include $(SCRIPTS_DIR)/generic_make_go.mk

--- a/components/director/Dockerfile
+++ b/components/director/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13.8-alpine3.11 as builder
+FROM golang:1.14.2-alpine3.11 as builder
 
 ENV BASE_APP_DIR /go/src/github.com/kyma-incubator/compass/components/director
 WORKDIR ${BASE_APP_DIR}

--- a/components/director/Makefile
+++ b/components/director/Makefile
@@ -1,6 +1,6 @@
 APP_NAME = compass-director
 APP_PATH = components/director
-BUILDPACK = eu.gcr.io/kyma-project/test-infra/buildpack-golang-toolbox:v20190913-65b55d1
+BUILDPACK = eu.gcr.io/kyma-project/test-infra/buildpack-golang-toolbox:v20200423-1d9d6590
 SCRIPTS_DIR = $(realpath $(shell pwd)/../..)/scripts
 export GO111MODULE = on
 export SKIP_STEP_MESSAGE = "Do nothing for Go modules project"

--- a/components/director/internal/domain/onetimetoken/coverter_test.go
+++ b/components/director/internal/domain/onetimetoken/coverter_test.go
@@ -61,5 +61,5 @@ func TestConverter_ToGraphQLForApplication_ErrorWithInvalidLegacyURL(t *testing.
 	// WHEN
 	_, err := conv.ToGraphQLForApplication(tokenModel)
 	//THEN
-	assert.EqualError(t, err, "while parsing string (:123:invalid-url) as the URL: parse :123:invalid-url: missing protocol scheme")
+	assert.EqualError(t, err, "while parsing string (:123:invalid-url) as the URL: parse \":123:invalid-url\": missing protocol scheme")
 }

--- a/components/director/internal/model/eventing_test.go
+++ b/components/director/internal/model/eventing_test.go
@@ -27,7 +27,7 @@ func TestNewRuntimeEventingConfiguration(t *testing.T) {
 		{
 			Name:          "Invalid rawURL",
 			RawURL:        "::",
-			ExpectedError: errors.New("parse ::: missing protocol scheme"),
+			ExpectedError: errors.New("parse \"::\": missing protocol scheme"),
 		},
 	}
 

--- a/components/director/internal/runtimemapping/token_verifier_test.go
+++ b/components/director/internal/runtimemapping/token_verifier_test.go
@@ -96,7 +96,7 @@ func TestJWKsFetch_GetKey(t *testing.T) {
 		_, err := jwksFetch.GetKey(token)
 
 		// THEN
-		require.EqualError(t, err, "while getting the JWKs URI: while getting the discovery URL: while parsing the issuer URL [issuer=:///cdef://]: parse :///cdef://: missing protocol scheme")
+		require.EqualError(t, err, "while getting the JWKs URI: while getting the discovery URL: while parsing the issuer URL [issuer=:///cdef://]: parse \":///cdef://\": missing protocol scheme")
 	})
 
 	t.Run("should return error when discovery URL does not return proper response", func(t *testing.T) {
@@ -109,7 +109,7 @@ func TestJWKsFetch_GetKey(t *testing.T) {
 
 		// THEN
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "while getting the JWKs URI: while getting the configuration discovery: Get http://domain.local/.well-known/openid-configuration: dial tcp: lookup domain.local")
+		assert.Contains(t, err.Error(), "while getting the JWKs URI: while getting the configuration discovery: Get \"http://domain.local/.well-known/openid-configuration\": dial tcp: lookup domain.local")
 	})
 
 	t.Run("should return error when discovery URL does not return proper response", func(t *testing.T) {

--- a/components/director/internal/tenantfetcher/client_test.go
+++ b/components/director/internal/tenantfetcher/client_test.go
@@ -77,7 +77,7 @@ func TestClient_FetchTenantEventsPage(t *testing.T) {
 		// WHEN
 		res, err := client.FetchTenantEventsPage(tenantfetcher.CreatedEventsType, 1)
 		// THEN
-		require.EqualError(t, err, "parse ___ :// ___ : first path segment in URL cannot contain colon")
+		require.EqualError(t, err, "parse \"___ :// ___ \": first path segment in URL cannot contain colon")
 		assert.Empty(t, res)
 	})
 
@@ -85,7 +85,7 @@ func TestClient_FetchTenantEventsPage(t *testing.T) {
 		// WHEN
 		res, err := client.FetchTenantEventsPage(tenantfetcher.DeletedEventsType, 1)
 		// THEN
-		require.EqualError(t, err, "while sending get request: Get http://127.0.0.1:8111/badpath?page=1&resultsPerPage=1000&ts=1: dial tcp 127.0.0.1:8111: connect: connection refused")
+		require.EqualError(t, err, "while sending get request: Get \"http://127.0.0.1:8111/badpath?page=1&resultsPerPage=1000&ts=1\": dial tcp 127.0.0.1:8111: connect: connection refused")
 		assert.Empty(t, res)
 	})
 }

--- a/components/external-services-mock/Dockerfile
+++ b/components/external-services-mock/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13.8-alpine3.11 as builder
+FROM golang:1.14.2-alpine3.11 as builder
 
 ENV BASE_APP_DIR /go/src/github.com/kyma-incubator/compass/components/external-services-mock
 WORKDIR ${BASE_APP_DIR}

--- a/components/external-services-mock/Makefile
+++ b/components/external-services-mock/Makefile
@@ -1,6 +1,6 @@
 APP_NAME = compass-external-services-mock
 APP_PATH = components/external-services-mock
-BUILDPACK = eu.gcr.io/kyma-project/test-infra/buildpack-golang-toolbox:v20190913-65b55d1
+BUILDPACK = eu.gcr.io/kyma-project/test-infra/buildpack-golang-toolbox:v20200423-1d9d6590
 SCRIPTS_DIR = $(realpath $(shell pwd)/../..)/scripts
 export GO111MODULE = on
 export SKIP_STEP_MESSAGE = "Do nothing for Go modules project"

--- a/components/gateway/Dockerfile
+++ b/components/gateway/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13.8-alpine3.11 as builder
+FROM golang:1.14.2-alpine3.11 as builder
 
 ENV BASE_APP_DIR /go/src/github.com/kyma-incubator/compass/components/gateway
 WORKDIR ${BASE_APP_DIR}

--- a/components/gateway/Makefile
+++ b/components/gateway/Makefile
@@ -1,7 +1,7 @@
 APP_NAME = compass-gateway
 APP_PATH = components/gateway
 ENTRYPOINT = cmd/main.go
-BUILDPACK = eu.gcr.io/kyma-project/test-infra/buildpack-golang-toolbox:v20190913-65b55d1
+BUILDPACK = eu.gcr.io/kyma-project/test-infra/buildpack-golang-toolbox:v20200423-1d9d6590
 SCRIPTS_DIR = $(realpath $(shell pwd)/../..)/scripts
 export GO111MODULE = on
 export SKIP_STEP_MESSAGE = "Do nothing for Go modules project"

--- a/components/healthchecker/Dockerfile
+++ b/components/healthchecker/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13.8-alpine3.11 as builder
+FROM golang:1.14.2-alpine3.11 as builder
 
 ENV BASE_APP_DIR /go/src/github.com/kyma-incubator/compass/components/healthchecker
 WORKDIR ${BASE_APP_DIR}

--- a/components/healthchecker/Makefile
+++ b/components/healthchecker/Makefile
@@ -1,7 +1,7 @@
 APP_NAME = compass-healthchecker
 APP_PATH = components/healthchecker
 ENTRYPOINT = cmd/main.go
-BUILDPACK = eu.gcr.io/kyma-project/test-infra/buildpack-golang-toolbox:v20190913-65b55d1
+BUILDPACK = eu.gcr.io/kyma-project/test-infra/buildpack-golang-toolbox:v20200423-1d9d6590
 SCRIPTS_DIR = $(realpath $(shell pwd)/../..)/scripts
 
 include $(SCRIPTS_DIR)/generic_make_go.mk

--- a/components/kyma-environment-broker/Dockerfile
+++ b/components/kyma-environment-broker/Dockerfile
@@ -1,5 +1,5 @@
 # Build image
-FROM golang:1.13.8-alpine3.11 AS build
+FROM golang:1.14.2-alpine3.11 AS build
 
 WORKDIR /go/src/github.com/kyma-incubator/compass/components/kyma-environment-broker
 

--- a/components/kyma-environment-broker/Makefile
+++ b/components/kyma-environment-broker/Makefile
@@ -1,7 +1,7 @@
 APP_NAME = kyma-environment-broker
 APP_PATH = components/kyma-environment-broker
 ENTRYPOINT = cmd/broker/main.go
-BUILDPACK = eu.gcr.io/kyma-project/test-infra/buildpack-golang-toolbox:v20200117-d3885041
+BUILDPACK = eu.gcr.io/kyma-project/test-infra/buildpack-golang-toolbox:v20200423-1d9d6590
 SCRIPTS_DIR = $(realpath $(shell pwd)/../..)/scripts
 DOCKER_SOCKET = /var/run/docker.sock
 TESTING_DB_NETWORK = test_network

--- a/components/pairing-adapter/Makefile
+++ b/components/pairing-adapter/Makefile
@@ -1,7 +1,7 @@
 APP_NAME = pairing-adapter
 APP_PATH = components/pairing-adapter
 ENTRYPOINT = cmd/main.go
-BUILDPACK = eu.gcr.io/kyma-project/test-infra/buildpack-golang-toolbox:v20190913-65b55d1
+BUILDPACK = eu.gcr.io/kyma-project/test-infra/buildpack-golang-toolbox:v20200423-1d9d6590
 SCRIPTS_DIR = $(realpath $(shell pwd)/../..)/scripts
 
 include $(SCRIPTS_DIR)/generic_make_go.mk

--- a/components/provisioner/Dockerfile
+++ b/components/provisioner/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13.8-alpine3.11 as builder
+FROM golang:1.14.2-alpine3.11 as builder
 
 ENV BASE_APP_DIR /go/src/github.com/kyma-incubator/compass/components/provisioner
 WORKDIR ${BASE_APP_DIR}

--- a/components/provisioner/Makefile
+++ b/components/provisioner/Makefile
@@ -1,7 +1,7 @@
 APP_NAME = compass-provisioner
 APP_PATH = components/provisioner
 ENTRYPOINT = cmd/main.go
-BUILDPACK = eu.gcr.io/kyma-project/test-infra/pr/buildpack-golang-kubebuilder2:PR-2326
+BUILDPACK = eu.gcr.io/kyma-project/test-infra/buildpack-golang-kubebuilder2:v20200506-76a53983
 SCRIPTS_DIR = $(realpath $(shell pwd)/../..)/scripts
 DOCKER_SOCKET = /var/run/docker.sock
 TESTING_DB_NETWORK = test_network

--- a/components/provisioner/Makefile
+++ b/components/provisioner/Makefile
@@ -1,7 +1,7 @@
 APP_NAME = compass-provisioner
 APP_PATH = components/provisioner
 ENTRYPOINT = cmd/main.go
-BUILDPACK = eu.gcr.io/kyma-project/test-infra/buildpack-golang-toolbox:v20200423-1d9d6590
+BUILDPACK = eu.gcr.io/kyma-project/test-infra/pr/buildpack-golang-kubebuilder2:PR-2326
 SCRIPTS_DIR = $(realpath $(shell pwd)/../..)/scripts
 DOCKER_SOCKET = /var/run/docker.sock
 TESTING_DB_NETWORK = test_network

--- a/components/provisioner/Makefile
+++ b/components/provisioner/Makefile
@@ -1,7 +1,7 @@
 APP_NAME = compass-provisioner
 APP_PATH = components/provisioner
 ENTRYPOINT = cmd/main.go
-BUILDPACK = eu.gcr.io/kyma-project/test-infra/buildpack-golang-kubebuilder2:v20200124-69faeef6
+BUILDPACK = eu.gcr.io/kyma-project/test-infra/buildpack-golang-toolbox:v20200423-1d9d6590
 SCRIPTS_DIR = $(realpath $(shell pwd)/../..)/scripts
 DOCKER_SOCKET = /var/run/docker.sock
 TESTING_DB_NETWORK = test_network

--- a/components/schema-migrator/Makefile
+++ b/components/schema-migrator/Makefile
@@ -1,6 +1,6 @@
 APP_NAME = compass-schema-migrator
 APP_PATH = components/schema-migrator
-BUILDPACK = eu.gcr.io/kyma-project/test-infra/buildpack-golang-toolbox:v20190913-65b55d1
+BUILDPACK = eu.gcr.io/kyma-project/test-infra/buildpack-golang-toolbox:v20200423-1d9d6590
 SCRIPTS_DIR = $(realpath $(shell pwd)/../..)/scripts
 
 include $(SCRIPTS_DIR)/generic_make_go.mk

--- a/tests/connectivity-adapter/Dockerfile
+++ b/tests/connectivity-adapter/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13.8-alpine3.11 as builder
+FROM golang:1.14.2-alpine3.11 as builder
 
 
 ENV BASE_TEST_DIR /go/src/github.com/kyma-incubator/compass/tests/connectivity-adapter

--- a/tests/connectivity-adapter/Makefile
+++ b/tests/connectivity-adapter/Makefile
@@ -1,6 +1,6 @@
 APP_NAME = connectivity-adapter-tests
 APP_PATH = tests/connectivity-adapter
-BUILDPACK = eu.gcr.io/kyma-project/test-infra/buildpack-golang-toolbox:v20200117-d3885041
+BUILDPACK = eu.gcr.io/kyma-project/test-infra/buildpack-golang-toolbox:v20200423-1d9d6590
 SCRIPTS_DIR = $(realpath $(shell pwd)/../..)/scripts
 
 include $(SCRIPTS_DIR)/generic_make_go.mk

--- a/tests/connector-tests/Dockerfile
+++ b/tests/connector-tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13.8-alpine3.11 as builder
+FROM golang:1.14.2-alpine3.11 as builder
 
 ENV SRC_DIR=/go/src/github.com/kyma-incubator/compass/tests/connector-tests
 

--- a/tests/connector-tests/Makefile
+++ b/tests/connector-tests/Makefile
@@ -1,6 +1,6 @@
 APP_NAME = connector-tests
 APP_PATH = tests/connector-tests
-BUILDPACK = eu.gcr.io/kyma-project/test-infra/buildpack-golang-toolbox:v20190913-65b55d1
+BUILDPACK = eu.gcr.io/kyma-project/test-infra/buildpack-golang-toolbox:v20200423-1d9d6590
 SCRIPTS_DIR = $(realpath $(shell pwd)/../..)/scripts
 
 include $(SCRIPTS_DIR)/generic_make_go.mk

--- a/tests/director/Dockerfile
+++ b/tests/director/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13.8-alpine3.11 as builder
+FROM golang:1.14.2-alpine3.11 as builder
 
 
 ENV BASE_TEST_DIR /go/src/github.com/kyma-incubator/compass/tests/director

--- a/tests/director/Makefile
+++ b/tests/director/Makefile
@@ -1,6 +1,6 @@
 APP_NAME = compass-director-tests
 APP_PATH = tests/director-tests
-BUILDPACK = eu.gcr.io/kyma-project/test-infra/buildpack-golang-toolbox:v20190913-65b55d1
+BUILDPACK = eu.gcr.io/kyma-project/test-infra/buildpack-golang-toolbox:v20200423-1d9d6590
 SCRIPTS_DIR = $(realpath $(shell pwd)/../..)/scripts
 DIRECTOR_GRAPHQL_API = "http://compass-dev-director:3000"
 export DIRECTOR_GRAPHQL_API

--- a/tests/e2e/provisioning/Dockerfile
+++ b/tests/e2e/provisioning/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13.8-alpine3.11 as builder
+FROM golang:1.14.2-alpine3.11 as builder
 
 ENV SRC_DIR=/go/src/github.com/kyma-incubator/compass/tests/e2e/provisioning
 

--- a/tests/e2e/provisioning/Makefile
+++ b/tests/e2e/provisioning/Makefile
@@ -1,6 +1,6 @@
 APP_NAME = e2e-provisioning-test
 APP_PATH = tests/e2e/provisioning
-BUILDPACK = eu.gcr.io/kyma-project/test-infra/buildpack-golang-toolbox:v20190913-65b55d1
+BUILDPACK = eu.gcr.io/kyma-project/test-infra/buildpack-golang-toolbox:v20200423-1d9d6590
 SCRIPTS_DIR = $(realpath $(shell pwd)/../../..)/scripts
 
 include $(SCRIPTS_DIR)/generic_make_go.mk

--- a/tests/provisioner-tests/Dockerfile
+++ b/tests/provisioner-tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13.8-alpine3.11 as builder
+FROM golang:1.14.2-alpine3.11 as builder
 
 ENV SRC_DIR=/go/src/github.com/kyma-incubator/compass/tests/provisioner-tests
 


### PR DESCRIPTION
**Description**

Some unit tests make error assertions which are breaking on Go 1.14.X due to missing quotation signs.

Changes proposed in this pull request:

- Adapt unit tests with missing quotes in certain error test expectations

Reference breaking change in Go: https://github.com/golang/go/issues/37630