### PR TITLE
Add cleanup step to Deprovisioning queue in Provisioner

### DIFF
--- a/chart/compass/charts/provisioner/templates/deployment.yaml
+++ b/chart/compass/charts/provisioner/templates/deployment.yaml
@@ -92,6 +92,8 @@ spec:
               value: "{{ .Values.gardener.clusterDeletionTimeout }}"
             - name: APP_DEPROVISIONING_TIMEOUT_WAITING_FOR_CLUSTER_DELETION
               value: "{{ .Values.gardener.waitingForClusterDeletionTimeout }}"
+            - name: APP_DEPROVISIONING_TIMEOUT_CLUSTER_CLEANUP
+              value: "{{ .Values.gardener.clusterCleanupTimeout }}"
             - name: APP_GARDENER_PROJECT
               value: {{ .Values.gardener.project }}
             - name: APP_GARDENER_KUBECONFIG_PATH
@@ -102,6 +104,8 @@ spec:
               value: {{ .Values.gardener.auditLogTenantConfigPath }}
             - name: APP_GARDENER_MAINTENANCE_WINDOW_CONFIG_PATH
               value: {{ .Values.gardener.maintenanceWindowConfigPath }}
+            - name: APP_GARDENER_CLUSTER_CLEANUP_RESOURCE_SELECTOR
+              value: {{ .Values.gardener.clusterCleanupResourceSelector }}
             - name: APP_PROVISIONER
               value: {{ .Values.provisioner }}
             - name: APP_LATEST_DOWNLOADED_RELEASES

--- a/chart/compass/charts/provisioner/values.yaml
+++ b/chart/compass/charts/provisioner/values.yaml
@@ -25,6 +25,8 @@ gardener:
   clusterCreationTimeout: 2h
   clusterDeletionTimeout: 30m
   waitingForClusterDeletionTimeout: 4h
+  clusterCleanupTimeout: 20m
+  clusterCleanupResourceSelector: "https://service-manager."
 
 provisioner: "gardener"
 

--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -36,7 +36,7 @@ global:
       version: "PR-1308"
     provisioner:
       dir:
-      version: "PR-1335"
+      version: "PR-1381"
     certs_setup_job:
       containerRegistry:
         path: eu.gcr.io/kyma-project

