### PR TITLE
Tenant Fetcher should not commit failed transaction

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -31,7 +31,7 @@ global:
       version: "PR-1747"
     tenant_fetcher:
       dir:
-      version: "PR-1752"
+      version: "PR-1754"
     ord_service:
       dir:
       version: "PR-14"
@@ -67,7 +67,7 @@ global:
         version: "PR-1717"
       tenant_fetcher:
         dir:
-        version: "PR-1752"
+        version: "PR-1754"
       system_broker:
         dir:
         version: "PR-1738"

--- a/components/tenant-fetcher/internal/tenant/service.go
+++ b/components/tenant-fetcher/internal/tenant/service.go
@@ -81,16 +81,18 @@ func (s *service) Create(writer http.ResponseWriter, request *http.Request) {
 
 	ctx = persistence.SaveToContext(ctx, tx)
 
-	if err := s.repository.Create(ctx, tenant); err != nil && !apperrors.IsNotUniqueError(err) {
-		logger.WithError(err).Error("while creating tenant")
-		http.Error(writer, err.Error(), http.StatusInternalServerError)
-		return
-	}
-
-	if err := tx.Commit(); err != nil {
-		logger.WithError(err).Error("while committing transaction")
-		http.Error(writer, err.Error(), http.StatusInternalServerError)
-		return
+	if err := s.repository.Create(ctx, tenant); err != nil {
+		if !apperrors.IsNotUniqueError(err) {
+			logger.WithError(err).Error("while creating tenant")
+			http.Error(writer, err.Error(), http.StatusInternalServerError)
+			return
+		}
+	} else {
+		if err := tx.Commit(); err != nil {
+			logger.WithError(err).Error("while committing transaction")
+			http.Error(writer, err.Error(), http.StatusInternalServerError)
+			return
+		}
 	}
 
 	writer.Header().Set("Content-Type", "text/plain")
@@ -131,16 +133,18 @@ func (s *service) DeleteByExternalID(writer http.ResponseWriter, request *http.R
 
 	ctx = persistence.SaveToContext(ctx, tx)
 
-	if err := s.repository.DeleteByExternalID(ctx, tenantId.String()); err != nil && !apperrors.IsNotFoundError(err) {
-		logger.WithError(err).Error("while deleting tenant")
-		http.Error(writer, err.Error(), http.StatusInternalServerError)
-		return
-	}
-
-	if err := tx.Commit(); err != nil {
-		logger.WithError(err).Error("while committing transaction")
-		http.Error(writer, err.Error(), http.StatusInternalServerError)
-		return
+	if err := s.repository.DeleteByExternalID(ctx, tenantId.String()); err != nil {
+		if !apperrors.IsNotFoundError(err) {
+			logger.WithError(err).Error("while deleting tenant")
+			http.Error(writer, err.Error(), http.StatusInternalServerError)
+			return
+		}
+	} else {
+		if err := tx.Commit(); err != nil {
+			logger.WithError(err).Error("while committing transaction")
+			http.Error(writer, err.Error(), http.StatusInternalServerError)
+			return
+		}
 	}
 
 	writer.Header().Set("Content-Type", "application/json")

--- a/components/tenant-fetcher/internal/tenant/service_test.go
+++ b/components/tenant-fetcher/internal/tenant/service_test.go
@@ -174,7 +174,7 @@ func TestService_Create(t *testing.T) {
 		},
 		{
 			Name: "Object Not Unique error when creating tenant in database should not fail",
-			TxFn: txGen.ThatSucceeds,
+			TxFn: txGen.ThatDoesntExpectCommit,
 			TenantRepoFn: func() *automock.TenantRepository {
 				tenantMappingRepo := &automock.TenantRepository{}
 				tenantMappingRepo.On("Create", txtest.CtxWithDBMatcher(), tenantModel).Return(apperrors.NewNotUniqueError(resource.Tenant))
@@ -404,7 +404,7 @@ func TestService_Delete(t *testing.T) {
 		},
 		{
 			Name: "Object Not Found error when deleting tenant from database should not fail",
-			TxFn: txGen.ThatSucceeds,
+			TxFn: txGen.ThatDoesntExpectCommit,
 			TenantRepoFn: func() *automock.TenantRepository {
 				tenantMappingRepo := &automock.TenantRepository{}
 				tenantMappingRepo.On("DeleteByExternalID", txtest.CtxWithDBMatcher(), testID).Return(apperrors.NewNotFoundError(resource.Tenant, testID))

--- a/tests/tenant-fetcher/tests/handler_test.go
+++ b/tests/tenant-fetcher/tests/handler_test.go
@@ -79,85 +79,154 @@ type Tenant struct {
 }
 
 func TestOnboardingHandler(t *testing.T) {
-	// GIVEN
 	config := loadConfig(t)
 
-	providedTenant := &Tenant{
-		TenantId: "ad0bb8f2-7b44-4dd2-bce1-fa0c19169b72",
-	}
+	t.Run("Success", func(t *testing.T) {
+		// GIVEN
 
-	cleanUp(t, providedTenant, config)
+		providedTenant := &Tenant{
+			TenantId: "ad0bb8f2-7b44-4dd2-bce1-fa0c19169b72",
+		}
 
-	oldTenantState, err := director.GetTenants(config.DirectorUrl, config.Tenant)
-	require.NoError(t, err)
+		cleanUp(t, providedTenant, config)
 
-	// WHEN
-	endpoint := strings.Replace(config.HandlerEndpoint, fmt.Sprintf("{%s}", config.TenantPathParam), providedTenant.TenantId, 1)
-	url := config.TenantFetcherURL + config.RootAPI + endpoint
+		oldTenantState, err := director.GetTenants(config.DirectorUrl, config.Tenant)
+		require.NoError(t, err)
 
-	byteTenant, err := json.Marshal(providedTenant)
-	require.NoError(t, err)
-	request, err := http.NewRequest(http.MethodPut, url, bytes.NewBuffer(byteTenant))
-	request.Header.Add("Authorization", fmt.Sprintf("Bearer %s", authentication.CreateNotSingedToken(t)))
-	require.NoError(t, err)
+		// WHEN
+		endpoint := strings.Replace(config.HandlerEndpoint, fmt.Sprintf("{%s}", config.TenantPathParam), providedTenant.TenantId, 1)
+		url := config.TenantFetcherURL + config.RootAPI + endpoint
 
-	httpClient := http.DefaultClient
-	httpClient.Timeout = 15 * time.Second
+		byteTenant, err := json.Marshal(providedTenant)
+		require.NoError(t, err)
+		request, err := http.NewRequest(http.MethodPut, url, bytes.NewBuffer(byteTenant))
+		require.NoError(t, err)
+		request.Header.Add("Authorization", fmt.Sprintf("Bearer %s", authentication.CreateNotSingedToken(t)))
 
-	response, err := httpClient.Do(request)
-	require.NoError(t, err)
+		httpClient := http.DefaultClient
+		httpClient.Timeout = 15 * time.Second
 
-	tenants, err := director.GetTenants(config.DirectorUrl, config.Tenant)
-	require.NoError(t, err)
+		response, err := httpClient.Do(request)
+		require.NoError(t, err)
 
-	// THEN
-	assert.Greater(t, len(tenants), len(oldTenantState))
-	require.Equal(t, http.StatusOK, response.StatusCode)
+		tenants, err := director.GetTenants(config.DirectorUrl, config.Tenant)
+		require.NoError(t, err)
+
+		// THEN
+		assert.Greater(t, len(tenants), len(oldTenantState))
+		require.Equal(t, http.StatusOK, response.StatusCode)
+	})
+
+	t.Run("Should not fail when tenant already exists", func(t *testing.T) {
+		providedTenant := &Tenant{
+			TenantId: config.Tenant,
+		}
+
+		oldTenantState, err := director.GetTenants(config.DirectorUrl, config.Tenant)
+		require.NoError(t, err)
+
+		endpoint := strings.Replace(config.HandlerEndpoint, fmt.Sprintf("{%s}", config.TenantPathParam), providedTenant.TenantId, 1)
+		url := config.TenantFetcherURL + config.RootAPI + endpoint
+
+		byteTenant, err := json.Marshal(providedTenant)
+		require.NoError(t, err)
+		request, err := http.NewRequest(http.MethodPut, url, bytes.NewBuffer(byteTenant))
+		require.NoError(t, err)
+		request.Header.Add("Authorization", fmt.Sprintf("Bearer %s", authentication.CreateNotSingedToken(t)))
+
+		httpClient := http.DefaultClient
+		httpClient.Timeout = 15 * time.Second
+
+		response, err := httpClient.Do(request)
+		require.NoError(t, err)
+
+		tenants, err := director.GetTenants(config.DirectorUrl, config.Tenant)
+		require.NoError(t, err)
+
+		// THEN
+		assert.Equal(t, len(tenants), len(oldTenantState))
+		require.Equal(t, http.StatusOK, response.StatusCode)
+	})
 }
 
 func TestDecommissioningHandler(t *testing.T) {
-	// GIVEN
-	providedTenant := &Tenant{
-		TenantId: "cb0bb8f2-7b44-4dd2-bce1-fa0c19169b79",
-	}
 	config := loadConfig(t)
-	cleanUp(t, providedTenant, config)
-	// WHEN
-	tenantID := "ad0bb8f2-7b44-4dd2-bce1-fa0c19169b72"
-	endpoint := strings.Replace(config.HandlerEndpoint, fmt.Sprintf("{%s}", config.TenantPathParam), tenantID, 1)
-	url := config.TenantFetcherURL + config.RootAPI + endpoint
 
-	// Add test tenant
-	byteTenant, err := json.Marshal(providedTenant)
-	require.NoError(t, err)
-	request, err := http.NewRequest(http.MethodPut, url, bytes.NewBuffer(byteTenant))
-	request.Header.Add("Authorization", fmt.Sprintf("Bearer %s", authentication.CreateNotSingedToken(t)))
-	require.NoError(t, err)
+	t.Run("Success", func(t *testing.T) {
+		// GIVEN
+		providedTenant := &Tenant{
+			TenantId: "cb0bb8f2-7b44-4dd2-bce1-fa0c19169b79",
+		}
+		cleanUp(t, providedTenant, config)
+		// WHEN
+		tenantID := "ad0bb8f2-7b44-4dd2-bce1-fa0c19169b72"
+		endpoint := strings.Replace(config.HandlerEndpoint, fmt.Sprintf("{%s}", config.TenantPathParam), tenantID, 1)
+		url := config.TenantFetcherURL + config.RootAPI + endpoint
 
-	httpClient := http.DefaultClient
-	httpClient.Timeout = 15 * time.Second
+		// Add test tenant
+		byteTenant, err := json.Marshal(providedTenant)
+		require.NoError(t, err)
+		request, err := http.NewRequest(http.MethodPut, url, bytes.NewBuffer(byteTenant))
+		require.NoError(t, err)
+		request.Header.Add("Authorization", fmt.Sprintf("Bearer %s", authentication.CreateNotSingedToken(t)))
 
-	response, err := httpClient.Do(request)
-	require.NoError(t, err)
+		httpClient := http.DefaultClient
+		httpClient.Timeout = 15 * time.Second
 
-	// Initial state
-	oldTenantState, err := director.GetTenants(config.DirectorUrl, config.Tenant)
-	require.NoError(t, err)
+		response, err := httpClient.Do(request)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, response.StatusCode)
 
-	request, err = http.NewRequest(http.MethodDelete, url, bytes.NewBuffer(byteTenant))
-	request.Header.Add("Authorization", fmt.Sprintf("Bearer %s", authentication.CreateNotSingedToken(t)))
-	require.NoError(t, err)
+		// Initial state
+		oldTenantState, err := director.GetTenants(config.DirectorUrl, config.Tenant)
+		require.NoError(t, err)
 
-	response, err = httpClient.Do(request)
-	require.NoError(t, err)
+		request, err = http.NewRequest(http.MethodDelete, url, bytes.NewBuffer(byteTenant))
+		require.NoError(t, err)
+		request.Header.Add("Authorization", fmt.Sprintf("Bearer %s", authentication.CreateNotSingedToken(t)))
 
-	newTenantState, err := director.GetTenants(config.DirectorUrl, config.Tenant)
-	require.NoError(t, err)
+		response, err = httpClient.Do(request)
+		require.NoError(t, err)
 
-	// THEN
-	require.NoError(t, err)
-	assert.Greater(t, len(oldTenantState), len(newTenantState))
-	require.Equal(t, http.StatusOK, response.StatusCode)
+		newTenantState, err := director.GetTenants(config.DirectorUrl, config.Tenant)
+		require.NoError(t, err)
+
+		// THEN
+		assert.Greater(t, len(oldTenantState), len(newTenantState))
+		require.Equal(t, http.StatusOK, response.StatusCode)
+	})
+
+	t.Run("Should not fail when tenant does not exists", func(t *testing.T) {
+		providedTenant := &Tenant{
+			TenantId: "cb0bb8f2-7b44-4dd2-bce1-fa0c19169b79",
+		}
+		cleanUp(t, providedTenant, config)
+
+		endpoint := strings.Replace(config.HandlerEndpoint, fmt.Sprintf("{%s}", config.TenantPathParam), providedTenant.TenantId, 1)
+		url := config.TenantFetcherURL + config.RootAPI + endpoint
+
+		oldTenantState, err := director.GetTenants(config.DirectorUrl, config.Tenant)
+		require.NoError(t, err)
+
+		byteTenant, err := json.Marshal(providedTenant)
+		require.NoError(t, err)
+		request, err := http.NewRequest(http.MethodDelete, url, bytes.NewBuffer(byteTenant))
+		require.NoError(t, err)
+		request.Header.Add("Authorization", fmt.Sprintf("Bearer %s", authentication.CreateNotSingedToken(t)))
+
+		httpClient := http.DefaultClient
+		httpClient.Timeout = 15 * time.Second
+
+		response, err := httpClient.Do(request)
+		require.NoError(t, err)
+
+		newTenantState, err := director.GetTenants(config.DirectorUrl, config.Tenant)
+		require.NoError(t, err)
+
+		// THEN
+		assert.Equal(t, len(oldTenantState), len(newTenantState))
+		require.Equal(t, http.StatusOK, response.StatusCode)
+	})
 }
 
 func loadConfig(t *testing.T) config {


### PR DESCRIPTION
Currently, if the tenant already exists in DB the error is skipped and the transaction is committed. This fails because the transaction is in a failed state and should not be commited.