### PR TITLE
Update the Runtime Provisioner documentation after zone changed to a list of zones

### DIFF
--- a/docs/internal/runtime-upgrade.md
+++ b/docs/internal/runtime-upgrade.md
@@ -196,7 +196,7 @@ mutation {
                 maxUnavailable 
                 kubernetesVersion 
                 providerSpecificConfig { 
-                __typename ... on GCPProviderConfig { zone } 
+                __typename ... on GCPProviderConfig { zones } 
                     ... on AzureProviderConfig {vnetCidr}
                 ... on AWSProviderConfig {zone internalCidr vpcCidr publicCidr}      
             }

--- a/docs/provisioner/08-02-provisioning-gardener.md
+++ b/docs/provisioner/08-02-provisioning-gardener.md
@@ -113,7 +113,7 @@ This tutorial shows how to provision clusters with Kyma Runtimes on Google Cloud
                 autoScalerMax: 4
                 maxSurge: 4
                 maxUnavailable: 1
-                providerSpecificConfig: { gcpConfig: { zone: "europe-west4-a" } }
+                providerSpecificConfig: { gcpConfig: { zones: ["europe-west4-a"] } }
               }
             }
             kymaConfig: {
@@ -205,7 +205,7 @@ This tutorial shows how to provision clusters with Kyma Runtimes on Google Cloud
                 autoScalerMax: 4
                 maxSurge: 4
                 maxUnavailable: 1
-                providerSpecificConfig: { azureConfig: { vnetCidr: "10.250.0.0/19" } }
+                providerSpecificConfig: { azureConfig: { vnetCidr: "10.250.0.0/19", zones: ["westeurope-1"] } }
               }
             }
             kymaConfig: {

--- a/docs/provisioner/08-02-provisioning-gardener.md
+++ b/docs/provisioner/08-02-provisioning-gardener.md
@@ -102,7 +102,6 @@ This tutorial shows how to provision clusters with Kyma Runtimes on Google Cloud
                 kubernetesVersion: "1.15.4"
                 diskType: "pd-standard"
                 volumeSizeGB: 30
-                nodeCount: 3
                 machineType: "n1-standard-4"
                 region: "europe-west4"
                 provider: "gcp"
@@ -194,7 +193,6 @@ This tutorial shows how to provision clusters with Kyma Runtimes on Google Cloud
                 kubernetesVersion: "1.15.4"
                 diskType: "Standard_LRS"
                 volumeSizeGB: 35
-                nodeCount: 3
                 machineType: "Standard_D2_v3"
                 region: "westeurope"
                 provider: "azure"
@@ -286,7 +284,6 @@ This tutorial shows how to provision clusters with Kyma Runtimes on Google Cloud
                 kubernetesVersion: "1.15.4"
                 diskType: "gp2"
                 volumeSizeGB: 35
-                nodeCount: 3
                 machineType: "m4.2xlarge"
                 region: "eu-west-1"
                 provider: "aws"

--- a/docs/provisioner/provisioning-api.md
+++ b/docs/provisioner/provisioning-api.md
@@ -66,7 +66,7 @@ These are the basic assumptions for the API design:
   - Name
   - Size
   - Memory
-  - Region and zone(s)
+  - Region and zone
   - Credentials
   - Version
   - Infrastructure provider (e.g. GKE, AKS)

--- a/docs/provisioner/provisioning-api.md
+++ b/docs/provisioner/provisioning-api.md
@@ -66,7 +66,7 @@ These are the basic assumptions for the API design:
   - Name
   - Size
   - Memory
-  - Region and zone
+  - Region and zone(s)
   - Credentials
   - Version
   - Infrastructure provider (e.g. GKE, AKS)


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Update the Runtime Provisioner documentation after the field zone provided in the Runtime provisioning mutation changed to a list of zones.

**Related issue(s)**
- #1277 
- #1296 
- kyma-project/kyma#8386
- #1306 
