### PR TITLE
Fix Runtime Provisioner naming in KEB docs

### DIFF
--- a/components/kyma-environment-broker/README.md
+++ b/components/kyma-environment-broker/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Kyma Environment Broker (KEB) is a component that allows you to provision Kyma as a Runtime on clusters provided by third-party providers. It uses Provisioner's API to install Kyma on a given cluster.
+Kyma Environment Broker (KEB) is a component that allows you to provision Kyma as a Runtime on clusters provided by third-party providers. It uses the Runtime Provisioner's API to install Kyma on a given cluster.
 
 For more information, read the [documentation](../../docs/kyma-environment-broker) where you can find information on:
 
@@ -26,8 +26,8 @@ KEB binary allows you to override some configuration parameters. You can specify
 |-----|---------|:--------:|
 | **APP_PORT** | Specifies the port on which the HTTP server listens. | `8080` |
 | **APP_PROVISIONING_DEFAULT_GARDENER_SHOOT_PURPOSE** | Specifies the purpose of the created cluster. The possible values are: `development`, `evaluation`, `production`, `testing`. | `development` |
-| **APP_PROVISIONING_URL** | Specifies a URL to the Provisioner's API. | None |
-| **APP_PROVISIONING_SECRET_NAME** | Specifies the name of the Secret which holds credentials to the Provisioner's API. | None |
+| **APP_PROVISIONING_URL** | Specifies a URL to the Runtime Provisioner's API. | None |
+| **APP_PROVISIONING_SECRET_NAME** | Specifies the name of the Secret which holds credentials to the Runtime Provisioner's API. | None |
 | **APP_PROVISIONING_GARDENER_PROJECT_NAME** | Defines the Gardener project name. | `true` |
 | **APP_PROVISIONING_GCP_SECRET_NAME** | Defines the name of the Secret which holds credentials to GCP. | None |
 | **APP_PROVISIONING_AWS_SECRET_NAME** | Defines the name of the Secret which holds credentials to AWS. | None |

--- a/docs/kyma-environment-broker/01-01-overview.md
+++ b/docs/kyma-environment-broker/01-01-overview.md
@@ -1,3 +1,3 @@
 # Kyma Environment Broker
 
-Kyma Environment Broker is a component that allows you to provision Kyma as a Runtime on clusters provided by third-party providers. It uses Provisioner's API to install Kyma on a given cluster. 
+Kyma Environment Broker is a component that allows you to provision Kyma as a Runtime on clusters provided by third-party providers. It uses the Runtime Provisioner's API to install Kyma on a given cluster. 

--- a/docs/kyma-environment-broker/02-01-architecture.md
+++ b/docs/kyma-environment-broker/02-01-architecture.md
@@ -12,7 +12,7 @@ The diagram and steps describe the Kyma Environment Broker (KEB) workflow and th
     
     c. If the authorization ends with success, the request is redirected to KEB.
     
-2. KEB proxies the request to create a new cluster to the Provisioner component.
+2. KEB proxies the request to create a new cluster to the Runtime Provisioner component.
 3. Provisioner registers a new cluster in the Director component.
 4. Provisioner creates a new cluster and installs Kyma Runtime.
 5. When the operation is successful, KEB keeps sending a request for a Dashboard URL to Director:

--- a/docs/kyma-environment-broker/03-03-runtime-provisioning-and-deprovisioning.md
+++ b/docs/kyma-environment-broker/03-03-runtime-provisioning-and-deprovisioning.md
@@ -8,7 +8,7 @@ Both provisioning and deprovisioning operation consist of several steps. Each st
 
 The provisioning and deprovisioning timeouts for processing an operation are set to `24h`.
 
-> **NOTE:** It's important to have lower timeouts for the Kyma installation in the Provisioner .
+> **NOTE:** It's important to have lower timeouts for the Kyma installation in the Runtime Provisioner .
 
 ## Provisioning
 
@@ -17,21 +17,21 @@ The provisioning process contains the following steps:
 
 | Name                                   | Domain                   | Description                                                                                                                                     | Owner            |
 |----------------------------------------|--------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------|------------------|
