### PR TITLE
Fix migration related to the extension of application resources

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -38,7 +38,7 @@ global:
       version: "PR-1720"
     schema_migrator:
       dir:
-      version: "PR-1714"
+      version: "PR-1727"
     system_broker:
       dir:
       version: "PR-1721"

--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -23,7 +23,7 @@ global:
       version: "PR-1720"
     director:
       dir:
-      version: "PR-1714"
+      version: "PR-1727"
     gateway:
       dir:
       version: "PR-1720"

--- a/components/director/internal/domain/api/converter.go
+++ b/components/director/internal/domain/api/converter.go
@@ -1,9 +1,10 @@
 package api
 
 import (
+	"time"
+
 	"github.com/kyma-incubator/compass/components/director/internal/domain/version"
 	"github.com/pkg/errors"
-	"time"
 
 	"github.com/kyma-incubator/compass/components/director/internal/model"
 	"github.com/kyma-incubator/compass/components/director/internal/repo"

--- a/components/director/internal/domain/api/converter.go
+++ b/components/director/internal/domain/api/converter.go
@@ -3,6 +3,7 @@ package api
 import (
 	"github.com/kyma-incubator/compass/components/director/internal/domain/version"
 	"github.com/pkg/errors"
+	"time"
 
 	"github.com/kyma-incubator/compass/components/director/internal/model"
 	"github.com/kyma-incubator/compass/components/director/internal/repo"
@@ -53,9 +54,9 @@ func (c *converter) ToGraphQL(in *model.APIDefinition, spec *model.Spec) (*graph
 		BaseEntity: &graphql.BaseEntity{
 			ID:        in.ID,
 			Ready:     in.Ready,
-			CreatedAt: graphql.Timestamp(in.CreatedAt),
-			UpdatedAt: graphql.Timestamp(in.UpdatedAt),
-			DeletedAt: graphql.Timestamp(in.DeletedAt),
+			CreatedAt: timePtrToTimestampPtr(in.CreatedAt),
+			UpdatedAt: timePtrToTimestampPtr(in.UpdatedAt),
+			DeletedAt: timePtrToTimestampPtr(in.DeletedAt),
 			Error:     in.Error,
 		},
 	}, nil
@@ -167,4 +168,13 @@ func (c *converter) convertVersionToEntity(inVer *model.Version) version.Version
 	}
 
 	return c.version.ToEntity(*inVer)
+}
+
+func timePtrToTimestampPtr(time *time.Time) *graphql.Timestamp {
+	if time == nil {
+		return nil
+	}
+
+	t := graphql.Timestamp(*time)
+	return &t
 }

--- a/components/director/internal/domain/api/fixtures_test.go
+++ b/components/director/internal/domain/api/fixtures_test.go
@@ -68,9 +68,9 @@ func fixFullAPIDefinitionModel(placeholder string) (model.APIDefinition, model.S
 		BaseEntity: &model.BaseEntity{
 			ID:        apiDefID,
 			Ready:     true,
-			CreatedAt: fixedTimestamp,
-			UpdatedAt: time.Time{},
-			DeletedAt: time.Time{},
+			CreatedAt: &fixedTimestamp,
+			UpdatedAt: &time.Time{},
+			DeletedAt: &time.Time{},
 			Error:     nil,
 		},
 	}, spec
@@ -108,9 +108,9 @@ func fixFullGQLAPIDefinition(placeholder string) *graphql.APIDefinition {
 			ID:        apiDefID,
 			Ready:     true,
 			Error:     nil,
-			CreatedAt: graphql.Timestamp(fixedTimestamp),
-			UpdatedAt: graphql.Timestamp(time.Time{}),
-			DeletedAt: graphql.Timestamp(time.Time{}),
+			CreatedAt: timeToTimestampPtr(fixedTimestamp),
+			UpdatedAt: timeToTimestampPtr(time.Time{}),
+			DeletedAt: timeToTimestampPtr(time.Time{}),
 		},
 	}
 }
@@ -205,9 +205,9 @@ func fixFullEntityAPIDefinition(apiDefID, placeholder string) *api.Entity {
 		BaseEntity: &repo.BaseEntity{
 			ID:        apiDefID,
 			Ready:     true,
-			CreatedAt: fixedTimestamp,
-			UpdatedAt: time.Time{},
-			DeletedAt: time.Time{},
+			CreatedAt: &fixedTimestamp,
+			UpdatedAt: &time.Time{},
+			DeletedAt: &time.Time{},
 			Error:     sql.NullString{},
 		},
 	}
@@ -257,4 +257,9 @@ func fixGQLFetchRequest(url string, timestamp time.Time) *graphql.FetchRequest {
 			Condition: graphql.FetchRequestStatusConditionInitial,
 		},
 	}
+}
+
+func timeToTimestampPtr(time time.Time) *graphql.Timestamp {
+	t := graphql.Timestamp(time)
+	return &t
 }

--- a/components/director/internal/domain/api/repository_test.go
+++ b/components/director/internal/domain/api/repository_test.go
@@ -230,8 +230,8 @@ func TestPgRepository_Update(t *testing.T) {
 		ctx := persistence.SaveToContext(context.TODO(), sqlxDB)
 		apiModel, _ := fixFullAPIDefinitionModel("update")
 		entity := fixFullEntityAPIDefinition(apiDefID, "update")
-		entity.UpdatedAt = fixedTimestamp
-		entity.DeletedAt = fixedTimestamp // This is needed as workaround so that updatedAt timestamp is not updated
+		entity.UpdatedAt = &fixedTimestamp
+		entity.DeletedAt = &fixedTimestamp // This is needed as workaround so that updatedAt timestamp is not updated
 
 		convMock := &automock.APIDefinitionConverter{}
 		convMock.On("ToEntity", apiModel).Return(entity, nil)

--- a/components/director/internal/domain/application/converter.go
+++ b/components/director/internal/domain/application/converter.go
@@ -96,9 +96,9 @@ func (c *converter) ToGraphQL(in *model.Application) *graphql.Application {
 		BaseEntity: &graphql.BaseEntity{
 			ID:        in.ID,
 			Ready:     in.Ready,
-			CreatedAt: graphql.Timestamp(in.CreatedAt),
-			UpdatedAt: graphql.Timestamp(in.UpdatedAt),
-			DeletedAt: graphql.Timestamp(in.DeletedAt),
+			CreatedAt: timePtrToTimestampPtr(in.CreatedAt),
+			UpdatedAt: timePtrToTimestampPtr(in.UpdatedAt),
+			DeletedAt: timePtrToTimestampPtr(in.DeletedAt),
 			Error:     in.Error,
 		},
 	}
@@ -261,4 +261,13 @@ func (c *converter) statusConditionToModel(in *graphql.ApplicationStatusConditio
 	}
 
 	return &condition
+}
+
+func timePtrToTimestampPtr(time *time.Time) *graphql.Timestamp {
+	if time == nil {
+		return nil
+	}
+
+	t := graphql.Timestamp(*time)
+	return &t
 }

