### PR TITLE
Provide Make targets for Minikube local development

### DIFF
--- a/chart/compass/charts/pairing-adapter/templates/deployment.yaml
+++ b/chart/compass/charts/pairing-adapter/templates/deployment.yaml
@@ -19,7 +19,7 @@ spec:
                 release: {{ .Release.Name }}
         spec:
             containers:
-            - name: main
+            - name: {{ .Chart.Name }}
               image: {{ .Values.global.images.containerRegistry.path }}/{{ .Values.global.images.pairing_adapter.dir }}pairing-adapter:{{ .Values.global.images.pairing_adapter.version }}
               imagePullPolicy: {{ .Values.deployment.image.pullPolicy }}
               env:

--- a/components/schema-migrator/Makefile
+++ b/components/schema-migrator/Makefile
@@ -2,6 +2,7 @@ APP_NAME = compass-schema-migrator
 APP_PATH = components/schema-migrator
 BUILDPACK = eu.gcr.io/kyma-project/test-infra/buildpack-golang-toolbox:v20190913-65b55d1
 SCRIPTS_DIR = $(realpath $(shell pwd)/../..)/scripts
+export SKIP_DEPLOY_MESSAGE = "Building minikube image and redeployment of Schema Migrator is not allowed"
 
 include $(SCRIPTS_DIR)/generic_make_go.mk
 
@@ -11,3 +12,9 @@ validate:
 	./validate.sh
 
 verify:: validate
+
+build-to-minikube:
+	@echo ${SKIP_DEPLOY_MESSAGE}
+
+deploy-on-minikube:
+	@echo ${SKIP_DEPLOY_MESSAGE}

--- a/scripts/generic_make_go.mk
+++ b/scripts/generic_make_go.mk
@@ -99,7 +99,7 @@ docker-create-opts:
 MOUNT_TARGETS = build resolve ensure dep-status check-imports imports check-fmt fmt errcheck vet generate pull-licenses gqlgen
 $(foreach t,$(MOUNT_TARGETS),$(eval $(call buildpack-mount,$(t))))
 
-# Builds new docker image inside Minikube's Docker Registry
+# Builds new Docker image into Minikube's Docker Registry
 build-to-minikube: pull-licenses
 	@eval $$(minikube docker-env) && docker build -t $(IMG_NAME) .
 

--- a/scripts/generic_make_go.mk
+++ b/scripts/generic_make_go.mk
@@ -180,7 +180,7 @@ exec:
     		-v $(COMPONENT_DIR):$(WORKSPACE_COMPONENT_DIR):delegated \
     		$(DOCKER_CREATE_OPTS) bash
 
-# Redeploys component in Minikube cluster by replacing old deployment with the newly built one
+# Sets locally built image for a given component in Minikube cluster 
 deploy-on-minikube: build-to-minikube
 	kubectl set image -n $(NAMESPACE) deployment/$(DEPLOYMENT_NAME) $(COMPONENT_NAME)=$(DEPLOYMENT_NAME):latest
 	kubectl rollout restart -n $(NAMESPACE) deployment/$(DEPLOYMENT_NAME)


### PR DESCRIPTION
**Description**

When developing and testing **Compass** components as a whole in a **Minikube** local environment developers will want to have a way to quickly integrate new changes and then assert them/test then. Manual intervention of Helm Charts and recreation of **Compass** each time a new change is made to the codebase is too slow to yield fast feedback to the developer.

A way to get faster feedback is to build a new Docker image of the **Compass** component being worked on and updating the corresponding deployment with the new image.

This change aims to automate this process by providing two new Make targets to the generic Makefile so that every **Compass** component can make use of them. Only the Schema Migrator component, being a one-time Job, doesn't make much sense and doesn't really fit to use use of these two targets, so it has been excluded from ability to run them.

Changes proposed in this pull request:

- `build-to-minikube` target - builds the corresponding **Compass** component Docker image to the Minikube's Docker Registry.
- `deploy-on-minikube` target - updates the corresponding **Compass** component's Deployment with the latest image and restarts the deployment.
- The Pairing Adapter Deployment container has been renamed to be equal to it's Chart Name to comply with the conventions of all the other **Compass** components which do that. This way the Make targets can work for the Pairing Adapter as well.
