### PR TITLE
Add labels to long named test definitions

### DIFF
--- a/chart/compass/charts/connectivity-adapter/templates/tests/tests.yaml
+++ b/chart/compass/charts/connectivity-adapter/templates/tests/tests.yaml
@@ -12,6 +12,9 @@ metadata:
 spec:
   disableConcurrency: false
   template:
+    metadata:
+      labels:
+        app: {{ .Chart.Name }}-tests
     spec:
       {{ if .Values.global.isLocalEnv }}
       hostAliases:

--- a/chart/compass/charts/connector/templates/tests/test-connector.yaml
+++ b/chart/compass/charts/connector/templates/tests/test-connector.yaml
@@ -12,6 +12,9 @@ metadata:
 spec:
   disableConcurrency: true
   template:
+    metadata:
+      labels:
+        app: {{ .Chart.Name }}-tests
     spec:
       serviceAccountName: {{ template "fullname" . }}-tests
       containers:

--- a/chart/compass/templates/director-api-test.yaml
+++ b/chart/compass/templates/director-api-test.yaml
@@ -14,7 +14,7 @@ spec:
       annotations:
         sidecar.istio.io/inject: "true"
       labels:
-        app: {{ .Chart.Name }}-tests-director-api
+        app: {{ .Chart.Name }}-director-api-tests
     spec:
       {{ if .Values.global.isLocalEnv }}
       hostAliases:

--- a/chart/compass/templates/director-api-test.yaml
+++ b/chart/compass/templates/director-api-test.yaml
@@ -13,6 +13,8 @@ spec:
     metadata:
       annotations:
         sidecar.istio.io/inject: "true"
+      labels:
+        app: {{ .Chart.Name }}-tests-director-api
     spec:
       {{ if .Values.global.isLocalEnv }}
       hostAliases:

--- a/chart/compass/templates/director-gateway-integration-test.yaml
+++ b/chart/compass/templates/director-gateway-integration-test.yaml
@@ -15,7 +15,7 @@ spec:
       annotations:
         sidecar.istio.io/inject: "true"
       labels:
-        app: {{ .Chart.Name }}-tests-director-gateway-integration
+        app: {{ .Chart.Name }}-director-gateway-integration-tests
     spec:
       {{ if .Values.global.isLocalEnv }}
       hostAliases:

--- a/chart/compass/templates/director-gateway-integration-test.yaml
+++ b/chart/compass/templates/director-gateway-integration-test.yaml
@@ -14,6 +14,8 @@ spec:
     metadata:
       annotations:
         sidecar.istio.io/inject: "true"
+      labels:
+        app: {{ .Chart.Name }}-tests
     spec:
       {{ if .Values.global.isLocalEnv }}
       hostAliases:

--- a/chart/compass/templates/director-gateway-integration-test.yaml
+++ b/chart/compass/templates/director-gateway-integration-test.yaml
@@ -15,7 +15,7 @@ spec:
       annotations:
         sidecar.istio.io/inject: "true"
       labels:
-        app: {{ .Chart.Name }}-tests
+        app: {{ .Chart.Name }}-tests-director-gateway-integration
     spec:
       {{ if .Values.global.isLocalEnv }}
       hostAliases:

--- a/chart/compass/templates/gateway-external-services-integration.yaml
+++ b/chart/compass/templates/gateway-external-services-integration.yaml
@@ -15,6 +15,8 @@ spec:
     metadata:
       annotations:
         sidecar.istio.io/inject: "true"
+      labels:
+        app: {{ .Chart.Name }}-tests
     spec:
       {{ if .Values.global.isLocalEnv }}
       hostAliases:

--- a/chart/compass/templates/gateway-external-services-integration.yaml
+++ b/chart/compass/templates/gateway-external-services-integration.yaml
@@ -16,7 +16,7 @@ spec:
       annotations:
         sidecar.istio.io/inject: "true"
       labels:
-        app: {{ .Chart.Name }}-tests
+        app: {{ .Chart.Name }}-tests-gateway-external-services-integration
     spec:
       {{ if .Values.global.isLocalEnv }}
       hostAliases:

--- a/chart/compass/templates/gateway-external-services-integration.yaml
+++ b/chart/compass/templates/gateway-external-services-integration.yaml
@@ -16,7 +16,7 @@ spec:
       annotations:
         sidecar.istio.io/inject: "true"
       labels:
-        app: {{ .Chart.Name }}-tests-gateway-external-services-integration
+        app: {{ .Chart.Name }}-gateway-external-services-integration-tests
     spec:
       {{ if .Values.global.isLocalEnv }}
       hostAliases:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Istio in version 1.5 adds labels to pods without app label based on a pod name. Pods cannot be scheduled when test definition name is too long, because the label exceeds the length of 63 characters.

Changes proposed in this pull request:

- Add label app

**Related issue(s)**
https://github.com/kyma-project/kyma/pull/8898
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
