### PR TITLE
Add migrations to rename WH type

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -38,7 +38,7 @@ global:
       version: "PR-13"
     schema_migrator:
       dir:
-      version: "PR-1730"
+      version: "PR-1736"
     system_broker:
       dir:
       version: "PR-1721"

--- a/components/schema-migrator/migrations/director/202012081537_ord_service_initial.down.sql
+++ b/components/schema-migrator/migrations/director/202012081537_ord_service_initial.down.sql
@@ -25,7 +25,7 @@ ALTER TABLE packages
 
 DROP TRIGGER set_release_status_api_def ON api_definitions;
 DROP TRIGGER set_release_status_event_def ON event_api_definitions;
-DROP FUNCTION set_release_status;
+DROP FUNCTION set_release_status();
 
 ALTER TABLE api_definitions
     DROP COLUMN ord_id,

--- a/components/schema-migrator/migrations/director/202102171005_unregister_webhook_type.down.sql
+++ b/components/schema-migrator/migrations/director/202102171005_unregister_webhook_type.down.sql
@@ -1,10 +1,17 @@
 BEGIN;
 
-ALTER TYPE webhook_type ADD VALUE 'DELETE_APPLICATION';
+ALTER TYPE webhook_type RENAME TO webhook_type_old;
+
+CREATE TYPE webhook_type_med AS ENUM (
+    'CONFIGURATION_CHANGED',
+    'REGISTER_APPLICATION',
+    'UNREGISTER_APPLICATION', 
+    'DELETE_APPLICATION'
+);
+
+ALTER TABLE webhooks ALTER COLUMN type TYPE webhook_type_med USING type::text::webhook_type_med;
 
 UPDATE webhooks SET type = 'DELETE_APPLICATION' WHERE type = 'UNREGISTER_APPLICATION';
-
-ALTER TYPE webhook_type RENAME TO webhook_type_old;
 
 CREATE TYPE webhook_type AS ENUM (
     'CONFIGURATION_CHANGED',
@@ -15,5 +22,6 @@ CREATE TYPE webhook_type AS ENUM (
 ALTER TABLE webhooks ALTER COLUMN type TYPE webhook_type USING type::text::webhook_type;
 
 DROP TYPE webhook_type_old;
+DROP TYPE webhook_type_med;
 
 COMMIT;

--- a/components/schema-migrator/migrations/director/202102171005_unregister_webhook_type.down.sql
+++ b/components/schema-migrator/migrations/director/202102171005_unregister_webhook_type.down.sql
@@ -1,0 +1,19 @@
+BEGIN;
+
+ALTER TYPE webhook_type ADD VALUE 'DELETE_APPLICATION';
+
+UPDATE webhooks SET type = 'DELETE_APPLICATION' WHERE type = 'UNREGISTER_APPLICATION';
+
+ALTER TYPE webhook_type RENAME TO webhook_type_old;
+
+CREATE TYPE webhook_type AS ENUM (
+    'CONFIGURATION_CHANGED',
+    'REGISTER_APPLICATION',
+    'DELETE_APPLICATION'
+);
+
+ALTER TABLE webhooks ALTER COLUMN type TYPE webhook_type USING type::text::webhook_type;
+
+DROP TYPE webhook_type_old;
+
+COMMIT;

--- a/components/schema-migrator/migrations/director/202102171005_unregister_webhook_type.up.sql
+++ b/components/schema-migrator/migrations/director/202102171005_unregister_webhook_type.up.sql
@@ -1,10 +1,17 @@
 BEGIN;
 
-ALTER TYPE webhook_type ADD VALUE 'UNREGISTER_APPLICATION';
+ALTER TYPE webhook_type RENAME TO webhook_type_old;
+
+CREATE TYPE webhook_type_med AS ENUM (
+    'CONFIGURATION_CHANGED',
+    'REGISTER_APPLICATION',
+    'UNREGISTER_APPLICATION', 
+    'DELETE_APPLICATION'
+);
+
+ALTER TABLE webhooks ALTER COLUMN type TYPE webhook_type_med USING type::text::webhook_type_med;
 
 UPDATE webhooks SET type = 'UNREGISTER_APPLICATION' WHERE type = 'DELETE_APPLICATION';
-
-ALTER TYPE webhook_type RENAME TO webhook_type_old;
 
 CREATE TYPE webhook_type AS ENUM (
     'CONFIGURATION_CHANGED',
@@ -15,5 +22,6 @@ CREATE TYPE webhook_type AS ENUM (
 ALTER TABLE webhooks ALTER COLUMN type TYPE webhook_type USING type::text::webhook_type;
 
 DROP TYPE webhook_type_old;
+DROP TYPE webhook_type_med;
 
 COMMIT;

--- a/components/schema-migrator/migrations/director/202102171005_unregister_webhook_type.up.sql
+++ b/components/schema-migrator/migrations/director/202102171005_unregister_webhook_type.up.sql
@@ -1,0 +1,19 @@
+BEGIN;
+
+ALTER TYPE webhook_type ADD VALUE 'UNREGISTER_APPLICATION';
+
+UPDATE webhooks SET type = 'UNREGISTER_APPLICATION' WHERE type = 'DELETE_APPLICATION';
+
+ALTER TYPE webhook_type RENAME TO webhook_type_old;
+
+CREATE TYPE webhook_type AS ENUM (
+    'CONFIGURATION_CHANGED',
+    'REGISTER_APPLICATION',
+    'UNREGISTER_APPLICATION'
+);
+
+ALTER TABLE webhooks ALTER COLUMN type TYPE webhook_type USING type::text::webhook_type;
+
+DROP TYPE webhook_type_old;
+
+COMMIT;

--- a/components/schema-migrator/validate.sh
+++ b/components/schema-migrator/validate.sh
@@ -15,7 +15,7 @@ set -e
 IMG_NAME="compass-schema-migrator"
 NETWORK="migration-test-network"
 POSTGRES_CONTAINER="test-postgres"
-POSTGRES_VERSION="11"
+POSTGRES_VERSION="9.6"
 
 DB_USER="usr"
 DB_PWD="pwd"


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:
- Rename WebHook type from Delete -> Unregister

- [x] Implementation
- [x] Unit tests
- [x] Integration tests
- [x] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
