### PR TITLE
Fix local Compass run script

### DIFF
--- a/installation/scripts/install-minimal-kyma.sh
+++ b/installation/scripts/install-minimal-kyma.sh
@@ -32,6 +32,8 @@ if [[ "$LOCAL_ENV" == "true" ]]; then
     ADDITIONAL_PARAMS="-o ${ISTIO_OVERRIDES}${ADDITIONAL_PARAMS}"
 fi
 
+echo "Configuring Tiller..."
+kubectl apply -f "${ROOT_PATH}"/installation/resources/tiller.yaml
 
 echo "Installing Kyma..."
 set -o xtrace


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Running the Compass locally in Minikube using the `run.sh` script in the `/installation/cmd/` folder (as described [here](https://github.com/kyma-incubator/compass/blob/master/docs/compass/04-01-installation.md#local-minikube-installation)) doesn't work out of the box because the Kyma Installator requires a K8s secret `tiller-secret` deployed first. This secret is part of a yaml file that is located in `/installation/resources/tiller.yaml`.

Changes proposed in this pull request:

- Setup Tiller before starting the Kyma installation.

**Related issue(s)**

Fixes #1518 
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
