### PR TITLE
Allow container in pod to be restarted on failure

### DIFF
--- a/chart/compass/templates/tenant-fetcher-job.yaml
+++ b/chart/compass/templates/tenant-fetcher-job.yaml
@@ -154,7 +154,7 @@ spec:
                 mountPath: /secrets/cloudsql-instance-credentials
                 readOnly: true
           {{end}}
-          restartPolicy: Never
+          restartPolicy: OnFailure
           shareProcessNamespace: true
           {{if eq $.Values.global.database.embedded.enabled false}}
           volumes:


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:
Sporadically the compass-tenant-fetcher job goes in "Error" state due to issues with CloudSQL proxy pod.
This change allow the crashed container to be automatically restarted.

**Related issue(s)**
N/A
