### PR TITLE
Fix istio installation on minikube

### DIFF
--- a/installation/resources/kyma/installer-overrides-istio.yaml
+++ b/installation/resources/kyma/installer-overrides-istio.yaml
@@ -16,6 +16,7 @@ data:
     spec:
       values:
         global:
+          jwtPolicy: first-party-jwt
           proxy:
             resources:
               requests:


### PR DESCRIPTION
Currently `./run.sh --kyma-installation minimal` fails when istalling istio:

```
istio-system     istiod-668d6fd7bb-xwvkc  0/1     ContainerCreating   0  9s

MountVolume.SetUp failed for volume "istio-token" : failed to fetch token: the server could not find the requested resource
```
This PR fixes this issue.

Reference: https://github.com/istio/istio/issues/24746