### PR TITLE
Block merging changes for Kyma Control Plane components

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -11,20 +11,20 @@
 /chart/compass/values.yaml @PK85 @crabtree @pkosiec @kfurgol @tgorgol @akgalwas @janmedrek @Szymongib @franpog859 @Maladie @dbadura @kjaksik @mszostok @piotrmiskiewicz @polskikiel @ksputo @jasiu001 @koala7659 @rafalpotempa
 
 # Registration job is used by provisioner and kyma-environment-broker
-/chart/compass/templates/registration-job.yaml @PK85 @crabtree @pkosiec @kfurgol @tgorgol @akgalwas @janmedrek @Szymongib @franpog859 @Maladie @dbadura @kjaksik @mszostok @piotrmiskiewicz @polskikiel @ksputo @jasiu001 @koala7659 @rafalpotempa
+/chart/compass/templates/registration-job.yaml @kyma-bot
 
 # Kyma Environment Broker
-/chart/compass/charts/kyma-environment-broker @PK85 @mszostok @piotrmiskiewicz @polskikiel @ksputo @jasiu001
-/components/kyma-environment-broker @PK85 @mszostok @piotrmiskiewicz @polskikiel @ksputo @jasiu001
-/docs/kyma-environment-broker @PK85 @mszostok @piotrmiskiewicz @polskikiel @ksputo @jasiu001
-/components/schema-migrator/migrations/kyma-environment-broker @PK85 @mszostok @piotrmiskiewicz @polskikiel @ksputo @jasiu001
+/chart/compass/charts/kyma-environment-broker @kyma-bot
+/components/kyma-environment-broker @kyma-bot
+/docs/kyma-environment-broker @kyma-bot
+/components/schema-migrator/migrations/kyma-environment-broker @kyma-bot
 
 # Runtime Provisioner
-/chart/compass/charts/provisioner @janmedrek @akgalwas @Szymongib @franpog859 @Maladie @koala7659 @rafalpotempa
-/components/provisioner @janmedrek @akgalwas @Szymongib @franpog859 @Maladie @koala7659 @rafalpotempa
-/docs/provisioner @janmedrek @akgalwas @Szymongib @franpog859 @Maladie @koala7659 @rafalpotempa
-/components/schema-migrator/migrations/provisioner @janmedrek @akgalwas @Szymongib @franpog859 @Maladie @koala7659 @rafalpotempa
-/tests/provisioner-tests @janmedrek @akgalwas @Szymongib @franpog859 @Maladie @koala7659 @rafalpotempa
+/chart/compass/charts/provisioner @kyma-bot
+/components/provisioner @kyma-bot
+/docs/provisioner @kyma-bot
+/components/schema-migrator/migrations/provisioner @kyma-bot
+/tests/provisioner-tests @kyma-bot
 
 # Director
 /chart/compass/charts/director @PK85 @crabtree @pkosiec @kfurgol @tgorgol @dbadura @kjaksik
@@ -58,18 +58,18 @@
 /chart/compass/charts/external-services-mock @PK85 @crabtree @pkosiec @kfurgol @tgorgol @dbadura @kjaksik
 
 # e2e-provisioning
-/tests/e2e/provisioning @PK85 @mszostok @piotrmiskiewicz @polskikiel @ksputo @jasiu001
+/tests/e2e/provisioning @kyma-bot
 
 # Compass UI
 /chart/compass/charts/cockpit @kwiatekus @dariadomagala @parostatkiem @akucharska @sjanota @Wawrzyn321
 
 # Metris
-/chart/compass/charts/metris @maksd
-/components/metris @maksd
+/chart/compass/charts/metris @kyma-bot
+/components/metris @kyma-bot
 
 # OIDC-Kubeconfig-Service
-/components/kubeconfig-service @piotrmsc @kubadz @strekm @jakkab @Tomasz-Smelcerz-SAP @Demonsthere @colunira
-/chart/oidc-kubeconfig-service @piotrmsc @kubadz @strekm @jakkab @Tomasz-Smelcerz-SAP @Demonsthere @colunira
+/components/kubeconfig-service @kyma-bot
+/chart/oidc-kubeconfig-service @kyma-bot
 
 # All .md files
 *.md @klaudiagrz @kazydek @tomekpapiernik @bszwarc @mmitoraj @majakurcius @alexandra-simeonova


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Block merging changes for Kyma Control Plane components

Kyma Control Plane components are moved to `kyma-project/control-plane` repo. They will be eventually removed from this repo.

**Related issue(s)**
Proposal: https://github.com/kyma-incubator/compass/pull/1463
