### PR TITLE
Add E2E tests for HasScenario directive

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -23,7 +23,7 @@ global:
       version: "PR-1595"
     director:
       dir:
-      version: "PR-1591"
+      version: "PR-1593"
     gateway:
       dir:
       version: "PR-1595"

--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -47,7 +47,7 @@ global:
     tests:
       director:
         dir:
-        version: "PR-1591"
+        version: "PR-1593"
       connector:
         dir:
         version: "PR-1582"

--- a/components/director/pkg/scenario/directive.go
+++ b/components/director/pkg/scenario/directive.go
@@ -3,6 +3,7 @@ package scenario
 import (
 	"context"
 	"fmt"
+	"github.com/kyma-incubator/compass/components/director/pkg/apperrors"
 
 	"github.com/kyma-incubator/compass/components/director/pkg/persistence"
 
@@ -91,7 +92,7 @@ func (d *directive) HasScenario(ctx context.Context, _ interface{}, next graphql
 	}
 
 	if len(commonScenarios) == 0 {
-		return nil, ErrMissingScenario
+		return nil, apperrors.NewInvalidOperationError("requesting runtime should be in same scenario as the requested application resource")
 	}
 	log.Debugf("Found the following common scenarios: %+v", commonScenarios)
 

--- a/components/director/pkg/scenario/directive.go
+++ b/components/director/pkg/scenario/directive.go
@@ -3,6 +3,7 @@ package scenario
 import (
 	"context"
 	"fmt"
+
 	"github.com/kyma-incubator/compass/components/director/pkg/apperrors"
 
 	"github.com/kyma-incubator/compass/components/director/pkg/persistence"

--- a/tests/director/api/application_api_test.go
+++ b/tests/director/api/application_api_test.go
@@ -477,33 +477,32 @@ func TestQuerySpecificApplication(t *testing.T) {
 		err = tc.RunOperation(context.Background(), queryAppReq, &actualApp)
 		saveExampleInCustomDir(t, queryAppReq.Query(), queryApplicationCategory, "query application")
 
-		//THEN
+		//THE
 		require.NoError(t, err)
 		assert.Equal(t, appID, actualApp.ID)
 	})
 
+	// update label definitions
+	ctx := context.Background()
+	tenantID := testTenants.GetDefaultTenantID()
+	scenarios := []string{defaultScenario, "test-scenario"}
+
+	jsonSchema := map[string]interface{}{
+		"type":        "array",
+		"minItems":    1,
+		"uniqueItems": true,
+		"items": map[string]interface{}{
+			"type": "string",
+			"enum": scenarios,
+		},
+	}
+	var schema interface{} = jsonSchema
+
+	updateLabelDefinitionWithinTenant(t, ctx, scenariosLabel, schema, tenantID)
+
 	t.Run("Query Application With Consumer Runtime in same scenario", func(t *testing.T) {
-		// update label definitions
-		ctx := context.Background()
-		tenantID := testTenants.GetDefaultTenantID()
-		scenarios := []string{defaultScenario, "test-scenario"}
-
-		jsonSchema := map[string]interface{}{
-			"type":        "array",
-			"minItems":    1,
-			"uniqueItems": true,
-			"items": map[string]interface{}{
-				"type": "string",
-				"enum": scenarios,
-			},
-		}
-		var schema interface{} = jsonSchema
-
-		updateLabelDefinitionWithinTenant(t, ctx, scenariosLabel, schema, tenantID)
-
 		// set application scenarios label
-		var labelValue interface{} = scenarios // TODO: Check if necessary
-		setApplicationLabel(t, ctx, appID, scenariosLabel, labelValue)
+		setApplicationLabel(t, ctx, appID, scenariosLabel, scenarios)
 
 		// register runtime
 		runtimeInput := fixRuntimeInput("runtime")
@@ -534,27 +533,8 @@ func TestQuerySpecificApplication(t *testing.T) {
 	})
 
 	t.Run("Query Application With Consumer Runtime not in same scenario", func(t *testing.T) {
-		// update label definitions
-		ctx := context.Background()
-		tenantID := testTenants.GetDefaultTenantID()
-		scenarios := []string{defaultScenario, "test-scenario"}
-
-		jsonSchema := map[string]interface{}{
-			"type":        "array",
-			"minItems":    1,
-			"uniqueItems": true,
-			"items": map[string]interface{}{
-				"type": "string",
-				"enum": scenarios,
-			},
-		}
-		var schema interface{} = jsonSchema
-
-		updateLabelDefinitionWithinTenant(t, ctx, scenariosLabel, schema, tenantID)
-
 		// set application scenarios label
-		var labelValue interface{} = scenarios[:1]                     // TODO: Check if necessary
-		setApplicationLabel(t, ctx, appID, scenariosLabel, labelValue) // leave out only DEFAULT scenario
+		setApplicationLabel(t, ctx, appID, scenariosLabel, scenarios[:1]) // leave out only DEFAULT scenario
 
 		// register runtime
 		runtimeInput := fixRuntimeInput("runtime")

--- a/tests/director/api/application_api_test.go
+++ b/tests/director/api/application_api_test.go
@@ -534,6 +534,7 @@ func TestQuerySpecificApplication(t *testing.T) {
 
 		//THEN
 		require.Error(t, err)
+		require.Contains(t, err.Error(), "The operation is not allowed")
 	})
 }
 

--- a/tests/director/api/application_api_test.go
+++ b/tests/director/api/application_api_test.go
@@ -507,7 +507,6 @@ func TestQuerySpecificApplication(t *testing.T) {
 		setRuntimeLabel(t, ctx, runtime.ID, scenariosLabel, scenarios[1:])
 		defer setRuntimeLabel(t, ctx, runtime.ID, scenariosLabel, scenarios[:1])
 
-		// query application
 		actualApp := graphql.Application{}
 
 		// WHEN
@@ -527,7 +526,6 @@ func TestQuerySpecificApplication(t *testing.T) {
 		setRuntimeLabel(t, ctx, runtime.ID, scenariosLabel, scenarios[1:])
 		defer setRuntimeLabel(t, ctx, runtime.ID, scenariosLabel, scenarios[:1])
 
-		// query application
 		actualApp := graphql.Application{}
 
 		// WHEN

--- a/tests/director/api/fixtures_queries_test.go
+++ b/tests/director/api/fixtures_queries_test.go
@@ -216,7 +216,41 @@ func createScenariosLabelDefinitionWithinTenant(t *testing.T, ctx context.Contex
 		"uniqueItems": true,
 	}
 
-	return createLabelDefinitionWithinTenant(t, ctx, "scenarios", jsonSchema, tenantID)
+	return createLabelDefinitionWithinTenant(t, ctx, scenariosLabel, jsonSchema, tenantID)
+}
+
+func updateLabelDefinitionWithinTenant(t *testing.T, ctx context.Context, key string, schema interface{}, tenantID string) *graphql.LabelDefinition {
+	input := graphql.LabelDefinitionInput{
+		Key:    key,
+		Schema: marshalJSONSchema(t, schema),
+	}
+
+	in, err := tc.graphqlizer.LabelDefinitionInputToGQL(input)
+	if err != nil {
+		return nil
+	}
+
+	updateRequest := fixUpdateLabelDefinitionRequest(in)
+
+	output := graphql.LabelDefinition{}
+	err = tc.RunOperationWithCustomTenant(ctx, tenantID, updateRequest, &output)
+	require.NoError(t, err)
+
+	return &output
+}
+
+func updateScenariosLabelDefinitionWithinTenant(t *testing.T, ctx context.Context, tenantID string, scenarios []string) *graphql.LabelDefinition {
+	jsonSchema := map[string]interface{}{
+		"items": map[string]interface{}{
+			"enum": scenarios,
+			"type": "string",
+		},
+		"type":        "array",
+		"minItems":    1,
+		"uniqueItems": true,
+	}
+
+	return updateLabelDefinitionWithinTenant(t, ctx, scenariosLabel, jsonSchema, tenantID)
 }
 
 func deleteLabelDefinition(t *testing.T, ctx context.Context, labelDefinitionKey string, deleteRelatedResources bool) {

--- a/tests/director/api/package_instance_auth_test.go
+++ b/tests/director/api/package_instance_auth_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"github.com/kyma-incubator/compass/tests/director/pkg/jwtbuilder"
 	"testing"
 
 	"github.com/kyma-incubator/compass/components/director/pkg/graphql"
@@ -56,6 +57,90 @@ func TestRequestPackageInstanceAuthCreation(t *testing.T) {
 	// Assert the package instance auth exist
 	require.Equal(t, instanceAuthID, pkgFromAPI.Package.InstanceAuth.ID)
 	require.Equal(t, graphql.PackageInstanceAuthStatusConditionPending, pkgFromAPI.Package.InstanceAuth.Status.Condition)
+}
+
+func TestRequestPackageInstanceAuthCreationAsRuntimeConsumer(t *testing.T) {
+	ctx := context.Background()
+
+	runtime := registerRuntime(t, ctx, "runtime-test")
+	defer unregisterRuntime(t, runtime.ID)
+
+	application := registerApplication(t, ctx, "app-test-package")
+	defer unregisterApplication(t, application.ID)
+
+	pkg := createPackage(t, ctx, application.ID, "pkg-app-1")
+	defer deletePackage(t, ctx, pkg.ID)
+
+	authCtx, inputParams := fixPackageInstanceAuthContextAndInputParams(t)
+	pkgInstanceAuthRequestInput := fixPackageInstanceAuthRequestInput(authCtx, inputParams)
+	pkgInstanceAuthRequestInputStr, err := tc.graphqlizer.PackageInstanceAuthRequestInputToGQL(pkgInstanceAuthRequestInput)
+	require.NoError(t, err)
+
+	pkgInstanceAuthCreationRequestReq := fixRequestPackageInstanceAuthCreationRequest(pkg.ID, pkgInstanceAuthRequestInputStr)
+	output := graphql.PackageInstanceAuth{}
+
+	scenarios := []string{defaultScenario, "test-scenario"}
+	updateScenariosLabelDefinitionWithinTenant(t, ctx, testTenants.GetDefaultTenantID(), scenarios)
+	defer updateScenariosLabelDefinitionWithinTenant(t, ctx, testTenants.GetDefaultTenantID(), scenarios[:1])
+
+	runtimeConsumer := tc.NewOperation(ctx).WithConsumer(&jwtbuilder.Consumer{
+		ID:   runtime.ID,
+		Type: jwtbuilder.RuntimeConsumer,
+	})
+
+	t.Run("When runtime is in the same scenario as application", func(t *testing.T) {
+		// set application scenarios label
+		setApplicationLabel(t, ctx, application.ID, scenariosLabel, scenarios[1:])
+		defer setApplicationLabel(t, ctx, application.ID, scenariosLabel, scenarios[:1])
+
+		// set runtime scenarios label
+		setRuntimeLabel(t, ctx, runtime.ID, scenariosLabel, scenarios[1:])
+		defer setRuntimeLabel(t, ctx, runtime.ID, scenariosLabel, scenarios[:1])
+
+		t.Log("Request package instance auth creation")
+		err = runtimeConsumer.Run(pkgInstanceAuthCreationRequestReq, &output)
+
+		// THEN
+		require.NoError(t, err)
+		assertPackageInstanceAuth(t, pkgInstanceAuthRequestInput, output)
+
+		// Fetch Application with packages
+		packagesForApplicationReq := fixPackagesRequest(application.ID)
+		pkgFromAPI := graphql.ApplicationExt{}
+
+		err = runtimeConsumer.Run(packagesForApplicationReq, &pkgFromAPI)
+		require.NoError(t, err)
+
+		// Assert the package instance auths exists
+		require.Equal(t, 1, len(pkgFromAPI.Packages.Data))
+		require.Equal(t, 1, len(pkgFromAPI.Packages.Data[0].InstanceAuths))
+
+		// Fetch Application with package instance auth
+		instanceAuthID := pkgFromAPI.Packages.Data[0].InstanceAuths[0].ID
+		packagesForApplicationWithInstanceAuthReq := fixPackageWithInstanceAuthRequest(application.ID, pkg.ID, instanceAuthID)
+
+		err = runtimeConsumer.Run(packagesForApplicationWithInstanceAuthReq, &pkgFromAPI)
+		require.NoError(t, err)
+
+		// Assert the package instance auth exist
+		require.Equal(t, instanceAuthID, pkgFromAPI.Package.InstanceAuth.ID)
+		require.Equal(t, graphql.PackageInstanceAuthStatusConditionPending, pkgFromAPI.Package.InstanceAuth.Status.Condition)
+	})
+
+	t.Run("When runtime is NOT in the same scenario as application", func(t *testing.T) {
+		// set application scenarios label
+		setApplicationLabel(t, ctx, application.ID, scenariosLabel, scenarios[:1])
+
+		// set runtime scenarios label
+		setRuntimeLabel(t, ctx, runtime.ID, scenariosLabel, scenarios[1:])
+		defer setRuntimeLabel(t, ctx, runtime.ID, scenariosLabel, scenarios[:1])
+
+		t.Log("Request package instance auth creation")
+		err = runtimeConsumer.Run(pkgInstanceAuthCreationRequestReq, &output)
+
+		// THEN
+		require.Error(t, err)
+	})
 }
 
 func TestRequestPackageInstanceAuthCreationWithDefaultAuth(t *testing.T) {
@@ -138,6 +223,67 @@ func TestRequestPackageInstanceAuthDeletion(t *testing.T) {
 	require.NoError(t, err)
 
 	saveExample(t, pkgInstanceAuthDeletionRequestReq.Query(), "request package instance auth deletion")
+}
+
+func TestRequestPackageInstanceAuthDeletionAsRuntimeConsumer(t *testing.T) {
+	ctx := context.Background()
+
+	runtime := registerRuntime(t, ctx, "runtime-test")
+	defer unregisterRuntime(t, runtime.ID)
+
+	application := registerApplication(t, ctx, "app-test-package")
+	defer unregisterApplication(t, application.ID)
+
+	pkg := createPackage(t, ctx, application.ID, "pkg-app-1")
+	defer deletePackage(t, ctx, pkg.ID)
+
+	pkgInstanceAuth := createPackageInstanceAuth(t, ctx, pkg.ID)
+
+	pkgInstanceAuthDeletionRequestReq := fixRequestPackageInstanceAuthDeletionRequest(pkgInstanceAuth.ID)
+
+	scenarios := []string{defaultScenario, "test-scenario"}
+	updateScenariosLabelDefinitionWithinTenant(t, ctx, testTenants.GetDefaultTenantID(), scenarios)
+	defer updateScenariosLabelDefinitionWithinTenant(t, ctx, testTenants.GetDefaultTenantID(), scenarios[:1])
+
+	runtimeConsumer := tc.NewOperation(ctx).WithConsumer(&jwtbuilder.Consumer{
+		ID:   runtime.ID,
+		Type: jwtbuilder.RuntimeConsumer,
+	})
+
+	t.Run("When runtime is in the same scenario as application", func(t *testing.T) {
+		// set application scenarios label
+		setApplicationLabel(t, ctx, application.ID, scenariosLabel, scenarios[1:])
+		defer setApplicationLabel(t, ctx, application.ID, scenariosLabel, scenarios[:1])
+
+		// set runtime scenarios label
+		setRuntimeLabel(t, ctx, runtime.ID, scenariosLabel, scenarios[1:])
+		defer setRuntimeLabel(t, ctx, runtime.ID, scenariosLabel, scenarios[:1])
+
+		// WHEN
+		t.Log("Request package instance auth deletion")
+		output := graphql.PackageInstanceAuth{}
+		err := runtimeConsumer.Run(pkgInstanceAuthDeletionRequestReq, &output)
+
+		// THEN
+		require.NoError(t, err)
+	})
+
+	t.Run("When runtime is NOT in the same scenario as application", func(t *testing.T) {
+		// set application scenarios label
+		setApplicationLabel(t, ctx, application.ID, scenariosLabel, scenarios[:1])
+
+		// set runtime scenarios label
+		setRuntimeLabel(t, ctx, runtime.ID, scenariosLabel, scenarios[1:])
+		defer setRuntimeLabel(t, ctx, runtime.ID, scenariosLabel, scenarios[:1])
+
+		// WHEN
+		t.Log("Request package instance auth deletion")
+		output := graphql.PackageInstanceAuth{}
+		err := runtimeConsumer.Run(pkgInstanceAuthDeletionRequestReq, &output)
+
+		// THEN
+		require.Error(t, err)
+	})
 }
 
 func TestSetPackageInstanceAuth(t *testing.T) {

--- a/tests/director/api/package_instance_auth_test.go
+++ b/tests/director/api/package_instance_auth_test.go
@@ -141,6 +141,7 @@ func TestRequestPackageInstanceAuthCreationAsRuntimeConsumer(t *testing.T) {
 
 		// THEN
 		require.Error(t, err)
+		require.Contains(t, err.Error(), "The operation is not allowed")
 	})
 }
 
@@ -284,6 +285,7 @@ func TestRequestPackageInstanceAuthDeletionAsRuntimeConsumer(t *testing.T) {
 
 		// THEN
 		require.Error(t, err)
+		require.Contains(t, err.Error(), "The operation is not allowed")
 	})
 }
 

--- a/tests/director/api/package_instance_auth_test.go
+++ b/tests/director/api/package_instance_auth_test.go
@@ -2,8 +2,9 @@ package api
 
 import (
 	"context"
-	"github.com/kyma-incubator/compass/tests/director/pkg/jwtbuilder"
 	"testing"
+
+	"github.com/kyma-incubator/compass/tests/director/pkg/jwtbuilder"
 
 	"github.com/kyma-incubator/compass/components/director/pkg/graphql"
 	"github.com/stretchr/testify/require"

--- a/tests/director/api/runtime_api_test.go
+++ b/tests/director/api/runtime_api_test.go
@@ -152,7 +152,7 @@ func TestRuntimeUnregisterDeletesScenarioAssignments(t *testing.T) {
 	marshalledSchema := marshalJSONSchema(t, schema)
 
 	givenLabelDef := graphql.LabelDefinitionInput{
-		Key:    "scenarios",
+		Key:    scenariosLabel,
 		Schema: marshalledSchema,
 	}
 	labelDefInGQL, err := tc.graphqlizer.LabelDefinitionInputToGQL(givenLabelDef)


### PR DESCRIPTION
# Overview

Some Kyma tests broke due to us not having E2E tests for the `HasScenario` directive. This PR adds such tests.