### PR TITLE
Make sure Azure resource names are in lower case

### DIFF
--- a/components/kyma-environment-broker/internal/process/provisioning/event_hub_step.go
+++ b/components/kyma-environment-broker/internal/process/provisioning/event_hub_step.go
@@ -102,7 +102,7 @@ func (p *ProvisionAzureEventHubStep) Run(operation internal.ProvisioningOperatio
 	}
 
 	// prepare a valid unique name for Azure resources
-	uniqueName := addPrefix(operation.InstanceID)
+	uniqueName := getAzureResourceName(operation.InstanceID)
 
 	// create Resource Group
 	groupName := uniqueName
@@ -207,6 +207,9 @@ func getKafkaChannelOverrides(brokerHostname, brokerPort, namespace, username, p
 	}
 }
 
-func addPrefix(name string) string {
-	return fmt.Sprintf("%s%s", prefix, name)
+// getAzureResourceName returns a valid Azure resource name that is in lower case and starts with a letter.
+func getAzureResourceName(name string) string {
+	name = fmt.Sprintf("%s%s", prefix, name)
+	name = strings.ToLower(name)
+	return name
 }

--- a/components/kyma-environment-broker/internal/process/provisioning/event_hub_step_test.go
+++ b/components/kyma-environment-broker/internal/process/provisioning/event_hub_step_test.go
@@ -187,6 +187,32 @@ func Test_StepsUnhappyPath(t *testing.T) {
 	}
 }
 
+func Test_getAzureResourceName(t *testing.T) {
+	tests := []struct {
+		name             string
+		givenName        string
+		wantResourceName string
+	}{
+		{
+			name:             "all lowercase and starts with digit",
+			givenName:        "1a23238d-1b04-3a9c-c139-405b75796ceb",
+			wantResourceName: "k1a23238d-1b04-3a9c-c139-405b75796ceb",
+		},
+		{
+			name:             "all uppercase and starts with digit",
+			givenName:        "1A23238D-1B04-3A9C-C139-405B75796CEB",
+			wantResourceName: "k1a23238d-1b04-3a9c-c139-405b75796ceb",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := getAzureResourceName(test.givenName)
+			assert.Equal(t, test.wantResourceName, got)
+		})
+	}
+}
+
 // operationManager.OperationFailed(...)
 // manager.go: if processedOperation.State != domain.InProgress { return 0, nil } => repeat
 // queue.go: if err == nil && when != 0 => repeat


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Make sure that the created Azure resource names are all in lower case.

For more info see: https://github.com/kyma-incubator/compass/issues/1359#issuecomment-631328399.

**Related issue(s)**

- https://github.com/kyma-incubator/compass/issues/1359.
