### PR TITLE
Use the InstanceID as a unique name for the EventHubs Resource Group and Namespace

### DIFF
--- a/components/kyma-environment-broker/.gitignore
+++ b/components/kyma-environment-broker/.gitignore
@@ -100,3 +100,4 @@ fabric.properties
 *.iml
 hack/scripts/kyma-lite/letsencrypt
 /internal/avs/verify/verify.go
+licenses/

--- a/components/kyma-environment-broker/internal/broker/instance_create_test.go
+++ b/components/kyma-environment-broker/internal/broker/instance_create_test.go
@@ -203,49 +203,6 @@ func TestProvision_Provision(t *testing.T) {
 		assert.Empty(t, response.OperationData)
 	})
 
-	t.Run("return error on using a cluster name of length less than 6 in parameters", func(t *testing.T) {
-		// given
-		// #setup memory storage
-		invalidClusterName := "foo"
-		memoryStorage := storage.NewMemoryStorage()
-		err := memoryStorage.Operations().InsertProvisioningOperation(fixExistOperation())
-		require.NoError(t, err)
-
-		factoryBuilder := &automock.PlanValidator{}
-		factoryBuilder.On("IsPlanSupport", planID).Return(true)
-
-		fixValidator, err := broker.NewPlansSchemaValidator()
-		require.NoError(t, err)
-
-		// #create provisioner endpoint
-		provisionEndpoint := broker.NewProvision(
-			broker.Config{EnablePlans: []string{"gcp", "azure"}},
-			memoryStorage.Operations(),
-			memoryStorage.Instances(),
-			nil,
-			factoryBuilder,
-			fixValidator,
-			false,
-			logrus.StandardLogger(),
-		)
-
-		// when
-		response, err := provisionEndpoint.Provision(fixReqCtxWithRegion(t, "dummy"), instanceID, domain.ProvisionDetails{
-			ServiceID: serviceID,
-			PlanID:    planID,
-			RawParameters: json.RawMessage(fmt.Sprintf(`{
-				"name": "%s",
-				"components": []
-				}`, invalidClusterName)),
-			RawContext: json.RawMessage(fmt.Sprintf(`{"globalaccount_id": "%s", "subaccount_id": "%s"}`, "1cafb9c8-c8f8-478a-948a-9cb53bb76aa4", subAccountID)),
-		}, true)
-
-		// then
-		assert.EqualError(t, err, `while validating input parameters: name: String length must be greater than or equal to 6`)
-		assert.False(t, response.IsAsync)
-		assert.Empty(t, response.OperationData)
-	})
-
 	t.Run("return error on adding KnativeProvisionerNatss and NatssStreaming to list of components", func(t *testing.T) {
 		// given
 		// #setup memory storage

--- a/components/kyma-environment-broker/internal/broker/plans.go
+++ b/components/kyma-environment-broker/internal/broker/plans.go
@@ -27,7 +27,6 @@ type Type struct {
 	Items           []Type        `json:"items,omitempty"`
 	AdditionalItems *bool         `json:"additionalItems,omitempty"`
 	UniqueItems     *bool         `json:"uniqueItems,omitempty"`
-	MinLength       int           `json:"minLength,omitempty"`
 }
 type RootSchema struct {
 	Schema string `json:"$schema"`
@@ -72,8 +71,7 @@ func GCPSchema() []byte {
 				UniqueItems:     t,
 			},
 			Name: Type{
-				Type:      "string",
-				MinLength: 6,
+				Type: "string",
 			},
 			DiskType: Type{Type: "string"},
 			VolumeSizeGb: Type{
@@ -156,8 +154,7 @@ func AzureSchema() []byte {
 				UniqueItems:     t,
 			},
 			Name: Type{
-				Type:      "string",
-				MinLength: 6,
+				Type: "string",
 			},
 			DiskType: Type{Type: "string"},
 			VolumeSizeGb: Type{

--- a/components/kyma-environment-broker/internal/broker/plans_test.go
+++ b/components/kyma-environment-broker/internal/broker/plans_test.go
@@ -32,8 +32,7 @@ func TestSchemaGenerator(t *testing.T) {
 			"uniqueItems": true
 		},
 			"name": {
-			"type": "string",
-			"minLength": 6
+			"type": "string"
 		},
 			"diskType": {
 			"type": "string"
@@ -89,8 +88,7 @@ func TestSchemaGenerator(t *testing.T) {
 			"uniqueItems": true
 		},
 			"name": {
-			"type": "string",
-			"minLength": 6
+			"type": "string"
 		},
 			"diskType": {
 			"type": "string"


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Use the InstanceID as a unique name for the EventHubs Resource Group and Namespace.

**Related issue(s)**

- https://github.com/kyma-incubator/compass/issues/1136.
