### PR TITLE
Ord api docs

### DIFF
--- a/chart/compass/charts/gateway/templates/oathkeeper-rules.yaml
+++ b/chart/compass/charts/gateway/templates/oathkeeper-rules.yaml
@@ -30,7 +30,7 @@ spec:
     url: "http://{{ .Values.global.ordService.host }}:{{ .Values.global.ordService.port }}"
   match:
     methods: ["GET"]
-    url: <http|https>://{{ .Values.global.gateway.tls.host }}.{{ .Values.global.ingress.domainName }}<(:(80|443))?>{{ .Values.global.ordService.prefix }}/<.*>
+    url: <http|https>://{{ .Values.global.gateway.tls.host }}.{{ .Values.global.ingress.domainName }}<(:(80|443))?>}<{{ .Values.global.ordService.prefix }}|{{ .Values.global.ordService.staticPrefix }}>/<.*>
   authenticators:
     - handler: oauth2_introspection
   authorizer:

--- a/chart/compass/charts/gateway/templates/oathkeeper-rules.yaml
+++ b/chart/compass/charts/gateway/templates/oathkeeper-rules.yaml
@@ -30,7 +30,7 @@ spec:
     url: "http://{{ .Values.global.ordService.host }}:{{ .Values.global.ordService.port }}"
   match:
     methods: ["GET"]
-    url: <http|https>://{{ .Values.global.gateway.tls.host }}.{{ .Values.global.ingress.domainName }}<(:(80|443))?>}<{{ .Values.global.ordService.prefix }}|{{ .Values.global.ordService.staticPrefix }}>/<.*>
+    url: <http|https>://{{ .Values.global.gateway.tls.host }}.{{ .Values.global.ingress.domainName }}<(:(80|443))?><{{ .Values.global.ordService.prefix }}|{{ .Values.global.ordService.staticPrefix }}>/<.*>
   authenticators:
     - handler: oauth2_introspection
   authorizer:

--- a/chart/compass/charts/gateway/templates/virtualservice.yaml
+++ b/chart/compass/charts/gateway/templates/virtualservice.yaml
@@ -38,7 +38,17 @@ spec:
             number: {{ .Values.global.tenantFetcher.port }}
     - match:
       - uri:
+          prefix:  {{ .Values.global.ordService.docsPrefix }}
+      route:
+      - destination:
+          host: {{ .Values.global.ordService.host }}
+          port:
+            number: {{ .Values.global.ordService.port }}
+    - match:
+      - uri:
           prefix: {{ .Values.global.ordService.prefix }}
+      - uri:
+          prefix: {{ .Values.global.ordService.staticPrefix }}
       route:
         - destination:
             host: {{ .Values.global.oathkeeper.host }}

--- a/chart/compass/charts/ord-service/templates/tests/ord-service-test.yaml
+++ b/chart/compass/charts/ord-service/templates/tests/ord-service-test.yaml
@@ -34,6 +34,8 @@ spec:
           env:
             - name: ORD_SERVICE_URL
               value: "https://{{ .Values.global.gateway.tls.host }}.{{ .Values.global.ingress.domainName }}{{ .Values.global.ordService.prefix }}"
+            - name: ORD_SERVICE_STATIC_URL
+              value: "https://{{ .Values.global.gateway.tls.host }}.{{ .Values.global.ingress.domainName }}{{ .Values.global.ordService.staticPrefix }}"
             - name: ORD_SERVICE_HEALTHZ_URL
               value: "http://compass-ord-service.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.global.director.port }}/actuator/health"
             - name: ORD_SERVICE_DEFAULT_RESPONSE_TYPE

--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -32,7 +32,7 @@ global:
       version: "PR-1698"
     ord_service:
       dir:
-      version: "PR-5"
+      version: "PR-9"
     healthchecker:
       dir:
       version: "PR-1698"

--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -260,7 +260,9 @@ global:
 
   ordService:
     host: compass-ord-service.compass-system.svc.cluster.local
