### PR TITLE
Forbid deletion of Scenario in Compass UI if there are existing associated runtimes

### DIFF
--- a/components/console/compass/src/components/Scenarios/ScenarioDetails/ScenarioDetails.js
+++ b/components/console/compass/src/components/Scenarios/ScenarioDetails/ScenarioDetails.js
@@ -13,12 +13,16 @@ ScenarioDetails.propTypes = {
 
 export default function ScenarioDetails({ scenarioName }) {
   const [applicationsCount, setApplicationsCount] = useState(0);
+  const [runtimesCount, setRuntimesCount] = useState(0);
 
   return (
     <ScenarioNameContext.Provider value={scenarioName}>
-      <ScenarioDetailsHeader applicationsCount={applicationsCount} />
+      <ScenarioDetailsHeader
+        applicationsCount={applicationsCount}
+        runtimesCount={runtimesCount}
+      />
       <ScenarioApplications updateApplicationsCount={setApplicationsCount} />
-      <ScenarioRuntimes />
+      <ScenarioRuntimes updateRuntimesCount={setRuntimesCount} />
     </ScenarioNameContext.Provider>
   );
 }

--- a/components/console/compass/src/components/Scenarios/ScenarioDetails/ScenarioDetailsHeader/ScenarioDetailsHeader.js
+++ b/components/console/compass/src/components/Scenarios/ScenarioDetails/ScenarioDetailsHeader/ScenarioDetailsHeader.js
@@ -36,7 +36,10 @@ function createNewInputForDeleteScenarioMutation(
   };
 }
 
-export default function ScenarioDetailsHeader({ applicationsCount }) {
+export default function ScenarioDetailsHeader({
+  applicationsCount,
+  runtimesCount,
+}) {
   const scenarioName = useContext(ScenarioNameContext);
 
   const { data: scenariosLabelSchema, error, loading } = useQuery(
@@ -54,7 +57,8 @@ export default function ScenarioDetailsHeader({ applicationsCount }) {
   const canDelete = () => {
     return (
       nonDeletableScenarioNames.includes(scenarioName) ||
-      applicationsCount !== 0
+      applicationsCount !== 0 ||
+      runtimesCount !== 0
     );
   };
 

--- a/components/console/compass/src/components/Scenarios/ScenarioDetails/ScenarioRuntimes/ScenarioRuntimes.component.js
+++ b/components/console/compass/src/components/Scenarios/ScenarioDetails/ScenarioRuntimes/ScenarioRuntimes.component.js
@@ -19,6 +19,7 @@ export default function ScenarioRuntimes({
   getRuntimesForScenario,
   setRuntimeScenarios,
   deleteRuntimeScenarios,
+  updateRuntimesCount,
 }) {
   const [sendNotification] = useMutation(SEND_NOTIFICATION);
 
@@ -62,6 +63,7 @@ export default function ScenarioRuntimes({
   ];
 
   const assignedRuntimes = getRuntimesForScenario.runtimes.data;
+  updateRuntimesCount(getRuntimesForScenario.runtimes.totalCount);
 
   const extraHeaderContent = (
     <AssignEntityToScenarioModal

--- a/components/console/compass/src/components/Scenarios/ScenarioDetails/ScenarioRuntimes/test/ScenarioRuntimes.test.js
+++ b/components/console/compass/src/components/Scenarios/ScenarioDetails/ScenarioRuntimes/test/ScenarioRuntimes.test.js
@@ -19,6 +19,7 @@ describe('ScenarioRuntimes', () => {
         deleteRuntimeScenarios={() => {}}
         setRuntimeScenarios={() => {}}
         sendNotification={() => {}}
+        updateRuntimesCount={() => {}}
       />,
     );
 

--- a/components/console/compass/src/components/Scenarios/ScenarioDetails/test/__snapshots__/ScenarioDetails.test.js.snap
+++ b/components/console/compass/src/components/Scenarios/ScenarioDetails/test/__snapshots__/ScenarioDetails.test.js.snap
@@ -6,10 +6,13 @@ exports[`ScenarioDetailsHeader Renders with minimal props 1`] = `
 >
   <ScenarioDetailsHeader
     applicationsCount={0}
+    runtimesCount={0}
   />
   <ScenarioApplications
     updateApplicationsCount={[Function]}
   />
-  <fromRenderProps(Apollo(Apollo(Apollo(Apollo(ScenarioRuntimes))))) />
+  <fromRenderProps(Apollo(Apollo(Apollo(Apollo(ScenarioRuntimes)))))
+    updateRuntimesCount={[Function]}
+  />
 </ContextProvider>
 `;


### PR DESCRIPTION
# Overview

This PR fixes the bug where the **Delete** scenario button would be clickable if there are existing runtimes associated with the scenario.

The bug would allow clicking **Delete** which resulted in a failed **updateLabelDefinition** backend request ultimately failing to delete the scenario anyway (but the Compass UI makes it look for a moment as if it was successful, not showing any errors at all).

![image](https://user-images.githubusercontent.com/15074116/97802636-6f484980-1c4d-11eb-9413-e67f1f9071f0.png)