### PR TITLE
Introduce automatic error logging in connector

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -14,7 +14,7 @@ global:
       path: eu.gcr.io/kyma-project/incubator
     connector:
       dir:
-      version: "PR-1538"
+      version: "PR-1540"
     connectivity_adapter:
       dir:
       version: "PR-1480"
@@ -23,7 +23,7 @@ global:
       version: "PR-1460"
     director:
       dir:
-      version: "PR-1529"
+      version: "PR-1540"
     gateway:
       dir:
       version: "PR-1460"

--- a/components/connector/Gopkg.lock
+++ b/components/connector/Gopkg.lock
@@ -91,6 +91,14 @@
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:ffe5ba52b122a56df4f9854ea2918e0d9f86e74919db63dc138f8fee3253d3d6"
+  name = "github.com/google/uuid"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "0e4e31197428a347842d152773b4cace4645ca25"
+  version = "v1.1.2"
+
+[[projects]]
   digest = "1:ca4524b4855ded427c7003ec903a5c854f37e7b1e8e2a93277243462c5b753a8"
   name = "github.com/googleapis/gnostic"
   packages = [
@@ -212,9 +220,12 @@
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:04457f9f6f3ffc5fea48e71d62f2ca256637dee0a04d710288e27e05c8b41976"
+  digest = "1:31538f8d774e8bf2fb9380d2d2a82d69e206a7d0603946586926f1819c546c26"
   name = "github.com/sirupsen/logrus"
-  packages = ["."]
+  packages = [
+    ".",
+    "hooks/test",
+  ]
   pruneopts = "UT"
   revision = "839c75faf7f98a33d445d181f3018b5c3409a45e"
   version = "v1.4.2"
@@ -666,17 +677,20 @@
     "github.com/99designs/gqlgen/graphql",
     "github.com/99designs/gqlgen/graphql/introspection",
     "github.com/99designs/gqlgen/handler",
+    "github.com/google/uuid",
     "github.com/gorilla/mux",
     "github.com/kisielk/errcheck",
     "github.com/machinebox/graphql",
     "github.com/patrickmn/go-cache",
     "github.com/pkg/errors",
     "github.com/sirupsen/logrus",
+    "github.com/sirupsen/logrus/hooks/test",
     "github.com/stretchr/testify/assert",
     "github.com/stretchr/testify/mock",
     "github.com/stretchr/testify/require",
     "github.com/vektah/gqlparser",
     "github.com/vektah/gqlparser/ast",
+    "github.com/vektah/gqlparser/gqlerror",
     "github.com/vrischmann/envconfig",
     "golang.org/x/tools/cmd/goimports",
     "k8s.io/api/core/v1",

--- a/components/connector/cmd/main.go
+++ b/components/connector/cmd/main.go
@@ -6,6 +6,9 @@ import (
 	"sync"
 	"time"
 
+	"github.com/kyma-incubator/compass/components/connector/internal/error_presenter"
+	"github.com/kyma-incubator/compass/components/connector/internal/uid"
+
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	"github.com/kyma-incubator/compass/components/connector/config"
@@ -49,8 +52,10 @@ func main() {
 
 	authContextMiddleware := authentication.NewAuthenticationContextMiddleware()
 
-	externalGqlServer := config.PrepareExternalGraphQLServer(cfg, certificateResolver, authContextMiddleware.PropagateAuthentication)
-	internalGqlServer := config.PrepareInternalGraphQLServer(cfg, tokenResolver)
+	presenter := error_presenter.NewPresenter(logrus.StandardLogger(), uid.NewService())
+
+	externalGqlServer := config.PrepareExternalGraphQLServer(cfg, certificateResolver, authContextMiddleware.PropagateAuthentication, presenter)
+	internalGqlServer := config.PrepareInternalGraphQLServer(cfg, tokenResolver, presenter)
 	hydratorServer := config.PrepareHydratorServer(cfg, internalComponents.TokenService, internalComponents.SubjectConsts, internalComponents.RevocationsRepository)
 
 	wg := &sync.WaitGroup{}

--- a/components/connector/internal/api/token_resolver.go
+++ b/components/connector/internal/api/token_resolver.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/kyma-incubator/compass/components/connector/internal/tokens"
 	"github.com/kyma-incubator/compass/components/connector/pkg/graphql/externalschema"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -32,8 +31,7 @@ func (r *tokenResolver) GenerateApplicationToken(ctx context.Context, appID stri
 
 	token, err := r.tokenService.CreateToken(appID, tokens.ApplicationToken)
 	if err != nil {
-		r.log.Errorf("Error occurred while creating one-time token for Application with id %s : %s ", appID, err.Error())
-		return &externalschema.Token{}, errors.Wrap(err, "Failed to create one-time token for Application")
+		return &externalschema.Token{}, err.Append("Error occurred while creating one-time token for Application with id %s", appID)
 	}
 
 	r.log.Infof("One-time token generated successfully for Application with id %s", appID)
@@ -45,8 +43,7 @@ func (r *tokenResolver) GenerateRuntimeToken(ctx context.Context, runtimeID stri
 
 	token, err := r.tokenService.CreateToken(runtimeID, tokens.RuntimeToken)
 	if err != nil {
-		r.log.Errorf("Error occurred while creating one-time token for Runtime with id %s : %s ", runtimeID, err.Error())
-		return &externalschema.Token{}, errors.Wrap(err, "Failed to create one-time token for Runtime")
+		return &externalschema.Token{}, err.Append("Error occurred while creating one-time token for Runtime with id %s", runtimeID)
 	}
 
 	r.log.Infof("One-time token generated successfully for Runtime with id %s", runtimeID)

--- a/components/connector/internal/authentication/context.go
+++ b/components/connector/internal/authentication/context.go
@@ -2,8 +2,8 @@ package authentication
 
 import (
 	"context"
-	"errors"
-	"fmt"
+
+	"github.com/kyma-incubator/compass/components/connector/internal/apperrors"
 )
 
 type ContextKey string
@@ -16,12 +16,12 @@ const (
 	ClientCertificateHashKey   ContextKey = "ClientCertificateHash"
 )
 
-func GetStringFromContext(ctx context.Context, key ContextKey) (string, error) {
+func GetStringFromContext(ctx context.Context, key ContextKey) (string, apperrors.AppError) {
 	value := ctx.Value(key)
 
 	str, ok := value.(string)
 	if !ok {
-		return "", errors.New(fmt.Sprintf("Cannot read %s key from context", string(key)))
+		return "", apperrors.NotAuthenticated("Cannot read %s key from context", string(key))
 	}
 
 	return str, nil

--- a/components/connector/internal/certificates/service.go
+++ b/components/connector/internal/certificates/service.go
@@ -45,15 +45,13 @@ func NewCertificateService(
 func (svc *certificateService) SignCSR(encodedCSR []byte, subject CSRSubject) (EncodedCertificateChain, apperrors.AppError) {
 	csr, err := svc.certUtil.LoadCSR(encodedCSR)
 	if err != nil {
-		log.Errorf("Error occurred while loading the CSR with Common Name %s", subject.CommonName)
-		return EncodedCertificateChain{}, err
+		return EncodedCertificateChain{}, err.Append("Error occurred while loading the CSR with Common Name %s", subject.CommonName)
 	}
 	log.Debugf("Successfully loaded the CSR with Common Name %s", subject.CommonName)
 
 	err = svc.checkCSR(csr, subject)
 	if err != nil {
-		log.Errorf("Error occurred while checking the values of the CSR with Common Name %s", subject.CommonName)
-		return EncodedCertificateChain{}, err
+		return EncodedCertificateChain{}, err.Append("Error occurred while checking the values of the CSR with Common Name %s", subject.CommonName)
 	}
 	log.Debugf("Successfully checked the values of the CSR with Common Name %s", subject.CommonName)
 

--- a/components/connector/internal/error_presenter/presenter.go
+++ b/components/connector/internal/error_presenter/presenter.go
@@ -1,0 +1,52 @@
+package error_presenter
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/kyma-incubator/compass/components/connector/internal/apperrors"
+
+	log "github.com/sirupsen/logrus"
+
+	"github.com/99designs/gqlgen/graphql"
+	"github.com/vektah/gqlparser/gqlerror"
+)
+
+type UUIDService interface {
+	Generate() string
+}
+
+type Presenter struct {
+	uuidService UUIDService
+	Logger      *log.Logger
+}
+
+func NewPresenter(logger *log.Logger, service UUIDService) *Presenter {
+	return &Presenter{Logger: logger, uuidService: service}
+}
+
+func (p *Presenter) Do(ctx context.Context, err error) *gqlerror.Error {
+	customErr := apperrors.Error{}
+	errID := p.uuidService.Generate()
+	if found := errors.As(err, &customErr); !found {
+		p.Logger.WithField("errorID", errID).Infof("Unknown error: %s", err.Error())
+		return newGraphqlErrorResponse(ctx, errID, "Internal Server Error")
+	}
+
+	if apperrors.ErrorCode(customErr) == apperrors.CodeInternal {
+		p.Logger.WithField("errorID", errID).Infof("Internal Server Error: %s", err.Error())
+		return newGraphqlErrorResponse(ctx, errID, "Internal Server Error")
+	}
+
+	p.Logger.WithField("errorID", errID).Info(err.Error())
+	return newGraphqlErrorResponse(ctx, errID, err.Error())
+}
+
+func newGraphqlErrorResponse(ctx context.Context, errID string, msg string, args ...interface{}) *gqlerror.Error {
+	return &gqlerror.Error{
+		Message:    fmt.Sprintf(msg, args...),
+		Path:       graphql.GetResolverContext(ctx).Path(),
+		Extensions: map[string]interface{}{"error_id": errID},
+	}
+}

--- a/components/connector/internal/error_presenter/presenter_test.go
+++ b/components/connector/internal/error_presenter/presenter_test.go
@@ -1,0 +1,64 @@
+package error_presenter_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/kyma-incubator/compass/components/connector/internal/apperrors"
+
+	"github.com/kyma-incubator/compass/components/connector/internal/error_presenter"
+	"github.com/kyma-incubator/compass/components/connector/internal/uid"
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/require"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPresenter_ErrorPresenter(t *testing.T) {
+	//given
+	errMsg := "testErr"
+	uidSvc := uid.NewService()
+	log, hook := test.NewNullLogger()
+	presenter := error_presenter.NewPresenter(log, uidSvc)
+
+	t.Run("Unknown error", func(t *testing.T) {
+		//when
+		err := presenter.Do(context.TODO(), errors.New(errMsg))
+
+		//then
+		entry := hook.LastEntry()
+		require.NotNil(t, entry)
+		assert.Equal(t, fmt.Sprintf("Unknown error: %s", errMsg), entry.Message)
+		assert.Contains(t, err.Error(), "Internal Server Error")
+		hook.Reset()
+	})
+
+	t.Run("Internal Error", func(t *testing.T) {
+		//given
+		customErr := apperrors.Internal(errMsg)
+
+		//when
+		err := presenter.Do(context.TODO(), customErr)
+
+		//then
+		entry := hook.LastEntry()
+		require.NotNil(t, entry)
+		assert.Equal(t, fmt.Sprintf("Internal Server Error: %s", errMsg), entry.Message)
+		assert.Contains(t, err.Error(), "Internal Server Error")
+		hook.Reset()
+	})
+
+	t.Run("Not Authenticated", func(t *testing.T) {
+		//given
+		customErr := apperrors.NotAuthenticated(errMsg)
+
+		//when
+		err := presenter.Do(context.TODO(), customErr)
+
+		//then
+		assert.EqualError(t, err, fmt.Sprint("input: ", errMsg))
+		hook.Reset()
+	})
+}

--- a/components/connector/internal/panic_handler/panic_handler.go
+++ b/components/connector/internal/panic_handler/panic_handler.go
@@ -1,0 +1,14 @@
+package panic_handler
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/kyma-incubator/compass/components/connector/internal/apperrors"
+)
+
+func RecoverFn(ctx context.Context, err interface{}) error {
+	errText := fmt.Sprintf("%+v", err)
+
+	return apperrors.Internal(errText)
+}

--- a/components/connector/internal/uid/service.go
+++ b/components/connector/internal/uid/service.go
@@ -1,0 +1,13 @@
+package uid
+
+import "github.com/google/uuid"
+
+type service struct{}
+
+func NewService() *service {
+	return &service{}
+}
+
+func (s *service) Generate() string {
+	return uuid.New().String()
+}

--- a/components/connector/pkg/graphql/clientset/clientset_main_test.go
+++ b/components/connector/pkg/graphql/clientset/clientset_main_test.go
@@ -5,6 +5,10 @@ import (
 	"fmt"
 	"io/ioutil"
 
+	"github.com/kyma-incubator/compass/components/connector/internal/error_presenter"
+	"github.com/kyma-incubator/compass/components/connector/internal/uid"
+	"github.com/sirupsen/logrus"
+
 	"k8s.io/client-go/kubernetes"
 
 	v1 "k8s.io/api/core/v1"
@@ -117,7 +121,9 @@ func TestMain(m *testing.M) {
 		})
 	}
 
-	externalGqlServer := config.PrepareExternalGraphQLServer(cfg, certificateResolver, authContextTestMiddleware)
+	presenter := error_presenter.NewPresenter(logrus.StandardLogger(), uid.NewService())
+
+	externalGqlServer := config.PrepareExternalGraphQLServer(cfg, certificateResolver, authContextTestMiddleware, presenter)
 	externalGqlServer.TLSConfig = &tls.Config{ClientAuth: tls.RequestClientCert}
 
 	go func() {

--- a/components/director/internal/domain/apptemplate/resolver.go
+++ b/components/director/internal/domain/apptemplate/resolver.go
@@ -188,7 +188,6 @@ func (r *Resolver) RegisterApplicationFromTemplate(ctx context.Context, in graph
 
 	ctx = persistence.SaveToContext(ctx, tx)
 
-	//log.Infof("Registering an Application from Application Template with name %s", in.TemplateName)
 	convertedIn := r.appTemplateConverter.ApplicationFromTemplateInputFromGraphQL(in)
 
 	log.Debugf("Extracting Application Template with name %s from GraphQL input", in.TemplateName)


### PR DESCRIPTION
**Description**

This PR introduces automatic logging of the returned errors. Until now each error must have been logged manually before it being returned which causes double maintenance.

Changes proposed in this pull request:
- Addition of `error_presenter` and `panic_handler` components similar to the ones in the Director for consistency reasons
- Several adaptations of the error handling according to the new changes
