### PR TITLE
Fix double marshalling in audit log service

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -27,7 +27,7 @@ global:
       version: "PR-1256"
     gateway:
       dir:
-      version: "PR-1270"
+      version: "PR-1330"
     healthchecker:
       dir: pr/
       version: "PR-357"

--- a/components/gateway/internal/auditlog/fixtures_test.go
+++ b/components/gateway/internal/auditlog/fixtures_test.go
@@ -42,11 +42,9 @@ func fixSuccessConfigChangeMsg(claims proxy.Claims, request, response string) mo
 }
 
 func fixSecurityEventMsg(t *testing.T, errors []model.ErrorMessage, claims proxy.Claims) model.SecurityEvent {
-	reason, err := json.Marshal(&errors)
-	require.NoError(t, err)
 	msgData := model.SecurityEventData{
 		ID:     fillID(claims, "Security Event"),
-		Reason: string(reason),
+		Reason: errors,
 	}
 	data, err := json.Marshal(&msgData)
 	require.NoError(t, err)

--- a/components/gateway/internal/auditlog/service.go
+++ b/components/gateway/internal/auditlog/service.go
@@ -90,13 +90,8 @@ func (svc *Service) Log(request, response string, claims proxy.Claims) error {
 	}
 
 	if svc.hasInsufficientScopeError(graphqlResponse.Errors) {
-		response, err := json.Marshal(&graphqlResponse.Errors)
-		if err != nil {
-			return errors.Wrap(err, "while marshalling graphql err")
-		}
-
 		msg := svc.msgFactory.CreateSecurityEvent()
-		eventData := model.SecurityEventData{ID: fillID(claims, "Security Event"), Reason: string(response)}
+		eventData := model.SecurityEventData{ID: fillID(claims, "Security Event"), Reason: graphqlResponse.Errors}
 		data, err := json.Marshal(&eventData)
 		if err != nil {
 			return errors.Wrap(err, "while marshalling security event data")

--- a/components/gateway/internal/auditlog/service_test.go
+++ b/components/gateway/internal/auditlog/service_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestAuditlogService_LogConfigurationChange(t *testing.T) {
+func TestAuditlogService_Log(t *testing.T) {
 	t.Run("Success mutation", func(t *testing.T) {
 		//GIVEN
 		factory := &automock.AuditlogMessageFactory{}

--- a/components/gateway/pkg/auditlog/model/auditlog.go
+++ b/components/gateway/pkg/auditlog/model/auditlog.go
@@ -35,7 +35,7 @@ type Metadata struct {
 
 type SecurityEventData struct {
 	ID     map[string]string `json:"id"`
-	Reason string            `json:"reason"`
+	Reason []ErrorMessage    `json:"reason"`
 }
 
 type Object struct {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Fixed double marshaling of `reason` field in audit log service
Example message after fix:
```
{{"operationName":"reg","variables":{},"query":"mutation reg {\n  registerRuntime(in: {name: \"my-name-123\"}) {\n    id\n  }\n}\n"} {"errors":[{"message":"insufficient scopes provided, required: [runtime:write], actual: [application:write]","path":["registerRuntime"]}],"data":null} {b732a8a6-7629-4ba0-87fa-06ab8057b448 application:write 94669751-eebe-4803-a4cc-741dea6ad66b Integration System}}
```

**Related issue(s)**
#1281 
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
