### PR TITLE
Use imagePullPolicy: Always for the installer

### DIFF
--- a/installation/resources/installer.yaml
+++ b/installation/resources/installer.yaml
@@ -116,7 +116,7 @@ spec:
       containers:
       - name: compass-installer-container
         image: eu.gcr.io/kyma-project/develop/installer:408cb6a6
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: Always
         env:
           - name: INST_RESOURCE
             value: "compass-installation"


### PR DESCRIPTION
**Description**

Change imagePullPolicy to Always. The changed file(installer.yaml) is used to generate compass-installer.yaml that we use to deploy the compass on the k8s cluster. This change is necessary when we use custom(PR) build compass version, from prow jobs, to ensure we get the latest changes.
