### PR TITLE
Modify GQL library config to reference bundles instead of packages

### DIFF
--- a/components/director/pkg/graphql/config.yaml
+++ b/components/director/pkg/graphql/config.yaml
@@ -62,9 +62,9 @@ models:
         resolver: true
       eventingConfiguration:
         resolver: true
-      packages:
+      bundles:
         resolver: true
-      package:
+      bundle:
         resolver: true
   Bundle:
     model: "github.com/kyma-incubator/compass/components/director/pkg/graphql.Bundle"


### PR DESCRIPTION
# Modify GQL library config to reference bundles instead of packages

Was forgotten in: https://github.com/kyma-incubator/compass/pull/1693