### PR TITLE
Change KEB logs to JSON

### DIFF
--- a/components/kyma-environment-broker/cmd/broker/main.go
+++ b/components/kyma-environment-broker/cmd/broker/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"io"
 	"log"
 	"net/http"
 	"os"
@@ -336,8 +337,10 @@ func main() {
 		route := router.PathPrefix(prefix).Subrouter()
 		broker.AttachRoutes(route, kymaEnvBroker, logger, creds)
 	}
+	svr := handlers.CustomLoggingHandler(os.Stdout, router, func(writer io.Writer, params handlers.LogFormatterParams) {
+		logs.Infof("Call handled: url=%s statusCode=%d size=%d", params.URL.Path, params.StatusCode, params.Size)
+	})
 
-	svr := handlers.LoggingHandler(os.Stdout, router)
 	fatalOnError(http.ListenAndServe(cfg.Host+":"+cfg.Port, svr))
 }
 

--- a/components/kyma-environment-broker/cmd/broker/main.go
+++ b/components/kyma-environment-broker/cmd/broker/main.go
@@ -105,6 +105,7 @@ func main() {
 	logger.Info("Starting Kyma Environment Broker")
 
 	logs := logrus.New()
+	logs.SetFormatter(&logrus.JSONFormatter{})
 
 	logger.Info("Registering healthz endpoint for health probes")
 	health.NewServer(cfg.Host, cfg.StatusPort, logs).ServeAsync()
@@ -130,13 +131,13 @@ func main() {
 	if cfg.DbInMemory {
 		db = storage.NewMemoryStorage()
 	} else {
-		db, err = storage.NewFromConfig(cfg.Database, logs)
+		db, err = storage.NewFromConfig(cfg.Database, logs.WithField("service", "storage"))
 		fatalOnError(err)
 	}
 
 	// LMS
 	fatalOnError(cfg.LMS.Validate())
-	lmsClient := lms.NewClient(cfg.LMS, logs)
+	lmsClient := lms.NewClient(cfg.LMS, logs.WithField("service", "lmsClient"))
 	lmsTenantManager := lms.NewTenantManager(db.LMSTenants(), lmsClient, logs.WithField("service", "lmsTenantManager"))
 
 	// Register disabler. Convention:
@@ -168,7 +169,7 @@ func main() {
 	inputFactory, err := input.NewInputBuilderFactory(optComponentsSvc, runtimeProvider, cfg.Provisioning, cfg.KymaVersion)
 	fatalOnError(err)
 
-	edpClient := edp.NewClient(cfg.EDP, logs)
+	edpClient := edp.NewClient(cfg.EDP, logs.WithField("service", "edpClient"))
 
 	avsDel := avs.NewDelegator(cfg.Avs, db.Operations())
 	externalEvalAssistant := avs.NewExternalEvalAssistant(cfg.Avs)
@@ -179,8 +180,8 @@ func main() {
 	iasTypeSetter := provisioning.NewIASType(bundleBuilder, cfg.IAS.Disabled)
 
 	// setup operation managers
-	provisionManager := provisioning.NewManager(db.Operations(), logs)
-	deprovisionManager := deprovisioning.NewManager(db.Operations(), logs)
+	provisionManager := provisioning.NewManager(db.Operations(), logs.WithField("provisioning", "manager"))
+	deprovisionManager := deprovisioning.NewManager(db.Operations(), logs.WithField("deprovisioning", "manager"))
 
 	// define steps
 	provisioningInit := provisioning.NewInitialisationStep(db.Operations(), db.Instances(),

--- a/components/kyma-environment-broker/internal/broker/instance_create.go
+++ b/components/kyma-environment-broker/internal/broker/instance_create.go
@@ -66,8 +66,8 @@ func NewProvision(cfg Config, operationsStorage storage.Operations, instanceStor
 //   PUT /v2/service_instances/{instance_id}
 func (b *ProvisionEndpoint) Provision(ctx context.Context, instanceID string, details domain.ProvisionDetails, asyncAllowed bool) (domain.ProvisionedServiceSpec, error) {
 	operationID := uuid.New().String()
-	logger := b.log.WithField("instanceID", instanceID).WithField("operationID", operationID)
-	logger.WithField("planID", details.PlanID).Info("Provision called")
+	logger := b.log.WithFields(logrus.Fields{"instanceID": instanceID, "operationID": operationID, "planID": details.PlanID})
+	logger.Info("Provision called")
 	// validation of incoming input
 	ersContext, parameters, err := b.validateAndExtract(details, logger)
 	if err != nil {

--- a/components/kyma-environment-broker/internal/broker/instance_create.go
+++ b/components/kyma-environment-broker/internal/broker/instance_create.go
@@ -89,14 +89,8 @@ func (b *ProvisionEndpoint) Provision(ctx context.Context, instanceID string, de
 		PlatformRegion: region,
 	}
 
-	logger.WithFields(logrus.Fields{
-		"Name":            parameters.Name,
-		"GlobalAccountID": ersContext.GlobalAccountID,
-		"SubAccountID":    ersContext.SubAccountID,
-		"PlatformRegion":  region,
-	}).Infof("Starting provisioning runtime")
-
-	logger.WithField("parameters", parameters).Info("Runtime parameters")
+	logger.Infof("Starting provisioning runtime: Name=%s, GlobalAccountID=%s, SubAccountID=%s PlatformRegion=%s", parameters.Name, ersContext.GlobalAccountID, ersContext.SubAccountID, region)
+	logger.Infof("Runtime parameters: %+v", parameters)
 
 	// check if operation with instance ID already created
 	existingOperation, errStorage := b.operationsStorage.GetProvisioningOperationByInstanceID(instanceID)

--- a/components/kyma-environment-broker/internal/broker/instance_deprovision.go
+++ b/components/kyma-environment-broker/internal/broker/instance_deprovision.go
@@ -41,7 +41,7 @@ func NewDeprovision(instancesStorage storage.Instances, operationsStorage storag
 //  DELETE /v2/service_instances/{instance_id}
 func (b *DeprovisionEndpoint) Deprovision(ctx context.Context, instanceID string, details domain.DeprovisionDetails, asyncAllowed bool) (domain.DeprovisionServiceSpec, error) {
 	operationID := uuid.New().String()
-	logger := b.log.WithField("instanceID", instanceID).WithField("operationID", operationID)
+	logger := b.log.WithFields(logrus.Fields{"instanceID": instanceID, "operationID": operationID})
 	logger.Infof("Deprovisioning triggered, details: %+v", details)
 
 	instance, err := b.instancesStorage.GetByID(instanceID)

--- a/components/kyma-environment-broker/internal/broker/instance_deprovision.go
+++ b/components/kyma-environment-broker/internal/broker/instance_deprovision.go
@@ -29,7 +29,7 @@ type DeprovisionEndpoint struct {
 
 func NewDeprovision(instancesStorage storage.Instances, operationsStorage storage.Operations, q Queue, log logrus.FieldLogger) *DeprovisionEndpoint {
 	return &DeprovisionEndpoint{
-		log:               log,
+		log:               log.WithField("service", "DeprovisionEndpoint"),
 		instancesStorage:  instancesStorage,
 		operationsStorage: operationsStorage,
 
@@ -57,6 +57,8 @@ func (b *DeprovisionEndpoint) Deprovision(ctx context.Context, instanceID string
 		return domain.DeprovisionServiceSpec{}, apiresponses.NewFailureResponse(fmt.Errorf("unable to get instance from the storage"), http.StatusInternalServerError, fmt.Sprintf("could not deprovision runtime, instanceID %s", instanceID))
 	}
 
+	logger = logger.WithFields(logrus.Fields{"runtimeID": instance.RuntimeID, "globalAccountID": instance.GlobalAccountID})
+
 	// check if operation with the same instance ID is already created
 	existingOperation, errStorage := b.operationsStorage.GetDeprovisioningOperationByInstanceID(instanceID)
 	switch {
@@ -71,7 +73,9 @@ func (b *DeprovisionEndpoint) Deprovision(ctx context.Context, instanceID string
 			if err != nil {
 				return domain.DeprovisionServiceSpec{}, errors.New("cannot update existing operation")
 			}
-			logger.Infof("Reprocessing failed deprovisioning of runtime: runtimeID=%s, globalAccountID=%s", instance.RuntimeID, instance.GlobalAccountID)
+
+			logger.Info("Reprocessing failed deprovisioning of runtime")
+
 			b.queue.Add(operationID)
 		}
 		// return existing operation
@@ -92,8 +96,7 @@ func (b *DeprovisionEndpoint) Deprovision(ctx context.Context, instanceID string
 		return domain.DeprovisionServiceSpec{}, errors.New("cannot save operation")
 	}
 
-	logger.Infof("Deprovisioning runtime: runtimeID=%s, globalAccountID=%s", instance.RuntimeID, instance.GlobalAccountID)
-
+	logger.Info("Adding operation to deprovisioning queue")
 	b.queue.Add(operationID)
 
 	return domain.DeprovisionServiceSpec{

--- a/components/kyma-environment-broker/internal/health/server.go
+++ b/components/kyma-environment-broker/internal/health/server.go
@@ -10,13 +10,13 @@ import (
 
 type Server struct {
 	Address string
-	Log     *log.Logger
+	Log     log.FieldLogger
 }
 
 func NewServer(host, port string, log *log.Logger) *Server {
 	return &Server{
 		Address: fmt.Sprintf("%s:%s", host, port),
-		Log:     log,
+		Log:     log.WithField("server", "health"),
 	}
 }
 

--- a/components/kyma-environment-broker/internal/process/deprovisioning/initialisation.go
+++ b/components/kyma-environment-broker/internal/process/deprovisioning/initialisation.go
@@ -75,7 +75,7 @@ func (s *InitialisationStep) Run(operation internal.DeprovisioningOperation, log
 			return operation, 0, nil
 		}
 		log.Info("instance being removed, check operation status")
-		return s.checkRuntimeStatus(operation, instance, log)
+		return s.checkRuntimeStatus(operation, instance, log.WithField("runtimeID", instance.RuntimeID))
 	case dberr.IsNotFound(err):
 		return s.operationManager.OperationSucceeded(operation, "instance already deprovisioned")
 	default:

--- a/components/kyma-environment-broker/internal/process/deprovisioning/manager.go
+++ b/components/kyma-environment-broker/internal/process/deprovisioning/manager.go
@@ -17,12 +17,12 @@ type Step interface {
 }
 
 type Manager struct {
-	log              *logrus.Logger
+	log              logrus.FieldLogger
 	steps            map[int][]Step
 	operationStorage storage.Operations
 }
 
-func NewManager(storage storage.Operations, logger *logrus.Logger) *Manager {
+func NewManager(storage storage.Operations, logger logrus.FieldLogger) *Manager {
 	return &Manager{
 		log:              logger,
 		operationStorage: storage,

--- a/components/kyma-environment-broker/internal/process/deprovisioning/remove_runtime.go
+++ b/components/kyma-environment-broker/internal/process/deprovisioning/remove_runtime.go
@@ -56,6 +56,7 @@ func (s *RemoveRuntimeStep) Run(operation internal.DeprovisioningOperation, log 
 		log.Warn("Runtime not exist")
 		return s.operationManager.OperationSucceeded(operation, "runtime was never provisioned")
 	}
+	log = log.WithField("runtimeID", instance.RuntimeID)
 
 	var provisionerResponse string
 	if operation.ProvisionerOperationID == "" {
@@ -74,7 +75,7 @@ func (s *RemoveRuntimeStep) Run(operation internal.DeprovisioningOperation, log 
 		}
 	}
 
-	log.WithField("runtimeID", instance.RuntimeID).Infof("runtime deletion process initiated successfully")
+	log.Infof("runtime deletion process initiated successfully")
 	// return repeat mode (1 sec) to start the initialization step which will now check the runtime status
 	return operation, 1 * time.Second, nil
 }

--- a/components/kyma-environment-broker/internal/process/deprovisioning/remove_runtime.go
+++ b/components/kyma-environment-broker/internal/process/deprovisioning/remove_runtime.go
@@ -74,7 +74,7 @@ func (s *RemoveRuntimeStep) Run(operation internal.DeprovisioningOperation, log 
 		}
 	}
 
-	log.Infof("runtime deletion process initiated successfully, RuntimeID=%s", instance.RuntimeID)
+	log.WithField("runtimeID", instance.RuntimeID).Infof("runtime deletion process initiated successfully")
 	// return repeat mode (1 sec) to start the initialization step which will now check the runtime status
 	return operation, 1 * time.Second, nil
 }

--- a/components/kyma-environment-broker/internal/process/provisioning/create_runtime.go
+++ b/components/kyma-environment-broker/internal/process/provisioning/create_runtime.go
@@ -81,7 +81,8 @@ func (s *CreateRuntimeStep) Run(operation internal.ProvisioningOperation, log lo
 	if provisionerResponse.RuntimeID == nil {
 		return operation, 1 * time.Minute, nil
 	}
-	log.Infof("fetched RuntimeID=%s", *provisionerResponse.RuntimeID)
+	log = log.WithField("runtimeID", *provisionerResponse.RuntimeID)
+	log.Infof("call to provisioner succeeded", *provisionerResponse.RuntimeID)
 
 	instance, err := s.instanceStorage.GetByID(operation.InstanceID)
 	if err != nil {

--- a/components/kyma-environment-broker/internal/process/provisioning/initialisation.go
+++ b/components/kyma-environment-broker/internal/process/provisioning/initialisation.go
@@ -75,7 +75,7 @@ func (s *InitialisationStep) Run(operation internal.ProvisioningOperation, log l
 			return s.initializeRuntimeInputRequest(operation, log)
 		}
 		log.Info("runtimeID exist, check instance status")
-		return s.checkRuntimeStatus(operation, log)
+		return s.checkRuntimeStatus(operation, log.WithField("runtimeID", inst.RuntimeID))
 	case dberr.IsNotFound(err):
 		log.Info("instance not exist")
 		return s.operationManager.OperationFailed(operation, "instance was not created")

--- a/components/kyma-environment-broker/internal/process/provisioning/lms_cert_step.go
+++ b/components/kyma-environment-broker/internal/process/provisioning/lms_cert_step.go
@@ -88,7 +88,8 @@ func (s *lmsCertStep) Run(operation internal.ProvisioningOperation, l logrus.Fie
 		return operation, tenantReadyRetryInterval, nil
 	}
 	if !(status.ElasticsearchDNSResolves && status.KibanaDNSResolves) {
-		logger.Infof("LMS tenant not ready: elasticDNS=%v, kibanaDNS=%v", status.ElasticsearchDNSResolves, status.KibanaDNSResolves)
+		logger = logger.WithFields(logrus.Fields{"elasticDNS": status.ElasticsearchDNSResolves, "kibanaDNS": status.KibanaDNSResolves})
+		logger.Info("LMS tenant not ready")
 		if time.Since(operation.Lms.RequestedAt) > lmsTimeout {
 			logger.Error("Setting LMS operation failed - tenant provisioning timed out")
 			return s.failLmsAndUpdate(operation)

--- a/components/kyma-environment-broker/internal/process/provisioning/lms_cert_step.go
+++ b/components/kyma-environment-broker/internal/process/provisioning/lms_cert_step.go
@@ -88,8 +88,7 @@ func (s *lmsCertStep) Run(operation internal.ProvisioningOperation, l logrus.Fie
 		return operation, tenantReadyRetryInterval, nil
 	}
 	if !(status.ElasticsearchDNSResolves && status.KibanaDNSResolves) {
-		logger = logger.WithFields(logrus.Fields{"elasticDNS": status.ElasticsearchDNSResolves, "kibanaDNS": status.KibanaDNSResolves})
-		logger.Info("LMS tenant not ready")
+		logger.Infof("LMS tenant not ready: elasticDNS=%v, kibanaDNS=%v", status.ElasticsearchDNSResolves, status.KibanaDNSResolves)
 		if time.Since(operation.Lms.RequestedAt) > lmsTimeout {
 			logger.Error("Setting LMS operation failed - tenant provisioning timed out")
 			return s.failLmsAndUpdate(operation)

--- a/components/kyma-environment-broker/internal/process/provisioning/manager.go
+++ b/components/kyma-environment-broker/internal/process/provisioning/manager.go
@@ -17,12 +17,12 @@ type Step interface {
 }
 
 type Manager struct {
-	log              *logrus.Logger
+	log              logrus.FieldLogger
 	steps            map[int][]Step
 	operationStorage storage.Operations
 }
 
-func NewManager(storage storage.Operations, logger *logrus.Logger) *Manager {
+func NewManager(storage storage.Operations, logger logrus.FieldLogger) *Manager {
 	return &Manager{
 		log:              logger,
 		operationStorage: storage,

--- a/components/kyma-environment-broker/internal/storage/storage.go
+++ b/components/kyma-environment-broker/internal/storage/storage.go
@@ -17,10 +17,14 @@ type BrokerStorage interface {
 }
 
 func NewFromConfig(cfg Config, log logrus.FieldLogger) (BrokerStorage, error) {
-	log.Infof("Setting DB connection pool params: connectionMaxLifetime=%s "+
-		"maxIdleConnections=%d maxOpenConnections=%d", cfg.ConnMaxLifetime, cfg.MaxIdleConns, cfg.MaxOpenConns)
+	log = log.WithFields(logrus.Fields{
+		"connectionMaxLifetime": cfg.ConnMaxLifetime,
+		"maxIdleConnections":    cfg.MaxIdleConns,
+		"maxOpenConnections":    cfg.MaxOpenConns,
+	})
+	log.Infof("Setting DB connection pool params")
 
-	connection, err := postsql.InitializeDatabase(cfg.ConnectionURL())
+	connection, err := postsql.InitializeDatabase(cfg.ConnectionURL(), log)
 	if err != nil {
 		return nil, err
 	}

--- a/components/kyma-environment-broker/internal/storage/storage.go
+++ b/components/kyma-environment-broker/internal/storage/storage.go
@@ -17,12 +17,8 @@ type BrokerStorage interface {
 }
 
 func NewFromConfig(cfg Config, log logrus.FieldLogger) (BrokerStorage, error) {
-	log = log.WithFields(logrus.Fields{
-		"connectionMaxLifetime": cfg.ConnMaxLifetime,
-		"maxIdleConnections":    cfg.MaxIdleConns,
-		"maxOpenConnections":    cfg.MaxOpenConns,
-	})
-	log.Infof("Setting DB connection pool params")
+	log.Infof("Setting DB connection pool params: connectionMaxLifetime=%s "+
+		"maxIdleConnections=%d maxOpenConnections=%d", cfg.ConnMaxLifetime, cfg.MaxIdleConns, cfg.MaxOpenConns)
 
 	connection, err := postsql.InitializeDatabase(cfg.ConnectionURL(), log)
 	if err != nil {

--- a/components/kyma-environment-broker/internal/storage/storage_test.go
+++ b/components/kyma-environment-broker/internal/storage/storage_test.go
@@ -37,7 +37,7 @@ func TestSchemaInitializer(t *testing.T) {
 			defer containerCleanupFunc()
 
 			// when
-			connection, err := postsql.InitializeDatabase(cfg.ConnectionURL())
+			connection, err := postsql.InitializeDatabase(cfg.ConnectionURL(), logrus.New())
 
 			require.NoError(t, err)
 			require.NotNil(t, connection)
@@ -57,7 +57,7 @@ func TestSchemaInitializer(t *testing.T) {
 			connString := "bad connection string"
 
 			// when
-			connection, err := postsql.InitializeDatabase(connString)
+			connection, err := postsql.InitializeDatabase(connString, logrus.New())
 
 			// then
 			assert.Error(t, err)

--- a/components/kyma-environment-broker/internal/storage/tests_utils.go
+++ b/components/kyma-environment-broker/internal/storage/tests_utils.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/kyma-incubator/compass/components/kyma-environment-broker/internal/storage/postsql"
 
 	"github.com/gocraft/dbr"
@@ -109,7 +111,7 @@ func InitTestDBContainer(t *testing.T, ctx context.Context, hostname string) (fu
 }
 
 func InitTestDBTables(t *testing.T, connectionURL string) error {
-	connection, err := postsql.WaitForDatabaseAccess(connectionURL, 10)
+	connection, err := postsql.WaitForDatabaseAccess(connectionURL, 10, logrus.New())
 	if err != nil {
 		t.Logf("Cannot connect to database with URL %s", connectionURL)
 		return err


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Changed KEB logs to JSON

Example logs:

```
{"timestamp":"1588628489.023205996","source":"kyma-env-broker","message":"kyma-env-broker.Starting Kyma Environment Broker","log_level":1,"data":{}}
{"timestamp":"1588628489.023662329","source":"kyma-env-broker","message":"kyma-env-broker.Registering healthz endpoint for health probes","log_level":1,"data":{}}
{"connectionMaxLifetime":1800000000000,"level":"info","maxIdleConnections":2,"maxOpenConnections":8,"msg":"Setting DB connection pool params","service":"storage","time":"2020-05-04T21:41:31Z"}
{"connectionMaxLifetime":1800000000000,"level":"info","maxIdleConnections":2,"maxOpenConnections":8,"msg":"Database already initialized","service":"storage","time":"2020-05-04T21:41:32Z"}
{"timestamp":"1588628492.602883577","source":"kyma-env-broker","message":"kyma-env-broker.Skipping processing operation in progress on start","log_level":1,"data":{}}
{"instanceID":"78810f43-fb38-4db2-845d-bff8ab2bdbcd","level":"info","msg":"Provision called","operationID":"60382909-5acd-435d-80e8-989d2d02ca8e","planID":"ca6e5357-707f-4565-bbbd-b3ab732597c6","service":"ProvisionEndpoint","time":"2020-05-04T21:44:07Z"}
{"GlobalAccountID":"3e64ebae-38b5-46a0-b1ed-9ccee153a0ae","Name":"mk-fix2","PlatformRegion":"cf-eu10","SubAccountID":"39ba9a66-2c1a-4fe4-a28e-6e5db434084e","instanceID":"78810f43-fb38-4db2-845d-bff8ab2bdbcd","level":"info","msg":"Starting provisioning runtime","operationID":"60382909-5acd-435d-80e8-989d2d02ca8e","service":"ProvisionEndpoint","time":"2020-05-04T21:44:07Z"}
{"instanceID":"78810f43-fb38-4db2-845d-bff8ab2bdbcd","level":"info","msg":"Runtime parameters","operationID":"60382909-5acd-435d-80e8-989d2d02ca8e","parameters":{"name":"mk-fix2","targetSecret":null,"volumeSizeGb":null,"machineType":null,"region":"europe-west4","zone":null,"autoScalerMin":null,"autoScalerMax":null,"maxSurge":null,"maxUnavailable":null,"components":[],"kymaVersion":""},"service":"ProvisionEndpoint","time":"2020-05-04T21:44:07Z"}
{"instanceID":"78810f43-fb38-4db2-845d-bff8ab2bdbcd","level":"info","msg":"Adding operation to provisioning queue","operationID":"60382909-5acd-435d-80e8-989d2d02ca8e","service":"ProvisionEndpoint","time":"2020-05-04T21:44:07Z"}
127.0.0.1 - - [04/May/2020:21:44:07 +0000] "PUT /v2/service_instances/78810f43-fb38-4db2-845d-bff8ab2bdbcd HTTP/1.1" 202 53
{"instanceID":"78810f43-fb38-4db2-845d-bff8ab2bdbcd","level":"info","msg":"Start process operation steps","operation":"60382909-5acd-435d-80e8-989d2d02ca8e","provisioning":"manager","time":"2020-05-04T21:44:07Z"}
{"instanceID":"78810f43-fb38-4db2-845d-bff8ab2bdbcd","level":"info","msg":"Start step","operation":"60382909-5acd-435d-80e8-989d2d02ca8e","provisioning":"manager","step":"Provision_Initialization","time":"2020-05-04T21:44:07Z"}
{"instanceID":"78810f43-fb38-4db2-845d-bff8ab2bdbcd","level":"info","msg":"runtimeID not exist, initialize runtime input request","operation":"60382909-5acd-435d-80e8-989d2d02ca8e","provisioning":"manager","step":"Provision_Initialization","time":"2020-05-04T21:44:07Z"}
{"instanceID":"78810f43-fb38-4db2-845d-bff8ab2bdbcd","level":"info","msg":"input builder setting up to work with default Kyma version","operation":"60382909-5acd-435d-80e8-989d2d02ca8e","provisioning":"manager","step":"Provision_Initialization","time":"2020-05-04T21:44:07Z"}
{"instanceID":"78810f43-fb38-4db2-845d-bff8ab2bdbcd","level":"info","msg":"create input creator for \"ca6e5357-707f-4565-bbbd-b3ab732597c6\" plan ID","operation":"60382909-5acd-435d-80e8-989d2d02ca8e","provisioning":"manager","step":"Provision_Initialization","time":"2020-05-04T21:44:07Z"}
{"instanceID":"78810f43-fb38-4db2-845d-bff8ab2bdbcd","level":"info","msg":"Process operation successful","operation":"60382909-5acd-435d-80e8-989d2d02ca8e","provisioning":"manager","step":"Provision_Initialization","time":"2020-05-04T21:44:07Z"}
{"instanceID":"78810f43-fb38-4db2-845d-bff8ab2bdbcd","level":"info","msg":"Start step","operation":"60382909-5acd-435d-80e8-989d2d02ca8e","provisioning":"manager","step":"Resolve_Target_Secret","time":"2020-05-04T21:44:07Z"}
{"instanceID":"78810f43-fb38-4db2-845d-bff8ab2bdbcd","level":"info","msg":"HAP lookup for credentials to provision cluster for global account ID 3e64ebae-38b5-46a0-b1ed-9ccee153a0ae on Hyperscaler gcp","operation":"60382909-5acd-435d-80e8-989d2d02ca8e","provisioning":"manager","step":"Resolve_Target_Secret","time":"2020-05-04T21:44:07Z"}
{"instanceID":"78810f43-fb38-4db2-845d-bff8ab2bdbcd","level":"info","msg":"Resolved gopher-dev-gcp-project as target secret name to use for cluster provisioning for global account ID 3e64ebae-38b5-46a0-b1ed-9ccee153a0ae on Hyperscaler gcp","operation":"60382909-5acd-435d-80e8-989d2d02ca8e","provisioning":"manager","step":"Resolve_Target_Secret","time":"2020-05-04T21:44:07Z"}
{"instanceID":"78810f43-fb38-4db2-845d-bff8ab2bdbcd","level":"info","msg":"Process operation successful","operation":"60382909-5acd-435d-80e8-989d2d02ca8e","provisioning":"manager","step":"Resolve_Target_Secret","time":"2020-05-04T21:44:07Z"}
{"instanceID":"78810f43-fb38-4db2-845d-bff8ab2bdbcd","level":"info","msg":"Start step","operation":"60382909-5acd-435d-80e8-989d2d02ca8e","provisioning":"manager","step":"AVS_Create_Internal_Eval_Step","time":"2020-05-04T21:44:07Z"}
{"instanceID":"78810f43-fb38-4db2-845d-bff8ab2bdbcd","level":"info","msg":"starting the step avs internal id [0] and avs external id [0]","operation":"60382909-5acd-435d-80e8-989d2d02ca8e","provisioning":"manager","step":"AVS_Create_Internal_Eval_Step","time":"2020-05-04T21:44:07Z"}
{"instanceID":"78810f43-fb38-4db2-845d-bff8ab2bdbcd","level":"info","msg":"creating the lazy client for avs..","operation":"60382909-5acd-435d-80e8-989d2d02ca8e","provisioning":"manager","step":"AVS_Create_Internal_Eval_Step","time":"2020-05-04T21:44:07Z"}
{"instanceID":"78810f43-fb38-4db2-845d-bff8ab2bdbcd","level":"info","msg":"Sending json body {\"definition_type\":\"BASIC\",\"name\":\"K8S-AZR-Kyma-int-39ba9a66-2c1a-4fe4-a28e-6e5db434084e-mk-fix2\",\"description\":\"SKR instance Name: mk-fix2, Global Account: 3e64ebae-38b5-46a0-b1ed-9ccee153a0ae, Subaccount: 39ba9a66-2c1a-4fe4-a28e-6e5db434084e\",\"service\":\"K8S-AZR-Kyma-int-39ba9a66-2c1a-4fe4-a28e-6e5db434084e-mk-fix2\",\"url\":\"\",\"check_type\":\"\",\"interval\":180,\"tester_access_id\":8281610,\"timeout\":30000,\"read_only\":false,\"content_check\":\"error\",\"content_check_type\":\"NOT_CONTAINS\",\"threshold\":\"30000\",\"group_id\":8278726,\"visibility\":\"PUBLIC\",\"parent_id\":11497735}","operation":"60382909-5acd-435d-80e8-989d2d02ca8e","provisioning":"manager","step":"AVS_Create_Internal_Eval_Step","time":"2020-05-04T21:44:08Z"}
{"instanceID":"78810f43-fb38-4db2-845d-bff8ab2bdbcd","level":"info","msg":"Process operation successful","operation":"60382909-5acd-435d-80e8-989d2d02ca8e","provisioning":"manager","step":"AVS_Create_Internal_Eval_Step","time":"2020-05-04T21:44:08Z"}
{"instanceID":"78810f43-fb38-4db2-845d-bff8ab2bdbcd","level":"info","msg":"Start step","operation":"60382909-5acd-435d-80e8-989d2d02ca8e","provisioning":"manager","step":"EDP_Registration","time":"2020-05-04T21:44:08Z"}
{"instanceID":"78810f43-fb38-4db2-845d-bff8ab2bdbcd","level":"info","msg":"Create DataTenant for 39ba9a66-2c1a-4fe4-a28e-6e5db434084e subaccount","operation":"60382909-5acd-435d-80e8-989d2d02ca8e","provisioning":"manager","step":"EDP_Registration","time":"2020-05-04T21:44:08Z"}
{"level":"info","msg":"Resource created: Response status code: 201 for request POST https://admin.yevents.io/namespaces/kyma-dev/dataTenants","service":"edpClient","time":"2020-05-04T21:44:08Z"}
{"instanceID":"78810f43-fb38-4db2-845d-bff8ab2bdbcd","level":"info","msg":"Create DataTenant metadata for 39ba9a66-2c1a-4fe4-a28e-6e5db434084e subaccount","operation":"60382909-5acd-435d-80e8-989d2d02ca8e","provisioning":"manager","step":"EDP_Registration","time":"2020-05-04T21:44:08Z"}
{"level":"info","msg":"Resource created: Response status code: 201 for request POST https://admin.yevents.io/namespaces/kyma-dev/dataTenants/39ba9a66-2c1a-4fe4-a28e-6e5db434084e/dev/metadata","service":"edpClient","time":"2020-05-04T21:44:08Z"}
{"level":"info","msg":"Resource created: Response status code: 201 for request POST https://admin.yevents.io/namespaces/kyma-dev/dataTenants/39ba9a66-2c1a-4fe4-a28e-6e5db434084e/dev/metadata","service":"edpClient","time":"2020-05-04T21:44:08Z"}
{"level":"info","msg":"Resource created: Response status code: 201 for request POST https://admin.yevents.io/namespaces/kyma-dev/dataTenants/39ba9a66-2c1a-4fe4-a28e-6e5db434084e/dev/metadata","service":"edpClient","time":"2020-05-04T21:44:08Z"}
{"instanceID":"78810f43-fb38-4db2-845d-bff8ab2bdbcd","level":"info","msg":"Process operation successful","operation":"60382909-5acd-435d-80e8-989d2d02ca8e","provisioning":"manager","step":"EDP_Registration","time":"2020-05-04T21:44:08Z"}
{"instanceID":"78810f43-fb38-4db2-845d-bff8ab2bdbcd","level":"info","msg":"Start step","operation":"60382909-5acd-435d-80e8-989d2d02ca8e","provisioning":"manager","step":"Provision Azure Event Hubs","time":"2020-05-04T21:44:08Z"}
{"instanceID":"78810f43-fb38-4db2-845d-bff8ab2bdbcd","level":"info","msg":"HAP lookup for credentials to provision cluster for global account ID 3e64ebae-38b5-46a0-b1ed-9ccee153a0ae on Hyperscaler azure","operation":"60382909-5acd-435d-80e8-989d2d02ca8e","provisioning":"manager","step":"Provision Azure Event Hubs","time":"2020-05-04T21:44:08Z"}
{"instanceID":"78810f43-fb38-4db2-845d-bff8ab2bdbcd","level":"info","msg":"Persisted Azure Resource Group [mk-fix2]","operation":"60382909-5acd-435d-80e8-989d2d02ca8e","provisioning":"manager","step":"Provision Azure Event Hubs","time":"2020-05-04T21:44:09Z"}
➜  examples git:(app-deprovision2) ✗ kc logs -n compass-system compass-kyma-environment-broker-mk-7b8f7bbbb8-vr6pz kyma-environment-broker-mk
{"timestamp":"1588628489.023205996","source":"kyma-env-broker","message":"kyma-env-broker.Starting Kyma Environment Broker","log_level":1,"data":{}}
{"timestamp":"1588628489.023662329","source":"kyma-env-broker","message":"kyma-env-broker.Registering healthz endpoint for health probes","log_level":1,"data":{}}
{"connectionMaxLifetime":1800000000000,"level":"info","maxIdleConnections":2,"maxOpenConnections":8,"msg":"Setting DB connection pool params","service":"storage","time":"2020-05-04T21:41:31Z"}
{"connectionMaxLifetime":1800000000000,"level":"info","maxIdleConnections":2,"maxOpenConnections":8,"msg":"Database already initialized","service":"storage","time":"2020-05-04T21:41:32Z"}
{"timestamp":"1588628492.602883577","source":"kyma-env-broker","message":"kyma-env-broker.Skipping processing operation in progress on start","log_level":1,"data":{}}
{"instanceID":"78810f43-fb38-4db2-845d-bff8ab2bdbcd","level":"info","msg":"Provision called","operationID":"60382909-5acd-435d-80e8-989d2d02ca8e","planID":"ca6e5357-707f-4565-bbbd-b3ab732597c6","service":"ProvisionEndpoint","time":"2020-05-04T21:44:07Z"}
{"GlobalAccountID":"3e64ebae-38b5-46a0-b1ed-9ccee153a0ae","Name":"mk-fix2","PlatformRegion":"cf-eu10","SubAccountID":"39ba9a66-2c1a-4fe4-a28e-6e5db434084e","instanceID":"78810f43-fb38-4db2-845d-bff8ab2bdbcd","level":"info","msg":"Starting provisioning runtime","operationID":"60382909-5acd-435d-80e8-989d2d02ca8e","service":"ProvisionEndpoint","time":"2020-05-04T21:44:07Z"}
{"instanceID":"78810f43-fb38-4db2-845d-bff8ab2bdbcd","level":"info","msg":"Runtime parameters","operationID":"60382909-5acd-435d-80e8-989d2d02ca8e","parameters":{"name":"mk-fix2","targetSecret":null,"volumeSizeGb":null,"machineType":null,"region":"europe-west4","zone":null,"autoScalerMin":null,"autoScalerMax":null,"maxSurge":null,"maxUnavailable":null,"components":[],"kymaVersion":""},"service":"ProvisionEndpoint","time":"2020-05-04T21:44:07Z"}
{"instanceID":"78810f43-fb38-4db2-845d-bff8ab2bdbcd","level":"info","msg":"Adding operation to provisioning queue","operationID":"60382909-5acd-435d-80e8-989d2d02ca8e","service":"ProvisionEndpoint","time":"2020-05-04T21:44:07Z"}
127.0.0.1 - - [04/May/2020:21:44:07 +0000] "PUT /v2/service_instances/78810f43-fb38-4db2-845d-bff8ab2bdbcd HTTP/1.1" 202 53
{"instanceID":"78810f43-fb38-4db2-845d-bff8ab2bdbcd","level":"info","msg":"Start process operation steps","operation":"60382909-5acd-435d-80e8-989d2d02ca8e","provisioning":"manager","time":"2020-05-04T21:44:07Z"}
{"instanceID":"78810f43-fb38-4db2-845d-bff8ab2bdbcd","level":"info","msg":"Start step","operation":"60382909-5acd-435d-80e8-989d2d02ca8e","provisioning":"manager","step":"Provision_Initialization","time":"2020-05-04T21:44:07Z"}
{"instanceID":"78810f43-fb38-4db2-845d-bff8ab2bdbcd","level":"info","msg":"runtimeID not exist, initialize runtime input request","operation":"60382909-5acd-435d-80e8-989d2d02ca8e","provisioning":"manager","step":"Provision_Initialization","time":"2020-05-04T21:44:07Z"}
{"instanceID":"78810f43-fb38-4db2-845d-bff8ab2bdbcd","level":"info","msg":"input builder setting up to work with default Kyma version","operation":"60382909-5acd-435d-80e8-989d2d02ca8e","provisioning":"manager","step":"Provision_Initialization","time":"2020-05-04T21:44:07Z"}
{"instanceID":"78810f43-fb38-4db2-845d-bff8ab2bdbcd","level":"info","msg":"create input creator for \"ca6e5357-707f-4565-bbbd-b3ab732597c6\" plan ID","operation":"60382909-5acd-435d-80e8-989d2d02ca8e","provisioning":"manager","step":"Provision_Initialization","time":"2020-05-04T21:44:07Z"}
{"instanceID":"78810f43-fb38-4db2-845d-bff8ab2bdbcd","level":"info","msg":"Process operation successful","operation":"60382909-5acd-435d-80e8-989d2d02ca8e","provisioning":"manager","step":"Provision_Initialization","time":"2020-05-04T21:44:07Z"}
{"instanceID":"78810f43-fb38-4db2-845d-bff8ab2bdbcd","level":"info","msg":"Start step","operation":"60382909-5acd-435d-80e8-989d2d02ca8e","provisioning":"manager","step":"Resolve_Target_Secret","time":"2020-05-04T21:44:07Z"}
{"instanceID":"78810f43-fb38-4db2-845d-bff8ab2bdbcd","level":"info","msg":"HAP lookup for credentials to provision cluster for global account ID 3e64ebae-38b5-46a0-b1ed-9ccee153a0ae on Hyperscaler gcp","operation":"60382909-5acd-435d-80e8-989d2d02ca8e","provisioning":"manager","step":"Resolve_Target_Secret","time":"2020-05-04T21:44:07Z"}
{"instanceID":"78810f43-fb38-4db2-845d-bff8ab2bdbcd","level":"info","msg":"Resolved gopher-dev-gcp-project as target secret name to use for cluster provisioning for global account ID 3e64ebae-38b5-46a0-b1ed-9ccee153a0ae on Hyperscaler gcp","operation":"60382909-5acd-435d-80e8-989d2d02ca8e","provisioning":"manager","step":"Resolve_Target_Secret","time":"2020-05-04T21:44:07Z"}
{"instanceID":"78810f43-fb38-4db2-845d-bff8ab2bdbcd","level":"info","msg":"Process operation successful","operation":"60382909-5acd-435d-80e8-989d2d02ca8e","provisioning":"manager","step":"Resolve_Target_Secret","time":"2020-05-04T21:44:07Z"}
{"instanceID":"78810f43-fb38-4db2-845d-bff8ab2bdbcd","level":"info","msg":"Start step","operation":"60382909-5acd-435d-80e8-989d2d02ca8e","provisioning":"manager","step":"AVS_Create_Internal_Eval_Step","time":"2020-05-04T21:44:07Z"}
{"instanceID":"78810f43-fb38-4db2-845d-bff8ab2bdbcd","level":"info","msg":"starting the step avs internal id [0] and avs external id [0]","operation":"60382909-5acd-435d-80e8-989d2d02ca8e","provisioning":"manager","step":"AVS_Create_Internal_Eval_Step","time":"2020-05-04T21:44:07Z"}
{"instanceID":"78810f43-fb38-4db2-845d-bff8ab2bdbcd","level":"info","msg":"creating the lazy client for avs..","operation":"60382909-5acd-435d-80e8-989d2d02ca8e","provisioning":"manager","step":"AVS_Create_Internal_Eval_Step","time":"2020-05-04T21:44:07Z"}
{"instanceID":"78810f43-fb38-4db2-845d-bff8ab2bdbcd","level":"info","msg":"Sending json body {\"definition_type\":\"BASIC\",\"name\":\"K8S-AZR-Kyma-int-39ba9a66-2c1a-4fe4-a28e-6e5db434084e-mk-fix2\",\"description\":\"SKR instance Name: mk-fix2, Global Account: 3e64ebae-38b5-46a0-b1ed-9ccee153a0ae, Subaccount: 39ba9a66-2c1a-4fe4-a28e-6e5db434084e\",\"service\":\"K8S-AZR-Kyma-int-39ba9a66-2c1a-4fe4-a28e-6e5db434084e-mk-fix2\",\"url\":\"\",\"check_type\":\"\",\"interval\":180,\"tester_access_id\":8281610,\"timeout\":30000,\"read_only\":false,\"content_check\":\"error\",\"content_check_type\":\"NOT_CONTAINS\",\"threshold\":\"30000\",\"group_id\":8278726,\"visibility\":\"PUBLIC\",\"parent_id\":11497735}","operation":"60382909-5acd-435d-80e8-989d2d02ca8e","provisioning":"manager","step":"AVS_Create_Internal_Eval_Step","time":"2020-05-04T21:44:08Z"}
{"instanceID":"78810f43-fb38-4db2-845d-bff8ab2bdbcd","level":"info","msg":"Process operation successful","operation":"60382909-5acd-435d-80e8-989d2d02ca8e","provisioning":"manager","step":"AVS_Create_Internal_Eval_Step","time":"2020-05-04T21:44:08Z"}
{"instanceID":"78810f43-fb38-4db2-845d-bff8ab2bdbcd","level":"info","msg":"Start step","operation":"60382909-5acd-435d-80e8-989d2d02ca8e","provisioning":"manager","step":"EDP_Registration","time":"2020-05-04T21:44:08Z"}
{"instanceID":"78810f43-fb38-4db2-845d-bff8ab2bdbcd","level":"info","msg":"Create DataTenant for 39ba9a66-2c1a-4fe4-a28e-6e5db434084e subaccount","operation":"60382909-5acd-435d-80e8-989d2d02ca8e","provisioning":"manager","step":"EDP_Registration","time":"2020-05-04T21:44:08Z"}
{"level":"info","msg":"Resource created: Response status code: 201 for request POST https://admin.yevents.io/namespaces/kyma-dev/dataTenants","service":"edpClient","time":"2020-05-04T21:44:08Z"}
{"instanceID":"78810f43-fb38-4db2-845d-bff8ab2bdbcd","level":"info","msg":"Create DataTenant metadata for 39ba9a66-2c1a-4fe4-a28e-6e5db434084e subaccount","operation":"60382909-5acd-435d-80e8-989d2d02ca8e","provisioning":"manager","step":"EDP_Registration","time":"2020-05-04T21:44:08Z"}
{"level":"info","msg":"Resource created: Response status code: 201 for request POST https://admin.yevents.io/namespaces/kyma-dev/dataTenants/39ba9a66-2c1a-4fe4-a28e-6e5db434084e/dev/metadata","service":"edpClient","time":"2020-05-04T21:44:08Z"}
{"level":"info","msg":"Resource created: Response status code: 201 for request POST https://admin.yevents.io/namespaces/kyma-dev/dataTenants/39ba9a66-2c1a-4fe4-a28e-6e5db434084e/dev/metadata","service":"edpClient","time":"2020-05-04T21:44:08Z"}
{"level":"info","msg":"Resource created: Response status code: 201 for request POST https://admin.yevents.io/namespaces/kyma-dev/dataTenants/39ba9a66-2c1a-4fe4-a28e-6e5db434084e/dev/metadata","service":"edpClient","time":"2020-05-04T21:44:08Z"}
{"instanceID":"78810f43-fb38-4db2-845d-bff8ab2bdbcd","level":"info","msg":"Process operation successful","operation":"60382909-5acd-435d-80e8-989d2d02ca8e","provisioning":"manager","step":"EDP_Registration","time":"2020-05-04T21:44:08Z"}
{"instanceID":"78810f43-fb38-4db2-845d-bff8ab2bdbcd","level":"info","msg":"Start step","operation":"60382909-5acd-435d-80e8-989d2d02ca8e","provisioning":"manager","step":"Provision Azure Event Hubs","time":"2020-05-04T21:44:08Z"}
{"instanceID":"78810f43-fb38-4db2-845d-bff8ab2bdbcd","level":"info","msg":"HAP lookup for credentials to provision cluster for global account ID 3e64ebae-38b5-46a0-b1ed-9ccee153a0ae on Hyperscaler azure","operation":"60382909-5acd-435d-80e8-989d2d02ca8e","provisioning":"manager","step":"Provision Azure Event Hubs","time":"2020-05-04T21:44:08Z"}
{"instanceID":"78810f43-fb38-4db2-845d-bff8ab2bdbcd","level":"info","msg":"Persisted Azure Resource Group [mk-fix2]","operation":"60382909-5acd-435d-80e8-989d2d02ca8e","provisioning":"manager","step":"Provision Azure Event Hubs","time":"2020-05-04T21:44:09Z"}
```

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
