### PR TITLE
Update the Runtime Provisioner e2e test

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -60,7 +60,7 @@ global:
         version: "PR-1270"
       provisioner:
         dir:
-        version: "PR-1270"
+        version: "PR-1306"
       e2e_provisioning:
         dir:
         version: "PR-1270"

--- a/tests/provisioner-tests/Gopkg.lock
+++ b/tests/provisioner-tests/Gopkg.lock
@@ -208,7 +208,7 @@
   version = "v1.0.2"
 
 [[projects]]
-  digest = "1:7cf610b4be7e3d97b44cdf11971aef30a3c10303958597af29d3d9ab32264a3b"
+  digest = "1:a265bd6d3c99c99ce337019e56245e1152f368bf2893cf1ba67945a52f2ba701"
   name = "github.com/kyma-incubator/compass"
   packages = [
     "components/director/internal/model",
@@ -220,7 +220,7 @@
     "components/provisioner/pkg/gqlschema",
   ]
   pruneopts = "UT"
-  revision = "b1da4ae4937a331fea6d517bdee91eeee183bb1d"
+  revision = "dad304da01da10bad9a123fd8852bf696607d4c1"
 
 [[projects]]
   digest = "1:5e4103e7b074ebc86f88f8fd93e4b7863744b86d9a8d53c442eab6d99d6ed6c7"

--- a/tests/provisioner-tests/Gopkg.toml
+++ b/tests/provisioner-tests/Gopkg.toml
@@ -5,7 +5,7 @@ required = [
 
 [[constraint]]
   name = "github.com/kyma-incubator/compass"
-  revision = "b1da4ae4937a331fea6d517bdee91eeee183bb1d"
+  revision = "dad304da01da10bad9a123fd8852bf696607d4c1"
 
 [[constraint]]
   name = "github.com/Masterminds/sprig"

--- a/tests/provisioner-tests/test/provisioner/e2e_test.go
+++ b/tests/provisioner-tests/test/provisioner/e2e_test.go
@@ -202,6 +202,7 @@ func verifyProviderConfig(t *testing.T, input gqlschema.ProviderSpecificInput, c
 		require.True(t, ok)
 
 		assertions.AssertNotNilAndEqualString(t, input.AzureConfig.VnetCidr, azureConfig.VnetCidr)
+		assert.ElementsMatch(t, input.AzureConfig.Zones, azureConfig.Zones)
 	}
 
 	if input.AwsConfig != nil {
@@ -218,7 +219,7 @@ func verifyProviderConfig(t *testing.T, input gqlschema.ProviderSpecificInput, c
 		gcpConfig, ok := providerSpecificConfig.(*gqlschema.GCPProviderConfig)
 		require.True(t, ok)
 
-		assertions.AssertNotNilAndEqualString(t, input.GcpConfig.Zone, gcpConfig.Zone)
+		assert.ElementsMatch(t, input.GcpConfig.Zones, gcpConfig.Zones)
 	}
 }
 

--- a/tests/provisioner-tests/test/testkit/compass/provisioner/graphqlizer.go
+++ b/tests/provisioner-tests/test/testkit/compass/provisioner/graphqlizer.go
@@ -3,9 +3,10 @@ package provisioner
 import (
 	"bytes"
 	"encoding/json"
-	"github.com/sirupsen/logrus"
 	"reflect"
 	"text/template"
+
+	"github.com/sirupsen/logrus"
 
 	"github.com/Masterminds/sprig"
 	"github.com/kyma-incubator/compass/components/provisioner/pkg/gqlschema"

--- a/tests/provisioner-tests/test/testkit/compass/provisioner/query.go
+++ b/tests/provisioner-tests/test/testkit/compass/provisioner/query.go
@@ -100,10 +100,11 @@ func clusterConfig() string {
 func providerSpecificConfig() string {
 	return fmt.Sprint(`
 		... on GCPProviderConfig { 
-			zone 
+			zones 
 		} 
 		... on AzureProviderConfig {
 			vnetCidr
+			zones
 		}
 		... on AWSProviderConfig {
 			zone 

--- a/tests/provisioner-tests/test/testkit/inputs.go
+++ b/tests/provisioner-tests/test/testkit/inputs.go
@@ -16,7 +16,7 @@ func CreateGardenerProvisioningInput(config *TestConfig, version, provider strin
 			TargetSecret: config.Gardener.GCPSecret,
 			ProviderSpecificConfig: &gqlschema.ProviderSpecificInput{
 				GcpConfig: &gqlschema.GCPProviderConfigInput{
-					Zone: "europe-west4-a",
+					Zones: []string{"europe-west4-a", "europe-west4-b", "europe-west4-c"},
 				},
 			},
 		},
@@ -28,6 +28,7 @@ func CreateGardenerProvisioningInput(config *TestConfig, version, provider strin
 			ProviderSpecificConfig: &gqlschema.ProviderSpecificInput{
 				AzureConfig: &gqlschema.AzureProviderConfigInput{
 					VnetCidr: "10.250.0.0/19",
+					Zones:    []string{"westeurope-1", "westeurope-2", "westeurope-3"},
 				},
 			},
 		},


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Update the e2e test for the Runtime Provisioner after the zone field in configuration changed to zones list.

**Related PR(s)**
- [implementation](https://github.com/kyma-incubator/compass/pull/1277)
- [changes in KEB](https://github.com/kyma-incubator/compass/pull/1296)
- [images bump in Kyma](https://github.com/kyma-project/kyma/pull/8386)
- [test bump in Kyma](https://github.com/kyma-project/kyma/pull/8411)
- [documentation update in Compass](https://github.com/kyma-incubator/compass/pull/1312/)
- [documentation update in Kyma](https://github.com/kyma-project/kyma/pull/8412)