### PR TITLE
Set increased resource limits explicitly on compass-installer container

### DIFF
--- a/installation/resources/installer.yaml
+++ b/installation/resources/installer.yaml
@@ -268,6 +268,13 @@ spec:
           - mountPath: /etc/certs
             name: helm-certs
             readOnly: true
+        resources:
+          requests:
+            memory: 256Mi
+            cpu: 40m
+          limits:
+            memory: 512Mi
+            cpu: 400m
       volumes:
       - name: helm-certs
         secret:


### PR DESCRIPTION
**Description**

Compass installer is OOMKilled with the current 256Mi limit applied by the LimitRange default rule:
```
Containers:
  compass-installer-container:
    Container ID:  docker://602cca9f21e30d9fa5f07da0d75c841539633cab39740b9ca062fbfd9202d316
    Image:         eu.gcr.io/kyma-project/compass-installer:master-782d4a4b-1592982669
    Image ID:      docker-pullable://eu.gcr.io/kyma-project/compass-installer@sha256:20cd5b98d16e85c9443cf7ce72c0c6f6cfd51d47993c418a5a57a1e4d82f03f1
    Port:          <none>
    Host Port:     <none>
    Args:
      -overrideLogFile=/app/overrides.txt
      -helmDebugMode=true
    State:          Waiting
      Reason:       CrashLoopBackOff
    Last State:     Terminated
      Reason:       OOMKilled
      Exit Code:    137
      Started:      Wed, 24 Jun 2020 14:05:25 +0200
      Finished:     Wed, 24 Jun 2020 14:05:32 +0200
    Ready:          False
    Restart Count:  2
    Limits:
      memory:  256Mi
    Requests:
      memory:  32Mi
```

Changes proposed in this pull request:

- Set explicit resource requests/limits for compass-installer-container
- Increase memory limit of the container to 512Mi

