### PR TITLE
Enable multiple Authenticator scope prefixes

### DIFF
--- a/components/director/internal/oathkeeper/model.go
+++ b/components/director/internal/oathkeeper/model.go
@@ -197,7 +197,7 @@ func (d *ReqData) GetScopes() (string, error) {
 
 // GetUserScopes returns scopes as string array from the parsed request input if defined;
 // also it strips the scopes from any potential authenticator prefixes
-func (d *ReqData) GetUserScopes(scopePrefix string) ([]string, error) {
+func (d *ReqData) GetUserScopes(scopePrefixes []string) ([]string, error) {
 	userScopes := make([]string, 0)
 	scopesVal, ok := d.Body.Extra[ScopesKey]
 	if !ok {
@@ -210,7 +210,11 @@ func (d *ReqData) GetUserScopes(scopePrefix string) ([]string, error) {
 			if err != nil {
 				return []string{}, errors.Wrapf(err, "while parsing the value for %s", ScopesKey)
 			}
-			actualScope := strings.TrimPrefix(scopeString, scopePrefix)
+
+			actualScope := scopeString
+			for _, prefix := range scopePrefixes {
+				actualScope = strings.TrimPrefix(actualScope, prefix)
+			}
 			userScopes = append(userScopes, actualScope)
 		}
 	}

--- a/components/director/internal/tenantmapping/authenticator_context_provider.go
+++ b/components/director/internal/tenantmapping/authenticator_context_provider.go
@@ -57,7 +57,7 @@ func (m *authenticatorContextProvider) GetObjectContext(ctx context.Context, req
 	authn := authDetails.Authenticator
 
 	log.C(ctx).Info("Getting scopes from token attribute")
-	userScopes, err := reqData.GetUserScopes(authn.ScopePrefix)
+	userScopes, err := reqData.GetUserScopes(authn.ScopePrefixes)
 	if err != nil {
 		return ObjectContext{}, err
 	}

--- a/components/director/pkg/authenticator/authenticator.go
+++ b/components/director/pkg/authenticator/authenticator.go
@@ -29,7 +29,7 @@ import (
 func InitFromEnv(envPrefix string) ([]Config, error) {
 	authenticators := make(map[string]*Config, 0)
 	attributesPattern := regexp.MustCompile(fmt.Sprintf("^%s_(.*)_AUTHENTICATOR_ATTRIBUTES$", envPrefix))
-	scopePrefixPattern := regexp.MustCompile(fmt.Sprintf("^%s_(.*)_AUTHENTICATOR_SCOPE_PREFIX$", envPrefix))
+	scopePrefixPattern := regexp.MustCompile(fmt.Sprintf("^%s_(.*)_AUTHENTICATOR_SCOPE_PREFIXES$", envPrefix))
 
 	for _, env := range os.Environ() {
 		pair := strings.SplitN(env, "=", 2)
@@ -60,12 +60,13 @@ func InitFromEnv(envPrefix string) ([]Config, error) {
 		if len(matches) > 0 {
 			authenticatorName := matches[1]
 
+			prefixes := strings.Split(value, ",")
 			if authenticator, exists := authenticators[authenticatorName]; exists {
-				authenticator.ScopePrefix = value
+				authenticator.ScopePrefixes = prefixes
 			} else {
 				authenticators[authenticatorName] = &Config{
-					Name:        authenticatorName,
-					ScopePrefix: value,
+					Name:          authenticatorName,
+					ScopePrefixes: prefixes,
 				}
 			}
 		}

--- a/components/director/pkg/authenticator/authenticator_test.go
+++ b/components/director/pkg/authenticator/authenticator_test.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/kyma-incubator/compass/components/director/pkg/authenticator"
@@ -34,8 +35,8 @@ func TestInitFromEnv(t *testing.T) {
 		defer os.Clearenv()
 
 		expectedAuthenticator := authenticator.Config{
-			Name:        "TEST_AUTHN",
-			ScopePrefix: "prefix!",
+			Name:          "TEST_AUTHN",
+			ScopePrefixes: []string{"prefix!"},
 			Attributes: authenticator.Attributes{
 				UniqueAttribute: authenticator.Attribute{
 					Key:   "test-unique-key",
@@ -56,7 +57,44 @@ func TestInitFromEnv(t *testing.T) {
 		err = os.Setenv(fmt.Sprintf("APP_%s_AUTHENTICATOR_ATTRIBUTES", expectedAuthenticator.Name), string(attributesJSON))
 		require.NoError(t, err)
 
-		err = os.Setenv(fmt.Sprintf("APP_%s_AUTHENTICATOR_SCOPE_PREFIX", expectedAuthenticator.Name), expectedAuthenticator.ScopePrefix)
+		err = os.Setenv(fmt.Sprintf("APP_%s_AUTHENTICATOR_SCOPE_PREFIXES", expectedAuthenticator.Name), expectedAuthenticator.ScopePrefixes[0])
+		require.NoError(t, err)
+
+		authenticators, err := authenticator.InitFromEnv(envPrefix)
+
+		require.NoError(t, err)
+		require.Equal(t, 1, len(authenticators))
+		require.Equal(t, expectedAuthenticator, authenticators[0])
+	})
+
+	t.Run("When environment contains authenticator configuration with multiple scope prefixes", func(t *testing.T) {
+		os.Clearenv()
+		defer os.Clearenv()
+
+		expectedAuthenticator := authenticator.Config{
+			Name:          "TEST_AUTHN",
+			ScopePrefixes: []string{"prefix1!", "prefix2!"},
+			Attributes: authenticator.Attributes{
+				UniqueAttribute: authenticator.Attribute{
+					Key:   "test-unique-key",
+					Value: "test-value",
+				},
+				TenantAttribute: authenticator.Attribute{
+					Key: "test-tenant-key",
+				},
+				IdentityAttribute: authenticator.Attribute{
+					Key: "test-identity-key",
+				},
+			},
+		}
+
+		attributesJSON, err := json.Marshal(expectedAuthenticator.Attributes)
+		require.NoError(t, err)
+
+		err = os.Setenv(fmt.Sprintf("APP_%s_AUTHENTICATOR_ATTRIBUTES", expectedAuthenticator.Name), string(attributesJSON))
+		require.NoError(t, err)
+
+		err = os.Setenv(fmt.Sprintf("APP_%s_AUTHENTICATOR_SCOPE_PREFIXES", expectedAuthenticator.Name), strings.Join(expectedAuthenticator.ScopePrefixes, ","))
 		require.NoError(t, err)
 
 		authenticators, err := authenticator.InitFromEnv(envPrefix)
@@ -71,8 +109,8 @@ func TestInitFromEnv(t *testing.T) {
 		defer os.Clearenv()
 
 		expectedAuthenticator1 := authenticator.Config{
-			Name:        "TEST_AUTHN1",
-			ScopePrefix: "prefix!",
+			Name:          "TEST_AUTHN1",
+			ScopePrefixes: []string{"prefix!"},
 			Attributes: authenticator.Attributes{
 				UniqueAttribute: authenticator.Attribute{
 					Key:   "test-unique-key",
@@ -88,8 +126,8 @@ func TestInitFromEnv(t *testing.T) {
 		}
 
 		expectedAuthenticator2 := authenticator.Config{
-			Name:        "TEST_AUTHN2",
-			ScopePrefix: "prefix!",
+			Name:          "TEST_AUTHN2",
+			ScopePrefixes: []string{"prefix!"},
 			Attributes: authenticator.Attributes{
 				UniqueAttribute: authenticator.Attribute{
 					Key:   "test-unique-key",
@@ -115,13 +153,13 @@ func TestInitFromEnv(t *testing.T) {
 		err = os.Setenv(fmt.Sprintf("APP_%s_AUTHENTICATOR_ATTRIBUTES", expectedAuthenticator1.Name), string(attributesJSON1))
 		require.NoError(t, err)
 
-		err = os.Setenv(fmt.Sprintf("APP_%s_AUTHENTICATOR_SCOPE_PREFIX", expectedAuthenticator1.Name), expectedAuthenticator1.ScopePrefix)
+		err = os.Setenv(fmt.Sprintf("APP_%s_AUTHENTICATOR_SCOPE_PREFIXES", expectedAuthenticator1.Name), expectedAuthenticator1.ScopePrefixes[0])
 		require.NoError(t, err)
 
 		err = os.Setenv(fmt.Sprintf("APP_%s_AUTHENTICATOR_ATTRIBUTES", expectedAuthenticator2.Name), string(attributesJSON2))
 		require.NoError(t, err)
 
-		err = os.Setenv(fmt.Sprintf("APP_%s_AUTHENTICATOR_SCOPE_PREFIX", expectedAuthenticator2.Name), expectedAuthenticator2.ScopePrefix)
+		err = os.Setenv(fmt.Sprintf("APP_%s_AUTHENTICATOR_SCOPE_PREFIXES", expectedAuthenticator2.Name), expectedAuthenticator2.ScopePrefixes[0])
 		require.NoError(t, err)
 
 		authenticators, err := authenticator.InitFromEnv(envPrefix)
@@ -145,8 +183,8 @@ func TestInitFromEnv(t *testing.T) {
 		defer os.Clearenv()
 
 		expectedAuthenticator := authenticator.Config{
-			Name:        "TEST_AUTHN",
-			ScopePrefix: "prefix!",
+			Name:          "TEST_AUTHN",
+			ScopePrefixes: []string{"prefix!"},
 			Attributes: authenticator.Attributes{
 				UniqueAttribute: authenticator.Attribute{
 					Key:   "test-unique-key",
@@ -167,7 +205,7 @@ func TestInitFromEnv(t *testing.T) {
 		err = os.Setenv(fmt.Sprintf("APP_%s_AUTHENTICATOR_ATTRIBUTES", expectedAuthenticator.Name), string(attributesJSON))
 		require.NoError(t, err)
 
-		err = os.Setenv(fmt.Sprintf("APP_%s_AUTHENTICATOR_SCOPE_PREFIX", expectedAuthenticator.Name), expectedAuthenticator.ScopePrefix)
+		err = os.Setenv(fmt.Sprintf("APP_%s_AUTHENTICATOR_SCOPE_PREFIXES", expectedAuthenticator.Name), expectedAuthenticator.ScopePrefixes[0])
 		require.NoError(t, err)
 
 		_, err = authenticator.InitFromEnv(envPrefix)
@@ -180,8 +218,8 @@ func TestInitFromEnv(t *testing.T) {
 		defer os.Clearenv()
 
 		expectedAuthenticator := authenticator.Config{
-			Name:        "TEST_AUTHN",
-			ScopePrefix: "prefix!",
+			Name:          "TEST_AUTHN",
+			ScopePrefixes: []string{"prefix!"},
 			Attributes: authenticator.Attributes{
 				UniqueAttribute: authenticator.Attribute{
 					Key:   "test-unique-key",
@@ -202,7 +240,7 @@ func TestInitFromEnv(t *testing.T) {
 		err = os.Setenv(fmt.Sprintf("APP_%s_AUTHENTICATOR_ATTRIBUTES", expectedAuthenticator.Name), string(attributesJSON))
 		require.NoError(t, err)
 
-		err = os.Setenv(fmt.Sprintf("APP_%s_AUTHENTICATOR_SCOPE_PREFIX", expectedAuthenticator.Name), expectedAuthenticator.ScopePrefix)
+		err = os.Setenv(fmt.Sprintf("APP_%s_AUTHENTICATOR_SCOPE_PREFIXES", expectedAuthenticator.Name), expectedAuthenticator.ScopePrefixes[0])
 		require.NoError(t, err)
 
 		_, err = authenticator.InitFromEnv(envPrefix)
@@ -234,9 +272,6 @@ func TestInitFromEnv(t *testing.T) {
 		require.NoError(t, err)
 
 		err = os.Setenv(fmt.Sprintf("APP_%s_AUTHENTICATOR_ATTRIBUTES", expectedAuthenticator.Name), string(attributesJSON))
-		require.NoError(t, err)
-
-		err = os.Setenv(fmt.Sprintf("APP_%s_AUTHENTICATOR_SCOPE_PREFIX", expectedAuthenticator.Name), expectedAuthenticator.ScopePrefix)
 		require.NoError(t, err)
 
 		authenticators, err := authenticator.InitFromEnv(envPrefix)

--- a/components/director/pkg/authenticator/types.go
+++ b/components/director/pkg/authenticator/types.go
@@ -20,9 +20,9 @@ import "errors"
 
 // Config holds all configuration related to an additional authenticator provided to the Director
 type Config struct {
-	Name        string     `json:"name"`
-	ScopePrefix string     `json:"scopePrefix"`
-	Attributes  Attributes `json:"attributes"`
+	Name          string     `json:"name"`
+	ScopePrefixes []string   `json:"scopePrefixes"`
+	Attributes    Attributes `json:"attributes"`
 }
 
 // Attributes holds all attribute properties and values related to an authenticator


### PR DESCRIPTION
# Enable multiple Authenticator scope prefixes

This change allows settings multiple scope prefixes to strip per authenticator.