### PR TITLE
Set CloudSQL Proxy Termination timeout

### DIFF
--- a/chart/compass/charts/director/templates/deployment.yaml
+++ b/chart/compass/charts/director/templates/deployment.yaml
@@ -140,7 +140,8 @@ spec:
           image: gcr.io/cloudsql-docker/gce-proxy:1.18.0-alpine
           command: ["/cloud_sql_proxy",
                     "-instances={{ .Values.global.database.managedGCP.instanceConnectionName }}=tcp:5432",
-                    "-credential_file=/secrets/cloudsql-instance-credentials/credentials.json"]
+                    "-credential_file=/secrets/cloudsql-instance-credentials/credentials.json",
+                    "-term_timeout=2s"]
           volumeMounts:
             - name: cloudsql-instance-credentials
               mountPath: /secrets/cloudsql-instance-credentials

--- a/chart/compass/charts/director/templates/tenant-loader-cronjob-external.yaml
+++ b/chart/compass/charts/director/templates/tenant-loader-cronjob-external.yaml
@@ -73,7 +73,7 @@ spec:
                             - /bin/sh
                           args:
                             - -c
-                            - "trap 'exit 0' SIGINT; /cloud_sql_proxy -instances={{ .Values.global.database.managedGCP.instanceConnectionName }}=tcp:5432 -credential_file=/secrets/cloudsql-instance-credentials/credentials.json"
+                            - "trap 'exit 0' SIGINT; /cloud_sql_proxy -instances={{ .Values.global.database.managedGCP.instanceConnectionName }}=tcp:5432 -credential_file=/secrets/cloudsql-instance-credentials/credentials.json -term_timeout=2s"
                           volumeMounts:
                             - name: cloudsql-instance-credentials
                               mountPath: /secrets/cloudsql-instance-credentials

--- a/chart/compass/charts/director/templates/tenant-loader-job-default.yaml
+++ b/chart/compass/charts/director/templates/tenant-loader-job-default.yaml
@@ -74,7 +74,7 @@ spec:
                     - /bin/sh
                   args:
                     - -c
-                    - "trap 'exit 0' SIGINT; /cloud_sql_proxy -instances={{ .Values.global.database.managedGCP.instanceConnectionName }}=tcp:5432 -credential_file=/secrets/cloudsql-instance-credentials/credentials.json"
+                    - "trap 'exit 0' SIGINT; /cloud_sql_proxy -instances={{ .Values.global.database.managedGCP.instanceConnectionName }}=tcp:5432 -credential_file=/secrets/cloudsql-instance-credentials/credentials.json -term_timeout=2s"
                   volumeMounts:
                     - name: cloudsql-instance-credentials
                       mountPath: /secrets/cloudsql-instance-credentials

--- a/chart/compass/templates/migrator-job.yaml
+++ b/chart/compass/templates/migrator-job.yaml
@@ -26,7 +26,7 @@ spec:
                   - /bin/sh
                   args:
                   - -c
-                  - "trap 'exit 0' SIGINT; /cloud_sql_proxy -instances={{ .Values.global.database.managedGCP.instanceConnectionName }}=tcp:5432 -credential_file=/secrets/cloudsql-instance-credentials/credentials.json"
+                  - "trap 'exit 0' SIGINT; /cloud_sql_proxy -instances={{ .Values.global.database.managedGCP.instanceConnectionName }}=tcp:5432 -credential_file=/secrets/cloudsql-instance-credentials/credentials.json -term_timeout=2s"
                   volumeMounts:
                       - name: cloudsql-instance-credentials
                         mountPath: /secrets/cloudsql-instance-credentials

--- a/chart/compass/templates/tenant-fetcher-job.yaml
+++ b/chart/compass/templates/tenant-fetcher-job.yaml
@@ -124,7 +124,7 @@ spec:
               - /bin/sh
             args:
               - -c
-              - "trap 'exit 0' SIGINT; /cloud_sql_proxy -instances={{ $.Values.global.database.managedGCP.instanceConnectionName }}=tcp:5432 -credential_file=/secrets/cloudsql-instance-credentials/credentials.json"
+              - "trap 'exit 0' SIGINT; /cloud_sql_proxy -instances={{ $.Values.global.database.managedGCP.instanceConnectionName }}=tcp:5432 -credential_file=/secrets/cloudsql-instance-credentials/credentials.json -term_timeout=2s"
             volumeMounts:
               - name: cloudsql-instance-credentials
                 mountPath: /secrets/cloudsql-instance-credentials


### PR DESCRIPTION
**Description**

This PR ensures that the CloudSQL Proxy waits on active connections to close before terminating as a result of SIGTERM signals by specifying a non-zero (the default) termination timeout.