### PR TITLE
Fix the Runtime Agent contract

### DIFF
--- a/docs/runtime-agent/runtime-agent-contract.md
+++ b/docs/runtime-agent/runtime-agent-contract.md
@@ -14,20 +14,3 @@ Runtime Agent automates the process of establishing trusted connection between t
 ## Renewing trusted connection
 
 Depending on the type of trusted connection, during the runtime lifecycle, it may be required to periodically renew trusted connection.
-
-## Configuring the Runtime
-
-> **NOTE:** To represent API and Event Definitions of the connected Applications on Runtime, Open Service Broker API usage is recommended.
-
-In Kyma Runtime, during Runtime configuration, Application's Packages are integrated into the Service Catalog using [Application](https://kyma-project.io/docs/components/application-connector#custom-resource-application) custom resources and [Application Broker](https://kyma-project.io/docs/components/application-connector#architecture-application-broker). By default, a single Application is represented as a ServiceClass, and a single Package is represented as a ServicePlan in the Service Catalog. To learn more about Packages, read [this](../compass/03-packages-api.md) document.
-
-Runtime Agent periodically requests for the configuration of its Runtime from the Management Plane. Changes in the configuration for the Runtime are applied by the Runtime Agent on the Runtime.
-
-To fetch the Runtime configuration, Runtime Agent calls `applicationsForRuntime(runtimeId: ID!, first: Int = 100, after: PageCursor)` query offered by the Director. The response for the query contains a page with the list of Applications assigned for the Runtime and info about the next page. Each Application will contain only credentials that are valid for the Runtime that called the query. Each Runtime Agent can fetch the configurations for Runtimes that belong to its tenant, there is no validation if the Runtime Agent is fetching the configuration for the Runtime on which it runs.
-
-Runtime Agent reports back to the Director the Runtime-specific LabelDefinitions that represent Runtime configuration together with their values.
-
-Runtime specific LabelDefinitions:
-
-- Events Gateway URL
-- Runtime Console URL

--- a/docs/runtime-agent/runtime-agent-contract.md
+++ b/docs/runtime-agent/runtime-agent-contract.md
@@ -14,3 +14,7 @@ Runtime Agent automates the process of establishing trusted connection between t
 ## Renewing trusted connection
 
 Depending on the type of trusted connection, during the runtime lifecycle, it may be required to periodically renew trusted connection.
+
+## Synchronizing Runtime with Director
+
+Runtime Agent is also responsible for synchronizing Applications in the Runtime down from the Director. This means it makes sure that the state in the Runtime matches the state in the Director.


### PR DESCRIPTION
**Description**

The Runtime Agent contract contains some information on the Kyma-specific implementation which has no place being there and needs to be removed. It also misses information on synchronizing Applications in the Runtime down from the Director. 

Changes proposed in this pull request:

- Remove the `Configuring the Runtime` section
- Add a short section on synchronizing Applications in the Runtime down from the Director
