### PR TITLE
Fix Update App mutation reseting application fields

### DIFF
--- a/components/director/internal/domain/application/fixtures_test.go
+++ b/components/director/internal/domain/application/fixtures_test.go
@@ -185,6 +185,12 @@ func fixModelApplicationUpdateInput(name, description, url string, statusConditi
 	}
 }
 
+func fixModelApplicationUpdateInputStatus(statusCondition model.ApplicationStatusCondition) model.ApplicationUpdateInput {
+	return model.ApplicationUpdateInput{
+		StatusCondition: &statusCondition,
+	}
+}
+
 func fixGQLApplicationRegisterInput(name, description string) graphql.ApplicationRegisterInput {
 	labels := graphql.Labels{
 		"test": []string{"val", "val2"},

--- a/components/director/internal/domain/application/service.go
+++ b/components/director/internal/domain/application/service.go
@@ -290,13 +290,12 @@ func (s *service) Update(ctx context.Context, id string, in model.ApplicationUpd
 		return errors.Wrap(err, "while updating Application")
 	}
 
-	intSysLabel := createLabel(intSysKey, "", id)
 	if in.IntegrationSystemID != nil {
-		intSysLabel = createLabel(intSysKey, *in.IntegrationSystemID, id)
-	}
-	err = s.SetLabel(ctx, intSysLabel)
-	if err != nil {
-		return errors.Wrap(err, "while setting the integration system label")
+		intSysLabel := createLabel(intSysKey, *in.IntegrationSystemID, id)
+		err = s.SetLabel(ctx, intSysLabel)
+		if err != nil {
+			return errors.Wrap(err, "while setting the integration system label")
+		}
 	}
 
 	labelName := createLabel(nameKey, app.Name, app.ID)

--- a/components/director/internal/model/application.go
+++ b/components/director/internal/model/application.go
@@ -21,11 +21,18 @@ func (app *Application) SetFromUpdateInput(update ApplicationUpdateInput, timest
 	if app.Status == nil {
 		app.Status = &ApplicationStatus{}
 	}
-
-	app.Description = update.Description
-	app.HealthCheckURL = update.HealthCheckURL
-	app.IntegrationSystemID = update.IntegrationSystemID
-	app.ProviderName = update.ProviderName
+	if update.Description != nil {
+		app.Description = update.Description
+	}
+	if update.HealthCheckURL != nil {
+		app.HealthCheckURL = update.HealthCheckURL
+	}
+	if update.IntegrationSystemID != nil {
+		app.IntegrationSystemID = update.IntegrationSystemID
+	}
+	if update.ProviderName != nil {
+		app.ProviderName = update.ProviderName
+	}
 	app.Status.Condition = getApplicationStatusConditionOrDefault(update.StatusCondition)
 	app.Status.Timestamp = timestamp
 }

--- a/components/director/internal/model/application_test.go
+++ b/components/director/internal/model/application_test.go
@@ -75,25 +75,59 @@ func TestApplicationCreateInput_ToApplication(t *testing.T) {
 }
 
 func TestApplicationUpdateInput_UpdateApplication(t *testing.T) {
-	//GIVEN
-	timestamp := time.Now()
-	statusCondition := model.ApplicationStatusConditionConnected
-	filledAppUpdate := model.ApplicationUpdateInput{
-		ProviderName:        str.Ptr("provider name"),
-		Description:         str.Ptr("description"),
-		HealthCheckURL:      str.Ptr("https://kyma-project.io"),
-		IntegrationSystemID: str.Ptr("int sys id"),
-		StatusCondition:     &statusCondition,
-	}
-	app := model.Application{}
+	const (
+		providerName   = "provider name"
+		description    = "description"
+		healthCheckURL = "https://kyma-project.io"
+		intSysID       = "int sys id"
+	)
+	t.Run("successfully overrides values with new input", func(t *testing.T) {
+		//GIVEN
+		timestamp := time.Now()
+		statusCondition := model.ApplicationStatusConditionConnected
+		filledAppUpdate := model.ApplicationUpdateInput{
+			ProviderName:        str.Ptr(providerName),
+			Description:         str.Ptr(description),
+			HealthCheckURL:      str.Ptr(healthCheckURL),
+			IntegrationSystemID: str.Ptr(intSysID),
+			StatusCondition:     &statusCondition,
+		}
+		app := model.Application{}
 
-	//WHEN
-	app.SetFromUpdateInput(filledAppUpdate, timestamp)
+		//WHEN
+		app.SetFromUpdateInput(filledAppUpdate, timestamp)
 
-	//THEN
-	assert.Equal(t, filledAppUpdate.Description, app.Description)
-	assert.Equal(t, filledAppUpdate.HealthCheckURL, app.HealthCheckURL)
-	assert.Equal(t, filledAppUpdate.IntegrationSystemID, app.IntegrationSystemID)
-	assert.Equal(t, filledAppUpdate.ProviderName, app.ProviderName)
-	assert.Equal(t, *filledAppUpdate.StatusCondition, app.Status.Condition)
+		//THEN
+		assert.Equal(t, filledAppUpdate.Description, app.Description)
+		assert.Equal(t, filledAppUpdate.HealthCheckURL, app.HealthCheckURL)
+		assert.Equal(t, filledAppUpdate.IntegrationSystemID, app.IntegrationSystemID)
+		assert.Equal(t, filledAppUpdate.ProviderName, app.ProviderName)
+		assert.Equal(t, *filledAppUpdate.StatusCondition, app.Status.Condition)
+	})
+
+	t.Run("does not override values when input is missing", func(t *testing.T) {
+		//GIVEN
+		timestamp := time.Now()
+		statusCondition := model.ApplicationStatusConditionConnected
+		filledAppUpdate := model.ApplicationUpdateInput{
+			StatusCondition: &statusCondition,
+		}
+
+		app := model.Application{
+			ProviderName:        str.Ptr(providerName),
+			Description:         str.Ptr(description),
+			HealthCheckURL:      str.Ptr(healthCheckURL),
+			IntegrationSystemID: str.Ptr(intSysID),
+		}
+
+		//WHEN
+		app.SetFromUpdateInput(filledAppUpdate, timestamp)
+
+		//THEN
+		assert.Equal(t, description, *app.Description)
+		assert.Equal(t, healthCheckURL, *app.HealthCheckURL)
+		assert.Equal(t, intSysID, *app.IntegrationSystemID)
+		assert.Equal(t, providerName, *app.ProviderName)
+		assert.Equal(t, *filledAppUpdate.StatusCondition, app.Status.Condition)
+	})
 }


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- fix update app mutation clearing already present fields on application if values are not provided during update mutation

**Steps to Reproduce**
- create application with description, provider, healthURL and integration system id
- update the application by only changing the statuus to Connected. Verify that with the fix, description, provider, healthURL and integration system id are not reseted.