### PR TITLE
Remove checking if request certificate is present on revocation list

### DIFF
--- a/components/connector/pkg/oathkeeper/validation_hydrator.go
+++ b/components/connector/pkg/oathkeeper/validation_hydrator.go
@@ -93,18 +93,6 @@ func (tvh *validationHydrator) ResolveIstioCertHeader(w http.ResponseWriter, r *
 		return
 	}
 
-	isCertificateRevoked, err := tvh.revocationList.Contains(hash)
-	if err != nil {
-		tvh.log.Infof("Failed to check if certificate is revoked: %s", err.Error())
-		respondWithAuthSession(w, authSession)
-		return
-	}
-	if isCertificateRevoked {
-		tvh.log.Info("Certificate is revoked.")
-		respondWithAuthSession(w, authSession)
-		return
-	}
-
 	if authSession.Header == nil {
 		authSession.Header = map[string][]string{}
 	}

--- a/components/connector/pkg/oathkeeper/validation_hydrator.go
+++ b/components/connector/pkg/oathkeeper/validation_hydrator.go
@@ -92,6 +92,7 @@ func (tvh *validationHydrator) ResolveIstioCertHeader(w http.ResponseWriter, r *
 		respondWithAuthSession(w, authSession)
 		return
 	}
+	// TODO Restore the functionality of verification whether the client certificate has been revoked inside validationHydrator in a safe way, probably with using a caching mechanism.
 
 	if authSession.Header == nil {
 		authSession.Header = map[string][]string{}

--- a/components/connector/pkg/oathkeeper/validation_hydrator_test.go
+++ b/components/connector/pkg/oathkeeper/validation_hydrator_test.go
@@ -224,59 +224,7 @@ func TestValidationHydrator_ResolveIstioCertHeader(t *testing.T) {
 		mock.AssertExpectationsForObjects(t, certHeaderParser)
 	})
 
-	t.Run("should not modify authentication session if certificate is revoked", func(t *testing.T) {
-		// given
-		req, err := http.NewRequest(http.MethodPost, "", bytes.NewBuffer(marshalledSession))
-		require.NoError(t, err)
-		rr := httptest.NewRecorder()
-
-		certHeaderParser := &mocks2.CertificateHeaderParser{}
-		certHeaderParser.On("GetCertificateData", req).Return(clientId, hash, true)
-		revocationList := &revocationMocks.RevocationListRepository{}
-		revocationList.On("Contains", hash).Return(true, nil)
-
-		validator := NewValidationHydrator(nil, certHeaderParser, revocationList)
-
-		// when
-		validator.ResolveIstioCertHeader(rr, req)
-
-		// then
-		assert.Equal(t, http.StatusOK, rr.Code)
-
-		var authSession AuthenticationSession
-		err = json.NewDecoder(rr.Body).Decode(&authSession)
-		require.NoError(t, err)
-
-		assert.Equal(t, emptyAuthSession(), authSession)
-		mock.AssertExpectationsForObjects(t, certHeaderParser)
-	})
-
-	t.Run("should not modify authentication session if failed to read revoked certificates", func(t *testing.T) {
-		// given
-		req, err := http.NewRequest(http.MethodPost, "", bytes.NewBuffer(marshalledSession))
-		require.NoError(t, err)
-		rr := httptest.NewRecorder()
-
-		certHeaderParser := &mocks2.CertificateHeaderParser{}
-		certHeaderParser.On("GetCertificateData", req).Return(clientId, hash, true)
-		revocationList := &revocationMocks.RevocationListRepository{}
-		revocationList.On("Contains", hash).Return(false, errors.Errorf("some error"))
-
-		validator := NewValidationHydrator(nil, certHeaderParser, revocationList)
-
-		// when
-		validator.ResolveIstioCertHeader(rr, req)
-
-		// then
-		assert.Equal(t, http.StatusOK, rr.Code)
-
-		var authSession AuthenticationSession
-		err = json.NewDecoder(rr.Body).Decode(&authSession)
-		require.NoError(t, err)
-
-		assert.Equal(t, emptyAuthSession(), authSession)
-		mock.AssertExpectationsForObjects(t, certHeaderParser)
-	})
+	// TODO: Restore tests for revoked certificates as soon the functionality of verification if certificate is revoked will be restored
 
 	t.Run("should return error when failed to unmarshal authentication session", func(t *testing.T) {
 		// given

--- a/components/connector/pkg/oathkeeper/validation_hydrator_test.go
+++ b/components/connector/pkg/oathkeeper/validation_hydrator_test.go
@@ -7,8 +7,6 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/pkg/errors"
-
 	"github.com/stretchr/testify/mock"
 
 	revocationMocks "github.com/kyma-incubator/compass/components/connector/internal/revocation/mocks"


### PR DESCRIPTION
This PR is workaround for a problem with flooding API server with requests from hydrator for endpoint ` /certificate/data/resolve` from checking certificate hash is present on revocation list. 

The revocation list was implemented with Kubernetes ConfigMap 

Please notice this is only a workaround to maintain production stability. The proper fix will be deployer later on.

