### PR TITLE
exclude any logs from LMS resulting from keycloak-gatekeeper

### DIFF
--- a/components/kyma-environment-broker/internal/process/provisioning/lms_cert_step.go
+++ b/components/kyma-environment-broker/internal/process/provisioning/lms_cert_step.go
@@ -188,7 +188,7 @@ func (s *lmsCertStep) Run(operation internal.ProvisioningOperation, l logrus.Fie
 		//kubernetes filter should not parse the document to avoid indexing on LMS side
 		{Key: "fluent-bit.conf.Filter.Kubernetes.Merge_Log", Value: "Off"},
 		//input should not contain dex logs as it contains sensitive data
-		{Key: "fluent-bit.conf.Input.Kubernetes.Exclude_Path", Value: "/var/log/containers/*_dex-*.log"},
+		{Key: "fluent-bit.conf.Input.Kubernetes.Exclude_Path", Value: "/var/log/containers/*_dex-*.log,/var/log/containers/*_kcproxy-*.log"},
 	})
 	return operation, 0, nil
 }


### PR DESCRIPTION

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:
Kyma is using the keycloak-gatekeeper in some places for verification of a authenticated user request. The logs created by the proxy will contain the email address of the user and should not get collected by LMS.
All these containers are named "kcproxy" derived from the former project name "keycloak-proxy", excluding that container name pattern for the LMS config will solve the problem.


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
