### PR TITLE
Fix Package and PackageInstanceAuth tables' foreign keys

### DIFF
--- a/components/schema-migrator/migrations/director/202008141052_fix_package_deletion.down.sql
+++ b/components/schema-migrator/migrations/director/202008141052_fix_package_deletion.down.sql
@@ -1,0 +1,15 @@
+BEGIN;
+
+ALTER TABLE packages
+DROP CONSTRAINT packages_tenant_id_fkey1,
+ADD CONSTRAINT packages_tenant_id_fkey1
+    FOREIGN KEY (tenant_id)
+    REFERENCES business_tenant_mappings(id);
+
+ALTER TABLE package_instance_auths
+DROP CONSTRAINT package_instance_auths_tenant_id_fkey1,
+ADD CONSTRAINT package_instance_auths_tenant_id_fkey1
+    FOREIGN KEY (tenant_id)
+    REFERENCES business_tenant_mappings(id);
+
+COMMIT;

--- a/components/schema-migrator/migrations/director/202008141052_fix_package_deletion.up.sql
+++ b/components/schema-migrator/migrations/director/202008141052_fix_package_deletion.up.sql
@@ -1,0 +1,17 @@
+BEGIN;
+
+ALTER TABLE packages
+DROP CONSTRAINT packages_tenant_id_fkey1,
+ADD CONSTRAINT packages_tenant_id_fkey1
+    FOREIGN KEY (tenant_id)
+    REFERENCES business_tenant_mappings(id)
+    ON DELETE CASCADE;
+
+ALTER TABLE package_instance_auths
+DROP CONSTRAINT package_instance_auths_tenant_id_fkey1,
+ADD CONSTRAINT package_instance_auths_tenant_id_fkey1
+    FOREIGN KEY (tenant_id)
+    REFERENCES business_tenant_mappings(id)
+    ON DELETE CASCADE;
+
+COMMIT;


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Introduce DB migrations which fix foreign keys of two of the tables - *packages* and *package_instance_auths* which are problematic upon deletion of a *business_tenant_mapping* record.

Changes proposed in this pull request:

- Add DB migrations which add delete cascades on one of the foreign keys of both of the tables *packages* and *package_instance_auths*.

**Related issue(s)**
Fixes #1520 
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
