### PR TITLE
Allow Tiller artifacts to not to exist

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -34,7 +34,7 @@ global:
       version: "PR-1308"
     provisioner:
       dir:
-      version: "PR-1381"
+      version: "PR-1406"
     certs_setup_job:
       containerRegistry:
         path: eu.gcr.io/kyma-project

--- a/components/provisioner/cmd/init.go
+++ b/components/provisioner/cmd/init.go
@@ -111,10 +111,10 @@ func newGardenerClusterConfig(cfg config) (*restclient.Config, error) {
 	return gardenerClusterConfig, nil
 }
 
-func newHTTPClient(skipCertVeryfication bool) *http.Client {
+func newHTTPClient(skipCertVerification bool) *http.Client {
 	return &http.Client{
 		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: skipCertVeryfication},
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: skipCertVerification},
 		},
 		Timeout: 30 * time.Second,
 	}

--- a/components/provisioner/go.mod
+++ b/components/provisioner/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/kubernetes/client-go v11.0.0+incompatible
 	github.com/kyma-incubator/compass/components/director v0.0.0-20200506060219-a2a2a07e1283
 	github.com/kyma-incubator/hydroform v0.0.0-20191217171037-affe7099c3b9
-	github.com/kyma-incubator/hydroform/install v0.0.0-20200514103120-0b6d49693c4d
+	github.com/kyma-incubator/hydroform/install v0.0.0-20200608065102-102f8232317b
 	github.com/kyma-project/kyma v0.5.1-0.20200323195746-ee2b142b8442
 	github.com/kyma-project/kyma/components/compass-runtime-agent v0.0.0-20200422062252-6074323197a6
 	github.com/lib/pq v1.2.0
@@ -59,5 +59,3 @@ replace golang.org/x/crypto => golang.org/x/crypto v0.0.0-20200317142112-1b76d66
 replace github.com/gophercloud/gophercloud => github.com/gophercloud/gophercloud v0.0.0-20190125124242-bb1ef8ce758c
 
 replace gopkg.in/yaml.v2 => gopkg.in/yaml.v2 v2.2.8
-
-replace github.com/kyma-incubator/hydroform/install => github.com/Szymongib/hydroform/install v0.0.0-20200529124552-33395ccd54e1

--- a/components/provisioner/go.mod
+++ b/components/provisioner/go.mod
@@ -59,3 +59,5 @@ replace golang.org/x/crypto => golang.org/x/crypto v0.0.0-20200317142112-1b76d66
 replace github.com/gophercloud/gophercloud => github.com/gophercloud/gophercloud v0.0.0-20190125124242-bb1ef8ce758c
 
 replace gopkg.in/yaml.v2 => gopkg.in/yaml.v2 v2.2.8
+
+replace github.com/kyma-incubator/hydroform/install => github.com/Szymongib/hydroform/install v0.0.0-20200529124552-33395ccd54e1

--- a/components/provisioner/go.sum
+++ b/components/provisioner/go.sum
@@ -99,6 +99,8 @@ github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdko
 github.com/QcloudApi/qcloud_sign_golang v0.0.0-20141224014652-e4130a326409/go.mod h1:1pk82RBxDY/JZnPQrtqHlUFfCctgdorsd9M06fMynOM=
 github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWXgklEdEo=
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
+github.com/Szymongib/hydroform/install v0.0.0-20200529124552-33395ccd54e1 h1:DNUUmBu63eS9G/MGzQTRQuHW6vVVXBW67UZ+kiiFRtA=
+github.com/Szymongib/hydroform/install v0.0.0-20200529124552-33395ccd54e1/go.mod h1:cu0KmMDfLm1nY+lkRWhckdjeo+lzUsI4YkLCkRc3zWY=
 github.com/Unknwon/com v0.0.0-20151008135407-28b053d5a292 h1:tuQ7w+my8a8mkwN7x2TSd7OzTjkZ7rAeSyH4xncuAMI=
 github.com/Unknwon/com v0.0.0-20151008135407-28b053d5a292/go.mod h1:KYCjqMOeHpNuTOiFQU6WEcTG7poCJrUs0YgyHNtn1no=
 github.com/abdullin/seq v0.0.0-20160510034733-d5467c17e7af h1:DBNMBMuMiWYu0b+8KMJuWmfCkcxl09JwdlqwDZZ6U14=

