### PR TITLE
Increase compass-installer container memory limit to 2Gi (#1506)

### DIFF
--- a/installation/resources/installer.yaml
+++ b/installation/resources/installer.yaml
@@ -17,7 +17,7 @@ metadata:
 spec:
   limits:
   - max:
-      memory: 1024Mi # Maximum memory that a container can request
+      memory: 2048Mi # Maximum memory that a container can request
     default:
       # If a container does not specify memory limit, this default value will be applied.
       # If a container tries to allocate more memory, container will be OOM killed.
@@ -220,7 +220,7 @@ spec:
             memory: 32Mi
             cpu: 40m
           limits:
-            memory: 1Gi
+            memory: 2Gi
             cpu: 400m
       volumes:
       - name: helm-certs


### PR DESCRIPTION
Also increased LimitRange to 2048Mi
	modified:   installation/resources/installer.yaml

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Increase compass-installer container memory limit to 2Gi (#1506)
- Also increased LimitRange to 2048Mi


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
Fixes #1506