### PR TITLE
Update KEB to support extended Avs configuration

### DIFF
--- a/chart/compass/charts/kyma-environment-broker/templates/_helpers.tpl
+++ b/chart/compass/charts/kyma-environment-broker/templates/_helpers.tpl
@@ -43,3 +43,15 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end -}}
+
+{{/*
+Utility function for joining Avs tag list into string.
+*/}}
+{{- define "avs.utils.joinTags" -}}
+{{- $local := dict "first" true -}}
+{{- range $k, $v := . -}}
+{{- if not $local.first -}},{{- end -}}
+{{ printf "{%q,%v,%q}" $v.content $v.tag_id $v.tag_name }}
+{{- $_ := set $local "first" false -}}
+{{- end -}}
+{{- end -}}

--- a/chart/compass/charts/kyma-environment-broker/templates/deployment.yaml
+++ b/chart/compass/charts/kyma-environment-broker/templates/deployment.yaml
@@ -205,6 +205,26 @@ spec:
                 secretKeyRef:
                   key: externalTesterAccessId
                   name: {{ .Values.avs.secretName }}
+            - name: APP_AVS_INTERNAL_TESTER_SERVICE
+              valueFrom:
+                secretKeyRef:
+                  key: internalTesterService
+                  name: {{ .Values.avs.secretName }}
+            - name: APP_AVS_EXTERNAL_TESTER_SERVICE
+              valueFrom:
+                secretKeyRef:
+                  key: externalTesterService
+                  name: {{ .Values.avs.secretName }}
+            - name: APP_AVS_INTERNAL_TESTER_TAGS
+              valueFrom:
+                secretKeyRef:
+                  key: internalTesterTags
+                  name: {{ .Values.avs.secretName }}
+            - name: APP_AVS_EXTERNAL_TESTER_TAGS
+              valueFrom:
+                secretKeyRef:
+                  key: externalTesterTags
+                  name: {{ .Values.avs.secretName }}
             - name: APP_AVS_GROUP_ID
               valueFrom:
                 secretKeyRef:

--- a/chart/compass/charts/kyma-environment-broker/templates/secrets.yaml
+++ b/chart/compass/charts/kyma-environment-broker/templates/secrets.yaml
@@ -21,6 +21,10 @@ data:
   oauthUserName: {{ .Values.avs.oauthUserName | b64enc | quote }}
   internalTesterAccessId: {{ .Values.avs.internalTesterAccessId | b64enc | quote }}
   externalTesterAccessId: {{ .Values.avs.externalTesterAccessId | b64enc | quote }}
+  internalTesterService: {{ .Values.avs.internalTesterService | b64enc | quote }}
+  externalTesterService: {{ .Values.avs.externalTesterService | b64enc | quote }}
+  internalTesterTags: {{ include "avs.utils.joinTags" .Values.avs.internalTesterTags | b64enc | quote }}
+  externalTesterTags: {{ include "avs.utils.joinTags" .Values.avs.externalTesterTags | b64enc | quote }}
   groupId: {{ .Values.avs.groupId | b64enc | quote }}
   parentId: {{ .Values.avs.parentId | b64enc | quote }}
 kind: Secret

--- a/chart/compass/charts/kyma-environment-broker/values.yaml
+++ b/chart/compass/charts/kyma-environment-broker/values.yaml
@@ -89,6 +89,19 @@ avs:
   externalTesterAccessId: "TBD"
   groupId: "TBD"
   parentId: "TBD"
+  # if set - overrides default tester service name
+  internalTesterService: ""
+  externalTesterService: ""
+  # List of tags to bind to testers.
+  # Example: 
+  #  - content: tag-A
+  #    tag_id: 1
+  #    tag_name: value-A
+  #  - content: tag-B
+  #    tag_id: 2
+  #    tag_name: value-B
+  internalTesterTags: []
+  externalTesterTags: []
 
 lms:
   secretName: "lms-creds"

--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -43,7 +43,7 @@ global:
       version: "0a651695"
     kyma_environment_broker:
       dir:
-      version: "e095a49b"
+      version: "c3a89e6f"
     external_services_mock:
       dir:
       version: "e2837b23"


### PR DESCRIPTION
**Description**

Enables Tags and Service configuration overrides for KEB internal Avs component defined by [kyma-incubator/compass/PR#1418](https://github.com/kyma-incubator/compass/pull/1418).

- Adds AVS internal configuration references
- Extends helper functions to allow the creation of specific configurations consumed by KEB internal Avs component

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
