### PR TITLE
Fix Azure zones input in Runtime Provisioner e2e test

### DIFF
--- a/tests/provisioner-tests/test/testkit/inputs.go
+++ b/tests/provisioner-tests/test/testkit/inputs.go
@@ -28,7 +28,7 @@ func CreateGardenerProvisioningInput(config *TestConfig, version, provider strin
 			ProviderSpecificConfig: &gqlschema.ProviderSpecificInput{
 				AzureConfig: &gqlschema.AzureProviderConfigInput{
 					VnetCidr: "10.250.0.0/19",
-					Zones:    []string{"westeurope-1", "westeurope-2", "westeurope-3"},
+					Zones:    []string{"1", "2", "3"},
 				},
 			},
 		},


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Fix Azure zones input in the e2e test for the Runtime Provisioner from `westeurope-1` to `1`.

**Related PR(s)**
- [implementation](https://github.com/kyma-incubator/compass/pull/1277)
- [changes in KEB](https://github.com/kyma-incubator/compass/pull/1296)
- [images bump in Kyma](https://github.com/kyma-project/kyma/pull/8386)
- [e2e test for the Runtime Provisioner updated](https://github.com/kyma-incubator/compass/pull/1306)
- [test bump in Kyma](https://github.com/kyma-project/kyma/pull/8411)
- [documentation update in Compass](https://github.com/kyma-incubator/compass/pull/1312/)
- [documentation update in Kyma](https://github.com/kyma-project/kyma/pull/8412)