### PR TITLE
Fix CloudSQL Proxy throttling issue with Tenant Fetcher

### DIFF
--- a/chart/compass/charts/director/templates/tenant-loader-cronjob-external.yaml
+++ b/chart/compass/charts/director/templates/tenant-loader-cronjob-external.yaml
@@ -68,12 +68,9 @@ spec:
                             - "./tenantloader; exit_code=$?; sleep 5; echo '# KILLING PILOT-AGENT #'; pkill -INT cloud_sql_proxy; curl -XPOST http://127.0.0.1:15020/quitquitquit; sleep 5; exit $exit_code;"
                       {{if eq .Values.global.database.embedded.enabled false}}
                         - name: cloudsql-proxy
-                          image: gcr.io/cloudsql-docker/gce-proxy:1.14
+                          image: gcr.io/cloudsql-docker/gce-proxy:1.16
                           command:
-                            - /bin/sh
-                          args:
-                            - -c
-                            - "trap 'exit 0' SIGINT; /cloud_sql_proxy -instances={{ .Values.global.database.managedGCP.instanceConnectionName }}=tcp:5432 -credential_file=/secrets/cloudsql-instance-credentials/credentials.json"
+                            - "/cloud_sql_proxy -instances={{ .Values.global.database.managedGCP.instanceConnectionName }}=tcp:5432 -credential_file=/secrets/cloudsql-instance-credentials/credentials.json"
                           volumeMounts:
                             - name: cloudsql-instance-credentials
                               mountPath: /secrets/cloudsql-instance-credentials

--- a/chart/compass/charts/director/templates/tenant-loader-job-default.yaml
+++ b/chart/compass/charts/director/templates/tenant-loader-job-default.yaml
@@ -69,12 +69,9 @@ spec:
                     - "./tenantloader; exit_code=$?; sleep 5; echo '# KILLING PILOT-AGENT #'; pkill -INT cloud_sql_proxy; curl -XPOST http://127.0.0.1:15020/quitquitquit; sleep 5; exit $exit_code;"
               {{if eq .Values.global.database.embedded.enabled false}}
                 - name: cloudsql-proxy
-                  image: gcr.io/cloudsql-docker/gce-proxy:1.14
+                  image: gcr.io/cloudsql-docker/gce-proxy:1.16
                   command:
-                    - /bin/sh
-                  args:
-                    - -c
-                    - "trap 'exit 0' SIGINT; /cloud_sql_proxy -instances={{ .Values.global.database.managedGCP.instanceConnectionName }}=tcp:5432 -credential_file=/secrets/cloudsql-instance-credentials/credentials.json"
+                    - "/cloud_sql_proxy -instances={{ .Values.global.database.managedGCP.instanceConnectionName }}=tcp:5432 -credential_file=/secrets/cloudsql-instance-credentials/credentials.json"
                   volumeMounts:
                     - name: cloudsql-instance-credentials
                       mountPath: /secrets/cloudsql-instance-credentials

--- a/chart/compass/templates/migrator-job.yaml
+++ b/chart/compass/templates/migrator-job.yaml
@@ -16,17 +16,14 @@ spec:
                 app: {{ .Chart.Name }}
                 release: {{ .Release.Name }}
         spec:
-            restartPolicy: Never
+            restartPolicy: OnFailure
             shareProcessNamespace: true
             containers:
                 {{if eq .Values.global.database.embedded.enabled false}}
                 - name: cloudsql-proxy
-                  image: gcr.io/cloudsql-docker/gce-proxy:1.14
+                  image: gcr.io/cloudsql-docker/gce-proxy:1.16
                   command:
-                  - /bin/sh
-                  args:
-                  - -c
-                  - "trap 'exit 0' SIGINT; /cloud_sql_proxy -instances={{ .Values.global.database.managedGCP.instanceConnectionName }}=tcp:5432 -credential_file=/secrets/cloudsql-instance-credentials/credentials.json"
+                  - "/cloud_sql_proxy -instances={{ .Values.global.database.managedGCP.instanceConnectionName }}=tcp:5432 -credential_file=/secrets/cloudsql-instance-credentials/credentials.json"
                   volumeMounts:
                       - name: cloudsql-instance-credentials
                         mountPath: /secrets/cloudsql-instance-credentials

--- a/chart/compass/templates/tenant-fetcher-job.yaml
+++ b/chart/compass/templates/tenant-fetcher-job.yaml
@@ -119,18 +119,15 @@ spec:
               - "./tenantfetcher; exit_code=$?; echo '# KILLING PILOT-AGENT #'; pkill -INT cloud_sql_proxy; curl -XPOST http://127.0.0.1:15020/quitquitquit; sleep 5; exit $exit_code;"
           {{if eq $.Values.global.database.embedded.enabled false}}
           - name: cloudsql-proxy
-            image: gcr.io/cloudsql-docker/gce-proxy:1.14
+            image: gcr.io/cloudsql-docker/gce-proxy:1.16
             command:
-              - /bin/sh
-            args:
-              - -c
-              - "trap 'exit 0' SIGINT; /cloud_sql_proxy -instances={{ $.Values.global.database.managedGCP.instanceConnectionName }}=tcp:5432 -credential_file=/secrets/cloudsql-instance-credentials/credentials.json"
+              - "/cloud_sql_proxy -instances={{ $.Values.global.database.managedGCP.instanceConnectionName }}=tcp:5432 -credential_file=/secrets/cloudsql-instance-credentials/credentials.json"
             volumeMounts:
               - name: cloudsql-instance-credentials
                 mountPath: /secrets/cloudsql-instance-credentials
                 readOnly: true
           {{end}}
-          restartPolicy: Never
+          restartPolicy: OnFailure
           shareProcessNamespace: true
           {{if eq $.Values.global.database.embedded.enabled false}}
           volumes:


### PR DESCRIPTION
# Overview

This PR fixes the issue where Tenant Fetcher's CloudSQL Proxy sidecar throttles on startup for a minute until it's able to start up. This slows down the Tenant Fetcher every time by a minute which as we've experienced may be critical in some situations when new trial tenants  try to provision Kyma runtime too quickly.

**Essentially this PR:**
- Increases the CloudSQL Proxy version to align with the version specified in the Director sidecar - from **1.14** to **1.16**;
- Add `restartPolicy: OnFailure` so that if issues arise with the CloudSQL Proxy container it can restart.

In both 1.14 and 1.16 the sidecar proxy fails initially to connect to the GCP SQL Instance a couple of times (this happens in the Director pod currently).

Difference is that with 1.14 it retries to connect again in the same process, but the second failure is handled by throttling for a minute - the current issue that we have.

In 1.16 when the sidecar fails to connect the first time it kills the process. This is why we need to set `restartPolicy: OnFailure`, because it's currently set to `restartPolicy: Never` and the sidecar will never start up again -> Tenant Fetcher won't be able to establish a DB connection.