### PR TITLE
Use tenant header when tenant isn't in token

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -23,7 +23,7 @@ global:
       version: "PR-1674"
     director:
       dir:
-      version: "PR-1673"
+      version: "PR-1687"
     gateway:
       dir:
       version: "PR-1674"


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Fallback mechanism for when the tenant could not be found in the token