### PR TITLE
Fix shortening response status for metrics in Tenant Fetcher

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -24,7 +24,7 @@ global:
       version: "PR-1270"
     director:
       dir:
-      version: "PR-1368"
+      version: "PR-1380"
     gateway:
       dir:
       version: "PR-1330"

--- a/components/director/internal/tenantfetcher/client.go
+++ b/components/director/internal/tenantfetcher/client.go
@@ -145,7 +145,7 @@ func (c *Client) failedRequestDesc(err error) string {
 		return e.Err.Error()
 	}
 
-	if len(err.Error()) == maxErrMessageLength {
+	if len(err.Error()) > maxErrMessageLength {
 		// not all errors are actually wrapped, sometimes the error message is just concatenated with ":"
 		errParts := strings.Split(err.Error(), ":")
 		return errParts[len(errParts)-1]

--- a/components/director/internal/tenantfetcher/client.go
+++ b/components/director/internal/tenantfetcher/client.go
@@ -41,7 +41,8 @@ type Client struct {
 }
 
 const (
-	pageSize = 1000
+	pageSize            = 1000
+	maxErrMessageLength = 50
 )
 
 func NewClient(oAuth2Config OAuth2Config, apiConfig APIConfig) *Client {
@@ -144,7 +145,11 @@ func (c *Client) failedRequestDesc(err error) string {
 		return e.Err.Error()
 	}
 
-	// not all errors are actually wrapped, sometimes the error message is just concatenated with ":"
-	errParts := strings.Split(err.Error(), ":")
-	return errParts[len(errParts)-1]
+	if len(err.Error()) == maxErrMessageLength {
+		// not all errors are actually wrapped, sometimes the error message is just concatenated with ":"
+		errParts := strings.Split(err.Error(), ":")
+		return errParts[len(errParts)-1]
+	}
+
+	return err.Error()
 }


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Fix shortening response status for metrics in Tenant Fetcher

**Related issue(s)**
#1235 