--- a/components/director/internal/domain/application/fixtures_test.go
+++ b/components/director/internal/domain/application/fixtures_test.go
@@ -112,9 +112,9 @@ func fixDetailedModelApplication(t *testing.T, id, tenant, name, description str
 			ID:        id,
 			Ready:     true,
 			Error:     nil,
-			CreatedAt: fixedTimestamp,
-			UpdatedAt: time.Time{},
-			DeletedAt: time.Time{},
+			CreatedAt: &fixedTimestamp,
+			UpdatedAt: &time.Time{},
+			DeletedAt: &time.Time{},
 		},
 	}
 }
@@ -137,9 +137,9 @@ func fixDetailedGQLApplication(t *testing.T, id, name, description string) *grap
 			ID:        id,
 			Ready:     true,
 			Error:     nil,
-			CreatedAt: graphql.Timestamp(fixedTimestamp),
-			UpdatedAt: graphql.Timestamp(time.Time{}),
-			DeletedAt: graphql.Timestamp(time.Time{}),
+			CreatedAt: timeToTimestampPtr(fixedTimestamp),
+			UpdatedAt: timeToTimestampPtr(time.Time{}),
+			DeletedAt: timeToTimestampPtr(time.Time{}),
 		},
 	}
 }
@@ -161,9 +161,9 @@ func fixDetailedEntityApplication(t *testing.T, id, tenant, name, description st
 			ID:        id,
 			Ready:     true,
 			Error:     sql.NullString{},
-			CreatedAt: fixedTimestamp,
-			UpdatedAt: time.Time{},
-			DeletedAt: time.Time{},
+			CreatedAt: &fixedTimestamp,
+			UpdatedAt: &time.Time{},
+			DeletedAt: &time.Time{},
 		},
 	}
 }
@@ -478,4 +478,9 @@ func fixBundlePage(bundles []*model.Bundle) *model.BundlePage {
 		},
 		TotalCount: len(bundles),
 	}
+}
+
+func timeToTimestampPtr(time time.Time) *graphql.Timestamp {
+	t := graphql.Timestamp(time)
+	return &t
 }

--- a/components/director/internal/domain/application/repository.go
+++ b/components/director/internal/domain/application/repository.go
@@ -70,8 +70,8 @@ func (r *pgRepository) Delete(ctx context.Context, tenant, id string) error {
 		}
 
 		app.Ready = false
-		if app.DeletedAt.IsZero() { // Needed for the tests but might be useful for the production also
-			app.DeletedAt = time.Now()
+		if app.GetDeletedAt().IsZero() { // Needed for the tests but might be useful for the production also
+			app.SetDeletedAt(time.Now())
 		}
 
 		return r.Update(ctx, app)

--- a/components/director/internal/domain/application/repository_test.go
+++ b/components/director/internal/domain/application/repository_test.go
@@ -92,7 +92,7 @@ func TestRepository_Delete(t *testing.T) {
 
 		appModel := fixDetailedModelApplication(t, givenID(), givenTenant(), "Test app", "Test app description")
 		appModel.Ready = false
-		appModel.DeletedAt = deletedAt
+		appModel.DeletedAt = &deletedAt
 		appEntity := fixDetailedEntityApplication(t, givenID(), givenTenant(), "Test app", "Test app description")
 
 		db, dbMock := testdb.MockDatabase(t)
@@ -112,7 +112,7 @@ func TestRepository_Delete(t *testing.T) {
 
 		appEntityWithDeletedTimestamp := fixDetailedEntityApplication(t, givenID(), givenTenant(), "Test app", "Test app description")
 		appEntityWithDeletedTimestamp.Ready = false
-		appEntityWithDeletedTimestamp.DeletedAt = deletedAt
+		appEntityWithDeletedTimestamp.DeletedAt = &deletedAt
 		mockConverter.On("ToEntity", appModel).Return(appEntityWithDeletedTimestamp, nil).Once()
 		defer mockConverter.AssertExpectations(t)
 
@@ -172,7 +172,7 @@ func TestRepository_Delete(t *testing.T) {
 
 		appModel := fixDetailedModelApplication(t, givenID(), givenTenant(), "Test app", "Test app description")
 		appModel.Ready = false
-		appModel.DeletedAt = deletedAt
+		appModel.DeletedAt = &deletedAt
 		appEntity := fixDetailedEntityApplication(t, givenID(), givenTenant(), "Test app", "Test app description")
 
 		db, dbMock := testdb.MockDatabase(t)
@@ -190,7 +190,7 @@ func TestRepository_Delete(t *testing.T) {
 
 		appEntityWithDeletedTimestamp := fixDetailedEntityApplication(t, givenID(), givenTenant(), "Test app", "Test app description")
 		appEntityWithDeletedTimestamp.Ready = false
-		appEntityWithDeletedTimestamp.DeletedAt = deletedAt
+		appEntityWithDeletedTimestamp.DeletedAt = &deletedAt
 		mockConverter.On("ToEntity", appModel).Return(appEntityWithDeletedTimestamp, nil).Once()
 		defer mockConverter.AssertExpectations(t)
 
@@ -342,8 +342,8 @@ func TestRepository_Update(t *testing.T) {
 		// given
 		appModel := fixDetailedModelApplication(t, givenID(), givenTenant(), "Test app", "Test app description")
 		appEntity := fixDetailedEntityApplication(t, givenID(), givenTenant(), "Test app", "Test app description")
-		appEntity.UpdatedAt = fixedTimestamp
-		appEntity.DeletedAt = fixedTimestamp // This is needed as workaround so that updatedAt timestamp is not updated
+		appEntity.UpdatedAt = &fixedTimestamp
+		appEntity.DeletedAt = &fixedTimestamp // This is needed as workaround so that updatedAt timestamp is not updated
 
 		mockConverter := &automock.EntityConverter{}
 		mockConverter.On("ToEntity", appModel).Return(appEntity, nil).Once()

--- a/components/director/internal/domain/bundle/converter.go
+++ b/components/director/internal/domain/bundle/converter.go
@@ -3,6 +3,7 @@ package mp_bundle
 import (
 	"database/sql"
 	"encoding/json"
+	"time"
 
 	"github.com/kyma-incubator/compass/components/director/pkg/apperrors"
 
@@ -114,9 +115,9 @@ func (c *converter) ToGraphQL(in *model.Bundle) (*graphql.Bundle, error) {
 		BaseEntity: &graphql.BaseEntity{
 			ID:        in.ID,
 			Ready:     in.Ready,
-			CreatedAt: graphql.Timestamp(in.CreatedAt),
-			UpdatedAt: graphql.Timestamp(in.UpdatedAt),
-			DeletedAt: graphql.Timestamp(in.DeletedAt),
+			CreatedAt: timePtrToTimestampPtr(in.CreatedAt),
+			UpdatedAt: timePtrToTimestampPtr(in.UpdatedAt),
+			DeletedAt: timePtrToTimestampPtr(in.DeletedAt),
 			Error:     in.Error,
 		},
 	}, nil
@@ -241,4 +242,13 @@ func (c *converter) jsonSchemaPtrToStrPtr(in *graphql.JSONSchema) *string {
 	}
 	out := string(*in)
 	return &out
+}
+
+func timePtrToTimestampPtr(time *time.Time) *graphql.Timestamp {
+	if time == nil {
+		return nil
+	}
+
+	t := graphql.Timestamp(*time)
+	return &t
 }

--- a/components/director/internal/domain/bundle/fixtures_test.go
+++ b/components/director/internal/domain/bundle/fixtures_test.go
@@ -183,9 +183,9 @@ func fixBundleModel(t *testing.T, name, desc string) *model.Bundle {
 			ID:        bundleID,
 			Ready:     true,
 			Error:     nil,
-			CreatedAt: fixedTimestamp,
-			UpdatedAt: time.Time{},
-			DeletedAt: time.Time{},
+			CreatedAt: &fixedTimestamp,
+			UpdatedAt: &time.Time{},
+			DeletedAt: &time.Time{},
 		},
 	}
 }
@@ -201,9 +201,9 @@ func fixGQLBundle(id, name, desc string) *graphql.Bundle {
 			ID:        id,
 			Ready:     true,
 			Error:     nil,
-			CreatedAt: graphql.Timestamp(fixedTimestamp),
-			UpdatedAt: graphql.Timestamp(time.Time{}),
-			DeletedAt: graphql.Timestamp(time.Time{}),
+			CreatedAt: timeToTimestampPtr(fixedTimestamp),
+			UpdatedAt: timeToTimestampPtr(time.Time{}),
+			DeletedAt: timeToTimestampPtr(time.Time{}),
 		},
 	}
 }
@@ -385,9 +385,9 @@ func fixEntityBundle(id, name, desc string) *mp_bundle.Entity {
 			ID:        id,
 			Ready:     true,
 			Error:     sql.NullString{},
-			CreatedAt: fixedTimestamp,
-			UpdatedAt: time.Time{},
-			DeletedAt: time.Time{},
+			CreatedAt: &fixedTimestamp,
+			UpdatedAt: &time.Time{},
+			DeletedAt: &time.Time{},
 		},
 	}
 }
