### PR TITLE
Enable local Director debugging through run.sh script

### DIFF
--- a/components/director/run.sh
+++ b/components/director/run.sh
@@ -114,7 +114,7 @@ if [[  ${DEBUG} ]]; then
     PORT=40000
     echo -e "${GREEN}Debug mode activated on port $PORT${NC}"
     cd $GOPATH/src/github.com/kyma-incubator/compass/components/director && \
-    CGO_ENABLED=0 go build ./cmd/director && \
+    CGO_ENABLED=0 go build -gcflags="all=-N -l" ./cmd/director && \
     dlv --listen=:$PORT --headless=true --api-version=2 exec ./director
     rm ./director
 else

--- a/components/director/run.sh
+++ b/components/director/run.sh
@@ -81,14 +81,14 @@ if [[ ${REUSE_DB} = true ]]; then
 else
     set +e
     echo -e "${GREEN}Start Postgres in detached mode${NC}"
-    OUTPUT=$(docker run -d --name ${POSTGRES_CONTAINER} \
+    docker run -d --name ${POSTGRES_CONTAINER} \
                 -e POSTGRES_HOST=${DB_HOST} \
                 -e POSTGRES_USER=${DB_USER} \
                 -e POSTGRES_PASSWORD=${DB_PWD} \
                 -e POSTGRES_DB=${DB_NAME} \
                 -e POSTGRES_PORT=${DB_PORT} \
                 -p ${DB_PORT}:${DB_PORT} \
-                postgres:${POSTGRES_VERSION})
+                postgres:${POSTGRES_VERSION}
 
     if [[ $? -ne 0 ]] ; then
         SKIP_DB_CLEANUP=true

--- a/components/director/run.sh
+++ b/components/director/run.sh
@@ -11,6 +11,9 @@ set -e
 
 ROOT_PATH=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
+SKIP_DB_CLEANUP=false
+REUSE_DB=false
+
 POSITIONAL=()
 while [[ $# -gt 0 ]]
 do
@@ -22,8 +25,22 @@ do
             SKIP_APP_START=true
             shift # past argument
         ;;
+        --skip-db-cleanup)
+            SKIP_DB_CLEANUP=true
+            shift
+        ;;
+        --reuse-db)
+            REUSE_DB=true
+            shift
+        ;;
         --debug)
             DEBUG=true
+            DEBUG_PORT=40000
+            shift
+        ;;
+        --debug-port)
+            DEBUG_PORT=$2
+            shift
             shift
         ;;
         --*)
@@ -33,7 +50,6 @@ do
     esac
 done
 set -- "${POSITIONAL[@]}" # restore positional parameters
-
 
 POSTGRES_CONTAINER="test-postgres"
 POSTGRES_VERSION="11"
@@ -45,48 +61,62 @@ DB_PORT="5432"
 DB_HOST="127.0.0.1"
 
 function cleanup() {
-    echo -e "${GREEN}Cleanup Postgres container${NC}"
-    docker rm --force ${POSTGRES_CONTAINER}
+    if [[ ${DEBUG} ]]; then
+       echo -e "${GREEN}Cleanup Director binary${NC}"
+       rm  $GOPATH/src/github.com/kyma-incubator/compass/components/director/director
+    fi
+
+    if [[ ${SKIP_DB_CLEANUP} = false ]]; then
+        echo -e "${GREEN}Cleanup Postgres container${NC}"
+        docker rm --force ${POSTGRES_CONTAINER}
+    else
+        echo -e "${GREEN}Skipping Postgres container cleanup${NC}"
+    fi
 }
 
 trap cleanup EXIT
 
-echo -e "${GREEN}Start Postgres in detached mode${NC}"
-docker run -d --name ${POSTGRES_CONTAINER} \
-            -e POSTGRES_HOST=${DB_HOST} \
-            -e POSTGRES_USER=${DB_USER} \
-            -e POSTGRES_PASSWORD=${DB_PWD} \
-            -e POSTGRES_DB=${DB_NAME} \
-            -e POSTGRES_PORT=${DB_PORT} \
-            -p ${DB_PORT}:${DB_PORT} \
-            postgres:${POSTGRES_VERSION}
 
