### PR TITLE
Update Provisioner and KEB documentation after changes to GraphQL schema

### DIFF
--- a/components/kyma-environment-broker/README.md
+++ b/components/kyma-environment-broker/README.md
@@ -25,7 +25,7 @@ KEB binary allows you to override some configuration parameters. You can specify
 | Name | Description | Default value |
 |-----|---------|:--------:|
 | **APP_PORT** | Specifies the port on which the HTTP server listens. | `8080` |
-| **APP_BROKER_DEFAULT_GARDENER_SHOOT_PURPOSE** | Specifies the purpose of the created cluster. The possible values are: `development`, `evaluation`, `production`, `testing`. | `development` |
+| **APP_PROVISIONING_DEFAULT_GARDENER_SHOOT_PURPOSE** | Specifies the purpose of the created cluster. The possible values are: `development`, `evaluation`, `production`, `testing`. | `development` |
 | **APP_PROVISIONING_URL** | Specifies a URL to the Provisioner's API. | None |
 | **APP_PROVISIONING_SECRET_NAME** | Specifies the name of the Secret which holds credentials to the Provisioner's API. | None |
 | **APP_PROVISIONING_GARDENER_PROJECT_NAME** | Defines the Gardener project name. | `true` |

--- a/components/kyma-environment-broker/README.md
+++ b/components/kyma-environment-broker/README.md
@@ -25,7 +25,7 @@ KEB binary allows you to override some configuration parameters. You can specify
 | Name | Description | Default value |
 |-----|---------|:--------:|
 | **APP_PORT** | Specifies the port on which the HTTP server listens. | `8080` |
-| **APP_BROKER_DEFAULT_GARDENER_SHOOT_PURPOSE** | Specifies the purpose of the created cluster. Possible values are: `development`, `evaluation`, `production`, `testing`. | `development` |
+| **APP_BROKER_DEFAULT_GARDENER_SHOOT_PURPOSE** | Specifies the purpose of the created cluster. The possible values are: `development`, `evaluation`, `production`, `testing`. | `development` |
 | **APP_PROVISIONING_URL** | Specifies a URL to the Provisioner's API. | None |
 | **APP_PROVISIONING_SECRET_NAME** | Specifies the name of the Secret which holds credentials to the Provisioner's API. | None |
 | **APP_PROVISIONING_GARDENER_PROJECT_NAME** | Defines the Gardener project name. | `true` |

--- a/components/kyma-environment-broker/README.md
+++ b/components/kyma-environment-broker/README.md
@@ -25,6 +25,7 @@ KEB binary allows you to override some configuration parameters. You can specify
 | Name | Description | Default value |
 |-----|---------|:--------:|
 | **APP_PORT** | Specifies the port on which the HTTP server listens. | `8080` |
+| **APP_BROKER_DEFAULT_GARDENER_SHOOT_PURPOSE** | Specifies the purpose of the created cluster. Possible values are: `development`, `evaluation`, `production`, `testing`. | `development` |
 | **APP_PROVISIONING_URL** | Specifies a URL to the Provisioner's API. | None |
 | **APP_PROVISIONING_SECRET_NAME** | Specifies the name of the Secret which holds credentials to the Provisioner's API. | None |
 | **APP_PROVISIONING_GARDENER_PROJECT_NAME** | Defines the Gardener project name. | `true` |

--- a/docs/kyma-environment-broker/03-01-service-description.md
+++ b/docs/kyma-environment-broker/03-01-service-description.md
@@ -22,7 +22,7 @@ These are the provisioning parameters for this plan:
 | **machineType** | string | Specifies the provider-specific virtual machine type. | No | `Standard_D8_v3` |
 | **region** | string | Defines the cluster region. | No | `westeurope` |
 | **zone** | string | Defines the cluster zone. | No | None |
-| **purpose** | string | Defines the purpose of the created cluster. Possible values are: `development`, `evaluation`, `production`, `testing`. | No | `development` |
+| **purpose** | string | Defines the purpose of the created cluster. The possible values are: `development`, `evaluation`, `production`, `testing`. | No | `development` |
 | **autoScalerMin** | int | Specifies the minimum number of virtual machines to create. | No | `2` |
 | **autoScalerMax** | int | Specifies the maximum number of virtual machines to create. | No | `4` |
 | **maxSurge** | int | Specifies the maximum number of virtual machines that are created during an update. | No | `4` |

--- a/docs/kyma-environment-broker/03-01-service-description.md
+++ b/docs/kyma-environment-broker/03-01-service-description.md
@@ -22,6 +22,7 @@ These are the provisioning parameters for this plan:
 | **machineType** | string | Specifies the provider-specific virtual machine type. | No | `Standard_D8_v3` |
 | **region** | string | Defines the cluster region. | No | `westeurope` |
 | **zone** | string | Defines the cluster zone. | No | None |