@@ -467,4 +467,9 @@ func fixGQLBundleInstanceAuth(id string) *graphql.BundleInstanceAuth {
 		Auth:        fixGQLAuth(),
 		Status:      &status,
 	}
+}
+
+func timeToTimestampPtr(time time.Time) *graphql.Timestamp {
+	t := graphql.Timestamp(time)
+	return &t
 }

--- a/components/director/internal/domain/bundle/repository_test.go
+++ b/components/director/internal/domain/bundle/repository_test.go
@@ -83,8 +83,8 @@ func TestPgRepository_Update(t *testing.T) {
 		ctx := persistence.SaveToContext(context.TODO(), sqlxDB)
 		bndl := fixBundleModel(t, "foo", "update")
 		entity := fixEntityBundle(bundleID, "foo", "update")
-		entity.UpdatedAt = fixedTimestamp
-		entity.DeletedAt = fixedTimestamp // This is needed as workaround so that updatedAt timestamp is not updated
+		entity.UpdatedAt = &fixedTimestamp
+		entity.DeletedAt = &fixedTimestamp // This is needed as workaround so that updatedAt timestamp is not updated
 
 		convMock := &automock.EntityConverter{}
 		convMock.On("ToEntity", bndl).Return(entity, nil)

--- a/components/director/internal/domain/document/converter.go
+++ b/components/director/internal/domain/document/converter.go
@@ -3,6 +3,7 @@ package document
 import (
 	"github.com/kyma-incubator/compass/components/director/internal/repo"
 	"github.com/pkg/errors"
+	"time"
 
 	"github.com/kyma-incubator/compass/components/director/internal/model"
 	"github.com/kyma-incubator/compass/components/director/pkg/graphql"
@@ -38,9 +39,9 @@ func (c *converter) ToGraphQL(in *model.Document) *graphql.Document {
 		BaseEntity: &graphql.BaseEntity{
 			ID:        in.ID,
 			Ready:     in.Ready,
-			CreatedAt: graphql.Timestamp(in.CreatedAt),
-			UpdatedAt: graphql.Timestamp(in.UpdatedAt),
-			DeletedAt: graphql.Timestamp(in.DeletedAt),
+			CreatedAt: timePtrToTimestampPtr(in.CreatedAt),
+			UpdatedAt: timePtrToTimestampPtr(in.UpdatedAt),
+			DeletedAt: timePtrToTimestampPtr(in.DeletedAt),
 			Error:     in.Error,
 		},
 	}
@@ -153,4 +154,13 @@ func (c *converter) FromEntity(in Entity) (model.Document, error) {
 		},
 	}
 	return out, nil
+}
+
+func timePtrToTimestampPtr(time *time.Time) *graphql.Timestamp {
+	if time == nil {
+		return nil
+	}
+
+	t := graphql.Timestamp(*time)
+	return &t
 }

--- a/components/director/internal/domain/document/converter.go
+++ b/components/director/internal/domain/document/converter.go
@@ -1,9 +1,10 @@
 package document
 
 import (
+	"time"
+
 	"github.com/kyma-incubator/compass/components/director/internal/repo"
 	"github.com/pkg/errors"
-	"time"
 
 	"github.com/kyma-incubator/compass/components/director/internal/model"
 	"github.com/kyma-incubator/compass/components/director/pkg/graphql"

--- a/components/director/internal/domain/document/converter_test.go
+++ b/components/director/internal/domain/document/converter_test.go
@@ -165,9 +165,9 @@ func TestToEntity(t *testing.T) {
 		BaseEntity: &model.BaseEntity{
 			ID:        "givenID",
 			Ready:     true,
-			CreatedAt: fixedTimestamp,
-			UpdatedAt: time.Time{},
-			DeletedAt: time.Time{},
+			CreatedAt: &fixedTimestamp,
+			UpdatedAt: &time.Time{},
+			DeletedAt: &time.Time{},
 			Error:     nil,
 		},
 	}

--- a/components/director/internal/domain/document/fixtures_test.go
+++ b/components/director/internal/domain/document/fixtures_test.go
@@ -36,9 +36,9 @@ func fixModelDocument(id, bundleID string) *model.Document {
 			ID:        id,
 			Ready:     true,
 			Error:     nil,
-			CreatedAt: fixedTimestamp,
-			UpdatedAt: time.Time{},
-			DeletedAt: time.Time{},
+			CreatedAt: &fixedTimestamp,
+			UpdatedAt: &time.Time{},
+			DeletedAt: &time.Time{},
 		},
 	}
 }
@@ -57,9 +57,9 @@ func fixEntityDocument(id, bundleID string) *document.Entity {
 			ID:        id,
 			Ready:     true,
 			Error:     sql.NullString{},
-			CreatedAt: fixedTimestamp,
-			UpdatedAt: time.Time{},
-			DeletedAt: time.Time{},
+			CreatedAt: &fixedTimestamp,
+			UpdatedAt: &time.Time{},
+			DeletedAt: &time.Time{},
 		},
 	}
 }
