### PR TITLE
Add ORD Service Default Response Format filter E2E tests

### DIFF
--- a/chart/compass/charts/ord-service/templates/deployment.yaml
+++ b/chart/compass/charts/ord-service/templates/deployment.yaml
@@ -54,6 +54,8 @@ spec:
               value: "{{ .Values.deployment.args.containerPort }}"
             - name: SERVER_SELF_URL
               value: "https://{{ .Values.global.gateway.tls.host }}.{{ .Values.global.ingress.domainName }}"
+            - name: SERVER_DEFAULT_RESPONSE_TYPE
+              value: {{ .Values.global.ordService.defaultResponseType }}
             - name: ODATA_JPA_REQUEST_MAPPING_PATH
               value: {{ .Values.global.ordService.prefix | trimPrefix "/" }}
             - name: SPRING_DATASOURCE_USERNAME

--- a/chart/compass/charts/ord-service/templates/tests/ord-service-test.yaml
+++ b/chart/compass/charts/ord-service/templates/tests/ord-service-test.yaml
@@ -37,7 +37,7 @@ spec:
             - name: ORD_SERVICE_HEALTHZ_URL
               value: "http://compass-ord-service.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.global.director.port }}/actuator/health"
             - name: ORD_SERVICE_DEFAULT_RESPONSE_TYPE
-              value: { { .Values.global.ordService.defaultResponseType } }
+              value: {{ .Values.global.ordService.defaultResponseType }}
             - name: DIRECTOR_URL
               value: "https://{{ .Values.global.gateway.tls.host }}.{{ .Values.global.ingress.domainName }}{{ .Values.global.director.prefix }}"
             - name: DIRECTOR_HEALTHZ_URL

--- a/chart/compass/charts/ord-service/templates/tests/ord-service-test.yaml
+++ b/chart/compass/charts/ord-service/templates/tests/ord-service-test.yaml
@@ -36,6 +36,8 @@ spec:
               value: "https://{{ .Values.global.gateway.tls.host }}.{{ .Values.global.ingress.domainName }}{{ .Values.global.ordService.prefix }}"
             - name: ORD_SERVICE_HEALTHZ_URL
               value: "http://compass-ord-service.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.global.director.port }}/actuator/health"
+            - name: ORD_SERVICE_DEFAULT_RESPONSE_TYPE
+              value: { { .Values.global.ordService.defaultResponseType } }
             - name: DIRECTOR_URL
               value: "https://{{ .Values.global.gateway.tls.host }}.{{ .Values.global.ingress.domainName }}{{ .Values.global.director.prefix }}"
             - name: DIRECTOR_HEALTHZ_URL

--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -32,7 +32,7 @@ global:
       version: "PR-1674"
     ord_service:
       dir:
-      version: "PR-2"
+      version: "PR-4"
     healthchecker:
       dir:
       version: "PR-1674"
@@ -65,7 +65,7 @@ global:
         version: "PR-1674"
       ord_service:
         dir:
-        version: "PR-1689"
+        version: "PR-1691"
   isLocalEnv: false
   oauth2:
     host: oauth2
@@ -262,6 +262,7 @@ global:
     host: compass-ord-service.compass-system.svc.cluster.local
     prefix: /open-resource-discovery
     port: 3000
+    defaultResponseType: "xml"
 
   tenantFetchers:
     job1:

--- a/components/ord-service/.gitignore
+++ b/components/ord-service/.gitignore
@@ -1,3 +1,0 @@
-/target
-/olingo-jpa-processor-v4
-/.mvn/

--- a/tests/ord-service/tests/api_test.go
+++ b/tests/ord-service/tests/api_test.go
@@ -488,7 +488,7 @@ func makeRequestWithStatusExpect(t *testing.T, httpClient *http.Client, url stri
 	require.NoError(t, err)
 	require.Equal(t, expectedHTTPStatus, response.StatusCode)
 
-	reqFormatPattern := regexp.MustCompile(fmt.Sprintf("^.*$format=(.*)$"))
+	reqFormatPattern := regexp.MustCompile(fmt.Sprintf("^.*\\$format=(.*)$"))
 	matches := reqFormatPattern.FindStringSubmatch(url)
 
 	contentType := response.Header.Get("Content-Type")

--- a/tests/ord-service/tests/api_test.go
+++ b/tests/ord-service/tests/api_test.go
@@ -25,6 +25,7 @@ import (
 	"net/http"
 	urlpkg "net/url"
 	"regexp"
+	"strings"
 	"testing"
 	"time"
 
@@ -488,14 +489,16 @@ func makeRequestWithStatusExpect(t *testing.T, httpClient *http.Client, url stri
 	require.NoError(t, err)
 	require.Equal(t, expectedHTTPStatus, response.StatusCode)
 
-	reqFormatPattern := regexp.MustCompile(fmt.Sprintf("^.*\\$format=(.*)$"))
-	matches := reqFormatPattern.FindStringSubmatch(url)
+	if !strings.Contains(url, "/specification") {
+		reqFormatPattern := regexp.MustCompile(fmt.Sprintf("^.*\\$format=(.*)$"))
+		matches := reqFormatPattern.FindStringSubmatch(url)
 
-	contentType := response.Header.Get("Content-Type")
-	if len(matches) > 1 {
-		require.Contains(t, contentType, matches[1])
-	} else {
-		require.Contains(t, contentType, testConfig.ORDServiceDefaultResponseType)
+		contentType := response.Header.Get("Content-Type")
+		if len(matches) > 1 {
+			require.Contains(t, contentType, matches[1])
+		} else {
+			require.Contains(t, contentType, testConfig.ORDServiceDefaultResponseType)
+		}
 	}
 
 	body, err := ioutil.ReadAll(response.Body)

--- a/tests/ord-service/tests/api_test.go
+++ b/tests/ord-service/tests/api_test.go
@@ -21,7 +21,6 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
-	"go/ast"
 	"io/ioutil"
 	"net/http"
 	urlpkg "net/url"

--- a/tests/ord-service/tests/main_test.go
+++ b/tests/ord-service/tests/main_test.go
@@ -27,9 +27,10 @@ import (
 )
 
 type config struct {
-	DefaultTenant string
-	DirectorURL   string
-	ORDServiceURL string
+	DefaultTenant                 string
+	DirectorURL                   string
+	ORDServiceURL                 string
+	ORDServiceDefaultResponseType string
 }
 
 var testConfig config


### PR DESCRIPTION
# Add ORD Service Default Response Format filter E2E tests

**Description**

Changes proposed in this pull request:

- E2E tests adapted to assert response type
- New E2E test added to validate Default Response Filter works properly

**Related issue(s)**
https://github.com/kyma-incubator/ord-service/pull/4