--- a/components/provisioner/cmd/main.go
+++ b/components/provisioner/cmd/main.go
@@ -73,11 +73,12 @@ type config struct {
 	DeprovisioningTimeout queue.DeprovisioningTimeouts
 
 	Gardener struct {
-		Project                     string `envconfig:"default=gardenerProject"`
-		KubeconfigPath              string `envconfig:"default=./dev/kubeconfig.yaml"`
-		AuditLogsPolicyConfigMap    string `envconfig:"optional"`
-		AuditLogsTenantConfigPath   string `envconfig:"optional"`
-		MaintenanceWindowConfigPath string `envconfig:"optional"`
+		Project                        string `envconfig:"default=gardenerProject"`
+		KubeconfigPath                 string `envconfig:"default=./dev/kubeconfig.yaml"`
+		AuditLogsPolicyConfigMap       string `envconfig:"optional"`
+		AuditLogsTenantConfigPath      string `envconfig:"optional"`
+		MaintenanceWindowConfigPath    string `envconfig:"optional"`
+		ClusterCleanupResourceSelector string `envconfig:"default=https://service-manager."`
 	}
 
 	Provisioner string `envconfig:"default=gardener"`
@@ -166,7 +167,7 @@ func main() {
 	}
 
 	dbsFactory := dbsession.NewFactory(connection)
-	installationService := installation.NewInstallationService(cfg.ProvisioningTimeout.Installation, installationHandlerConstructor)
+	installationService := installation.NewInstallationService(cfg.ProvisioningTimeout.Installation, installationHandlerConstructor, cfg.Gardener.ClusterCleanupResourceSelector)
 
 	directorClient, err := newDirectorClient(cfg)
 	exitOnError(err, "Failed to initialize Director client")

--- a/components/provisioner/go.mod
+++ b/components/provisioner/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/gorilla/mux v1.7.3
 	github.com/hashicorp/hil v0.0.0-20190212132231-97b3a9cdfa93 // indirect
 	github.com/hashicorp/terraform v0.12.25-0.20200512183839-7c646ddeced3
+	github.com/kubernetes-sigs/service-catalog v0.3.0-beta.2
 	github.com/kubernetes/client-go v11.0.0+incompatible
 	github.com/kyma-incubator/compass/components/director v0.0.0-20200506060219-a2a2a07e1283
 	github.com/kyma-incubator/hydroform v0.0.0-20191217171037-affe7099c3b9
@@ -28,7 +29,9 @@ require (
 	github.com/testcontainers/testcontainers-go v0.3.1
 	github.com/vektah/gqlparser v1.2.0
 	github.com/vrischmann/envconfig v1.2.0
+	golang.org/x/net v0.0.0-20200226121028-0de0cce0169b // indirect
 	golang.org/x/time v0.0.0-20190921001708-c4c64cad1fd0 // indirect
+	golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 // indirect
 	google.golang.org/genproto v0.0.0-20190927181202-20e1ac93f88c // indirect
 	google.golang.org/grpc v1.24.0 // indirect
 	k8s.io/api v0.17.2

--- a/components/provisioner/go.sum
+++ b/components/provisioner/go.sum
@@ -690,6 +690,8 @@ github.com/kr/pty v1.1.3/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.5/go.mod h1:9r2w37qlBe7rQ6e1fg1S/9xpWHSnaqNdHD3WcMdbPDA=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/kubernetes-sigs/service-catalog v0.3.0-beta.2 h1:+OQqvd5QN/g++TYaMS/YscePfu4YdVFalbp3/i4x+/Q=
+github.com/kubernetes-sigs/service-catalog v0.3.0-beta.2/go.mod h1:fmRsWJ38Od93DQ7cOXR9mMSSwmjyDS1EAomWxBlumuo=
 github.com/kubernetes/client-go v11.0.0+incompatible h1:g8FB7QVXKKp4imk86Dgc+FxjLFqUfn/p/1i3yC0WEAg=
 github.com/kubernetes/client-go v11.0.0+incompatible/go.mod h1:kszVi2i+FeqECZHhjpkV5h5zM0GnURfJv897YzgoAQ8=
 github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348/go.mod h1:B69LEHPfb2qLo0BaaOLcbitczOKLWTsrBG9LczfCD4k=
@@ -1005,6 +1007,7 @@ github.com/vektah/dataloaden v0.2.1-0.20190515034641-a19b9a6e7c9e/go.mod h1:/HUd
 github.com/vektah/gqlparser v1.1.2/go.mod h1:1ycwN7Ij5njmMkPPAOaRFY4rET2Enx7IkVv3vaXspKw=
 github.com/vektah/gqlparser v1.2.0 h1:ntkSCX7F5ZJKl+HIVnmLaO269MruasVpNiMOjX9kgo0=
 github.com/vektah/gqlparser v1.2.0/go.mod h1:bkVf0FX+Stjg/MHnm8mEyubuaArhNEqfQhF+OTiAL74=
+github.com/vektra/mockery v0.0.0-20181123154057-e78b021dcbb5 h1:Xim2mBRFdXzXmKRO8DJg/FJtn/8Fj9NOEpO6+WuMPmk=
 github.com/vektra/mockery v0.0.0-20181123154057-e78b021dcbb5/go.mod h1:ppEjwdhyy7Y31EnHRDm1JkChoC7LXIJ7Ex0VYLWtZtQ=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=
 github.com/vmihailenco/msgpack v4.0.1+incompatible h1:RMF1enSPeKTlXrXdOcqjFUElywVZjjC6pqse21bKbEU=
@@ -1112,6 +1115,8 @@ golang.org/x/net v0.0.0-20191119073136-fc4aabc6c914 h1:MlY3mEfbnWGmUi4rtHOtNnnnN
 golang.org/x/net v0.0.0-20191119073136-fc4aabc6c914/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200202094626-16171245cfb2 h1:CCH4IOTTfewWjGOlSp+zGcjutRKlBEZQ6wTn8ozI/nI=
 golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20200226121028-0de0cce0169b h1:0mm1VjtFUOIlE1SbDlwjYaDxZVDP2S5ou6y0gSgXHu8=
+golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20181017192945-9dcd33a902f4/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20181203162652-d668ce993890/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -1212,6 +1217,8 @@ golang.org/x/tools v0.0.0-20191118222007-07fc4c7f2b98 h1:tZwpOHmF1OEL9wJGSgBALnh
 golang.org/x/tools v0.0.0-20191118222007-07fc4c7f2b98/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7 h1:9zdDQZ7Thm29KFXgAX/+yaf3eVbP7djjWp/dXAppNCc=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gomodules.xyz/jsonpatch/v2 v2.0.0/go.mod h1:IhYNNY4jnS53ZnfE4PAmpKtDpTCj1JFXc+3mwe7XcUU=
 gomodules.xyz/jsonpatch/v2 v2.0.1 h1:xyiBuvkD2g5n7cYzx6u2sxQvsAy4QJsZFCzGVdzOXZ0=
 gomodules.xyz/jsonpatch/v2 v2.0.1/go.mod h1:IhYNNY4jnS53ZnfE4PAmpKtDpTCj1JFXc+3mwe7XcUU=

--- a/components/provisioner/internal/api/resolver_integration_with_gardener_test.go
+++ b/components/provisioner/internal/api/resolver_integration_with_gardener_test.go
@@ -140,6 +140,7 @@ func TestProvisioning_ProvisionRuntimeWithDatabase(t *testing.T) {
 	installationServiceMock.On("TriggerUpgrade", mock.Anything, mock.AnythingOfType("model.Release"),
 		mock.AnythingOfType("model.Configuration"), mock.AnythingOfType("[]model.KymaComponentConfig")).Return(nil)
 
+	installationServiceMock.On("PerformCleanup", mock.Anything).Return(nil)
 	installationServiceMock.On("TriggerUninstall", mock.Anything).Return(nil)
 
 	ctx := context.WithValue(context.Background(), middlewares.Tenant, tenant)
@@ -399,6 +400,7 @@ func testProvisioningTimeouts() queue.ProvisioningTimeouts {
 
 func testDeprovisioningTimeouts() queue.DeprovisioningTimeouts {
 	return queue.DeprovisioningTimeouts{
+		ClusterCleanup:            5 * time.Minute,
 		ClusterDeletion:           5 * time.Minute,
 		WaitingForClusterDeletion: 5 * time.Minute,
 	}

--- a/components/provisioner/internal/gardener/provisioner.go
+++ b/components/provisioner/internal/gardener/provisioner.go
@@ -114,7 +114,7 @@ func (g *GardenerProvisioner) DeprovisionCluster(cluster model.Cluster, operatio
 	}
 
 	message := fmt.Sprintf("Deprovisioning started")
-	return newDeprovisionOperation(operationId, cluster.ID, message, model.InProgress, model.TriggerKymaUninstall, deletionTime), nil
+	return newDeprovisionOperation(operationId, cluster.ID, message, model.InProgress, model.CleanupCluster, deletionTime), nil
 }
 
 func annotateWithConfirmDeletion(shoot *gardener_types.Shoot) {

--- a/components/provisioner/internal/installation/installation.go
+++ b/components/provisioner/internal/installation/installation.go
@@ -39,18 +39,29 @@ type Service interface {
 	TriggerInstallation(kubeconfigRaw *rest.Config, release model.Release, globalConfig model.Configuration, componentsConfig []model.KymaComponentConfig) error
 	TriggerUpgrade(kubeconfigRaw *rest.Config, release model.Release, globalConfig model.Configuration, componentsConfig []model.KymaComponentConfig) error
 	TriggerUninstall(kubeconfig *rest.Config) error
+	PerformCleanup(kubeconfig *rest.Config) error
 }
 
-func NewInstallationService(installationTimeout time.Duration, installationHandler InstallationHandler) Service {
+func NewInstallationService(installationTimeout time.Duration, installationHandler InstallationHandler, clusterCleanupResourceSelector string) Service {
 	return &installationService{
-		kymaInstallationTimeout: installationTimeout,
-		installationHandler:     installationHandler,
+		kymaInstallationTimeout:        installationTimeout,
+		installationHandler:            installationHandler,
+		clusterCleanupResourceSelector: clusterCleanupResourceSelector,
 	}
 }
 
 type installationService struct {
-	kymaInstallationTimeout time.Duration
-	installationHandler     InstallationHandler
+	kymaInstallationTimeout        time.Duration
+	installationHandler            InstallationHandler
+	clusterCleanupResourceSelector string
+}
+
+func (s *installationService) PerformCleanup(kubeconfig *rest.Config) error {
+	cli, err := NewServiceCatalogClient(kubeconfig)
+	if err != nil {
+		return err
+	}
+	return cli.PerformCleanup(s.clusterCleanupResourceSelector)
 }
 
 func (s *installationService) TriggerInstallation(kubeconfig *rest.Config, release model.Release, globalConfig model.Configuration, componentsConfig []model.KymaComponentConfig) error {

--- a/components/provisioner/internal/installation/installation_test.go
+++ b/components/provisioner/internal/installation/installation_test.go
@@ -55,7 +55,8 @@ users:
     client-key-data: LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlFcEFJQkFBS0NBUUVBdW4raWVvTVNLUDROdEtmdVlhNXlFNGhzaC9MVkpsNHJ2Q0dmamsvdnJZNEx2YllNCnFvSjdKZnhnamsreTJmTSt6VS9waXhpZjNTZzFnRnNLSlRWUy9LdDlod1dhK3dvald2cVFLcEZ4Z3Qrayt1QTkKaGZjU3lvbEdad0JESVYxZlpvY25nYzQ1YXZMdXFYRGtwSE1pRjdacmprd0JGbXZtV2NrVnpYS1lXOXJlYWs2bgo0Ui9BdVJBdVFmaVovaWlsZ24rZXB5WFd6NG9KeE1jUjJHZHFFanh1WXMzWnhuZUdjSUxidE8rSkpvVXB1YmQ1Ci9OdW8vL3FKdjUxTW9BQXA5dW5idnBtWU9EcW9ISmd2cjZWN2dOaFo3NXpTdi9lV3Z1QWU2WkRDdzdwY24wTjkKYS9SS3ZxYmFYZVE3bUkzcm1YQ2o2c0wxS1ZOMkVFaEMxRXRKRVFJREFRQUJBb0lCQVFDTEVFa3pXVERkYURNSQpGb0JtVGhHNkJ1d0dvMGZWQ0R0TVdUWUVoQTZRTjI4QjB4RzJ3dnpZNGt1TlVsaG10RDZNRVo1dm5iajJ5OWk1CkVTbUxmU3VZUkxlaFNzaTVrR0cwb1VtR3RGVVQ1WGU3cWlHMkZ2bm9GRnh1eVg5RkRiN3BVTFpnMEVsNE9oVkUKTzI0Q1FlZVdEdXc4ZXVnRXRBaGJ3dG1ERElRWFdPSjcxUEcwTnZKRHIwWGpkcW1aeExwQnEzcTJkZTU2YmNjawpPYzV6dmtJNldrb0o1TXN0WkZpU3pVRDYzN3lIbjh2NGd3cXh0bHFoNWhGLzEwV296VmZqVGdWSG0rc01ZaU9SCmNIZ0dMNUVSbDZtVlBsTTQzNUltYnFnU1R2NFFVVGpzQjRvbVBsTlV5Yksvb3pPSWx3RjNPTkJjVVV6eDQ1cGwKSHVJQlQwZ1JBb0dCQU9SR2lYaVBQejdsay9Bc29tNHkxdzFRK2hWb3Yvd3ovWFZaOVVkdmR6eVJ1d3gwZkQ0QgpZVzlacU1hK0JodnB4TXpsbWxYRHJBMklYTjU3UEM3ZUo3enhHMEVpZFJwN3NjN2VmQUN0eDN4N0d0V2pRWGF2ClJ4R2xDeUZxVG9LY3NEUjBhQ0M0Um15VmhZRTdEY0huLy9oNnNzKys3U2tvRVMzNjhpS1RiYzZQQW9HQkFORW0KTHRtUmZieHIrOE5HczhvdnN2Z3hxTUlxclNnb2NmcjZoUlZnYlU2Z3NFd2pMQUs2ZHdQV0xWQmVuSWJ6bzhodApocmJHU1piRnF0bzhwS1Q1d2NxZlpKSlREQnQxYmhjUGNjWlRmSnFmc0VISXc0QW5JMVdRMlVzdzVPcnZQZWhsCmh0ek95cXdBSGZvWjBUTDlseTRJUHRqbXArdk1DQ2NPTHkwanF6NWZBb0dCQUlNNGpRT3hqSkN5VmdWRkV5WTMKc1dsbE9DMGdadVFxV3JPZnY2Q04wY1FPbmJCK01ZRlBOOXhUZFBLeC96OENkVyszT0syK2FtUHBGRUdNSTc5cApVdnlJdUxzTGZMZDVqVysyY3gvTXhaU29DM2Z0ZmM4azJMeXEzQ2djUFA5VjVQQnlUZjBwRU1xUWRRc2hrRG44CkRDZWhHTExWTk8xb3E5OTdscjhMY3A2L0FvR0FYNE5KZC9CNmRGYjRCYWkvS0lGNkFPQmt5aTlGSG9iQjdyVUQKbTh5S2ZwTGhrQk9yNEo4WkJQYUZnU09ENWhsVDNZOHZLejhJa2tNNUVDc0xvWSt4a1lBVEpNT3FUc3ZrOThFRQoyMlo3Qy80TE55K2hJR0EvUWE5Qm5KWDZwTk9XK1ErTWRFQTN6QzdOZ2M3U2U2L1ZuNThDWEhtUmpCeUVTSm13CnI3T1BXNDhDZ1lBVUVoYzV2VnlERXJxVDBjN3lIaXBQbU1wMmljS1hscXNhdC94YWtobENqUjZPZ2I5aGQvNHIKZm1wUHJmd3hjRmJrV2tDRUhJN01EdDJrZXNEZUhRWkFxN2xEdjVFT2k4ZG1uM0ZPNEJWczhCOWYzdm52MytmZwpyV2E3ZGtyWnFudU12cHhpSWlqOWZEak9XbzdxK3hTSFcxWWdSNGV2Q1p2NGxJU0FZRlViemc9PQotLS0tLUVORCBSU0EgUFJJVkFURSBLRVktLS0tLQo=
 `
 
-	runtimeId = "abcd-efgh"
+	runtimeId               = "abcd-efgh"
+	resourceCleanupSelector = "https://some-broker."
 )
 
 func TestInstallationService_TriggerInstallation(t *testing.T) {
@@ -77,7 +78,7 @@ func TestInstallationService_TriggerInstallation(t *testing.T) {
 
 	t.Run("should trigger installation", func(t *testing.T) {
 		installationHandlerConstructor := newMockInstallerHandler(t, expectedInstallation, nil, nil)
-		installationSvc := NewInstallationService(10*time.Minute, installationHandlerConstructor)
+		installationSvc := NewInstallationService(10*time.Minute, installationHandlerConstructor, resourceCleanupSelector)
 
 		// when
 		err := installationSvc.TriggerInstallation(k8sConfig, kymaRelease, globalConfig, componentsConfig)
@@ -178,7 +179,7 @@ func TestInstallationService_InstallKyma(t *testing.T) {
 			errChannel := make(chan error)
 
 			installationHandlerConstructor := newMockInstallerHandler(t, testCase.expectedInstallation, stateChannel, errChannel)
-			installationSvc := NewInstallationService(10*time.Minute, installationHandlerConstructor)
+			installationSvc := NewInstallationService(10*time.Minute, installationHandlerConstructor, resourceCleanupSelector)
 
 			go testCase.installationMock(stateChannel, errChannel)
 
@@ -197,7 +198,7 @@ func TestInstallationService_InstallKyma(t *testing.T) {
 	t.Run("should return error when failed to trigger installation", func(t *testing.T) {
 		// given
 		installationHandlerConstructor := newErrorInstallerHandler(t, nil, errors.New("error"))
-		installationSvc := NewInstallationService(10*time.Minute, installationHandlerConstructor)
+		installationSvc := NewInstallationService(10*time.Minute, installationHandlerConstructor, resourceCleanupSelector)
 
 		// when
 		err := installationSvc.InstallKyma(runtimeId, kubeconfig, kymaRelease, globalConfig, componentsConfig)
@@ -209,7 +210,7 @@ func TestInstallationService_InstallKyma(t *testing.T) {
 	t.Run("should return error when failed to prepare installation", func(t *testing.T) {
 		// given
 		installationHandlerConstructor := newErrorInstallerHandler(t, errors.New("error"), nil)
-		installationSvc := NewInstallationService(10*time.Minute, installationHandlerConstructor)
+		installationSvc := NewInstallationService(10*time.Minute, installationHandlerConstructor, resourceCleanupSelector)
 
 		// when
 		err := installationSvc.InstallKyma(runtimeId, kubeconfig, kymaRelease, globalConfig, componentsConfig)
@@ -220,7 +221,7 @@ func TestInstallationService_InstallKyma(t *testing.T) {
 
 	t.Run("should return error when failed to parse kubeconfig", func(t *testing.T) {
 		// given
-		installationSvc := NewInstallationService(10*time.Minute, nil)
+		installationSvc := NewInstallationService(10*time.Minute, nil, resourceCleanupSelector)
 
 		// when
 		err := installationSvc.InstallKyma(runtimeId, "", kymaRelease, globalConfig, componentsConfig)
@@ -294,7 +295,7 @@ func TestInstallationService_TriggerUpgrade(t *testing.T) {
 
 	t.Run("should trigger upgrade", func(t *testing.T) {
 		installationHandlerConstructor := newMockInstallerHandler(t, expectedInstallation, nil, nil)
-		installationSvc := NewInstallationService(10*time.Minute, installationHandlerConstructor)
+		installationSvc := NewInstallationService(10*time.Minute, installationHandlerConstructor, resourceCleanupSelector)
 
 		// when
 		err := installationSvc.TriggerUpgrade(k8sConfig, kymaRelease, globalConfig, componentsConfig)
@@ -306,7 +307,7 @@ func TestInstallationService_TriggerUpgrade(t *testing.T) {
 	t.Run("should return error when failed to prepare upgrade", func(t *testing.T) {
 		installationHandlerConstructor := newErrorInstallerHandler(t, errors.New("failed to prepare upgrade"), nil)
 
-		installationSvc := NewInstallationService(10*time.Minute, installationHandlerConstructor)
+		installationSvc := NewInstallationService(10*time.Minute, installationHandlerConstructor, resourceCleanupSelector)
 
 		// when
 		err := installationSvc.TriggerUpgrade(k8sConfig, kymaRelease, globalConfig, componentsConfig)
@@ -318,7 +319,7 @@ func TestInstallationService_TriggerUpgrade(t *testing.T) {
 	t.Run("should return error when failed to start upgrade", func(t *testing.T) {
 		installationHandlerConstructor := newErrorInstallerHandler(t, nil, errors.New("failed to start upgrade"))
 
-		installationSvc := NewInstallationService(10*time.Minute, installationHandlerConstructor)
+		installationSvc := NewInstallationService(10*time.Minute, installationHandlerConstructor, resourceCleanupSelector)
 
 		// when
 		err := installationSvc.TriggerUpgrade(k8sConfig, kymaRelease, globalConfig, componentsConfig)

--- a/components/provisioner/internal/installation/mocks/Service.go
+++ b/components/provisioner/internal/installation/mocks/Service.go
@@ -52,6 +52,20 @@ func (_m *Service) InstallKyma(runtimeId string, kubeconfigRaw string, release m
 	return r0
 }
 
+// PerformCleanup provides a mock function with given fields: kubeconfig
+func (_m *Service) PerformCleanup(kubeconfig *rest.Config) error {
+	ret := _m.Called(kubeconfig)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(*rest.Config) error); ok {
+		r0 = rf(kubeconfig)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // TriggerInstallation provides a mock function with given fields: kubeconfigRaw, release, globalConfig, componentsConfig
 func (_m *Service) TriggerInstallation(kubeconfigRaw *rest.Config, release model.Release, globalConfig model.Configuration, componentsConfig []model.KymaComponentConfig) error {
 	ret := _m.Called(kubeconfigRaw, release, globalConfig, componentsConfig)

--- a/components/provisioner/internal/installation/resource_cleanup.go
+++ b/components/provisioner/internal/installation/resource_cleanup.go
@@ -1,0 +1,209 @@
+package installation
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+	"time"
+
+	"github.com/kubernetes-sigs/service-catalog/pkg/apis/servicecatalog/v1beta1"
+	sc "github.com/kubernetes-sigs/service-catalog/pkg/client/clientset_generated/clientset"
+	"github.com/kubernetes-sigs/service-catalog/pkg/util"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	apiErrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/rest"
+)
+
+const (
+	ClusterServiceBrokerNameLabel   = "servicecatalog.k8s.io/spec.clusterServiceBrokerName"
+	ClusterServiceClassRefNameLabel = "servicecatalog.k8s.io/spec.clusterServiceClassRef.name"
+)
+
+type ServiceCatalogClient interface {
+	PerformCleanup(resourceSelector string) error
+	listClusterServiceBroker(metav1.ListOptions) (*v1beta1.ClusterServiceBrokerList, error)
+	listClusterServiceClass(metav1.ListOptions) (*v1beta1.ClusterServiceClassList, error)
+	listServiceInstance(metav1.ListOptions) (*v1beta1.ServiceInstanceList, error)
+}
+
+func NewServiceCatalogClient(kubeconfig *rest.Config) (ServiceCatalogClient, error) {
+	scCli, err := sc.NewForConfig(kubeconfig)
+	if err != nil {
+		return &serviceCatalogClient{}, err
+	}
+
+	return &serviceCatalogClient{client: scCli}, nil
+}
+
+type serviceCatalogClient struct {
+	client sc.Interface
+}
+
+func (s *serviceCatalogClient) PerformCleanup(resourceSelector string) error {
+	clusterServiceBrokers, err := s.listClusterServiceBroker(metav1.ListOptions{})
+	if err != nil {
+		return errors.Wrapf(err, "while listing ClusterServiceBrokers")
+	}
+
+	logrus.Debugf("Filtering ClusterServiceBrokers with url prefix %s", resourceSelector)
+	brokersWithUrlPrefix := s.filterCsbWithUrlPrefix(clusterServiceBrokers, resourceSelector)
+	logrus.Debugf("Got %d ClusterServiceBrokers to process", len(brokersWithUrlPrefix))
+
+	cscWithMatchingLabel, err := s.getClusterServiceClassesForBrokers(brokersWithUrlPrefix)
+	if err != nil {
+		return errors.Wrapf(err, "while getting ClusterServiceClasses")
+	}
+
+	serviceInstances, err := s.getServiceInstancesForClusterServiceClasses(cscWithMatchingLabel)
+	if err != nil {
+		return errors.Wrapf(err, "while getting ServiceInstances")
+	}
+
+	s.deleteServiceInstances(serviceInstances)
+
+	return nil
+}
+
+func (s *serviceCatalogClient) listClusterServiceBroker(options metav1.ListOptions) (*v1beta1.ClusterServiceBrokerList, error) {
+	result := &v1beta1.ClusterServiceBrokerList{}
+	logrus.Debugf("trying to list ClusterServiceBrokers...")
+	err := wait.PollImmediate(10*time.Second, 2*time.Minute, func() (done bool, err error) {
+		csbList, err := s.client.ServicecatalogV1beta1().ClusterServiceBrokers().List(options)
+		if err != nil {
+			logrus.Errorf("while listing ClusterServiceBrokers: %s", err.Error())
+			return false, nil
+		}
+		result = csbList
+		return true, nil
+	})
+	return result, err
+}
+
+func (s *serviceCatalogClient) listClusterServiceClass(options metav1.ListOptions) (*v1beta1.ClusterServiceClassList, error) {
+	result := &v1beta1.ClusterServiceClassList{}
+	logrus.Debugf("trying to list ClusterServiceClasses...")
+	err := wait.PollImmediate(10*time.Second, 2*time.Minute, func() (done bool, err error) {
+		cscList, err := s.client.ServicecatalogV1beta1().ClusterServiceClasses().List(options)
+		if err != nil {
+			logrus.Errorf("while listing ClusterServiceClasses: %s", err.Error())
+			return false, nil
+		}
+		result = cscList
+		return true, nil
+	})
+	return result, err
+}
+
+func (s *serviceCatalogClient) listServiceInstance(options metav1.ListOptions) (*v1beta1.ServiceInstanceList, error) {
+	result := &v1beta1.ServiceInstanceList{}
+	logrus.Debugf("trying to list ServiceInstances...")
+	err := wait.PollImmediate(10*time.Second, 2*time.Minute, func() (done bool, err error) {
+		siList, err := s.client.ServicecatalogV1beta1().ServiceInstances(metav1.NamespaceAll).List(options)
+		if err != nil {
+			logrus.Errorf("while listing ServiceInstances: %s", err.Error())
+			return false, nil
+		}
+		result = siList
+		return true, nil
+	})
+	return result, err
+}
+
+func (s *serviceCatalogClient) filterCsbWithUrlPrefix(csbList *v1beta1.ClusterServiceBrokerList, urlPrefix string) []v1beta1.ClusterServiceBroker {
+	var csbWithBrokerUrlPrefix []v1beta1.ClusterServiceBroker
+	for _, clusterServiceBroker := range csbList.Items {
+		if strings.HasPrefix(clusterServiceBroker.Spec.URL, urlPrefix) {
+			csbWithBrokerUrlPrefix = append(csbWithBrokerUrlPrefix, clusterServiceBroker)
+		}
+	}
+
+	return csbWithBrokerUrlPrefix
+}
+
+func (s *serviceCatalogClient) getClusterServiceClassesForBrokers(brokers []v1beta1.ClusterServiceBroker) ([]v1beta1.ClusterServiceClass, error) {
+	var cscWithMatchingLabel []v1beta1.ClusterServiceClass
+
+	for _, csb := range brokers {
+		labelValue := util.GenerateSHA(csb.Name)
+		csbListOptions := fixListOptionsWithLabelSelector(ClusterServiceBrokerNameLabel, labelValue)
+
+		clusterServiceClasses, err := s.listClusterServiceClass(csbListOptions)
+		if err != nil {
+			return []v1beta1.ClusterServiceClass{}, errors.Wrapf(err, "while listing ClusterServiceClasses for ClusterServiceBroker %q", csb.Name)
+		}
+
+		for _, serviceClass := range clusterServiceClasses.Items {
+			logrus.Debugf("found ClusterServiceClass with label %q: %s", labelValue, serviceClass.Name)
+			cscWithMatchingLabel = append(cscWithMatchingLabel, serviceClass)
+		}
+	}
+
+	return cscWithMatchingLabel, nil
+}
+
+func (s *serviceCatalogClient) getServiceInstancesForClusterServiceClasses(serviceClasses []v1beta1.ClusterServiceClass) ([]v1beta1.ServiceInstance, error) {
+	var serviceInstances []v1beta1.ServiceInstance
+
+	for _, clusterServiceClass := range serviceClasses {
+		labelValue := util.GenerateSHA(clusterServiceClass.Name)
+
+		options := fixListOptionsWithLabelSelector(ClusterServiceClassRefNameLabel, labelValue)
+
+		serviceInstancesList, err := s.listServiceInstance(options)
+		if err != nil {
+			return []v1beta1.ServiceInstance{}, errors.Wrapf(err, "while listing ServiceInstances")
+		}
+
+		for _, serviceInstance := range serviceInstancesList.Items {
+			logrus.Debugf("found ServiceInstance with label %q: %s", labelValue, serviceInstance.Name)
+			serviceInstances = append(serviceInstances, serviceInstance)
+		}
+	}
+	return serviceInstances, nil
+}
+
+func (s *serviceCatalogClient) deleteServiceInstances(serviceInstances []v1beta1.ServiceInstance) {
+	for _, serviceInstance := range serviceInstances {
+		logrus.Debugf("trying to delete ServiceInstance %q", serviceInstance.Name)
+
+		_ = wait.PollImmediate(10*time.Second, 2*time.Minute, func() (done bool, err error) {
+			if err := s.client.ServicecatalogV1beta1().ServiceInstances(serviceInstance.Namespace).Delete(serviceInstance.Name, &metav1.DeleteOptions{}); err != nil {
+				logrus.Errorf("while removing ServiceInstance %s: %s", serviceInstance.Name, err.Error())
+				if apiErrors.IsNotFound(err) {
+					return true, nil
+				}
+				return false, nil
+			}
+			return true, nil
+		})
+	}
+}
+
+func fixListOptionsWithLabelSelector(labelName, labelValue string) metav1.ListOptions {
+	labelSelector := metav1.LabelSelector{
+		MatchLabels: map[string]string{labelName: labelValue},
+	}
+
+	return metav1.ListOptions{
+		LabelSelector: labels.Set(labelSelector.MatchLabels).String(),
+	}
+}
+
+// GenerateSHA generates the sha224 value from the given string
+// the function is used to provide a string length less than 63 characters, this string is used in label of resource
+// sha algorithm cannot be changed in the future because of backward compatibles
+func GenerateSHA(input string) string {
+	// TODO: remove this and import from "github.com/kubernetes-sigs/service-catalog/pkg/util" when service-catalog v0.3 is released
+	h := sha256.New224()
+	_, err := h.Write([]byte(input))
+	if err != nil {
+		logrus.Errorf("cannot generate SHA224 from string %q: %s", input, err)
+		return ""
+	}
+
+	return hex.EncodeToString(h.Sum(nil))
+}

--- a/components/provisioner/internal/installation/resource_cleanup.go
+++ b/components/provisioner/internal/installation/resource_cleanup.go
@@ -23,9 +23,6 @@ const (
 
 type ServiceCatalogClient interface {
 	PerformCleanup(resourceSelector string) error
-	listClusterServiceBroker(metav1.ListOptions) (*v1beta1.ClusterServiceBrokerList, error)
-	listClusterServiceClass(metav1.ListOptions) (*v1beta1.ClusterServiceClassList, error)
-	listServiceInstance(metav1.ListOptions) (*v1beta1.ServiceInstanceList, error)
 }
 
 func NewServiceCatalogClient(kubeconfig *rest.Config) (ServiceCatalogClient, error) {

--- a/components/provisioner/internal/installation/resource_cleanup_test.go
+++ b/components/provisioner/internal/installation/resource_cleanup_test.go
@@ -101,21 +101,6 @@ func TestServiceCatalogClient_PerformCleanup(t *testing.T) {
 		// then
 		require.Error(t, err)
 	})
-
-	t.Run("should fail cleanup when unable to delete ServiceInstances", func(t *testing.T) {
-		// given
-		fakeClient := scfake.NewSimpleClientset(newTestCR()...)
-		cli := &serviceCatalogClient{client: fakeClient}
-		fakeClient.PrependReactor("delete", "serviceinstances", func(action clientgotesting.Action) (bool, runtime.Object, error) {
-			return true, nil, errors.New("error deleting serviceinstances")
-		})
-
-		// when
-		err := cli.PerformCleanup(TestResourceSelector)
-
-		// then
-		require.Error(t, err)
-	})
 }
 
 func TestServiceCatalogClient_ListClusterServiceBroker(t *testing.T) {

--- a/components/provisioner/internal/installation/resource_cleanup_test.go
+++ b/components/provisioner/internal/installation/resource_cleanup_test.go
@@ -101,6 +101,21 @@ func TestServiceCatalogClient_PerformCleanup(t *testing.T) {
 		// then
 		require.Error(t, err)
 	})
+
+	t.Run("should fail cleanup when unable to delete ServiceInstances", func(t *testing.T) {
+		// given
+		fakeClient := scfake.NewSimpleClientset(newTestCR()...)
+		cli := &serviceCatalogClient{client: fakeClient}
+		fakeClient.PrependReactor("delete", "serviceinstances", func(action clientgotesting.Action) (bool, runtime.Object, error) {
+			return true, nil, errors.New("error deleting serviceinstances")
+		})
+
+		// when
+		err := cli.PerformCleanup(TestResourceSelector)
+
+		// then
+		require.Error(t, err)
+	})
 }
 
 func TestServiceCatalogClient_ListClusterServiceBroker(t *testing.T) {

--- a/components/provisioner/internal/installation/resource_cleanup_test.go
+++ b/components/provisioner/internal/installation/resource_cleanup_test.go
@@ -1,0 +1,431 @@
+package installation
+
+import (
+	"testing"
+
+	"github.com/kubernetes-sigs/service-catalog/pkg/apis/servicecatalog/v1beta1"
+	scfake "github.com/kubernetes-sigs/service-catalog/pkg/client/clientset_generated/clientset/fake"
+	"github.com/kyma-incubator/compass/components/provisioner/internal/util/k8s"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgotesting "k8s.io/client-go/testing"
+)
+
+const (
+	TestResourceSelector = "https://service-manager."
+
+	ClusterBrokerNameProvidingClusterServiceClasses    = "sm-working-broker"
+	ClusterBrokerNameNotProvidingClusterServiceClasses = "sm-fake-broker"
+
+	ClusterServiceClassFixedName = "some-serviceclass-name"
+)
+
+func TestNewServiceCatalogClient(t *testing.T) {
+	//given
+	k8sConfig, err := k8s.ParseToK8sConfig([]byte(kubeconfig))
+	require.NoError(t, err)
+
+	t.Run("should create client with valid kubeconfig", func(t *testing.T) {
+		// when
+		cli, err := NewServiceCatalogClient(k8sConfig)
+
+		//then
+		require.NoError(t, err)
+		require.NotNil(t, cli)
+	})
+}
+
+func TestServiceCatalogClient_PerformCleanup(t *testing.T) {
+	// given
+	fakeClient := scfake.NewSimpleClientset(newTestCR()...)
+	cli := &serviceCatalogClient{client: fakeClient}
+
+	t.Run("should perform resource cleanup succesfully with happy path", func(t *testing.T) {
+		// when
+		err := cli.PerformCleanup(TestResourceSelector)
+
+		// then
+		require.NoError(t, err)
+
+		// when
+		res, err := cli.listServiceInstance(metav1.ListOptions{})
+		require.NoError(t, err)
+		assert.Nil(t, res.Items)
+	})
+
+	t.Run("should fail cleanup when unable to list ClusterServiceBrokers", func(t *testing.T) {
+		// given
+		fakeClient := scfake.NewSimpleClientset(newTestCR()...)
+		cli := &serviceCatalogClient{client: fakeClient}
+		fakeClient.PrependReactor("list", "clusterservicebrokers", func(action clientgotesting.Action) (bool, runtime.Object, error) {
+			return true, nil, errors.New("error listing clusterservicebrokers")
+		})
+
+		// when
+		err := cli.PerformCleanup(TestResourceSelector)
+
+		// then
+		require.Error(t, err)
+	})
+
+	t.Run("should fail cleanup when unable to list ClusterServiceClasses", func(t *testing.T) {
+		// given
+		fakeClient := scfake.NewSimpleClientset(newTestCR()...)
+		cli := &serviceCatalogClient{client: fakeClient}
+		fakeClient.PrependReactor("list", "clusterserviceclasses", func(action clientgotesting.Action) (bool, runtime.Object, error) {
+			return true, nil, errors.New("error listing clusterserviceclasses")
+		})
+
+		// when
+		err := cli.PerformCleanup(TestResourceSelector)
+
+		// then
+		require.Error(t, err)
+	})
+
+	t.Run("should fail cleanup when unable to list ServiceInstances", func(t *testing.T) {
+		// given
+		fakeClient := scfake.NewSimpleClientset(newTestCR()...)
+		cli := &serviceCatalogClient{client: fakeClient}
+		fakeClient.PrependReactor("list", "serviceinstances", func(action clientgotesting.Action) (bool, runtime.Object, error) {
+			return true, nil, errors.New("error listing serviceinstances")
+		})
+
+		// when
+		err := cli.PerformCleanup(TestResourceSelector)
+
+		// then
+		require.Error(t, err)
+	})
+}
+
+func TestServiceCatalogClient_ListClusterServiceBroker(t *testing.T) {
+	// given
+	fakeClient := scfake.NewSimpleClientset(newTestCR()...)
+	cli := &serviceCatalogClient{client: fakeClient}
+
+	t.Run("should list ClusterServiceBrokers successfully", func(t *testing.T) {
+		// when
+		list, err := cli.listClusterServiceBroker(metav1.ListOptions{})
+
+		// then
+		require.NoError(t, err)
+		require.NotNil(t, list.Items)
+		assert.Len(t, list.Items, 3)
+	})
+
+	//given
+	fakeClient = scfake.NewSimpleClientset()
+	cli = &serviceCatalogClient{client: fakeClient}
+
+	t.Run("should return nil if no ClusterServiceBrokers found", func(t *testing.T) {
+		// when
+		list, _ := cli.listClusterServiceBroker(metav1.ListOptions{})
+		// then
+		require.Nil(t, list.Items)
+	})
+}
+
+func TestServiceCatalogClient_ListClusterServiceClass(t *testing.T) {
+	//given
+	fakeClient := scfake.NewSimpleClientset(newTestCR()...)
+	cli := &serviceCatalogClient{client: fakeClient}
+
+	t.Run("should list cluster service classes successfully", func(t *testing.T) {
+		// when
+		list, err := cli.listClusterServiceClass(metav1.ListOptions{})
+
+		// then
+		require.NoError(t, err)
+		require.NotNil(t, list.Items)
+	})
+
+	//given
+	fakeClient = scfake.NewSimpleClientset()
+	cli = &serviceCatalogClient{client: fakeClient}
+
+	t.Run("should return nil if no ClusterServiceClasses found", func(t *testing.T) {
+		// when
+		list, _ := cli.listClusterServiceClass(metav1.ListOptions{})
+		// then
+		require.Nil(t, list.Items)
+	})
+}
+
+func TestServiceCatalogClient_ListServiceInstance(t *testing.T) {
+	//given
+	fakeClient := scfake.NewSimpleClientset(newTestCR()...)
+	cli := &serviceCatalogClient{client: fakeClient}
+
+	t.Run("should list service instances successfully", func(t *testing.T) {
+		// when
+		list, err := cli.listServiceInstance(metav1.ListOptions{})
+
+		// then
+		require.NoError(t, err)
+		require.NotNil(t, list.Items)
+	})
+
+	//given
+	fakeClient = scfake.NewSimpleClientset()
+	cli = &serviceCatalogClient{client: fakeClient}
+
+	t.Run("should return nil if no ServiceInstances found", func(t *testing.T) {
+		// when
+		list, _ := cli.listServiceInstance(metav1.ListOptions{})
+		// then
+		require.Nil(t, list.Items)
+	})
+}
+
+func TestServiceCatalogClient_FilterCsbWithUrlPrefix(t *testing.T) {
+	// given
+	fakeClient := scfake.NewSimpleClientset(newTestCR()...)
+	cli := &serviceCatalogClient{client: fakeClient}
+
+	brokerList := fixClusterServiceBrokerList()
+	brokerUrlPrefix := "https://service-manager."
+	expectedSpecUrl := "https://service-manager.katagida.dev"
+
+	t.Run("should return only ClusterServiceBrokers with matching url prefix", func(t *testing.T) {
+		// when
+		resultList := cli.filterCsbWithUrlPrefix(brokerList, brokerUrlPrefix)
+
+		// then
+		assert.Len(t, resultList, 2)
+		for _, csb := range resultList {
+			assert.EqualValues(t, expectedSpecUrl, csb.Spec.URL)
+		}
+
+	})
+}
+
+func TestServiceCatalogClient_GetClusterServiceClassesForBrokers(t *testing.T) {
+	// given
+	fakeClient := scfake.NewSimpleClientset(newTestCR()...)
+	cli := &serviceCatalogClient{client: fakeClient}
+	expectedBrokenNameSHA := "f17be81c5d87f618a16cfa4e7196494de37016490cd869d740181e2f"
+
+	filteredBrokers := cli.filterCsbWithUrlPrefix(fixClusterServiceBrokerList(), "https://service-manager.")
+
+	t.Run("should list ClusterServiceClasses for ClusterServiceBroker when provided", func(t *testing.T) {
+		// when
+		resultList, err := cli.getClusterServiceClassesForBrokers(filteredBrokers)
+
+		// then
+		require.NoError(t, err)
+		assert.Len(t, resultList, 1)
+		assert.EqualValues(t, resultList[0].Labels[ClusterServiceBrokerNameLabel], expectedBrokenNameSHA)
+	})
+
+	// given
+	fakeClient = scfake.NewSimpleClientset()
+	cli = &serviceCatalogClient{client: fakeClient}
+
+	t.Run("should return nil if given ClusterServiceBroker do not provide ClusterServiceClass", func(t *testing.T) {
+		// when
+		resultList, _ := cli.getClusterServiceClassesForBrokers([]v1beta1.ClusterServiceBroker{
+			{
+				TypeMeta:   metav1.TypeMeta{},
+				ObjectMeta: metav1.ObjectMeta{},
+				Spec:       v1beta1.ClusterServiceBrokerSpec{},
+				Status:     v1beta1.ClusterServiceBrokerStatus{},
+			},
+		})
+
+		// then
+		assert.Nil(t, resultList)
+	})
+
+}
+
+func TestServiceCatalogClient_GetServiceInstancesForClusterServiceClasses(t *testing.T) {
+	// given
+	fakeClient := scfake.NewSimpleClientset(newTestCR()...)
+	cli := &serviceCatalogClient{client: fakeClient}
+
+	clusterServiceClassList := fixClusterServiceClassList().Items
+	expectedLabelValue := "0a3439490f8ad9b70c36c184b1110c044920a99f1b51ce9c3984ae7c"
+
+	t.Run("should list ServiceInstances for ClusterServiceClass", func(t *testing.T) {
+		// when
+		resultList, err := cli.getServiceInstancesForClusterServiceClasses(clusterServiceClassList)
+
+		// then
+		require.NoError(t, err)
+		assert.Len(t, resultList, 2)
+		for _, serviceInstance := range resultList {
+			assert.EqualValues(t, serviceInstance.Labels[ClusterServiceClassRefNameLabel], expectedLabelValue)
+		}
+	})
+
+	// given
+	fakeClient = scfake.NewSimpleClientset()
+	cli = &serviceCatalogClient{client: fakeClient}
+
+	t.Run("should return nil if no ServiceInstances found", func(t *testing.T) {
+		// when
+		resultList, _ := cli.getServiceInstancesForClusterServiceClasses([]v1beta1.ClusterServiceClass{
+			{
+				TypeMeta:   metav1.TypeMeta{},
+				ObjectMeta: metav1.ObjectMeta{},
+				Spec:       v1beta1.ClusterServiceClassSpec{},
+				Status:     v1beta1.ClusterServiceClassStatus{},
+			},
+		})
+
+		// then
+		assert.Nil(t, resultList)
+	})
+}
+
+func fixClusterServiceBrokerList() *v1beta1.ClusterServiceBrokerList {
+	return &v1beta1.ClusterServiceBrokerList{
+		TypeMeta: metav1.TypeMeta{},
+		ListMeta: metav1.ListMeta{},
+		Items: []v1beta1.ClusterServiceBroker{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      ClusterBrokerNameProvidingClusterServiceClasses,
+					Namespace: "compass-system",
+				},
+				Spec: v1beta1.ClusterServiceBrokerSpec{
+					CommonServiceBrokerSpec: v1beta1.CommonServiceBrokerSpec{
+						URL: "https://service-manager.katagida.dev",
+					},
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      ClusterBrokerNameNotProvidingClusterServiceClasses,
+					Namespace: "compass-system",
+				},
+				Spec: v1beta1.ClusterServiceBrokerSpec{
+					CommonServiceBrokerSpec: v1beta1.CommonServiceBrokerSpec{
+						URL: "https://service-manager.katagida.dev",
+					},
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "hb-other-broker",
+					Namespace: "kyma-system",
+				},
+				Spec: v1beta1.ClusterServiceBrokerSpec{
+					CommonServiceBrokerSpec: v1beta1.CommonServiceBrokerSpec{
+						URL: "https://other-broker.katagida.dev",
+					},
+				},
+			},
+		},
+	}
+
+}
+
+func fixClusterServiceClassList() *v1beta1.ClusterServiceClassList {
+	return &v1beta1.ClusterServiceClassList{
+		TypeMeta: metav1.TypeMeta{},
+		ListMeta: metav1.ListMeta{},
+		Items: []v1beta1.ClusterServiceClass{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "saas-fake-service-class",
+					Labels: map[string]string{ClusterServiceBrokerNameLabel: fixGenerateSHA(ClusterBrokerNameProvidingClusterServiceClasses)},
+				},
+				Spec: v1beta1.ClusterServiceClassSpec{
+					ClusterServiceBrokerName: ClusterBrokerNameProvidingClusterServiceClasses,
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   ClusterServiceClassFixedName,
+					Labels: map[string]string{ClusterServiceBrokerNameLabel: fixGenerateSHA(ClusterBrokerNameNotProvidingClusterServiceClasses)},
+				},
+				Spec: v1beta1.ClusterServiceClassSpec{
+					ClusterServiceBrokerName: ClusterBrokerNameNotProvidingClusterServiceClasses,
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "another-fake-service-class",
+					Labels: map[string]string{ClusterServiceBrokerNameLabel: fixGenerateSHA("hb-other-broker")},
+				},
+				Spec: v1beta1.ClusterServiceClassSpec{
+					ClusterServiceBrokerName: "hb-other-broker",
+				},
+			},
+		},
+	}
+}
+
+func fixGenerateSHA(resourceName string) string {
+	return GenerateSHA(resourceName)
+}
+
+func newTestCR() []runtime.Object {
+	return []runtime.Object{
+		&v1beta1.ClusterServiceBroker{},
+		&v1beta1.ClusterServiceBroker{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      ClusterBrokerNameProvidingClusterServiceClasses,
+				Namespace: "compass-system",
+			},
+			Spec: v1beta1.ClusterServiceBrokerSpec{
+				CommonServiceBrokerSpec: v1beta1.CommonServiceBrokerSpec{
+					URL: "https://service-manager.katagida.dev",
+				},
+			},
+		},
+		&v1beta1.ClusterServiceBroker{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "hb-other-broker",
+				Namespace: "kyma-system",
+			},
+			Spec: v1beta1.ClusterServiceBrokerSpec{
+				CommonServiceBrokerSpec: v1beta1.CommonServiceBrokerSpec{
+					URL: "https://other-broker.katagida.dev",
+				},
+			},
+		},
+		&v1beta1.ClusterServiceClass{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   ClusterServiceClassFixedName,
+				Labels: map[string]string{ClusterServiceBrokerNameLabel: fixGenerateSHA(ClusterBrokerNameProvidingClusterServiceClasses)},
+			},
+			Spec: v1beta1.ClusterServiceClassSpec{
+				ClusterServiceBrokerName: ClusterBrokerNameProvidingClusterServiceClasses,
+			},
+		},
+		&v1beta1.ClusterServiceClass{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   "another-fake-service-class",
+				Labels: map[string]string{ClusterServiceBrokerNameLabel: fixGenerateSHA("hb-other-broker")},
+			},
+			Spec: v1beta1.ClusterServiceClassSpec{
+				ClusterServiceBrokerName: "hb-other-broker",
+			},
+		},
+		&v1beta1.ClusterServiceClass{},
+		&v1beta1.ServiceInstance{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "fake-instance-one",
+				Namespace: "cstmr-ns",
+				Labels: map[string]string{
+					ClusterServiceClassRefNameLabel: fixGenerateSHA(ClusterServiceClassFixedName),
+				},
+			},
+		},
+		&v1beta1.ServiceInstance{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "fake-instance-two",
+				Namespace: "cstmr-ns",
+				Labels: map[string]string{
+					ClusterServiceClassRefNameLabel: fixGenerateSHA(ClusterServiceClassFixedName),
+				},
+			},
+		},
+	}
+}

--- a/components/provisioner/internal/installation/resource_cleanup_test.go
+++ b/components/provisioner/internal/installation/resource_cleanup_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/kubernetes-sigs/service-catalog/pkg/apis/servicecatalog/v1beta1"
 	scfake "github.com/kubernetes-sigs/service-catalog/pkg/client/clientset_generated/clientset/fake"
+	"github.com/kubernetes-sigs/service-catalog/pkg/util"
 	"github.com/kyma-incubator/compass/components/provisioner/internal/util/k8s"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
@@ -362,7 +363,7 @@ func fixClusterServiceClassList() *v1beta1.ClusterServiceClassList {
 }
 
 func fixGenerateSHA(resourceName string) string {
-	return GenerateSHA(resourceName)
+	return util.GenerateSHA(resourceName)
 }
 
 func newTestCR() []runtime.Object {

--- a/components/provisioner/internal/model/types.go
+++ b/components/provisioner/internal/model/types.go
@@ -34,6 +34,7 @@ const (
 	TriggerKymaUninstall   OperationStage = "TriggerKymaUninstall"
 	WaitForClusterDeletion OperationStage = "WaitForClusterDeletion"
 	DeleteCluster          OperationStage = "DeprovisionCluster"
+	CleanupCluster         OperationStage = "CleanupCluster"
 
 	StartingUpgrade      OperationStage = "StartingUpgrade"
 	UpdatingUpgradeState OperationStage = "UpdatingUpgradeState"

--- a/components/provisioner/internal/operations/stages/deprovisioning/cleanup_cluster.go
+++ b/components/provisioner/internal/operations/stages/deprovisioning/cleanup_cluster.go
@@ -1,0 +1,55 @@
+package deprovisioning
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/kyma-incubator/compass/components/provisioner/internal/installation"
+	"github.com/kyma-incubator/compass/components/provisioner/internal/model"
+	"github.com/kyma-incubator/compass/components/provisioner/internal/operations"
+	"github.com/kyma-incubator/compass/components/provisioner/internal/util/k8s"
+	"github.com/sirupsen/logrus"
+)
+
+type CleanupClusterStep struct {
+	installationService installation.Service
+	nextStep            model.OperationStage
+	timeLimit           time.Duration
+}
+
+func NewCleanupClusterStep(installationService installation.Service, nextStep model.OperationStage, timeLimit time.Duration) *CleanupClusterStep {
+	return &CleanupClusterStep{
+		installationService: installationService,
+		nextStep:            nextStep,
+		timeLimit:           timeLimit,
+	}
+}
+
+func (s *CleanupClusterStep) Name() model.OperationStage {
+	return model.CleanupCluster
+}
+
+func (s *CleanupClusterStep) TimeLimit() time.Duration {
+	return s.timeLimit
+}
+
+func (s *CleanupClusterStep) Run(cluster model.Cluster, _ model.Operation, logger logrus.FieldLogger) (operations.StageResult, error) {
+	logger.Debugf("Starting cleanup cluster step for %s ...", cluster.ID)
+	if cluster.Kubeconfig == nil {
+		// Kubeconfig can be nil if Gardener failed to create cluster. We must go to the next step to finalize deprovisioning
+		return operations.StageResult{Stage: s.nextStep, Delay: 0}, nil
+	}
+
+	k8sConfig, err := k8s.ParseToK8sConfig([]byte(*cluster.Kubeconfig))
+	if err != nil {
+		err := fmt.Errorf("error: failed to create kubernetes config from raw: %s", err.Error())
+		return operations.StageResult{}, operations.NewNonRecoverableError(err)
+	}
+
+	err = s.installationService.PerformCleanup(k8sConfig)
+	if err != nil {
+		return operations.StageResult{}, err
+	}
+
+	return operations.StageResult{Stage: s.nextStep, Delay: 0}, nil
+}

--- a/components/provisioner/internal/operations/stages/deprovisioning/cleanup_cluster_test.go
+++ b/components/provisioner/internal/operations/stages/deprovisioning/cleanup_cluster_test.go
@@ -1,0 +1,122 @@
+package deprovisioning
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/kyma-incubator/compass/components/provisioner/internal/operations"
+
+	installationMocks "github.com/kyma-incubator/compass/components/provisioner/internal/installation/mocks"
+	"github.com/kyma-incubator/compass/components/provisioner/internal/model"
+	"github.com/kyma-incubator/compass/components/provisioner/internal/util"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCleanupCluster_Run(t *testing.T) {
+
+	clusterWithKubeconfig := model.Cluster{
+		ClusterConfig: model.GardenerConfig{
+			Name: clusterName,
+		},
+		Kubeconfig: util.StringPtr(kubeconfig),
+	}
+
+	clusterWithoutKubeconfig := model.Cluster{
+		ClusterConfig: model.GardenerConfig{
+			Name: clusterName,
+		},
+	}
+
+	invalidKubeconfig := "invalid"
+
+	for _, testCase := range []struct {
+		description   string
+		mockFunc      func(installationSvc *installationMocks.Service)
+		expectedStage model.OperationStage
+		expectedDelay time.Duration
+		cluster       model.Cluster
+	}{
+		{
+			description: "should go to the next step when kubeconfig is empty",
+			mockFunc: func(installationSvc *installationMocks.Service) {
+			},
+			expectedStage: nextStageName,
+			expectedDelay: 0,
+			cluster:       clusterWithoutKubeconfig,
+		},
+		{
+			description: "should go to the next step when cleanup was performed successfully",
+			mockFunc: func(installationSvc *installationMocks.Service) {
+				installationSvc.On("PerformCleanup", mock.AnythingOfType("*rest.Config")).Return(nil)
+			},
+			expectedStage: nextStageName,
+			expectedDelay: 0,
+			cluster:       clusterWithKubeconfig,
+		},
+	} {
+		t.Run(testCase.description, func(t *testing.T) {
+			// given
+			installationSvc := &installationMocks.Service{}
+
+			testCase.mockFunc(installationSvc)
+
+			cleanupClusterStep := NewCleanupClusterStep(installationSvc, nextStageName, 10*time.Minute)
+
+			// when
+			result, err := cleanupClusterStep.Run(testCase.cluster, model.Operation{}, logrus.New())
+
+			// then
+			require.NoError(t, err)
+			assert.Equal(t, testCase.expectedStage, result.Stage)
+			assert.Equal(t, testCase.expectedDelay, result.Delay)
+			installationSvc.AssertExpectations(t)
+		})
+	}
+
+	for _, testCase := range []struct {
+		description        string
+		mockFunc           func(installationSvc *installationMocks.Service)
+		cluster            model.Cluster
+		unrecoverableError bool
+	}{
+		{
+			description: "should return error is failed to parse kubeconfig",
+			mockFunc: func(installationSvc *installationMocks.Service) {
+			},
+			cluster: model.Cluster{
+				Kubeconfig: &invalidKubeconfig,
+			},
+			unrecoverableError: true,
+		},
+		{
+			description: "should return error when failed to perform cleanup",
+			mockFunc: func(installationSvc *installationMocks.Service) {
+				installationSvc.On("PerformCleanup", mock.AnythingOfType("*rest.Config")).Return(errors.New("some error"))
+			},
+			cluster:            clusterWithKubeconfig,
+			unrecoverableError: false,
+		},
+	} {
+		t.Run(testCase.description, func(t *testing.T) {
+			// given
+			installationSvc := &installationMocks.Service{}
+
+			testCase.mockFunc(installationSvc)
+
+			cleanupClusterStep := NewCleanupClusterStep(installationSvc, nextStageName, 10*time.Minute)
+
+			// when
+			_, err := cleanupClusterStep.Run(testCase.cluster, model.Operation{}, logrus.New())
+
+			// then
+			require.Error(t, err)
+			nonRecoverable := operations.NonRecoverableError{}
+			require.Equal(t, testCase.unrecoverableError, errors.As(err, &nonRecoverable))
+			installationSvc.AssertExpectations(t)
+		})
+	}
+}

--- a/components/provisioner/internal/operations/stages/deprovisioning/delete_cluster_test.go
+++ b/components/provisioner/internal/operations/stages/deprovisioning/delete_cluster_test.go
@@ -64,10 +64,10 @@ func TestDeprovisionCluster_Run(t *testing.T) {
 
 			testCase.mockFunc(gardenerClient)
 
-			deprovisionClusterStep := NewDeleteClusterStep(gardenerClient, nextStageName, 10*time.Minute)
+			deleteClusterStep := NewDeleteClusterStep(gardenerClient, nextStageName, 10*time.Minute)
 
 			// when
-			result, err := deprovisionClusterStep.Run(cluster, model.Operation{}, logrus.New())
+			result, err := deleteClusterStep.Run(cluster, model.Operation{}, logrus.New())
 
 			// then
 			require.NoError(t, err)
@@ -108,10 +108,10 @@ func TestDeprovisionCluster_Run(t *testing.T) {
 
 			testCase.mockFunc(gardenerClient)
 
-			deprovisionClusterStep := NewDeleteClusterStep(gardenerClient, nextStageName, 10*time.Minute)
+			deleteClusterStep := NewDeleteClusterStep(gardenerClient, nextStageName, 10*time.Minute)
 
 			// when
-			_, err := deprovisionClusterStep.Run(testCase.cluster, model.Operation{}, logrus.New())
+			_, err := deleteClusterStep.Run(testCase.cluster, model.Operation{}, logrus.New())
 
 			// then
 			require.Error(t, err)

--- a/components/provisioner/internal/operations/stages/deprovisioning/trigger_kyma_uninstall_test.go
+++ b/components/provisioner/internal/operations/stages/deprovisioning/trigger_kyma_uninstall_test.go
@@ -89,10 +89,10 @@ func TestTriggerKymaUninstall_Run(t *testing.T) {
 
 			testCase.mockFunc(installationSvc)
 
-			waitForInstallationStep := NewTriggerKymaUninstallStep(installationSvc, nextStageName, 10*time.Minute, delay)
+			triggerKymaUninstallStep := NewTriggerKymaUninstallStep(installationSvc, nextStageName, 10*time.Minute, delay)
 
 			// when
-			result, err := waitForInstallationStep.Run(testCase.cluster, model.Operation{}, logrus.New())
+			result, err := triggerKymaUninstallStep.Run(testCase.cluster, model.Operation{}, logrus.New())
 
 			// then
 			require.NoError(t, err)
@@ -132,10 +132,10 @@ func TestTriggerKymaUninstall_Run(t *testing.T) {
 
 			testCase.mockFunc(installationSvc)
 
-			waitForInstallationStep := NewTriggerKymaUninstallStep(installationSvc, nextStageName, 10*time.Minute, delay)
+			triggerKymaUninstallStep := NewTriggerKymaUninstallStep(installationSvc, nextStageName, 10*time.Minute, delay)
 
 			// when
-			_, err := waitForInstallationStep.Run(testCase.cluster, model.Operation{}, logrus.New())
+			_, err := triggerKymaUninstallStep.Run(testCase.cluster, model.Operation{}, logrus.New())
 
 			// then
 			require.Error(t, err)

--- a/components/provisioner/internal/operations/stages/deprovisioning/wait_for_cluster_deletion_test.go
+++ b/components/provisioner/internal/operations/stages/deprovisioning/wait_for_cluster_deletion_test.go
@@ -84,10 +84,10 @@ func TestWaitForClusterDeletion_Run(t *testing.T) {
 
 			testCase.mockFunc(gardenerClient, dbSessionFactory, directorClient)
 
-			deprovisionClusterStep := NewWaitForClusterDeletionStep(gardenerClient, dbSessionFactory, directorClient, nextStageName, 10*time.Minute)
+			waitForClusterDeletionStep := NewWaitForClusterDeletionStep(gardenerClient, dbSessionFactory, directorClient, nextStageName, 10*time.Minute)
 
 			// when
-			result, err := deprovisionClusterStep.Run(cluster, model.Operation{}, logrus.New())
+			result, err := waitForClusterDeletionStep.Run(cluster, model.Operation{}, logrus.New())
 
 			// then
 			require.NoError(t, err)
@@ -192,10 +192,10 @@ func TestWaitForClusterDeletion_Run(t *testing.T) {
 
 			testCase.mockFunc(gardenerClient, dbSessionFactory, directorClient)
 
-			deprovisionClusterStep := NewWaitForClusterDeletionStep(gardenerClient, dbSessionFactory, directorClient, nextStageName, 10*time.Minute)
+			waitForClusterDeletionStep := NewWaitForClusterDeletionStep(gardenerClient, dbSessionFactory, directorClient, nextStageName, 10*time.Minute)
 
 			// when
-			_, err := deprovisionClusterStep.Run(testCase.cluster, model.Operation{}, logrus.New())
+			_, err := waitForClusterDeletionStep.Run(testCase.cluster, model.Operation{}, logrus.New())
 
 			// then
 			require.Error(t, err)

--- a/components/provisioner/internal/operations/stages/provisioning/wait_for_cluster_creation_test.go
+++ b/components/provisioner/internal/operations/stages/provisioning/wait_for_cluster_creation_test.go
@@ -79,9 +79,9 @@ func TestWaitForClusterInitialization_Run(t *testing.T) {
 
 			testCase.mockFunc(gardenerClient, dbSession, kubeconfigProvider)
 
-			waitForClusterInitializationStep := NewWaitForClusterCreationStep(gardenerClient, dbSession, kubeconfigProvider, nextStageName, 10*time.Minute)
+			waitForClusterCreationStep := NewWaitForClusterCreationStep(gardenerClient, dbSession, kubeconfigProvider, nextStageName, 10*time.Minute)
 			// when
-			result, err := waitForClusterInitializationStep.Run(cluster, model.Operation{}, logrus.New())
+			result, err := waitForClusterCreationStep.Run(cluster, model.Operation{}, logrus.New())
 
 			// then
 			require.NoError(t, err)
@@ -149,10 +149,10 @@ func TestWaitForClusterInitialization_Run(t *testing.T) {
 
 			testCase.mockFunc(gardenerClient, dbSession, kubeconfigProvider)
 
-			waitForClusterInitializationStep := NewWaitForClusterCreationStep(gardenerClient, dbSession, kubeconfigProvider, nextStageName, 10*time.Minute)
+			waitForClusterCreationStep := NewWaitForClusterCreationStep(gardenerClient, dbSession, kubeconfigProvider, nextStageName, 10*time.Minute)
 
 			// when
-			_, err := waitForClusterInitializationStep.Run(testCase.cluster, model.Operation{}, logrus.New())
+			_, err := waitForClusterCreationStep.Run(testCase.cluster, model.Operation{}, logrus.New())
 
 			// then
 			require.Error(t, err)


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Before Provisioner triggers Kyma runtime uninstallation and Gardener Shoot deletion, all ServiceInstances connected with certain ClusterServiceBroker need to be deleted.

Changes proposed in this pull request:

- Added Cleanup Step to Deprovisioning queue
- ...
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
