### PR TITLE
change label key dashes for underscores

### DIFF
--- a/components/director/internal/domain/eventing/service.go
+++ b/components/director/internal/domain/eventing/service.go
@@ -379,5 +379,5 @@ func buildQueryForScenarios(scenarios []string) string {
 }
 
 func getDefaultEventingForAppLabelKey(appID uuid.UUID) string {
-	return fmt.Sprintf(RuntimeDefaultEventingLabelf, appID.String())
+	return strings.ReplaceAll(fmt.Sprintf(RuntimeDefaultEventingLabelf, appID.String()), "-", "_")
 }


### PR DESCRIPTION
# **DO NOT MERGE. Requires migration to be done in existing data**

**Fix incorrect label key**

Changes proposed in this pull request:

- Fixes label key which uses app guid for key and exchanges the dashes with underscores
- The fix is needed because graphql does not support dashes in keys and thus makes some queries/mutation incorrect
