### PR TITLE
Update KEB documentation after Provisioner's GraphQL schema changed

### DIFF
--- a/docs/kyma-environment-broker/03-01-service-description.md
+++ b/docs/kyma-environment-broker/03-01-service-description.md
@@ -21,7 +21,7 @@ These are the provisioning parameters for this plan:
 | **volumeSizeGb** | int | Specifies the size of the root volume. | No | `50` |
 | **machineType** | string | Specifies the provider-specific virtual machine type. | No | `Standard_D8_v3` |
 | **region** | string | Defines the cluster region. | No | `westeurope` |
-| **zones** | string | Defines the list of zones in which to create the cluster. | No | `["1", "2", "3"]` |
+| **zones** | string | Defines the list of zones in which the Runtime Provisioner creates the cluster. | No | `["1", "2", "3"]` |
 | **purpose** | string | Defines the purpose of the created cluster. The possible values are: `development`, `evaluation`, `production`, `testing`. | No | `development` |
 | **autoScalerMin** | int | Specifies the minimum number of virtual machines to create. | No | `2` |
 | **autoScalerMax** | int | Specifies the maximum number of virtual machines to create. | No | `4` |

--- a/docs/kyma-environment-broker/03-01-service-description.md
+++ b/docs/kyma-environment-broker/03-01-service-description.md
@@ -21,7 +21,7 @@ These are the provisioning parameters for this plan:
 | **volumeSizeGb** | int | Specifies the size of the root volume. | No | `50` |
 | **machineType** | string | Specifies the provider-specific virtual machine type. | No | `Standard_D8_v3` |
 | **region** | string | Defines the cluster region. | No | `westeurope` |
-| **zone** | string | Defines the cluster zone. | No | None |
+| **zones** | string | Defines the list of zones in which to create the cluster. | No | `["1", "2", "3"]` |
 | **purpose** | string | Defines the purpose of the created cluster. The possible values are: `development`, `evaluation`, `production`, `testing`. | No | `development` |
 | **autoScalerMin** | int | Specifies the minimum number of virtual machines to create. | No | `2` |
 | **autoScalerMax** | int | Specifies the maximum number of virtual machines to create. | No | `4` |


### PR DESCRIPTION
**Description**

Changes to the Runtime Provisioner's GraphQL schema parts of the KEB documentation are no longer valid and need to be updated.

Changes proposed in this pull request:

- Update KEB documentation to be in line with the Runtime Provisioner's GraphQL schema.

**Related issue(s)**
See #1296 