-| Initialisation                         | Provisioning             | Starts the provisioning process and asks the Director for the Dashboard URL if the provisioning in Gardener is finished.                                | @jasiu001 (Team Gopher)       |
+| Initialization                         | Provisioning             | Starts the provisioning process and asks the Director for the Dashboard URL if the provisioning in Gardener is finished.                                | @jasiu001 (Team Gopher)       |
 | Resolve_Target_Secret                  | Hyperscaler Account Pool | Provides the name of a Gardener Secret that contains  Hypescaler account credentials used during cluster provisioning.                                | @koala7659 (Team Framefrog)      |
 | AVS_Configuration_Step                 | AvS                      | Sets up external and internal monitoring of Kyma Runtime.                                      | @abbi-guarav     |
 | Create_LMS_Tenant                      | LMS                      | Requests a tenant in the LMS system or provides a tenant ID if it was created before.                                                              | @piotrmiskiewicz (Team Gopher) |
 | IAS_Registration                       | Identity Authentication Service | Registers a new ServiceProvider on IAS, generates client ID and Secret, and inserts them to Grafana overrides. This step is not required and can be disabled. | @jasiu001 (Team Gopher) |
-| EDP_Registration                       | Event Data Platform      | Registers a SKR on Event Data Platform with the necessary parameters. This step is not required and can be disabled. | @jasiu001 (Team Gopher) |
+| EDP_Registration                       | Event Data Platform      | Registers an SKR on Event Data Platform with the necessary parameters. This step is not required and can be disabled. | @jasiu001 (Team Gopher) |
 | Provision Azure Event Hubs             | Event Hub                | Creates the Azure Event Hub Namespace which is a managed Kafka cluster for a Kyma Runtime.                                                       | @anishj0shi (Team SkyDivingTunas)     |
 | Overrides_From_Secrets_And_Config_Step | Kyma overrides           | Configures default overrides for Kyma.                                                                                                          | @jasiu001 (Team Gopher)        |
 | ServiceManagerOverrides                | Service Manager          | Configures overrides with Service Manager credentials.                                                                                          | @mszostok (Team Gopher)        |
-| Request_LMS_Certificates               | LMS                      | Checks if the LMS tenant is ready and requests certificates. The step configures Fluent Bit in a Kyma Runtime. It requires the Create_LMS_Tenant step to be completed before. The step does not fail the provisioning operation. | @piotrmiskiewicz (Team Gopher) |
+| Request_LMS_Certificates               | LMS                      | Checks if the LMS tenant is ready and requests certificates. The step configures Fluent Bit in a Kyma Runtime. It requires the Create_LMS_Tenant step to be completed beforehand. The step does not fail the provisioning operation. | @piotrmiskiewicz (Team Gopher) |
 | Create_Runtime                         | Provisioning             | Triggers provisioning of a Runtime in the Runtime Provisioner.                                                                                                       | @jasiu001 (Team Gopher)        |
 
 ## Deprovisioning
 
-Each deprovisioning step is responsible for a separate part of cleaning Runtime dependencies. To properly deprovision all Runtime dependencies, you need the data used during the Runtime provisioning. You can fetch this data from the **ProvisioningOperation** struct in the [initialisation](https://github.com/kyma-incubator/compass/blob/master/components/kyma-environment-broker/internal/process/deprovisioning/initialisation.go#L46) step.
+Each deprovisioning step is responsible for a separate part of cleaning Runtime dependencies. To properly deprovision all Runtime dependencies, you need the data used during the Runtime provisioning. You can fetch this data from the **ProvisioningOperation** struct in the [initialization](https://github.com/kyma-incubator/compass/blob/master/components/kyma-environment-broker/internal/process/deprovisioning/initialisation.go#L46) step.
 
 Any deprovisioning step shouldn't block the entire deprovisioning operation. Use the `RetryOperationWithoutFail` function from the `DeprovisionOperationManager` struct to skip your step in case of retry timeout. Set at most 5min timeout for retries in your step.
 

--- a/docs/kyma-environment-broker/08-01-provisioning-kyma-environment.md
+++ b/docs/kyma-environment-broker/08-01-provisioning-kyma-environment.md
@@ -11,6 +11,7 @@ This tutorial shows how to provision Kyma Runtime on Azure using Kyma Environmen
 ## Steps
 
 1. Export these values as environment variables:
+
 ```bash
 export BROKER_URL={KYMA_ENVIRONMENT_BROKER_URL}
 export INSTANCE_ID={INSTANCE_ID}

--- a/docs/kyma-environment-broker/08-04-instance-details.md
+++ b/docs/kyma-environment-broker/08-04-instance-details.md
@@ -38,7 +38,7 @@ A successful call returns the instance details:
         "region": "westeurope",
         "targetSecret": "azrspn-ce-skr-dev-00001",
         "volumeSizeGb": 50,
-        "zone": null
+        "zones": ["1", "2", "3"]
     }
 }
 ```


### PR DESCRIPTION
**Description**

Since the Runtime Provisioner is often colloquially called Compass Provisioner or just Provisioner for short, it often results in incorrect naming in the documentation. That is why the naming should be fixed and made consistent.

Changes proposed in this pull request:

- Correct `Provisioner` to `the Runtime Provisioner` in KEB documentation.