+| **purpose** | string | Defines the purpose of the created cluster. Possible values are: `development`, `evaluation`, `production`, `testing`. | No | `development` |
 | **autoScalerMin** | int | Specifies the minimum number of virtual machines to create. | No | `2` |
 | **autoScalerMax** | int | Specifies the maximum number of virtual machines to create. | No | `4` |
 | **maxSurge** | int | Specifies the maximum number of virtual machines that are created during an update. | No | `4` |

--- a/docs/provisioner/08-02-provisioning-gardener.md
+++ b/docs/provisioner/08-02-provisioning-gardener.md
@@ -105,7 +105,7 @@ This tutorial shows how to provision clusters with Kyma Runtimes on Google Cloud
                 machineType: "n1-standard-4"
                 region: "europe-west4"
                 provider: "gcp"
-                purpose: "testing" # possible values: "development", "evaluation", "production", "testing"; default value: "development"
+                purpose: "testing" # possible values: "development", "evaluation", "production", "testing"; default value: "evaluation"
                 targetSecret: "{GARDENER_GCP_SECRET_NAME}"
                 workerCidr: "10.250.0.0/19"
                 autoScalerMin: 2
@@ -196,7 +196,7 @@ This tutorial shows how to provision clusters with Kyma Runtimes on Google Cloud
                 machineType: "Standard_D2_v3"
                 region: "westeurope"
                 provider: "azure"
-                purpose: "testing" # possible values: "development", "evaluation", "production", "testing"; default value: "development"
+                purpose: "testing" # possible values: "development", "evaluation", "production", "testing"; default value: "evaluation"
                 targetSecret: "{GARDENER_AZURE_SECRET_NAME}"
                 workerCidr: "10.250.0.0/19"
                 autoScalerMin: 2
@@ -287,7 +287,7 @@ This tutorial shows how to provision clusters with Kyma Runtimes on Google Cloud
                 machineType: "m4.2xlarge"
                 region: "eu-west-1"
                 provider: "aws"
-                purpose: "testing" # possible values: "development", "evaluation", "production", "testing"; default value: "development"
+                purpose: "testing" # possible values: "development", "evaluation", "production", "testing"; default value: "evaluation"
                 targetSecret: "{GARDENER_AWS_SECRET_NAME}"
                 workerCidr: "10.250.0.0/19"
                 autoScalerMin: 2

--- a/docs/provisioner/08-02-provisioning-gardener.md
+++ b/docs/provisioner/08-02-provisioning-gardener.md
@@ -80,7 +80,7 @@ This tutorial shows how to provision clusters with Kyma Runtimes on Google Cloud
 
   1. Access your project on [Gardener](https://dashboard.garden.canary.k8s.ondemand.com).
 
-  2. In the **Secrets** tab, add a new Google Secret for GCP. Use the `json` file with the service account key you downloaded from GCP.
+  2. In the **Secrets** tab, add a new Google Secret for GCP. Use the JSON file with the service account key you downloaded from GCP.
 
   3. In the **Members** tab, create a service account for Gardener. 
     
@@ -105,6 +105,7 @@ This tutorial shows how to provision clusters with Kyma Runtimes on Google Cloud
                 machineType: "n1-standard-4"
                 region: "europe-west4"
                 provider: "gcp"
+                purpose: "testing" # possible values: "development", "evaluation", "production", "testing"; default value: "development"
                 targetSecret: "{GARDENER_GCP_SECRET_NAME}"
                 workerCidr: "10.250.0.0/19"
                 autoScalerMin: 2
@@ -195,6 +196,7 @@ This tutorial shows how to provision clusters with Kyma Runtimes on Google Cloud
                 machineType: "Standard_D2_v3"
                 region: "westeurope"
                 provider: "azure"
+                purpose: "testing" # possible values: "development", "evaluation", "production", "testing"; default value: "development"
                 targetSecret: "{GARDENER_AZURE_SECRET_NAME}"
                 workerCidr: "10.250.0.0/19"
                 autoScalerMin: 2
@@ -285,6 +287,7 @@ This tutorial shows how to provision clusters with Kyma Runtimes on Google Cloud
                 machineType: "m4.2xlarge"
                 region: "eu-west-1"
                 provider: "aws"
+                purpose: "testing" # possible values: "development", "evaluation", "production", "testing"; default value: "development"
                 targetSecret: "{GARDENER_AWS_SECRET_NAME}"
                 workerCidr: "10.250.0.0/19"
                 autoScalerMin: 2


### PR DESCRIPTION
**Description**

Recently, the Runtime Provisioner GraphQL schema got a new field, `purpose`. 
This requires documentation update for the Runtime Provisioner and Kyma Environment Broker.

Changes proposed in this pull request:

- Update documentation for the Runtime Provisioner and KEB.

**Related PR**
See #1425 