-    prefix: /open-resource-discovery
+    prefix: /open-resource-discovery-service
+    docsPrefix: /open-resource-discovery-docs
+    staticPrefix: /open-resource-discovery-static
     port: 3000
     defaultResponseType: "xml"
 

--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -65,7 +65,7 @@ global:
         version: "PR-1698"
       ord_service:
         dir:
-        version: "PR-1702"
+        version: "PR-1705"
   isLocalEnv: false
   oauth2:
     host: oauth2

--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -260,9 +260,9 @@ global:
 
   ordService:
     host: compass-ord-service.compass-system.svc.cluster.local
-    prefix: /open-resource-discovery-service
+    prefix: /open-resource-discovery-service/v0
     docsPrefix: /open-resource-discovery-docs
-    staticPrefix: /open-resource-discovery-static
+    staticPrefix: /open-resource-discovery-static/v0
     port: 3000
     defaultResponseType: "xml"
 

--- a/tests/ord-service/tests/api_test.go
+++ b/tests/ord-service/tests/api_test.go
@@ -129,19 +129,19 @@ func TestORDService(t *testing.T) {
 	})
 
 	t.Run("400 when requests to ORD Service api specification do not have tenant header", func(t *testing.T) {
-		makeRequestWithStatusExpect(t, httpClient, fmt.Sprintf(testConfig.ORDServiceURL+"/api/%s/specification", apiDefinitionIDDefaultTenant), http.StatusBadRequest)
+		makeRequestWithStatusExpect(t, httpClient, fmt.Sprintf(testConfig.ORDServiceStaticURL+"/api/%s/specification", apiDefinitionIDDefaultTenant), http.StatusBadRequest)
 	})
 
 	t.Run("400 when requests to ORD Service event specification do not have tenant header", func(t *testing.T) {
-		makeRequestWithStatusExpect(t, httpClient, fmt.Sprintf(testConfig.ORDServiceURL+"/event/%s/specification", eventDefinitionIDDefaultTenant), http.StatusBadRequest)
+		makeRequestWithStatusExpect(t, httpClient, fmt.Sprintf(testConfig.ORDServiceStaticURL+"/event/%s/specification", eventDefinitionIDDefaultTenant), http.StatusBadRequest)
 	})
 
 	t.Run("400 when requests to ORD Service api specification have wrong tenant header", func(t *testing.T) {
-		makeRequestWithHeadersAndStatusExpect(t, httpClient, fmt.Sprintf(testConfig.ORDServiceURL+"/api/%s/specification", apiDefinitionIDDefaultTenant), map[string][]string{tenantHeader: {"wrong-tenant"}}, http.StatusBadRequest)
+		makeRequestWithHeadersAndStatusExpect(t, httpClient, fmt.Sprintf(testConfig.ORDServiceStaticURL+"/api/%s/specification", apiDefinitionIDDefaultTenant), map[string][]string{tenantHeader: {"wrong-tenant"}}, http.StatusBadRequest)
 	})
 
 	t.Run("400 when requests to ORD Service event specification have wrong tenant header", func(t *testing.T) {
-		makeRequestWithHeadersAndStatusExpect(t, httpClient, fmt.Sprintf(testConfig.ORDServiceURL+"/event/%s/specification", eventDefinitionIDDefaultTenant), map[string][]string{tenantHeader: {"wrong-tenant"}}, http.StatusBadRequest)
+		makeRequestWithHeadersAndStatusExpect(t, httpClient, fmt.Sprintf(testConfig.ORDServiceStaticURL+"/event/%s/specification", eventDefinitionIDDefaultTenant), map[string][]string{tenantHeader: {"wrong-tenant"}}, http.StatusBadRequest)
 	})
 
 	t.Run("Requesting entities without specifying response format falls back to configured default response type when Accept header allows everything", func(t *testing.T) {
@@ -244,7 +244,7 @@ func TestORDService(t *testing.T) {
 
 				specURL := specs[0].Get("url").String()
 				specPath := fmt.Sprintf("/api/%s/specification", apiID)
-				require.Equal(t, testConfig.ORDServiceURL+specPath, specURL)
+				require.Equal(t, testConfig.ORDServiceStaticURL+specPath, specURL)
 
 				respBody := makeRequestWithHeaders(t, httpClient, specURL, map[string][]string{tenantHeader: {testData.tenant}})
 
@@ -310,7 +310,7 @@ func TestORDService(t *testing.T) {
 
 				specURL := specs[0].Get("url").String()
 				specPath := fmt.Sprintf("/event/%s/specification", eventID)
-				require.Equal(t, testConfig.ORDServiceURL+specPath, specURL)
+				require.Equal(t, testConfig.ORDServiceStaticURL+specPath, specURL)
 
 				respBody := makeRequestWithHeaders(t, httpClient, specURL, map[string][]string{tenantHeader: {testData.tenant}})
 
@@ -477,13 +477,13 @@ func TestORDService(t *testing.T) {
 	}
 
 	t.Run("404 when request to ORD Service for api spec have another tenant header value", func(t *testing.T) {
-		makeRequestWithHeadersAndStatusExpect(t, httpClient, fmt.Sprintf(testConfig.ORDServiceURL+"/api/%s/specification", apiDefinitionIDDefaultTenant), map[string][]string{tenantHeader: {testConfig.Tenant}}, http.StatusNotFound)
-		makeRequestWithHeadersAndStatusExpect(t, httpClient, fmt.Sprintf(testConfig.ORDServiceURL+"/api/%s/specification", apiDefinitionIDDefaultTenant), map[string][]string{tenantHeader: {testConfig.DefaultTenant}}, http.StatusOK)
+		makeRequestWithHeadersAndStatusExpect(t, httpClient, fmt.Sprintf(testConfig.ORDServiceStaticURL+"/api/%s/specification", apiDefinitionIDDefaultTenant), map[string][]string{tenantHeader: {testConfig.Tenant}}, http.StatusNotFound)
+		makeRequestWithHeadersAndStatusExpect(t, httpClient, fmt.Sprintf(testConfig.ORDServiceStaticURL+"/api/%s/specification", apiDefinitionIDDefaultTenant), map[string][]string{tenantHeader: {testConfig.DefaultTenant}}, http.StatusOK)
 	})
 
 	t.Run("404 when request to ORD Service for event spec have another tenant header value", func(t *testing.T) {
-		makeRequestWithHeadersAndStatusExpect(t, httpClient, fmt.Sprintf(testConfig.ORDServiceURL+"/event/%s/specification", eventDefinitionIDDefaultTenant), map[string][]string{tenantHeader: {testConfig.Tenant}}, http.StatusNotFound)
-		makeRequestWithHeadersAndStatusExpect(t, httpClient, fmt.Sprintf(testConfig.ORDServiceURL+"/event/%s/specification", eventDefinitionIDDefaultTenant), map[string][]string{tenantHeader: {testConfig.DefaultTenant}}, http.StatusOK)
+		makeRequestWithHeadersAndStatusExpect(t, httpClient, fmt.Sprintf(testConfig.ORDServiceStaticURL+"/event/%s/specification", eventDefinitionIDDefaultTenant), map[string][]string{tenantHeader: {testConfig.Tenant}}, http.StatusNotFound)
+		makeRequestWithHeadersAndStatusExpect(t, httpClient, fmt.Sprintf(testConfig.ORDServiceStaticURL+"/event/%s/specification", eventDefinitionIDDefaultTenant), map[string][]string{tenantHeader: {testConfig.DefaultTenant}}, http.StatusOK)
 	})
 
 	t.Run("Errors generate user-friendly message", func(t *testing.T) {

--- a/tests/ord-service/tests/main_test.go
+++ b/tests/ord-service/tests/main_test.go
@@ -31,6 +31,7 @@ type config struct {
 	Tenant                        string
 	DirectorURL                   string
 	ORDServiceURL                 string
+	ORDServiceStaticURL           string
 	ORDServiceDefaultResponseType string
 }
 


### PR DESCRIPTION
- Add versioning of the ORD service APIs
- Swagger docs for REST APIs of the ORD service.
- Add full version in $metadata endpoint of the OData API