### PR TITLE
Use minikube docker driver to run a cluster alongside VPN

### DIFF
--- a/installation/cmd/run.sh
+++ b/installation/cmd/run.sh
@@ -37,6 +37,10 @@ do
             SKIP_KYMA_START=true
             shift # past argument
         ;;
+        --docker-driver)
+            DOCKER_DRIVER=true
+            shift # past argument
+        ;;
         --minikube-cpus)
             checkInputParameterValue "${2}"
             MINIKUBE_CPUS="${2}"
@@ -77,7 +81,11 @@ fi
 
 if [[ ! ${SKIP_MINIKUBE_START} ]]; then
   echo "Provisioning Minikube cluster..."
-  kyma provision minikube --cpus ${MINIKUBE_CPUS} --memory ${MINIKUBE_MEMORY} --timeout ${MINIKUBE_TIMEOUT}
+  if [[ ! ${DOCKER_DRIVER} ]]; then
+    kyma provision minikube --cpus ${MINIKUBE_CPUS} --memory ${MINIKUBE_MEMORY} --timeout ${MINIKUBE_TIMEOUT}
+  else
+    kyma provision minikube --cpus ${MINIKUBE_CPUS} --memory ${MINIKUBE_MEMORY} --timeout ${MINIKUBE_TIMEOUT} --vm-driver docker --docker-ports 443:443 --docker-ports 80:80
+  fi
 fi
 
 if [[ ! ${SKIP_KYMA_START} ]]; then


### PR DESCRIPTION
If you specify `--docker-driver` flag then you should have kyma cli build with the changes in this PR (https://github.com/kyma-project/cli/pull/645).
The following flags are available only on minikube versions `>= v1.14.0`

This will spin up minikube in a docker container and install kyma + compass on it. The whole process of installation and running works alongside VPN.