### PR TITLE
Disable audit logging for graphql queries

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -26,7 +26,7 @@ global:
       version: "PR-1529"
     gateway:
       dir:
-      version: "PR-1460"
+      version: "PR-1559"
     healthchecker:
       dir:
       version: "PR-1460"

--- a/components/gateway/pkg/proxy/transport.go
+++ b/components/gateway/pkg/proxy/transport.go
@@ -97,8 +97,8 @@ func checkQueryType(requestBody []byte, typee string) (bool, error) {
 	if !ok {
 		return false, errors.New("query is not a string")
 	}
-
-	if strings.HasPrefix(string(queryString), typee) {
+	queryString = strings.TrimSpace(queryString)
+	if strings.HasPrefix(queryString, typee) {
 		return true, nil
 	}
 	return false, nil


### PR DESCRIPTION
Changes proposed in this pull request:

- Check the type of the graphql query and if it is not a *mutation* do not audit log