--- a/components/provisioner/go.sum
+++ b/components/provisioner/go.sum
@@ -711,6 +711,8 @@ github.com/kyma-incubator/hydroform v0.0.0-20191217171037-affe7099c3b9 h1:YERsmP
 github.com/kyma-incubator/hydroform v0.0.0-20191217171037-affe7099c3b9/go.mod h1:AxIzJWwHlpqqSdLjwV+bMBK2dpTaQaVpFRprmum1BB8=
 github.com/kyma-incubator/hydroform/install v0.0.0-20200514103120-0b6d49693c4d h1:WW9GT7TOx+hKlCeqOWsdMlYAg8XVJHA1jQwhj5734Dw=
 github.com/kyma-incubator/hydroform/install v0.0.0-20200514103120-0b6d49693c4d/go.mod h1:cu0KmMDfLm1nY+lkRWhckdjeo+lzUsI4YkLCkRc3zWY=
+github.com/kyma-incubator/hydroform/install v0.0.0-20200608065102-102f8232317b h1:jpwEOxIcaLRpX4n4Y8XO2MhT3qyNQaSIw1dRF6PSqzI=
+github.com/kyma-incubator/hydroform/install v0.0.0-20200608065102-102f8232317b/go.mod h1:cu0KmMDfLm1nY+lkRWhckdjeo+lzUsI4YkLCkRc3zWY=
 github.com/kyma-project/kyma v0.5.1-0.20191031094708-0559e17e7979/go.mod h1:cfj5AQwIOmmoXLZUhW3bIiaB66Z6vgjCYu7TRK3+1lc=
 github.com/kyma-project/kyma v0.5.1-0.20191106070956-5aa08d114ca0/go.mod h1:cfj5AQwIOmmoXLZUhW3bIiaB66Z6vgjCYu7TRK3+1lc=
 github.com/kyma-project/kyma v0.5.1-0.20200317154738-0bb20217c2cb/go.mod h1:cfj5AQwIOmmoXLZUhW3bIiaB66Z6vgjCYu7TRK3+1lc=

