### PR TITLE
Wait for healthy connection on bootstrap

### DIFF
--- a/chart/compass/charts/connector/templates/certs-setup-job.yaml
+++ b/chart/compass/charts/connector/templates/certs-setup-job.yaml
@@ -4,9 +4,6 @@ kind: Job
 metadata:
   name: {{ .Chart.Name }}-certs-setup-job
   namespace: {{ .Release.Namespace }}
-  annotations:
-    helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
   labels:
     release: {{ .Release.Name }}
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}

--- a/chart/compass/charts/connector/templates/deployment.yaml
+++ b/chart/compass/charts/connector/templates/deployment.yaml
@@ -93,6 +93,10 @@ spec:
               value: "https://{{ .Values.global.gateway.mtls.host }}.{{ .Values.global.ingress.domainName }}/director/graphql"
             - name: APP_CERTIFICATE_SECURED_CONNECTOR_URL
               value: "https://{{ .Values.global.gateway.mtls.host }}.{{ .Values.global.ingress.domainName }}/connector/graphql"
+            - name: APP_KUBERNETES_CLIENT_POLL_INTERVAL
+              value: {{ .Values.deployment.kubernetesClient.pollInterval | quote }}
+            - name: APP_KUBERNETES_CLIENT_POLL_TIMEOUT
+              value: {{ .Values.deployment.kubernetesClient.pollTimeout | quote }}
           {{- with .Values.deployment.securityContext }}
           securityContext:
 {{ toYaml . | indent 12 }}

--- a/chart/compass/charts/connector/values.yaml
+++ b/chart/compass/charts/connector/values.yaml
@@ -16,6 +16,9 @@ deployment:
       province: "province"
     certificateValidityTime: "2160h"
     attachRootCAToChain: false
+  kubernetesClient:
+    pollInterval: 2s
+    pollTimeout: 1m
 
   strategy: {} # Read more: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
 

--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -14,7 +14,7 @@ global:
       path: eu.gcr.io/kyma-project/incubator
     connector:
       dir:
-      version: "PR-1529"
+      version: "PR-1538"
     connectivity_adapter:
       dir:
       version: "PR-1480"

--- a/components/connector/Gopkg.lock
+++ b/components/connector/Gopkg.lock
@@ -683,6 +683,7 @@
     "k8s.io/apimachinery/pkg/api/errors",
     "k8s.io/apimachinery/pkg/apis/meta/v1",
     "k8s.io/apimachinery/pkg/types",
+    "k8s.io/apimachinery/pkg/util/wait",
     "k8s.io/client-go/kubernetes",
     "k8s.io/client-go/kubernetes/fake",
     "k8s.io/client-go/plugin/pkg/client/auth/gcp",

--- a/components/connector/config/config.go
+++ b/components/connector/config/config.go
@@ -43,6 +43,10 @@ type Config struct {
 
 	DirectorURL                    string `envconfig:"default=127.0.0.1:3003"`
 	CertificateSecuredConnectorURL string `envconfig:"default=https://compass-gateway-mtls.kyma.local"`
+	KubernetesClient               struct {
+		PollInteval time.Duration `envconfig:"default=2s"`
+		PollTimeout time.Duration `envconfig:"default=1m"`
+	}
 }
 
 func (c *Config) String() string {
@@ -54,7 +58,8 @@ func (c *Config) String() string {
 		"CertificateSecuredConnectorURL: %s, "+
 		"RevocationConfigMapName: %s, "+
 		"TokenLength: %d, TokenRuntimeExpiration: %s, TokenApplicationExpiration: %s, TokenCSRExpiration: %s, "+
-		"DirectorURL: %s",
+		"DirectorURL: %s "+
+		"KubernetesClientPollInteval: %s, KubernetesClientPollTimeout: %s",
 		c.ExternalAddress, c.InternalAddress, c.APIEndpoint, c.HydratorAddress,
 		c.CSRSubject.Country, c.CSRSubject.Organization, c.CSRSubject.OrganizationalUnit,
 		c.CSRSubject.Locality, c.CSRSubject.Province,
@@ -63,5 +68,6 @@ func (c *Config) String() string {
 		c.CertificateSecuredConnectorURL,
 		c.RevocationConfigMapName,
 		c.Token.Length, c.Token.RuntimeExpiration.String(), c.Token.ApplicationExpiration.String(), c.Token.CSRExpiration.String(),
-		c.DirectorURL)
+		c.DirectorURL,
+		c.KubernetesClient.PollInteval, c.KubernetesClient.PollTimeout)
 }


### PR DESCRIPTION
Description

Changes proposed in this pull request:

- certs-setup-job.yaml is modified, job is no longer post-install hook. That way cert secrets will be created during the installation of the connector helm chart. This job is triggered only on local dev and its purpose is to generate the cert secrets.
- wait for healthy connection with api-server on bootstrap (configuration is added)

Related issue(s)
See #1515