@@ -77,9 +77,9 @@ func fixGQLDocument(id, bundleID string) *graphql.Document {
 			ID:        id,
 			Ready:     true,
 			Error:     nil,
-			CreatedAt: graphql.Timestamp(fixedTimestamp),
-			UpdatedAt: graphql.Timestamp(time.Time{}),
-			DeletedAt: graphql.Timestamp(time.Time{}),
+			CreatedAt: timeToTimestampPtr(fixedTimestamp),
+			UpdatedAt: timeToTimestampPtr(time.Time{}),
+			DeletedAt: timeToTimestampPtr(time.Time{}),
 		},
 	}
 }
@@ -148,4 +148,9 @@ func fixGQLDocumentInput(id string) *graphql.DocumentInput {
 		Kind:        &docKind,
 		Data:        &docCLOB,
 	}
+}
+
+func timeToTimestampPtr(time time.Time) *graphql.Timestamp {
+	t := graphql.Timestamp(time)
+	return &t
 }

--- a/components/director/internal/domain/eventdef/converter.go
+++ b/components/director/internal/domain/eventdef/converter.go
@@ -6,6 +6,7 @@ import (
 	"github.com/kyma-incubator/compass/components/director/internal/repo"
 	"github.com/kyma-incubator/compass/components/director/pkg/graphql"
 	"github.com/pkg/errors"
+	"time"
 )
 
 //go:generate mockery -name=VersionConverter -output=automock -outpkg=automock -case=underscore
@@ -51,9 +52,9 @@ func (c *converter) ToGraphQL(in *model.EventDefinition, spec *model.Spec) (*gra
 		BaseEntity: &graphql.BaseEntity{
 			ID:        in.ID,
 			Ready:     in.Ready,
-			CreatedAt: graphql.Timestamp(in.CreatedAt),
-			UpdatedAt: graphql.Timestamp(in.UpdatedAt),
-			DeletedAt: graphql.Timestamp(in.DeletedAt),
+			CreatedAt: timePtrToTimestampPtr(in.CreatedAt),
+			UpdatedAt: timePtrToTimestampPtr(in.UpdatedAt),
+			DeletedAt: timePtrToTimestampPtr(in.DeletedAt),
 			Error:     in.Error,
 		},
 	}, nil
@@ -160,4 +161,13 @@ func (c *converter) convertVersionToEntity(inVer *model.Version) version.Version
 	}
 
 	return c.vc.ToEntity(*inVer)
+}
+
+func timePtrToTimestampPtr(time *time.Time) *graphql.Timestamp {
+	if time == nil {
+		return nil
+	}
+
+	t := graphql.Timestamp(*time)
+	return &t
 }

--- a/components/director/internal/domain/eventdef/converter.go
+++ b/components/director/internal/domain/eventdef/converter.go
@@ -1,12 +1,13 @@
 package eventdef
 
 import (
+	"time"
+
 	"github.com/kyma-incubator/compass/components/director/internal/domain/version"
 	"github.com/kyma-incubator/compass/components/director/internal/model"
 	"github.com/kyma-incubator/compass/components/director/internal/repo"
 	"github.com/kyma-incubator/compass/components/director/pkg/graphql"
 	"github.com/pkg/errors"
-	"time"
 )
 
 //go:generate mockery -name=VersionConverter -output=automock -outpkg=automock -case=underscore

--- a/components/director/internal/domain/eventdef/fixtures_test.go
+++ b/components/director/internal/domain/eventdef/fixtures_test.go
@@ -64,9 +64,9 @@ func fixFullEventDefinitionModel(placeholder string) (model.EventDefinition, mod
 		BaseEntity: &model.BaseEntity{
 			ID:        eventID,
 			Ready:     true,
-			CreatedAt: fixedTimestamp,
-			UpdatedAt: time.Time{},
-			DeletedAt: time.Time{},
+			CreatedAt: &fixedTimestamp,
+			UpdatedAt: &time.Time{},
+			DeletedAt: &time.Time{},
 			Error:     nil,
 		},
 	}, spec
@@ -103,9 +103,9 @@ func fixFullGQLEventDefinition(placeholder string) *graphql.EventDefinition {
 			ID:        eventID,
 			Ready:     true,
 			Error:     nil,
-			CreatedAt: graphql.Timestamp(fixedTimestamp),
-			UpdatedAt: graphql.Timestamp(time.Time{}),
-			DeletedAt: graphql.Timestamp(time.Time{}),
+			CreatedAt: timeToTimestampPtr(fixedTimestamp),
+			UpdatedAt: timeToTimestampPtr(time.Time{}),
+			DeletedAt: timeToTimestampPtr(time.Time{}),
 		},
 	}
 }
@@ -196,9 +196,9 @@ func fixFullEntityEventDefinition(eventID, placeholder string) *event.Entity {
 		BaseEntity: &repo.BaseEntity{
 			ID:        eventID,
 			Ready:     true,
-			CreatedAt: fixedTimestamp,
-			UpdatedAt: time.Time{},
-			DeletedAt: time.Time{},
+			CreatedAt: &fixedTimestamp,
+			UpdatedAt: &time.Time{},
+			DeletedAt: &time.Time{},
 			Error:     sql.NullString{},
 		},
 	}
@@ -246,4 +246,9 @@ func fixGQLFetchRequest(url string, timestamp time.Time) *graphql.FetchRequest {
 			Condition: graphql.FetchRequestStatusConditionInitial,
 		},
 	}
+}
+
+func timeToTimestampPtr(time time.Time) *graphql.Timestamp {
+	t := graphql.Timestamp(time)
+	return &t
 }

