### PR TITLE
Add status code check to tenant fetcher

### DIFF
--- a/components/director/internal/tenantfetcher/client.go
+++ b/components/director/internal/tenantfetcher/client.go
@@ -3,6 +3,7 @@ package tenantfetcher
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"net"
 	"net/http"
@@ -101,6 +102,11 @@ func (c *Client) FetchTenantEventsPage(eventsType EventsType, additionalQueryPar
 	if err != nil {
 		return nil, pkgErrors.Wrap(err, "while reading response body")
 	}
+
+	if res.StatusCode != http.StatusOK && res.StatusCode != http.StatusNoContent {
+		return nil, fmt.Errorf("request to %q returned status code %d and body %q", reqURL, res.StatusCode, bytes)
+	}
+
 	return bytes, nil
 }
 


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

Currently, the tenant fetcher does not return an error if the request to the tenant's provider service returns status code that is not expected (200 OK and 204 No Content).
This PR adds a check for the status code from that call and a test for it.
