### PR TITLE
Fix proxy error logs in gateway

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -25,7 +25,7 @@ global:
       version: "PR-1733"
     gateway:
       dir:
-      version: "PR-1720"
+      version: "PR-1756"
     operations_controller:
       dir:
       version: "PR-1747"

--- a/components/gateway/pkg/proxy/proxy.go
+++ b/components/gateway/pkg/proxy/proxy.go
@@ -1,11 +1,12 @@
 package proxy
 
 import (
-	"github.com/kyma-incubator/compass/components/director/pkg/log"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
 	"strings"
+
+	"github.com/kyma-incubator/compass/components/director/pkg/log"
 
 	"github.com/pkg/errors"
 )


### PR DESCRIPTION
Currently, gateway's proxy uses the default error handler which uses the default logging:

```go
func (p *ReverseProxy) defaultErrorHandler(rw http.ResponseWriter, req *http.Request, err error) {
	p.logf("http: proxy error: %v", err)
	rw.WriteHeader(http.StatusBadGateway)
}
```

Which results in logs like this:

```
2021/03/02 08:28:22 http: proxy error: could not check query type: could not unmarshal query: invalid character '5' after object key:value pair
```
And most importantly there isn't any correlation id information.

In this PR custom error handler is passed to the proxy which logs with our logging infrastructure. In result logs look like this:

```
ERRO[0080] Error while proxying request to "http://127.0.0.1:3002/"  component="proxy/proxy.go:44:proxy.New.func2" error="dial tcp 127.0.0.1:3002: connect: connection refused" error_source="check component log field" x-request-id=e56abe5e-2dcd-4763-839a-05d906abc1c3
```