--- a/components/director/internal/domain/eventdef/repository_test.go
+++ b/components/director/internal/domain/eventdef/repository_test.go
@@ -229,8 +229,8 @@ func TestPgRepository_Update(t *testing.T) {
 		ctx := persistence.SaveToContext(context.TODO(), sqlxDB)
 		eventModel, _ := fixFullEventDefinitionModel("update")
 		entity := fixFullEntityEventDefinition(eventID, "update")
-		entity.UpdatedAt = fixedTimestamp
-		entity.DeletedAt = fixedTimestamp // This is needed as workaround so that updatedAt timestamp is not updated
+		entity.UpdatedAt = &fixedTimestamp
+		entity.DeletedAt = &fixedTimestamp // This is needed as workaround so that updatedAt timestamp is not updated
 
 		convMock := &automock.EventAPIDefinitionConverter{}
 		convMock.On("ToEntity", eventModel).Return(entity, nil)

--- a/components/director/internal/model/base_entity.go
+++ b/components/director/internal/model/base_entity.go
@@ -46,9 +46,9 @@ type Entity interface {
 type BaseEntity struct {
 	ID        string
 	Ready     bool
-	CreatedAt time.Time
-	UpdatedAt time.Time
-	DeletedAt time.Time
+	CreatedAt *time.Time
+	UpdatedAt *time.Time
+	DeletedAt *time.Time
 	Error     *string
 }
 
@@ -69,27 +69,36 @@ func (e *BaseEntity) SetReady(ready bool) {
 }
 
 func (e *BaseEntity) GetCreatedAt() time.Time {
-	return e.CreatedAt
+	if e.CreatedAt == nil {
+		return time.Time{}
+	}
+	return *e.CreatedAt
 }
 
 func (e *BaseEntity) SetCreatedAt(t time.Time) {
-	e.CreatedAt = t
+	e.CreatedAt = &t
 }
 
 func (e *BaseEntity) GetUpdatedAt() time.Time {
-	return e.UpdatedAt
+	if e.UpdatedAt == nil {
+		return time.Time{}
+	}
+	return *e.UpdatedAt
 }
 
 func (e *BaseEntity) SetUpdatedAt(t time.Time) {
-	e.UpdatedAt = t
+	e.UpdatedAt = &t
 }
 
 func (e *BaseEntity) GetDeletedAt() time.Time {
-	return e.DeletedAt
+	if e.DeletedAt == nil {
+		return time.Time{}
+	}
+	return *e.DeletedAt
 }
 
 func (e *BaseEntity) SetDeletedAt(t time.Time) {
-	e.DeletedAt = t
+	e.DeletedAt = &t
 }
 
 func (e *BaseEntity) GetError() *string {

--- a/components/director/internal/repo/sql_types.go
+++ b/components/director/internal/repo/sql_types.go
@@ -26,9 +26,9 @@ type Entity interface {
 type BaseEntity struct {
 	ID        string         `db:"id"`
 	Ready     bool           `db:"ready"`
-	CreatedAt time.Time      `db:"created_at"`
-	UpdatedAt time.Time      `db:"updated_at"`
-	DeletedAt time.Time      `db:"deleted_at"`
+	CreatedAt *time.Time     `db:"created_at"`
+	UpdatedAt *time.Time     `db:"updated_at"`
+	DeletedAt *time.Time     `db:"deleted_at"`
 	Error     sql.NullString `db:"error"`
 }
 
@@ -41,27 +41,36 @@ func (e *BaseEntity) SetReady(ready bool) {
 }
 
 func (e *BaseEntity) GetCreatedAt() time.Time {
-	return e.CreatedAt
+	if e.CreatedAt == nil {
+		return time.Time{}
+	}
+	return *e.CreatedAt
 }
 
 func (e *BaseEntity) SetCreatedAt(t time.Time) {
-	e.CreatedAt = t
+	e.CreatedAt = &t
 }
 
 func (e *BaseEntity) GetUpdatedAt() time.Time {
-	return e.UpdatedAt
+	if e.UpdatedAt == nil {
+		return time.Time{}
+	}
+	return *e.UpdatedAt
 }
 
 func (e *BaseEntity) SetUpdatedAt(t time.Time) {
-	e.UpdatedAt = t
+	e.UpdatedAt = &t
 }
 
 func (e *BaseEntity) GetDeletedAt() time.Time {
-	return e.DeletedAt
+	if e.DeletedAt == nil {
+		return time.Time{}
+	}
+	return *e.DeletedAt
 }
 
 func (e *BaseEntity) SetDeletedAt(t time.Time) {
-	e.DeletedAt = t
+	e.DeletedAt = &t
 }
 
 func (e *BaseEntity) GetError() sql.NullString {

--- a/components/director/pkg/graphql/base_entity.go
+++ b/components/director/pkg/graphql/base_entity.go
@@ -24,12 +24,12 @@ type Entity interface {
 }
 
 type BaseEntity struct {
-	ID        string    `json:"id"`
-	Ready     bool      `json:"ready"`
-	CreatedAt Timestamp `json:"createdAt"`
-	UpdatedAt Timestamp `json:"updatedAt"`
-	DeletedAt Timestamp `json:"deletedAt"`
-	Error     *string   `json:"error"`
+	ID        string     `json:"id"`
+	Ready     bool       `json:"ready"`
+	CreatedAt *Timestamp `json:"createdAt"`
+	UpdatedAt *Timestamp `json:"updatedAt"`
+	DeletedAt *Timestamp `json:"deletedAt"`
+	Error     *string    `json:"error"`
 }
 
 func (e *BaseEntity) GetID() string {

--- a/components/director/pkg/graphql/schema_gen.go
+++ b/components/director/pkg/graphql/schema_gen.go
@@ -6968,10 +6968,10 @@ func (ec *executionContext) _APIDefinition_created_at(ctx context.Context, field
 	if resTmp == nil {
 		return graphql.Null
 	}
-	res := resTmp.(Timestamp)
+	res := resTmp.(*Timestamp)
 	rctx.Result = res
 	ctx = ec.Tracer.StartFieldChildExecution(ctx)
-	return ec.marshalOTimestamp2githubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋdirectorᚋpkgᚋgraphqlᚐTimestamp(ctx, field.Selections, res)
+	return ec.marshalOTimestamp2ᚖgithubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋdirectorᚋpkgᚋgraphqlᚐTimestamp(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _APIDefinition_updated_at(ctx context.Context, field graphql.CollectedField, obj *APIDefinition) (ret graphql.Marshaler) {
@@ -7002,10 +7002,10 @@ func (ec *executionContext) _APIDefinition_updated_at(ctx context.Context, field
 	if resTmp == nil {
 		return graphql.Null
 	}
-	res := resTmp.(Timestamp)
+	res := resTmp.(*Timestamp)
 	rctx.Result = res
 	ctx = ec.Tracer.StartFieldChildExecution(ctx)
-	return ec.marshalOTimestamp2githubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋdirectorᚋpkgᚋgraphqlᚐTimestamp(ctx, field.Selections, res)
+	return ec.marshalOTimestamp2ᚖgithubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋdirectorᚋpkgᚋgraphqlᚐTimestamp(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _APIDefinition_deleted_at(ctx context.Context, field graphql.CollectedField, obj *APIDefinition) (ret graphql.Marshaler) {
@@ -7036,10 +7036,10 @@ func (ec *executionContext) _APIDefinition_deleted_at(ctx context.Context, field
 	if resTmp == nil {
 		return graphql.Null
 	}
-	res := resTmp.(Timestamp)
+	res := resTmp.(*Timestamp)
 	rctx.Result = res
 	ctx = ec.Tracer.StartFieldChildExecution(ctx)
-	return ec.marshalOTimestamp2githubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋdirectorᚋpkgᚋgraphqlᚐTimestamp(ctx, field.Selections, res)
+	return ec.marshalOTimestamp2ᚖgithubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋdirectorᚋpkgᚋgraphqlᚐTimestamp(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _APIDefinition_error(ctx context.Context, field graphql.CollectedField, obj *APIDefinition) (ret graphql.Marshaler) {
@@ -7866,10 +7866,10 @@ func (ec *executionContext) _Application_createdAt(ctx context.Context, field gr
 	if resTmp == nil {
 		return graphql.Null
 	}
-	res := resTmp.(Timestamp)
+	res := resTmp.(*Timestamp)
 	rctx.Result = res
 	ctx = ec.Tracer.StartFieldChildExecution(ctx)
-	return ec.marshalOTimestamp2githubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋdirectorᚋpkgᚋgraphqlᚐTimestamp(ctx, field.Selections, res)
+	return ec.marshalOTimestamp2ᚖgithubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋdirectorᚋpkgᚋgraphqlᚐTimestamp(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _Application_updatedAt(ctx context.Context, field graphql.CollectedField, obj *Application) (ret graphql.Marshaler) {
@@ -7900,10 +7900,10 @@ func (ec *executionContext) _Application_updatedAt(ctx context.Context, field gr
 	if resTmp == nil {
 		return graphql.Null
 	}
-	res := resTmp.(Timestamp)
+	res := resTmp.(*Timestamp)
 	rctx.Result = res
 	ctx = ec.Tracer.StartFieldChildExecution(ctx)
-	return ec.marshalOTimestamp2githubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋdirectorᚋpkgᚋgraphqlᚐTimestamp(ctx, field.Selections, res)
+	return ec.marshalOTimestamp2ᚖgithubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋdirectorᚋpkgᚋgraphqlᚐTimestamp(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _Application_deletedAt(ctx context.Context, field graphql.CollectedField, obj *Application) (ret graphql.Marshaler) {
@@ -7934,10 +7934,10 @@ func (ec *executionContext) _Application_deletedAt(ctx context.Context, field gr
 	if resTmp == nil {
 		return graphql.Null
 	}
-	res := resTmp.(Timestamp)
+	res := resTmp.(*Timestamp)
 	rctx.Result = res
 	ctx = ec.Tracer.StartFieldChildExecution(ctx)
-	return ec.marshalOTimestamp2githubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋdirectorᚋpkgᚋgraphqlᚐTimestamp(ctx, field.Selections, res)
+	return ec.marshalOTimestamp2ᚖgithubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋdirectorᚋpkgᚋgraphqlᚐTimestamp(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _Application_error(ctx context.Context, field graphql.CollectedField, obj *Application) (ret graphql.Marshaler) {
@@ -9554,10 +9554,10 @@ func (ec *executionContext) _Bundle_createdAt(ctx context.Context, field graphql
 	if resTmp == nil {
 		return graphql.Null
 	}
-	res := resTmp.(Timestamp)
+	res := resTmp.(*Timestamp)
 	rctx.Result = res
 	ctx = ec.Tracer.StartFieldChildExecution(ctx)
-	return ec.marshalOTimestamp2githubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋdirectorᚋpkgᚋgraphqlᚐTimestamp(ctx, field.Selections, res)
+	return ec.marshalOTimestamp2ᚖgithubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋdirectorᚋpkgᚋgraphqlᚐTimestamp(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _Bundle_updatedAt(ctx context.Context, field graphql.CollectedField, obj *Bundle) (ret graphql.Marshaler) {
@@ -9588,10 +9588,10 @@ func (ec *executionContext) _Bundle_updatedAt(ctx context.Context, field graphql
 	if resTmp == nil {
 		return graphql.Null
 	}
-	res := resTmp.(Timestamp)
+	res := resTmp.(*Timestamp)
 	rctx.Result = res
 	ctx = ec.Tracer.StartFieldChildExecution(ctx)
-	return ec.marshalOTimestamp2githubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋdirectorᚋpkgᚋgraphqlᚐTimestamp(ctx, field.Selections, res)
+	return ec.marshalOTimestamp2ᚖgithubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋdirectorᚋpkgᚋgraphqlᚐTimestamp(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _Bundle_deletedAt(ctx context.Context, field graphql.CollectedField, obj *Bundle) (ret graphql.Marshaler) {
@@ -9622,10 +9622,10 @@ func (ec *executionContext) _Bundle_deletedAt(ctx context.Context, field graphql
 	if resTmp == nil {
 		return graphql.Null
 	}
-	res := resTmp.(Timestamp)
+	res := resTmp.(*Timestamp)
 	rctx.Result = res
 	ctx = ec.Tracer.StartFieldChildExecution(ctx)
-	return ec.marshalOTimestamp2githubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋdirectorᚋpkgᚋgraphqlᚐTimestamp(ctx, field.Selections, res)
+	return ec.marshalOTimestamp2ᚖgithubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋdirectorᚋpkgᚋgraphqlᚐTimestamp(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _Bundle_error(ctx context.Context, field graphql.CollectedField, obj *Bundle) (ret graphql.Marshaler) {
@@ -10690,10 +10690,10 @@ func (ec *executionContext) _Document_createdAt(ctx context.Context, field graph
 	if resTmp == nil {
 		return graphql.Null
 	}
-	res := resTmp.(Timestamp)
+	res := resTmp.(*Timestamp)
 	rctx.Result = res
 	ctx = ec.Tracer.StartFieldChildExecution(ctx)
-	return ec.marshalOTimestamp2githubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋdirectorᚋpkgᚋgraphqlᚐTimestamp(ctx, field.Selections, res)
+	return ec.marshalOTimestamp2ᚖgithubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋdirectorᚋpkgᚋgraphqlᚐTimestamp(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _Document_updatedAt(ctx context.Context, field graphql.CollectedField, obj *Document) (ret graphql.Marshaler) {
@@ -10724,10 +10724,10 @@ func (ec *executionContext) _Document_updatedAt(ctx context.Context, field graph
 	if resTmp == nil {
 		return graphql.Null
 	}
-	res := resTmp.(Timestamp)
+	res := resTmp.(*Timestamp)
 	rctx.Result = res
 	ctx = ec.Tracer.StartFieldChildExecution(ctx)
-	return ec.marshalOTimestamp2githubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋdirectorᚋpkgᚋgraphqlᚐTimestamp(ctx, field.Selections, res)
+	return ec.marshalOTimestamp2ᚖgithubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋdirectorᚋpkgᚋgraphqlᚐTimestamp(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _Document_deletedAt(ctx context.Context, field graphql.CollectedField, obj *Document) (ret graphql.Marshaler) {
@@ -10758,10 +10758,10 @@ func (ec *executionContext) _Document_deletedAt(ctx context.Context, field graph
 	if resTmp == nil {
 		return graphql.Null
 	}
-	res := resTmp.(Timestamp)
+	res := resTmp.(*Timestamp)
 	rctx.Result = res
 	ctx = ec.Tracer.StartFieldChildExecution(ctx)
-	return ec.marshalOTimestamp2githubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋdirectorᚋpkgᚋgraphqlᚐTimestamp(ctx, field.Selections, res)
+	return ec.marshalOTimestamp2ᚖgithubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋdirectorᚋpkgᚋgraphqlᚐTimestamp(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _Document_error(ctx context.Context, field graphql.CollectedField, obj *Document) (ret graphql.Marshaler) {
@@ -11184,10 +11184,10 @@ func (ec *executionContext) _EventDefinition_createdAt(ctx context.Context, fiel
 	if resTmp == nil {
 		return graphql.Null
 	}
-	res := resTmp.(Timestamp)
+	res := resTmp.(*Timestamp)
 	rctx.Result = res
 	ctx = ec.Tracer.StartFieldChildExecution(ctx)
-	return ec.marshalOTimestamp2githubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋdirectorᚋpkgᚋgraphqlᚐTimestamp(ctx, field.Selections, res)
+	return ec.marshalOTimestamp2ᚖgithubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋdirectorᚋpkgᚋgraphqlᚐTimestamp(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _EventDefinition_updatedAt(ctx context.Context, field graphql.CollectedField, obj *EventDefinition) (ret graphql.Marshaler) {
@@ -11218,10 +11218,10 @@ func (ec *executionContext) _EventDefinition_updatedAt(ctx context.Context, fiel
 	if resTmp == nil {
 		return graphql.Null
 	}
-	res := resTmp.(Timestamp)
+	res := resTmp.(*Timestamp)
 	rctx.Result = res
 	ctx = ec.Tracer.StartFieldChildExecution(ctx)
-	return ec.marshalOTimestamp2githubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋdirectorᚋpkgᚋgraphqlᚐTimestamp(ctx, field.Selections, res)
+	return ec.marshalOTimestamp2ᚖgithubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋdirectorᚋpkgᚋgraphqlᚐTimestamp(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _EventDefinition_deletedAt(ctx context.Context, field graphql.CollectedField, obj *EventDefinition) (ret graphql.Marshaler) {
@@ -11252,10 +11252,10 @@ func (ec *executionContext) _EventDefinition_deletedAt(ctx context.Context, fiel
 	if resTmp == nil {
 		return graphql.Null
 	}
-	res := resTmp.(Timestamp)
+	res := resTmp.(*Timestamp)
 	rctx.Result = res
 	ctx = ec.Tracer.StartFieldChildExecution(ctx)
-	return ec.marshalOTimestamp2githubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋdirectorᚋpkgᚋgraphqlᚐTimestamp(ctx, field.Selections, res)
+	return ec.marshalOTimestamp2ᚖgithubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋdirectorᚋpkgᚋgraphqlᚐTimestamp(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _EventDefinition_error(ctx context.Context, field graphql.CollectedField, obj *EventDefinition) (ret graphql.Marshaler) {
@@ -28049,6 +28049,21 @@ func (ec *executionContext) unmarshalOTimestamp2githubᚗcomᚋkymaᚑincubator�
 }
 
 func (ec *executionContext) marshalOTimestamp2githubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋdirectorᚋpkgᚋgraphqlᚐTimestamp(ctx context.Context, sel ast.SelectionSet, v Timestamp) graphql.Marshaler {
+	return v
+}
+
+func (ec *executionContext) unmarshalOTimestamp2ᚖgithubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋdirectorᚋpkgᚋgraphqlᚐTimestamp(ctx context.Context, v interface{}) (*Timestamp, error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := ec.unmarshalOTimestamp2githubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋdirectorᚋpkgᚋgraphqlᚐTimestamp(ctx, v)
+	return &res, err
+}
+
+func (ec *executionContext) marshalOTimestamp2ᚖgithubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋdirectorᚋpkgᚋgraphqlᚐTimestamp(ctx context.Context, sel ast.SelectionSet, v *Timestamp) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
 	return v
 }
 

--- a/components/director/pkg/operation/api_test.go
+++ b/components/director/pkg/operation/api_test.go
@@ -224,7 +224,7 @@ func TestServeHTTP(t *testing.T) {
 		cases := []testCase{
 			{
 				Name:        "Successful CREATE Operation",
-				Application: &model.Application{BaseEntity: &model.BaseEntity{ID: resourceID, CreatedAt: now, UpdatedAt: time.Time{}, DeletedAt: time.Time{}, Ready: true}},
+				Application: &model.Application{BaseEntity: &model.BaseEntity{ID: resourceID, CreatedAt: &now, UpdatedAt: &time.Time{}, DeletedAt: &time.Time{}, Ready: true}},
 				ExpectedResponse: operation.OperationResponse{
 					Operation: &operation.Operation{
 						ResourceID:    resourceID,
@@ -236,7 +236,7 @@ func TestServeHTTP(t *testing.T) {
 			},
 			{
 				Name:        "Successful UPDATE Operation",
-				Application: &model.Application{BaseEntity: &model.BaseEntity{ID: resourceID, CreatedAt: now, UpdatedAt: now.Add(1 * time.Minute), DeletedAt: time.Time{}, Ready: true}},
+				Application: &model.Application{BaseEntity: &model.BaseEntity{ID: resourceID, CreatedAt: &now, UpdatedAt: timeToTimePtr(now.Add(1 * time.Minute)), DeletedAt: &time.Time{}, Ready: true}},
 				ExpectedResponse: operation.OperationResponse{
 					Operation: &operation.Operation{
 						ResourceID:    resourceID,
@@ -248,7 +248,7 @@ func TestServeHTTP(t *testing.T) {
 			},
 			{
 				Name:        "Successful DELETE Operation",
-				Application: &model.Application{BaseEntity: &model.BaseEntity{ID: resourceID, CreatedAt: now, UpdatedAt: now, DeletedAt: now.Add(1 * time.Minute), Ready: true}},
+				Application: &model.Application{BaseEntity: &model.BaseEntity{ID: resourceID, CreatedAt: &now, UpdatedAt: &now, DeletedAt: timeToTimePtr(now.Add(1 * time.Minute)), Ready: true}},
 				ExpectedResponse: operation.OperationResponse{
 					Operation: &operation.Operation{
 						ResourceID:    resourceID,
@@ -260,7 +260,7 @@ func TestServeHTTP(t *testing.T) {
 			},
 			{
 				Name:        "In Progress CREATE Operation",
-				Application: &model.Application{BaseEntity: &model.BaseEntity{ID: resourceID, CreatedAt: now, UpdatedAt: time.Time{}, DeletedAt: time.Time{}, Ready: false}},
+				Application: &model.Application{BaseEntity: &model.BaseEntity{ID: resourceID, CreatedAt: &now, UpdatedAt: &time.Time{}, DeletedAt: &time.Time{}, Ready: false}},
 				ExpectedResponse: operation.OperationResponse{
 					Operation: &operation.Operation{
 						ResourceID:    resourceID,
@@ -272,7 +272,7 @@ func TestServeHTTP(t *testing.T) {
 			},
 			{
 				Name:        "In Progress UPDATE Operation",
-				Application: &model.Application{BaseEntity: &model.BaseEntity{ID: resourceID, CreatedAt: now, UpdatedAt: now.Add(1 * time.Minute), DeletedAt: time.Time{}, Ready: false}},
+				Application: &model.Application{BaseEntity: &model.BaseEntity{ID: resourceID, CreatedAt: &now, UpdatedAt: timeToTimePtr(now.Add(1 * time.Minute)), DeletedAt: &time.Time{}, Ready: false}},
 				ExpectedResponse: operation.OperationResponse{
 					Operation: &operation.Operation{
 						ResourceID:    resourceID,
@@ -284,7 +284,7 @@ func TestServeHTTP(t *testing.T) {
 			},
 			{
 				Name:        "In Progress DELETE Operation",
-				Application: &model.Application{BaseEntity: &model.BaseEntity{ID: resourceID, CreatedAt: now, UpdatedAt: now, DeletedAt: now.Add(1 * time.Minute), Ready: false}},
+				Application: &model.Application{BaseEntity: &model.BaseEntity{ID: resourceID, CreatedAt: &now, UpdatedAt: &now, DeletedAt: timeToTimePtr(now.Add(1 * time.Minute)), Ready: false}},
 				ExpectedResponse: operation.OperationResponse{
 					Operation: &operation.Operation{
 						ResourceID:    resourceID,
@@ -296,7 +296,7 @@ func TestServeHTTP(t *testing.T) {
 			},
 			{
 				Name:        "Failed CREATE Operation",
-				Application: &model.Application{BaseEntity: &model.BaseEntity{ID: resourceID, CreatedAt: now, UpdatedAt: time.Time{}, DeletedAt: time.Time{}, Ready: false, Error: &mockedErr}},
+				Application: &model.Application{BaseEntity: &model.BaseEntity{ID: resourceID, CreatedAt: &now, UpdatedAt: &time.Time{}, DeletedAt: &time.Time{}, Ready: false, Error: &mockedErr}},
 				ExpectedResponse: operation.OperationResponse{
 					Operation: &operation.Operation{
 						ResourceID:    resourceID,
@@ -309,7 +309,7 @@ func TestServeHTTP(t *testing.T) {
 			},
 			{
 				Name:        "Failed UPDATE Operation",
-				Application: &model.Application{BaseEntity: &model.BaseEntity{ID: resourceID, CreatedAt: now, UpdatedAt: now.Add(1 * time.Minute), DeletedAt: time.Time{}, Ready: false, Error: &mockedErr}},
+				Application: &model.Application{BaseEntity: &model.BaseEntity{ID: resourceID, CreatedAt: &now, UpdatedAt: timeToTimePtr(now.Add(1 * time.Minute)), DeletedAt: &time.Time{}, Ready: false, Error: &mockedErr}},
 				ExpectedResponse: operation.OperationResponse{
 					Operation: &operation.Operation{
 						ResourceID:    resourceID,
@@ -322,7 +322,7 @@ func TestServeHTTP(t *testing.T) {
 			},
 			{
 				Name:        "Failed DELETE Operation",
-				Application: &model.Application{BaseEntity: &model.BaseEntity{ID: resourceID, CreatedAt: now, UpdatedAt: now, DeletedAt: now.Add(1 * time.Minute), Ready: false, Error: &mockedErr}},
+				Application: &model.Application{BaseEntity: &model.BaseEntity{ID: resourceID, CreatedAt: &now, UpdatedAt: &now, DeletedAt: timeToTimePtr(now.Add(1 * time.Minute)), Ready: false, Error: &mockedErr}},
 				ExpectedResponse: operation.OperationResponse{
 					Operation: &operation.Operation{
 						ResourceID:    resourceID,
@@ -368,4 +368,8 @@ func fixEmptyRequest(t *testing.T, ctx context.Context) *http.Request {
 
 func loadTenantFunc(_ context.Context) (string, error) {
 	return tenantID, nil
+}
+
+func timeToTimePtr(time time.Time) *time.Time {
+	return &time
 }

--- a/components/schema-migrator/migrations/director/202102031458_extend_application_resources.up.sql
+++ b/components/schema-migrator/migrations/director/202102031458_extend_application_resources.up.sql
@@ -1,38 +1,38 @@
 BEGIN;
 
 ALTER TABLE applications
-    ADD COLUMN ready bool NOT NULL DEFAULT TRUE,
-    ADD COLUMN created_at timestamp NOT NULL,
-    ADD COLUMN updated_at timestamp NOT NULL,
-    ADD COLUMN deleted_at timestamp NOT NULL,
+    ADD COLUMN ready bool DEFAULT TRUE,
+    ADD COLUMN created_at timestamp,
+    ADD COLUMN updated_at timestamp,
+    ADD COLUMN deleted_at timestamp,
     ADD COLUMN error jsonb;
 
 ALTER TABLE bundles
-    ADD COLUMN ready bool NOT NULL DEFAULT TRUE,
-    ADD COLUMN created_at timestamp NOT NULL,
-    ADD COLUMN updated_at timestamp NOT NULL,
-    ADD COLUMN deleted_at timestamp NOT NULL,
+    ADD COLUMN ready bool DEFAULT TRUE,
+    ADD COLUMN created_at timestamp,
+    ADD COLUMN updated_at timestamp,
+    ADD COLUMN deleted_at timestamp,
     ADD COLUMN error jsonb;
 
 ALTER TABLE api_definitions
-    ADD COLUMN ready bool NOT NULL DEFAULT TRUE,
-    ADD COLUMN created_at timestamp NOT NULL,
-    ADD COLUMN updated_at timestamp NOT NULL,
-    ADD COLUMN deleted_at timestamp NOT NULL,
+    ADD COLUMN ready bool DEFAULT TRUE,
+    ADD COLUMN created_at timestamp,
+    ADD COLUMN updated_at timestamp,
+    ADD COLUMN deleted_at timestamp,
     ADD COLUMN error jsonb;
 
 ALTER TABLE event_api_definitions
-    ADD COLUMN ready bool NOT NULL DEFAULT TRUE,
-    ADD COLUMN created_at timestamp NOT NULL,
-    ADD COLUMN updated_at timestamp NOT NULL,
-    ADD COLUMN deleted_at timestamp NOT NULL,
+    ADD COLUMN ready bool DEFAULT TRUE,
+    ADD COLUMN created_at timestamp,
+    ADD COLUMN updated_at timestamp,
+    ADD COLUMN deleted_at timestamp,
     ADD COLUMN error jsonb;
 
 ALTER TABLE documents
-    ADD COLUMN ready bool NOT NULL DEFAULT TRUE,
-    ADD COLUMN created_at timestamp NOT NULL,
-    ADD COLUMN updated_at timestamp NOT NULL,
-    ADD COLUMN deleted_at timestamp NOT NULL,
+    ADD COLUMN ready bool DEFAULT TRUE,
+    ADD COLUMN created_at timestamp,
+    ADD COLUMN updated_at timestamp,
+    ADD COLUMN deleted_at timestamp,
     ADD COLUMN error jsonb;
 
 ALTER TABLE applications


### PR DESCRIPTION
# Fix migration related to the extension of application resources

**Description**

Changes proposed in this pull request:
- Drop the NOT NULL requirement for the new application resources columns
- Set created_at, updated_at, deleted_at as pointer timestamps

**Related issue(s)**
https://github.com/kyma-incubator/compass/pull/1714
