### PR TITLE
Improve Logging for Retry Operation in KEB

### DIFF
--- a/components/kyma-environment-broker/internal/process/deprovision_operation.go
+++ b/components/kyma-environment-broker/internal/process/deprovision_operation.go
@@ -72,6 +72,7 @@ func (om *DeprovisionOperationManager) RetryOperationOnce(operation internal.Dep
 func (om *DeprovisionOperationManager) RetryOperation(operation internal.DeprovisioningOperation, errorMessage string, retryInterval time.Duration, maxTime time.Duration, log logrus.FieldLogger) (internal.DeprovisioningOperation, time.Duration, error) {
 	since := time.Since(operation.UpdatedAt)
 
+	log.Infof("Retry Operation was triggered with message: %s", errorMessage)
 	log.Infof("Retrying for %s in %s steps, error: %s", maxTime.String(), retryInterval.String(), errorMessage)
 	if since < maxTime {
 		return operation, retryInterval, nil
@@ -84,6 +85,7 @@ func (om *DeprovisionOperationManager) RetryOperation(operation internal.Deprovi
 func (om *DeprovisionOperationManager) RetryOperationWithoutFail(operation internal.DeprovisioningOperation, description string, retryInterval, maxTime time.Duration, log logrus.FieldLogger) (internal.DeprovisioningOperation, time.Duration, error) {
 	since := time.Since(operation.UpdatedAt)
 
+	log.Infof("Retry Operation was triggered with message: %s", description)
 	log.Infof("Retrying for %s in %s steps", maxTime.String(), retryInterval.String())
 	if since < maxTime {
 		return operation, retryInterval, nil

--- a/components/kyma-environment-broker/internal/process/deprovision_operation.go
+++ b/components/kyma-environment-broker/internal/process/deprovision_operation.go
@@ -72,7 +72,6 @@ func (om *DeprovisionOperationManager) RetryOperationOnce(operation internal.Dep
 func (om *DeprovisionOperationManager) RetryOperation(operation internal.DeprovisioningOperation, errorMessage string, retryInterval time.Duration, maxTime time.Duration, log logrus.FieldLogger) (internal.DeprovisioningOperation, time.Duration, error) {
 	since := time.Since(operation.UpdatedAt)
 
-	log.Infof("Retry Operation was triggered with message: %s", errorMessage)
 	log.Infof("Retrying for %s in %s steps, error: %s", maxTime.String(), retryInterval.String(), errorMessage)
 	if since < maxTime {
 		return operation, retryInterval, nil

--- a/components/kyma-environment-broker/internal/process/provision_operation.go
+++ b/components/kyma-environment-broker/internal/process/provision_operation.go
@@ -61,6 +61,7 @@ func (om *ProvisionOperationManager) RetryOperationOnce(operation internal.Provi
 func (om *ProvisionOperationManager) RetryOperation(operation internal.ProvisioningOperation, errorMessage string, retryInterval time.Duration, maxTime time.Duration, log logrus.FieldLogger) (internal.ProvisioningOperation, time.Duration, error) {
 	since := time.Since(operation.UpdatedAt)
 
+	log.Infof("Retry Operation was triggered with message: %s", errorMessage)
 	log.Infof("Retrying for %s in %s steps", maxTime.String(), retryInterval.String())
 	if since < maxTime {
 		return operation, retryInterval, nil


### PR DESCRIPTION
Currently when a retry operation is triggered. it's really difficult to know, why it was triggered on the first place. because the errormessage passed in the function will only be used if the operation is failed. 
Introducing additional log to specify that a retry operation was triggered due to an error message. 