--- a/components/provisioner/internal/installation/installation.go
+++ b/components/provisioner/internal/installation/installation.go
@@ -35,7 +35,6 @@ type InstallationHandler func(*rest.Config, ...installation.InstallationOption) 
 type Service interface {
 	InstallKyma(runtimeId, kubeconfigRaw string, release model.Release, globalConfig model.Configuration, componentsConfig []model.KymaComponentConfig) error
 	CheckInstallationState(kubeconfig *rest.Config) (installation.InstallationState, error)
-	// TODO: this will block for quite a while, consider running it in gorutine or split it to more steps (install tillert -> check periodicaly -> deploy installer -> trigger installation)
 	TriggerInstallation(kubeconfigRaw *rest.Config, release model.Release, globalConfig model.Configuration, componentsConfig []model.KymaComponentConfig) error
 	TriggerUpgrade(kubeconfigRaw *rest.Config, release model.Release, globalConfig model.Configuration, componentsConfig []model.KymaComponentConfig) error
 	TriggerUninstall(kubeconfig *rest.Config) error

--- a/components/provisioner/internal/installation/release/downloader_test.go
+++ b/components/provisioner/internal/installation/release/downloader_test.go
@@ -17,69 +17,85 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+type testRelease struct {
+	githubRelease   model.GithubRelease
+	expectedRelease model.Release
+}
+
 func TestArtifactsDownloader_FetchPeriodically(t *testing.T) {
 
 	longInterval := 3 * time.Second
 	shortInterval := 1 * time.Second
 
-	installerURL := "https://github.com/kyma-project/kyma/releases/download/version/kyma-installer-cluster.yaml"
+	installerURL := "https://github.com/kyma-project/kyma/testReleases/download/version/kyma-installer-cluster.yaml"
 	installerContent := "some installer content"
 	tillerContent := "some tiller content"
 
 	//given
-	githubReleaseOne := model.GithubRelease{
-		Id:         100,
-		Name:       "1.7",
-		Prerelease: false,
-		Assets: []model.Asset{
-			{Name: "kyma-installer-cluster.yaml", Url: installerURL},
-			{Name: "some-other-asset", Url: ""},
-		}}
+	testReleases := []testRelease{
+		{
+			githubRelease: model.GithubRelease{
+				Id:         100,
+				Name:       "1.7",
+				Prerelease: false,
+				Assets: []model.Asset{
+					{Name: "kyma-installer-cluster.yaml", Url: installerURL},
+					{Name: "some-other-asset", Url: ""},
+				}},
+			expectedRelease: model.Release{
+				Version:       "1.7",
+				TillerYAML:    tillerContent,
+				InstallerYAML: installerContent,
+			},
+		},
+		{
+			githubRelease: model.GithubRelease{
+				Id:         101,
+				Name:       "1.8",
+				Prerelease: false,
+				Assets: []model.Asset{
+					{Name: "kyma-installer-cluster.yaml", Url: installerURL},
+					{Name: "ya-ya-cthulhu-fhtagn", Url: ""},
+				}},
+			expectedRelease: model.Release{
+				Version:       "1.8",
+				TillerYAML:    tillerContent,
+				InstallerYAML: installerContent,
+			},
+		},
+		{
+			githubRelease: model.GithubRelease{
+				Id:         102,
+				Name:       "1.9-rc2",
+				Prerelease: true,
+				Assets: []model.Asset{
+					{Name: "kyma-installer-cluster.yaml", Url: installerURL},
+					{Name: "ya-ya-cthulhu-fhtagn", Url: ""},
+				}},
+			expectedRelease: model.Release{
+				Version:       "1.9-rc2",
+				TillerYAML:    "",
+				InstallerYAML: installerContent,
+			},
+		},
+	}
 
-	githubReleaseTwo := model.GithubRelease{
-		Id:         101,
-		Name:       "1.8",
-		Prerelease: false,
-		Assets: []model.Asset{
-			{Name: "kyma-installer-cluster.yaml", Url: installerURL},
-			{Name: "ya-ya-cthulhu-fhtagn", Url: ""},
-		}}
-
-	githubReleaseThree := model.GithubRelease{
-		Id:         102,
-		Name:       "1.9-rc2",
-		Prerelease: true,
-		Assets: []model.Asset{
-			{Name: "kyma-installer-cluster.yaml", Url: installerURL},
-			{Name: "ya-ya-cthulhu-fhtagn", Url: ""},
-		}}
-
-	t.Run("Should fetch releases", func(t *testing.T) {
+	t.Run("Should fetch testReleases", func(t *testing.T) {
 		//given
-		releases := []model.GithubRelease{githubReleaseOne, githubReleaseTwo}
+		releases := []model.GithubRelease{testReleases[0].githubRelease, testReleases[1].githubRelease}
 
-		client := setClient(t, releases, installerURL, installerContent, tillerContent)
-
-		expectedReleaseOne := model.Release{
-			Version:       "1.7",
-			TillerYAML:    tillerContent,
-			InstallerYAML: installerContent,
-		}
-		expectedReleaseTwo := model.Release{
-			Version:       "1.8",
-			TillerYAML:    tillerContent,
-			InstallerYAML: installerContent,
-		}
+		client := newMockClient(t, releases, installerURL, installerContent, tillerContent)
+		fileDownloader := NewFileDownloader(client)
 
 		repository := &mocks.Repository{}
 		repository.On("ReleaseExists", mock.Anything).Return(false, nil)
 
-		repository.On("SaveRelease", expectedReleaseOne).Return(expectedReleaseOne, nil)
-		repository.On("SaveRelease", expectedReleaseTwo).Return(expectedReleaseTwo, nil)
+		repository.On("SaveRelease", testReleases[0].expectedRelease).Return(testReleases[0].expectedRelease, nil)
+		repository.On("SaveRelease", testReleases[1].expectedRelease).Return(testReleases[1].expectedRelease, nil)
 
 		entry := logrus.WithField("Component", "ArtifactsDownloaderTests")
 
-		downloader := NewArtifactsDownloader(repository, 3, true, client, entry)
+		downloader := NewArtifactsDownloader(repository, 3, true, client, fileDownloader, entry)
 
 		ctx := context.Background()
 		ctx, _ = context.WithTimeout(ctx, 5*time.Second)
@@ -91,32 +107,22 @@ func TestArtifactsDownloader_FetchPeriodically(t *testing.T) {
 		repository.AssertExpectations(t)
 	})
 
-	t.Run("Should fetch releases without prereleases", func(t *testing.T) {
+	t.Run("Should fetch testReleases without prereleases", func(t *testing.T) {
 		//given
-		releases := []model.GithubRelease{githubReleaseOne, githubReleaseTwo, githubReleaseThree}
+		releases := []model.GithubRelease{testReleases[0].githubRelease, testReleases[1].githubRelease, testReleases[2].githubRelease}
 
-		client := setClient(t, releases, installerURL, installerContent, tillerContent)
-
-		expectedReleaseOne := model.Release{
-			Version:       "1.7",
-			TillerYAML:    tillerContent,
-			InstallerYAML: installerContent,
-		}
-		expectedReleaseTwo := model.Release{
-			Version:       "1.8",
-			TillerYAML:    tillerContent,
-			InstallerYAML: installerContent,
-		}
+		client := newMockClient(t, releases, installerURL, installerContent, tillerContent)
+		fileDownloader := NewFileDownloader(client)
 
 		repository := &mocks.Repository{}
 		repository.On("ReleaseExists", mock.Anything).Return(false, nil)
 
-		repository.On("SaveRelease", expectedReleaseOne).Return(expectedReleaseOne, nil)
-		repository.On("SaveRelease", expectedReleaseTwo).Return(expectedReleaseTwo, nil)
+		repository.On("SaveRelease", testReleases[0].expectedRelease).Return(testReleases[0].expectedRelease, nil)
+		repository.On("SaveRelease", testReleases[1].expectedRelease).Return(testReleases[1].expectedRelease, nil)
 
 		entry := logrus.WithField("Component", "ArtifactsDownloaderTests")
 
-		downloader := NewArtifactsDownloader(repository, 3, false, client, entry)
+		downloader := NewArtifactsDownloader(repository, 3, false, client, fileDownloader, entry)
 
 		ctx := context.Background()
 		ctx, _ = context.WithTimeout(ctx, 5*time.Second)
@@ -129,9 +135,10 @@ func TestArtifactsDownloader_FetchPeriodically(t *testing.T) {
 	})
 
 	t.Run("Should fetch only one, latest, release", func(t *testing.T) {
-		releases := []model.GithubRelease{githubReleaseOne, githubReleaseTwo, githubReleaseThree}
+		releases := []model.GithubRelease{testReleases[0].githubRelease, testReleases[1].githubRelease, testReleases[2].githubRelease}
 
-		client := setClient(t, releases, installerURL, installerContent, tillerContent)
+		client := newMockClient(t, releases, installerURL, installerContent, tillerContent)
+		fileDownloader := NewFileDownloader(client)
 
 		expectedReleaseThree := model.Release{
 			Version:       "1.9-rc2",
@@ -146,7 +153,33 @@ func TestArtifactsDownloader_FetchPeriodically(t *testing.T) {
 
 		entry := logrus.WithField("Component", "ArtifactsDownloaderTests")
 
-		downloader := NewArtifactsDownloader(repository, 1, true, client, entry)
+		downloader := NewArtifactsDownloader(repository, 1, true, client, fileDownloader, entry)
+
+		ctx := context.Background()
+		ctx, _ = context.WithTimeout(ctx, 5*time.Second)
+
+		//when
+		downloader.FetchPeriodically(ctx, shortInterval, longInterval)
+
+		//then
+		repository.AssertExpectations(t)
+	})
+
+	t.Run("Should fetch release without Tiller", func(t *testing.T) {
+		//given
+		releases := []model.GithubRelease{testReleases[2].githubRelease}
+
+		client := newMockClient(t, releases, installerURL, installerContent, "")
+		fileDownloader := NewFileDownloader(client)
+
+		repository := &mocks.Repository{}
+		repository.On("ReleaseExists", mock.Anything).Return(false, nil)
+
+		repository.On("SaveRelease", testReleases[2].expectedRelease).Return(testReleases[2].expectedRelease, nil)
+
+		entry := logrus.WithField("Component", "ArtifactsDownloaderTests")
+
+		downloader := NewArtifactsDownloader(repository, 3, true, client, fileDownloader, entry)
 
 		ctx := context.Background()
 		ctx, _ = context.WithTimeout(ctx, 5*time.Second)
@@ -159,15 +192,17 @@ func TestArtifactsDownloader_FetchPeriodically(t *testing.T) {
 	})
 
 	t.Run("Should not save release if already exists in database", func(t *testing.T) {
-		releases := []model.GithubRelease{githubReleaseThree}
-		client := setClient(t, releases, installerURL, installerContent, tillerContent)
+		releases := []model.GithubRelease{testReleases[2].githubRelease}
+
+		client := newMockClient(t, releases, installerURL, installerContent, tillerContent)
+		fileDownloader := NewFileDownloader(client)
 
 		repository := &mocks.Repository{}
 		repository.On("ReleaseExists", "1.9-rc2").Return(true, nil)
 
 		entry := logrus.WithField("Component", "ArtifactsDownloaderTests")
 
-		downloader := NewArtifactsDownloader(repository, 1, true, client, entry)
+		downloader := NewArtifactsDownloader(repository, 1, true, client, fileDownloader, entry)
 
 		ctx := context.Background()
 		ctx, _ = context.WithTimeout(ctx, 5*time.Second)
@@ -180,7 +215,7 @@ func TestArtifactsDownloader_FetchPeriodically(t *testing.T) {
 	})
 }
 
-func setClient(t *testing.T, releases []model.GithubRelease, installerURL, installerContent, tillerContent string) *http.Client {
+func newMockClient(t *testing.T, releases []model.GithubRelease, installerURL, installerContent, tillerContent string) *http.Client {
 	return newTestClient(func(req *http.Request) *http.Response {
 		if req.URL.String() == releaseFetchURL {
 
@@ -202,6 +237,13 @@ func setClient(t *testing.T, releases []model.GithubRelease, installerURL, insta
 		}
 
 		if strings.Contains(req.URL.String(), "tiller.yaml") {
+			if tillerContent == "" {
+				return &http.Response{
+					StatusCode: http.StatusNotFound,
+					Body:       ioutil.NopCloser(bytes.NewBufferString("404 not found")),
+				}
+			}
+
 			return &http.Response{
 				StatusCode: http.StatusOK,
 				Body:       ioutil.NopCloser(bytes.NewBufferString(tillerContent)),

--- a/components/provisioner/internal/installation/release/file_downloader.go
+++ b/components/provisioner/internal/installation/release/file_downloader.go
@@ -1,0 +1,63 @@
+package release
+
+import (
+	"github.com/kyma-incubator/compass/components/provisioner/internal/util"
+	"github.com/pkg/errors"
+	"io/ioutil"
+	"net/http"
+)
+
+type httpGetter interface {
+	Get(url string) (resp *http.Response, err error)
+}
+
+// FileDownloader downloads text files
+type FileDownloader struct {
+	httpGetter httpGetter
+}
+
+func NewFileDownloader(getter httpGetter) *FileDownloader {
+	return &FileDownloader{
+		httpGetter: getter,
+	}
+}
+
+// Download downloads text file
+func (fd *FileDownloader) Download(url string) (string, error) {
+	resp, err := fd.httpGetter.Get(url)
+	if err != nil {
+		return "", errors.Wrapf(err, "while executing get request on url: %q", url)
+	}
+	defer util.Close(resp.Body)
+
+	return fd.readResponse(resp)
+}
+
+// DownloadOrEmpty downloads text file
+// If the response status is 404 return empty string with no error
+func (fd *FileDownloader) DownloadOrEmpty(url string) (string, error) {
+	resp, err := fd.httpGetter.Get(url)
+	if err != nil {
+		return "", errors.Wrapf(err, "while executing get request on url: %q", url)
+	}
+	defer util.Close(resp.Body)
+
+	if resp.StatusCode == http.StatusNotFound {
+		return "", nil
+	}
+
+	return fd.readResponse(resp)
+}
+
+func (fd *FileDownloader) readResponse(resp *http.Response) (string, error) {
+	if resp.StatusCode != http.StatusOK {
+		return "", errors.Errorf("received unexpected http status %d", resp.StatusCode)
+	}
+
+	reqBody, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return "", errors.Wrap(err, "while reading body")
+	}
+
+	return string(reqBody), nil
+}

--- a/components/provisioner/internal/installation/release/file_downloader.go
+++ b/components/provisioner/internal/installation/release/file_downloader.go
@@ -1,10 +1,11 @@
 package release
 
 import (
-	"github.com/kyma-incubator/compass/components/provisioner/internal/util"
-	"github.com/pkg/errors"
 	"io/ioutil"
 	"net/http"
+
+	"github.com/kyma-incubator/compass/components/provisioner/internal/util"
+	"github.com/pkg/errors"
 )
 
 type httpGetter interface {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

After switching Kyma Installation to Helm 3 Tiller will no longer be needed, therefore the artifacts will not exist.
This PR will handle the case that Tiller artifacts do not exist. This way Provisioner can handle the installation of both older Kyma version (with Tiller) and new ones.

Changes proposed in this pull request:

- Handle case when Tiller artifacts do not exist
- Update Installation SDK version

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
