### PR TITLE
Bump kyma version for management plane migration

### DIFF
--- a/installation/resources/KYMA_VERSION
+++ b/installation/resources/KYMA_VERSION
@@ -1,1 +1,1 @@
-master-ba94daa7
+master-5b367c59


### PR DESCRIPTION
**Description**
In order to migrate kyma management plane pipelines to the split kyma-installer/compass-installer, the the kyma version should be as recent as the current deployed one by the existing installation method.

