### PR TITLE
Ensure empty services are not present in System Broker Catalog

### DIFF
--- a/components/system-broker/internal/osb/catalog.go
+++ b/components/system-broker/internal/osb/catalog.go
@@ -18,7 +18,6 @@ package osb
 
 import (
 	"context"
-
 	schema "github.com/kyma-incubator/compass/components/director/pkg/graphql"
 
 	"github.com/kyma-incubator/compass/components/system-broker/pkg/log"
@@ -27,7 +26,7 @@ import (
 )
 
 type converter interface {
-	Convert(app *schema.ApplicationExt) ([]domain.Service, error)
+	Convert(app *schema.ApplicationExt) (domain.Service, error)
 }
 
 type CatalogEndpoint struct {
@@ -50,11 +49,14 @@ func (b *CatalogEndpoint) Services(ctx context.Context) ([]domain.Service, error
 		// if app == nil {
 		// 	continue
 		// }
-		s, err := b.converter.Convert(&app)
+		svc, err := b.converter.Convert(&app)
 		if err != nil {
 			return nil, errors.Wrap(err, "while converting application to OSB services")
 		}
-		resp = append(resp, s...)
+
+		if len(svc.Plans) > 0 {
+			resp = append(resp, svc)
+		}
 	}
 
 	return resp, nil

--- a/components/system-broker/internal/osb/catalog_converter.go
+++ b/components/system-broker/internal/osb/catalog_converter.go
@@ -31,10 +31,10 @@ type Converter struct {
 	baseURL string
 }
 
-func (c Converter) Convert(app *schema.ApplicationExt) ([]domain.Service, error) {
+func (c Converter) Convert(app *schema.ApplicationExt) (domain.Service, error) {
 	plans, err := c.toPlans(app.ID, app.Packages.Data)
 	if err != nil {
-		return nil, err
+		return domain.Service{}, err
 	}
 
 	desc := ptrStrToStr(app.Description)
@@ -42,18 +42,16 @@ func (c Converter) Convert(app *schema.ApplicationExt) ([]domain.Service, error)
 		desc = fmt.Sprintf("service generated from system with name %s", app.Name)
 	}
 
-	return []domain.Service{
-		{
-			ID:                   app.ID,
-			Name:                 app.Name,
-			Description:          desc,
-			Bindable:             true,
-			InstancesRetrievable: false,
-			BindingsRetrievable:  false,
-			PlanUpdatable:        false,
-			Plans:                plans,
-			Metadata:             c.toServiceMetadata(app),
-		},
+	return domain.Service{
+		ID:                   app.ID,
+		Name:                 app.Name,
+		Description:          desc,
+		Bindable:             true,
+		InstancesRetrievable: false,
+		BindingsRetrievable:  false,
+		PlanUpdatable:        false,
+		Plans:                plans,
+		Metadata:             c.toServiceMetadata(app),
 	}, nil
 }
 

--- a/components/system-broker/tests/catalog_test/catalog_test.go
+++ b/components/system-broker/tests/catalog_test/catalog_test.go
@@ -25,7 +25,7 @@ const (
     }
   }
 }`
-	appsMockResponse = `{
+	appsEmptyPackagesMockResponse = `{
   "data": {
     "result": {
       "data": [
@@ -76,8 +76,8 @@ const (
     }
   }
 }`
-	appsExpectedCatalog = `{"services":[{"id":"3e3cecce-74b3-4881-854e-58791021b522","name":"test-app","description":"a test application","bindable":true,"plan_updateable":false,"plans":null,"metadata":{"displayName":"test-app","group":["production","experimental"],"integrationSystemID":"","name":"test-app","providerDisplayName":"test provider","scenarios":["DEFAULT"]}}]}` + "\n"
-	appsPageResponse1   = `{
+	appsExpectedEmptyCatalog = `{"services":[]}` + "\n"
+	appsPageResponse1        = `{
   "data": {
     "result": {
       "data": [
@@ -314,15 +314,15 @@ func (suite *OSBCatalogTestSuite) TestEmptyResponse() {
 	assert.NoError(suite.T(), err)
 	suite.testContext.SystemBroker.GET("/v2/catalog").WithHeader("X-Broker-API-Version", "2.15").Expect().
 		Status(http.StatusOK).
-		Body().Equal("{\"services\":[]}\n")
+		Body().Equal(appsExpectedEmptyCatalog)
 }
 
 func (suite *OSBCatalogTestSuite) TestResponseWithOnePage() {
-	err := suite.testContext.ConfigureResponse(suite.configURL, "query", "applications", appsMockResponse)
+	err := suite.testContext.ConfigureResponse(suite.configURL, "query", "applications", appsEmptyPackagesMockResponse)
 	assert.NoError(suite.T(), err)
 	suite.testContext.SystemBroker.GET("/v2/catalog").WithHeader("X-Broker-API-Version", "2.15").Expect().
 		Status(http.StatusOK).
-		Body().Equal(appsExpectedCatalog)
+		Body().Equal(appsExpectedEmptyCatalog)
 }
 
 func (suite *OSBCatalogTestSuite) TestResponseWithSeveralPages() {


### PR DESCRIPTION
**Description**

This PR ensures that empty services are not present in System Broker Catalog. Empty services is an issue on some OSB platforms like Cloud Foundry.