-set +e
-echo '# WAITING FOR CONNECTION WITH DATABASE #'
-for i in {1..30}
-do
-    docker exec ${POSTGRES_CONTAINER} pg_isready -U "${DB_USER}" -h "${DB_HOST}" -p "${DB_PORT}" -d "${DB_NAME}"
-    if [ $? -eq 0 ]
-    then
-        dbReady=true
-        break
+if [[ ${REUSE_DB} = true ]]; then
+    echo -e "${GREEN}Will reuse existing Postgres container${NC}"
+else
+    echo -e "${GREEN}Start Postgres in detached mode${NC}"
+    docker run -d --name ${POSTGRES_CONTAINER} \
+                -e POSTGRES_HOST=${DB_HOST} \
+                -e POSTGRES_USER=${DB_USER} \
+                -e POSTGRES_PASSWORD=${DB_PWD} \
+                -e POSTGRES_DB=${DB_NAME} \
+                -e POSTGRES_PORT=${DB_PORT} \
+                -p ${DB_PORT}:${DB_PORT} \
+                postgres:${POSTGRES_VERSION}
+
+    set +e
+    echo '# WAITING FOR CONNECTION WITH DATABASE #'
+    for i in {1..30}
+    do
+        docker exec ${POSTGRES_CONTAINER} pg_isready -U "${DB_USER}" -h "${DB_HOST}" -p "${DB_PORT}" -d "${DB_NAME}"
+        if [ $? -eq 0 ]
+        then
+            dbReady=true
+            break
+        fi
+        sleep 1
+    done
+
+    if [ "${dbReady}" != true ] ; then
+        echo '# COULD NOT ESTABLISH CONNECTION TO DATABASE #'
+        exit 1
     fi
-    sleep 1
-done
 
-if [ "${dbReady}" != true ] ; then
-    echo '# COULD NOT ESTABLISH CONNECTION TO DATABASE #'
-    exit 1
+    set -e
+
+    echo -e "${GREEN}Populate DB${NC}"
+
+    cat ${ROOT_PATH}/../schema-migrator/migrations/director/*.up.sql | \
+        docker exec -i ${POSTGRES_CONTAINER} psql -U "${DB_USER}" -h "${DB_HOST}" -p "${DB_PORT}" -d "${DB_NAME}"
+    cat ${ROOT_PATH}/../schema-migrator/seeds/director/*.sql | \
+        docker exec -i ${POSTGRES_CONTAINER} psql -U "${DB_USER}" -h "${DB_HOST}" -p "${DB_PORT}" -d "${DB_NAME}"
 fi
-
-set -e
-
-echo -e "${GREEN}Populate DB${NC}"
-
-cat ${ROOT_PATH}/../schema-migrator/migrations/director/*.up.sql | \
-    docker exec -i ${POSTGRES_CONTAINER} psql -U "${DB_USER}" -h "${DB_HOST}" -p "${DB_PORT}" -d "${DB_NAME}"
-cat ${ROOT_PATH}/../schema-migrator/seeds/director/*.sql | \
-    docker exec -i ${POSTGRES_CONTAINER} psql -U "${DB_USER}" -h "${DB_HOST}" -p "${DB_PORT}" -d "${DB_NAME}"
 
 if [[  ${SKIP_APP_START} ]]; then
     echo -e "${GREEN}Skipping starting application${NC}"
@@ -111,12 +141,10 @@ export APP_CONNECTOR_URL="http://connector.not.configured.url/graphql"
 export APP_LEGACY_CONNECTOR_URL="https://adapter-gateway.kyma.local/v1/applications/signingRequests/info"
 
 if [[  ${DEBUG} ]]; then
-    PORT=40000
-    echo -e "${GREEN}Debug mode activated on port $PORT${NC}"
-    cd $GOPATH/src/github.com/kyma-incubator/compass/components/director && \
-    CGO_ENABLED=0 go build -gcflags="all=-N -l" ./cmd/director && \
-    dlv --listen=:$PORT --headless=true --api-version=2 exec ./director
-    rm ./director
+    echo -e "${GREEN}Debug mode activated on port $DEBUG_PORT${NC}"
+    cd $GOPATH/src/github.com/kyma-incubator/compass/components/director
+    CGO_ENABLED=0 go build -gcflags="all=-N -l" ./cmd/director
+    dlv --listen=:$DEBUG_PORT --headless=true --api-version=2 exec ./director
 else
     go run ${ROOT_PATH}/cmd/director/main.go
 fi


### PR DESCRIPTION
**Description**

Currently the Director component can be run standalone through the `run.sh` script in its component folder.
This PR adds the `--debug` flag to the `run.sh` script so that Director could be debugged easily as well.

Running the script with `--debug` flag starts a debug process on port 40000 on your `localhost` which will wait for you to attach and start debugging. To attach from your IDE you have to create a **Go Remote** run configuration like so:

![image](https://user-images.githubusercontent.com/15074116/97574986-b7206400-19f4-11eb-9501-30ef7a911a43.png)

More information on how to do that here: https://www.jetbrains.com/help/go/attach-to-running-go-processes-with-debugger.html#step-4-start-the-debugging-process-on-the-client-computer

Having the runtime configuration you are set:
1. Run `./run.sh --debug`
2. Run your remote run configuration in your IDE in debug mode

You should now be able to place breakpoints and debug the Director code.

Other useful flags added:
- `--debug-port <port>` - allows you to specify on which port the debug process will run;
- `--skip-db-cleanup` - allows you to choose if you want to skip the cleanup of the postgres container at the end of the process;
- `--reuse-db` - allows you to specify that you want to reuse an existing already running postgres container.

> **NOTE:** _Cleanup will be skipped in the cases when an existing postgres container exists even if the flag is not provided. This is so that you don't accidentally remove your existing postgres container._