### PR TITLE
Disable envoy proxy for (cron) jobs

### DIFF
--- a/chart/compass/templates/migrator-job.yaml
+++ b/chart/compass/templates/migrator-job.yaml
@@ -1,84 +1,86 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-    name: compass-migration
-    labels:
-        app: {{ .Chart.Name }}
-        release: {{ .Release.Name }}
-    annotations:
-        "helm.sh/hook": post-install,post-upgrade
-        "helm.sh/hook-weight": "0"
-        "helm.sh/hook-delete-policy": before-hook-creation
+  name: compass-migration
+  labels:
+    app: { { .Chart.Name } }
+    release: { { .Release.Name } }
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation
 spec:
-    template:
-        metadata:
-            labels:
-                app: {{ .Chart.Name }}
-                release: {{ .Release.Name }}
-        spec:
-            restartPolicy: Never
-            shareProcessNamespace: true
-            containers:
-                {{if eq .Values.global.database.embedded.enabled false}}
-                - name: cloudsql-proxy
-                  image: gcr.io/cloudsql-docker/gce-proxy:1.18.0-alpine
-                  command:
-                  - /bin/sh
-                  args:
-                  - -c
-                  - "trap 'exit 0' SIGINT; echo 'Waiting for istio-proxy to start...' && sleep 15; /cloud_sql_proxy -instances={{ .Values.global.database.managedGCP.instanceConnectionName }}=tcp:5432 -credential_file=/secrets/cloudsql-instance-credentials/credentials.json -term_timeout=2s"
-                  volumeMounts:
-                      - name: cloudsql-instance-credentials
-                        mountPath: /secrets/cloudsql-instance-credentials
-                        readOnly: true
-                {{end}}
-                - name: migrator
-                  image: {{ .Values.global.images.containerRegistry.path }}/{{ .Values.global.images.schema_migrator.dir }}compass-schema-migrator:{{ .Values.global.images.schema_migrator.version }}
-                  imagePullPolicy: IfNotPresent
-                  env:
-                      - name: DB_USER
-                        valueFrom:
-                            secretKeyRef:
-                                name: compass-postgresql
-                                key: postgresql-director-username
-                      - name: DB_PASSWORD
-                        valueFrom:
-                            secretKeyRef:
-                                name: compass-postgresql
-                                key: postgresql-director-password
-                      - name: DB_HOST
-                        valueFrom:
-                            secretKeyRef:
-                                name: compass-postgresql
-                                key: postgresql-serviceName
-                      - name: DB_PORT
-                        valueFrom:
-                            secretKeyRef:
-                                name: compass-postgresql
-                                key: postgresql-servicePort
-                      - name: DB_NAME
-                        valueFrom:
-                            secretKeyRef:
-                                name: compass-postgresql
-                                key: postgresql-director-db-name
-                      - name: DB_SSL
-                        valueFrom:
-                            secretKeyRef:
-                                name: compass-postgresql
-                                key: postgresql-sslMode
-                      - name: MIGRATION_PATH
-                        value: "director"
-                      - name: "DIRECTION"
-                        value: "up"
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
+      labels:
+        app: { { .Chart.Name } }
+        release: { { .Release.Name } }
+    spec:
+      restartPolicy: Never
+      shareProcessNamespace: true
+      containers:
+        {{if eq .Values.global.database.embedded.enabled false}}
+        - name: cloudsql-proxy
+          image: gcr.io/cloudsql-docker/gce-proxy:1.18.0-alpine
+          command:
+            - /bin/sh
+          args:
+            - -c
+            - "trap 'exit 0' SIGINT; echo 'Waiting for istio-proxy to start...' && sleep 15; /cloud_sql_proxy -instances={{ .Values.global.database.managedGCP.instanceConnectionName }}=tcp:5432 -credential_file=/secrets/cloudsql-instance-credentials/credentials.json -term_timeout=2s"
+          volumeMounts:
+            - name: cloudsql-instance-credentials
+              mountPath: /secrets/cloudsql-instance-credentials
+              readOnly: true
+        {{end}}
+        - name: migrator
+          image: { { .Values.global.images.containerRegistry.path } }/{{ .Values.global.images.schema_migrator.dir }}compass-schema-migrator:{{ .Values.global.images.schema_migrator.version }}
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: DB_USER
+              valueFrom:
+                secretKeyRef:
+                  name: compass-postgresql
+                  key: postgresql-director-username
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: compass-postgresql
+                  key: postgresql-director-password
+            - name: DB_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: compass-postgresql
+                  key: postgresql-serviceName
+            - name: DB_PORT
+              valueFrom:
+                secretKeyRef:
+                  name: compass-postgresql
+                  key: postgresql-servicePort
+            - name: DB_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: compass-postgresql
+                  key: postgresql-director-db-name
+            - name: DB_SSL
+              valueFrom:
+                secretKeyRef:
+                  name: compass-postgresql
+                  key: postgresql-sslMode
+            - name: MIGRATION_PATH
+              value: "director"
+            - name: "DIRECTION"
+              value: "up"
 
-                  command:
-                    - "/bin/bash"
-                  args:
-                    - "-c"
-                    - "sleep 20; ./run.sh; exit_code=$?; echo '# KILLING PILOT-AGENT #'; pkill -INT cloud_sql_proxy; curl -XPOST http://127.0.0.1:15020/quitquitquit; sleep 5; exit $exit_code;"
-            {{if eq .Values.global.database.embedded.enabled false}}
-            volumes:
-              - name: cloudsql-instance-credentials
-                secret:
-                  secretName: cloudsql-instance-credentials
-            {{end}}
+          command:
+            - "/bin/bash"
+          args:
+            - "-c"
+            - "sleep 20; ./run.sh; exit_code=$?; echo '# KILLING PILOT-AGENT #'; pkill -INT cloud_sql_proxy; curl -XPOST http://127.0.0.1:15020/quitquitquit; sleep 5; exit $exit_code;"
+      {{if eq .Values.global.database.embedded.enabled false}}
+      volumes:
+        - name: cloudsql-instance-credentials
+          secret:
+            secretName: cloudsql-instance-credentials
+      {{end}}

--- a/chart/compass/templates/tenant-fetcher-job.yaml
+++ b/chart/compass/templates/tenant-fetcher-job.yaml
@@ -26,6 +26,8 @@ spec:
     spec:
       template:
         metadata:
+          annotations:
+            sidecar.istio.io/inject: "false"
           labels:
             cronjob: tenant-fetcher
         spec:


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:
- The `compass-migration` job and `tenant-fetcher` cron jobs do not need an envoy proxy, hence we can disable the sidecar injection. Pros: Kyma update runs smoothly, otherwise we have to manually delete all pods from these jobs because of [this script](https://github.com/kyma-project/kyma/blob/release-1.17/resources/istio/files/istio-proxy-reset.sh), that runs during the migration.