### PR TITLE
[HOTFIX] Fix connectivity-adapter json marshalling issue

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -16,7 +16,7 @@ global:
       version: "PR-1762"
     connectivity_adapter:
       dir:
-      version: "PR-1750"
+      version: "PR-1771"
     pairing_adapter:
       dir:
       version: "PR-1750"

--- a/components/connectivity-adapter/internal/appregistry/service/converter.go
+++ b/components/connectivity-adapter/internal/appregistry/service/converter.go
@@ -3,7 +3,6 @@ package service
 import (
 	"encoding/json"
 	"fmt"
-	"strconv"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -128,25 +127,25 @@ func (c *converter) DetailsToGraphQLCreateInput(deprecated model.ServiceDetails)
 			}
 		}
 
-		if deprecated.Api.Spec != "" {
+		if deprecated.Api.Spec != nil {
 			if apiDef.Spec == nil {
 				apiDef.Spec = &graphql.APISpecInput{}
 			}
-			apiDef.Spec.Data = ptrClob(graphql.CLOB(deprecated.Api.Spec))
+			apiDef.Spec.Data = ptrClob(graphql.CLOB(*deprecated.Api.Spec))
 			if apiDef.Spec.Type == "" {
 				apiDef.Spec.Type = graphql.APISpecTypeOpenAPI
 			}
 
-			if c.isXML(deprecated.Api.Spec) {
+			if model.IsXML(string(*deprecated.Api.Spec)) {
 				apiDef.Spec.Format = graphql.SpecFormatXML
-			} else if c.isJSON(deprecated.Api.Spec) {
+			} else if c.isJSON(string(*deprecated.Api.Spec)) {
 				apiDef.Spec.Format = graphql.SpecFormatJSON
 			} else {
 				apiDef.Spec.Format = graphql.SpecFormatYaml
 			}
 		}
 
-		if deprecated.Api.Spec == "" { // TODO provide test for that
+		if deprecated.Api.Spec == nil { // TODO provide test for that
 
 			lowercaseDeprecatedAPIType := strings.ToLower(deprecated.Api.ApiType)
 			if deprecated.Api.SpecificationUrl != "" || deprecated.Api.SpecificationCredentials != nil || deprecated.Api.SpecificationRequestParameters != nil || lowercaseDeprecatedAPIType == oDataSpecType {
@@ -223,14 +222,14 @@ func (c *converter) DetailsToGraphQLCreateInput(deprecated model.ServiceDetails)
 
 	out.DefaultInstanceAuth = defaultInstanceAuth
 
-	if deprecated.Events != nil && deprecated.Events.Spec != "" {
+	if deprecated.Events != nil && deprecated.Events.Spec != nil {
 		var eventDef *graphql.EventDefinitionInput
 
 		// TODO add tests
 		var format graphql.SpecFormat
-		if c.isXML(deprecated.Events.Spec) {
+		if model.IsXML(string(*deprecated.Events.Spec)) {
 			format = graphql.SpecFormatXML
-		} else if c.isJSON(deprecated.Events.Spec) {
+		} else if c.isJSON(string(*deprecated.Events.Spec)) {
 			format = graphql.SpecFormatJSON
 		} else {
 			format = graphql.SpecFormatYaml
@@ -240,7 +239,7 @@ func (c *converter) DetailsToGraphQLCreateInput(deprecated model.ServiceDetails)
 			&graphql.EventDefinitionInput{
 				Name: deprecated.Name,
 				Spec: &graphql.EventSpecInput{
-					Data:   ptrClob(graphql.CLOB(deprecated.Events.Spec)),
+					Data:   ptrClob(graphql.CLOB(*deprecated.Events.Spec)),
 					Type:   graphql.EventSpecTypeAsyncAPI,
 					Format: format,
 				},
@@ -349,7 +348,7 @@ func (c *converter) GraphQLToServiceDetails(in graphql.BundleExt, legacyServiceR
 		if apiDef.Spec != nil {
 			outDeprecated.Api.ApiType = string(apiDef.Spec.Type)
 			if apiDef.Spec.Data != nil {
-				outDeprecated.Api.Spec = string(*apiDef.Spec.Data)
+				outDeprecated.Api.Spec = ptrSpecResponse(model.SpecResponse(*apiDef.Spec.Data))
 			}
 		}
 
@@ -476,7 +475,7 @@ func (c *converter) GraphQLToServiceDetails(in graphql.BundleExt, legacyServiceR
 
 		if eventDef.Spec != nil && eventDef.Spec.Data != nil {
 			outDeprecated.Events = &model.Events{
-				Spec: string(*eventDef.Spec.Data),
+				Spec: ptrSpecResponse(model.SpecResponse(*eventDef.Spec.Data)),
 			}
 		}
 		//TODO: convert also fetchRequest
@@ -509,27 +508,6 @@ func (c *converter) ServiceDetailsToService(in model.ServiceDetails, serviceID s
 	}, nil
 }
 
-func (c *converter) isXML(content string) bool {
-	const snippetLength = 512
-
-	if unquoted, err := strconv.Unquote(content); err == nil {
-		content = unquoted
-	}
-
-	var snippet string
-	length := len(content)
-	if length < snippetLength {
-		snippet = content
-	} else {
-		snippet = content[:snippetLength]
-	}
-
-	openingIndex := strings.Index(snippet, "<")
-	closingIndex := strings.Index(snippet, ">")
-
-	return openingIndex == 0 && openingIndex < closingIndex
-}
-
 func (c *converter) isJSON(content string) bool {
 	out := map[string]interface{}{}
 	err := json.Unmarshal([]byte(content), &out)
@@ -537,5 +515,9 @@ func (c *converter) isJSON(content string) bool {
 }
 
 func ptrClob(in graphql.CLOB) *graphql.CLOB {
+	return &in
+}
+
+func ptrSpecResponse(in model.SpecResponse) *model.SpecResponse {
 	return &in
 }

--- a/components/connectivity-adapter/internal/appregistry/service/converter_test.go
+++ b/components/connectivity-adapter/internal/appregistry/service/converter_test.go
@@ -114,7 +114,7 @@ func TestConverter_DetailsToGraphQLCreateInput(t *testing.T) {
 		"API with directly spec provided in YAML": {
 			given: model.ServiceDetails{
 				Api: &model.API{
-					Spec: `openapi: "3.0.0"`,
+					Spec: ptrSpecResponse(`openapi: "3.0.0"`),
 				},
 			},
 			expected: graphql.BundleCreateInput{
@@ -134,7 +134,7 @@ func TestConverter_DetailsToGraphQLCreateInput(t *testing.T) {
 		"API with directly spec provided in JSON": {
 			given: model.ServiceDetails{
 				Api: &model.API{
-					Spec: `{"spec":"v0.0.1"}`,
+					Spec: ptrSpecResponse(`{"spec":"v0.0.1"}`),
 				},
 			},
 			expected: graphql.BundleCreateInput{
@@ -154,7 +154,7 @@ func TestConverter_DetailsToGraphQLCreateInput(t *testing.T) {
 		"API with directly spec provided in XML": {
 			given: model.ServiceDetails{
 				Api: &model.API{
-					Spec: `<spec></spec>"`,
+					Spec: ptrSpecResponse(`<spec></spec>"`),
 				},
 			},
 			expected: graphql.BundleCreateInput{
@@ -458,7 +458,7 @@ func TestConverter_DetailsToGraphQLCreateInput(t *testing.T) {
 			given: model.ServiceDetails{
 				Name: "foo",
 				Events: &model.Events{
-					Spec: `asyncapi: "1.2.0"`,
+					Spec: ptrSpecResponse(`asyncapi: "1.2.0"`),
 				},
 			},
 			expected: graphql.BundleCreateInput{
@@ -762,7 +762,7 @@ func TestConverter_GraphQLToServiceDetails(t *testing.T) {
 					Data: []*graphql.EventAPIDefinitionExt{{
 						Spec: &graphql.EventAPISpecExt{
 							EventSpec: graphql.EventSpec{
-								Data: ptrClob(`asyncapi: "1.2.0"`),
+								Data: ptrClob(`{"asyncapi": "1.2.0"}`),
 							},
 						}},
 					},
@@ -770,7 +770,7 @@ func TestConverter_GraphQLToServiceDetails(t *testing.T) {
 			},
 			expected: model.ServiceDetails{
 				Events: &model.Events{
-					Spec: `asyncapi: "1.2.0"`,
+					Spec: ptrSpecResponse(`{"asyncapi": "1.2.0"}`),
 				},
 				Labels: emptyLabels(),
 			},
@@ -789,7 +789,7 @@ func TestConverter_GraphQLToServiceDetails(t *testing.T) {
 			},
 			expected: model.ServiceDetails{
 				Events: &model.Events{
-					Spec: `<xml></xml>`,
+					Spec: ptrSpecResponse(`<xml></xml>`),
 				},
 				Labels: emptyLabels(),
 			},
@@ -808,7 +808,7 @@ func TestConverter_GraphQLToServiceDetails(t *testing.T) {
 			},
 			expected: model.ServiceDetails{
 				Api: &model.API{
-					Spec: `<xml></xml>`,
+					Spec: ptrSpecResponse(`<xml></xml>`),
 				},
 				Labels: emptyLabels(),
 			},
@@ -1002,5 +1002,9 @@ func ptrString(in string) *string {
 }
 
 func ptrClob(in graphql.CLOB) *graphql.CLOB {
+	return &in
+}
+
+func ptrSpecResponse(in model.SpecResponse) *model.SpecResponse {
 	return &in
 }

--- a/components/connectivity-adapter/internal/appregistry/service/converter_test.go
+++ b/components/connectivity-adapter/internal/appregistry/service/converter_test.go
@@ -114,7 +114,7 @@ func TestConverter_DetailsToGraphQLCreateInput(t *testing.T) {
 		"API with directly spec provided in YAML": {
 			given: model.ServiceDetails{
 				Api: &model.API{
-					Spec: json.RawMessage(`openapi: "3.0.0"`),
+					Spec: ptrClob(`openapi: "3.0.0"`),
 				},
 			},
 			expected: graphql.BundleCreateInput{
@@ -122,7 +122,7 @@ func TestConverter_DetailsToGraphQLCreateInput(t *testing.T) {
 				APIDefinitions: []*graphql.APIDefinitionInput{
 					{
 						Spec: &graphql.APISpecInput{
-							Data:   ptrClob(graphql.CLOB(`openapi: "3.0.0"`)),
+							Data:   ptrClob(`openapi: "3.0.0"`),
 							Type:   graphql.APISpecTypeOpenAPI,
 							Format: graphql.SpecFormatYaml,
 						},
@@ -134,7 +134,7 @@ func TestConverter_DetailsToGraphQLCreateInput(t *testing.T) {
 		"API with directly spec provided in JSON": {
 			given: model.ServiceDetails{
 				Api: &model.API{
-					Spec: json.RawMessage(`{"spec":"v0.0.1"}`),
+					Spec: ptrClob(`{"spec":"v0.0.1"}`),
 				},
 			},
 			expected: graphql.BundleCreateInput{
@@ -142,7 +142,7 @@ func TestConverter_DetailsToGraphQLCreateInput(t *testing.T) {
 				APIDefinitions: []*graphql.APIDefinitionInput{
 					{
 						Spec: &graphql.APISpecInput{
-							Data:   ptrClob(graphql.CLOB(`{"spec":"v0.0.1"}`)),
+							Data:   ptrClob(`{"spec":"v0.0.1"}`),
 							Type:   graphql.APISpecTypeOpenAPI,
 							Format: graphql.SpecFormatJSON,
 						},
@@ -154,7 +154,7 @@ func TestConverter_DetailsToGraphQLCreateInput(t *testing.T) {
 		"API with directly spec provided in XML": {
 			given: model.ServiceDetails{
 				Api: &model.API{
-					Spec: json.RawMessage(`<spec></spec>"`),
+					Spec: ptrClob(`<spec></spec>"`),
 				},
 			},
 			expected: graphql.BundleCreateInput{
@@ -162,7 +162,7 @@ func TestConverter_DetailsToGraphQLCreateInput(t *testing.T) {
 				APIDefinitions: []*graphql.APIDefinitionInput{
 					{
 						Spec: &graphql.APISpecInput{
-							Data:   ptrClob(graphql.CLOB(`<spec></spec>"`)),
+							Data:   ptrClob(`<spec></spec>"`),
 							Type:   graphql.APISpecTypeOpenAPI,
 							Format: graphql.SpecFormatXML,
 						},
@@ -458,7 +458,7 @@ func TestConverter_DetailsToGraphQLCreateInput(t *testing.T) {
 			given: model.ServiceDetails{
 				Name: "foo",
 				Events: &model.Events{
-					Spec: json.RawMessage(`asyncapi: "1.2.0"`),
+					Spec: ptrClob(`asyncapi: "1.2.0"`),
 				},
 			},
 			expected: graphql.BundleCreateInput{
@@ -770,7 +770,45 @@ func TestConverter_GraphQLToServiceDetails(t *testing.T) {
 			},
 			expected: model.ServiceDetails{
 				Events: &model.Events{
-					Spec: json.RawMessage(`asyncapi: "1.2.0"`),
+					Spec: ptrClob(`asyncapi: "1.2.0"`),
+				},
+				Labels: emptyLabels(),
+			},
+		},
+		"events with XML spec": {
+			given: graphql.BundleExt{
+				EventDefinitions: graphql.EventAPIDefinitionPageExt{
+					Data: []*graphql.EventAPIDefinitionExt{{
+						Spec: &graphql.EventAPISpecExt{
+							EventSpec: graphql.EventSpec{
+								Data: ptrClob(`<xml></xml>`),
+							},
+						}},
+					},
+				},
+			},
+			expected: model.ServiceDetails{
+				Events: &model.Events{
+					Spec: ptrClob(`<xml></xml>`),
+				},
+				Labels: emptyLabels(),
+			},
+		},
+		"API with XML spec": {
+			given: graphql.BundleExt{
+				APIDefinitions: graphql.APIDefinitionPageExt{
+					Data: []*graphql.APIDefinitionExt{{
+						Spec: &graphql.APISpecExt{
+							APISpec: graphql.APISpec{
+								Data: ptrClob(`<xml></xml>`),
+							},
+						}},
+					},
+				},
+			},
+			expected: model.ServiceDetails{
+				Api: &model.API{
+					Spec: ptrClob(`<xml></xml>`),
 				},
 				Labels: emptyLabels(),
 			},
@@ -782,6 +820,8 @@ func TestConverter_GraphQLToServiceDetails(t *testing.T) {
 			// THEN
 			require.NoError(t, err)
 			assert.Equal(t, tc.expected, actual)
+			_, err = json.Marshal(actual)
+			require.NoError(t, err)
 		})
 	}
 
@@ -823,7 +863,7 @@ func TestConverter_ServiceDetailsToService(t *testing.T) {
 		Name:             "name",
 		Description:      "description",
 		ShortDescription: "short description",
-		Identifier:       "identifie",
+		Identifier:       "identifier",
 		Labels:           &map[string]string{"blalb": "blalba"},
 	}
 	id := "id"

--- a/components/connectivity-adapter/internal/appregistry/service/converter_test.go
+++ b/components/connectivity-adapter/internal/appregistry/service/converter_test.go
@@ -114,7 +114,7 @@ func TestConverter_DetailsToGraphQLCreateInput(t *testing.T) {
 		"API with directly spec provided in YAML": {
 			given: model.ServiceDetails{
 				Api: &model.API{
-					Spec: ptrClob(`openapi: "3.0.0"`),
+					Spec: `openapi: "3.0.0"`,
 				},
 			},
 			expected: graphql.BundleCreateInput{
@@ -134,7 +134,7 @@ func TestConverter_DetailsToGraphQLCreateInput(t *testing.T) {
 		"API with directly spec provided in JSON": {
 			given: model.ServiceDetails{
 				Api: &model.API{
-					Spec: ptrClob(`{"spec":"v0.0.1"}`),
+					Spec: `{"spec":"v0.0.1"}`,
 				},
 			},
 			expected: graphql.BundleCreateInput{
@@ -154,7 +154,7 @@ func TestConverter_DetailsToGraphQLCreateInput(t *testing.T) {
 		"API with directly spec provided in XML": {
 			given: model.ServiceDetails{
 				Api: &model.API{
-					Spec: ptrClob(`<spec></spec>"`),
+					Spec: `<spec></spec>"`,
 				},
 			},
 			expected: graphql.BundleCreateInput{
@@ -458,7 +458,7 @@ func TestConverter_DetailsToGraphQLCreateInput(t *testing.T) {
 			given: model.ServiceDetails{
 				Name: "foo",
 				Events: &model.Events{
-					Spec: ptrClob(`asyncapi: "1.2.0"`),
+					Spec: `asyncapi: "1.2.0"`,
 				},
 			},
 			expected: graphql.BundleCreateInput{
@@ -770,7 +770,7 @@ func TestConverter_GraphQLToServiceDetails(t *testing.T) {
 			},
 			expected: model.ServiceDetails{
 				Events: &model.Events{
-					Spec: ptrClob(`asyncapi: "1.2.0"`),
+					Spec: `asyncapi: "1.2.0"`,
 				},
 				Labels: emptyLabels(),
 			},
@@ -789,7 +789,7 @@ func TestConverter_GraphQLToServiceDetails(t *testing.T) {
 			},
 			expected: model.ServiceDetails{
 				Events: &model.Events{
-					Spec: ptrClob(`<xml></xml>`),
+					Spec: `<xml></xml>`,
 				},
 				Labels: emptyLabels(),
 			},
@@ -808,7 +808,7 @@ func TestConverter_GraphQLToServiceDetails(t *testing.T) {
 			},
 			expected: model.ServiceDetails{
 				Api: &model.API{
-					Spec: ptrClob(`<xml></xml>`),
+					Spec: `<xml></xml>`,
 				},
 				Labels: emptyLabels(),
 			},

--- a/components/connectivity-adapter/internal/appregistry/service/fixtures_test.go
+++ b/components/connectivity-adapter/internal/appregistry/service/fixtures_test.go
@@ -1,6 +1,9 @@
 package service_test
 
-import "github.com/kyma-incubator/compass/components/connectivity-adapter/pkg/model"
+import (
+	"github.com/kyma-incubator/compass/components/connectivity-adapter/pkg/model"
+	"github.com/kyma-incubator/compass/components/director/pkg/graphql"
+)
 
 func fixAPIOpenAPIYAML() model.API {
 	spec := `openapi: 3.0.0
@@ -29,7 +32,7 @@ paths:
                   type: string`
 
 	return model.API{
-		Spec: []byte(spec),
+		Spec: ptrClob(graphql.CLOB(spec)),
 	}
 }
 
@@ -104,7 +107,7 @@ func fixAPIOpenAPIJSON() model.API {
 }`
 
 	return model.API{
-		Spec: []byte(spec),
+		Spec: ptrClob(graphql.CLOB(spec)),
 	}
 }
 
@@ -271,7 +274,7 @@ func fixAPIODataXML() model.API {
 </edmx:Edmx>`
 
 	return model.API{
-		Spec:    []byte(spec),
+		Spec:    ptrClob(graphql.CLOB(spec)),
 		ApiType: "odata",
 	}
 }
@@ -310,7 +313,7 @@ components:
           type: string`
 
 	return model.Events{
-		Spec: []byte(spec),
+		Spec: ptrClob(graphql.CLOB(spec)),
 	}
 }
 
@@ -340,7 +343,7 @@ func fixEventsAsyncAPIJSON() model.Events {
 }`
 
 	return model.Events{
-		Spec: []byte(spec),
+		Spec: ptrClob(graphql.CLOB(spec)),
 	}
 }
 

--- a/components/connectivity-adapter/internal/appregistry/service/fixtures_test.go
+++ b/components/connectivity-adapter/internal/appregistry/service/fixtures_test.go
@@ -2,7 +2,6 @@ package service_test
 
 import (
 	"github.com/kyma-incubator/compass/components/connectivity-adapter/pkg/model"
-	"github.com/kyma-incubator/compass/components/director/pkg/graphql"
 )
 
 func fixAPIOpenAPIYAML() model.API {
@@ -32,7 +31,7 @@ paths:
                   type: string`
 
 	return model.API{
-		Spec: ptrClob(graphql.CLOB(spec)),
+		Spec: spec,
 	}
 }
 
@@ -107,7 +106,7 @@ func fixAPIOpenAPIJSON() model.API {
 }`
 
 	return model.API{
-		Spec: ptrClob(graphql.CLOB(spec)),
+		Spec: spec,
 	}
 }
 
@@ -274,7 +273,7 @@ func fixAPIODataXML() model.API {
 </edmx:Edmx>`
 
 	return model.API{
-		Spec:    ptrClob(graphql.CLOB(spec)),
+		Spec:    spec,
 		ApiType: "odata",
 	}
 }
@@ -313,7 +312,7 @@ components:
           type: string`
 
 	return model.Events{
-		Spec: ptrClob(graphql.CLOB(spec)),
+		Spec: spec,
 	}
 }
 
@@ -343,7 +342,7 @@ func fixEventsAsyncAPIJSON() model.Events {
 }`
 
 	return model.Events{
-		Spec: ptrClob(graphql.CLOB(spec)),
+		Spec: spec,
 	}
 }
 

--- a/components/connectivity-adapter/internal/appregistry/service/fixtures_test.go
+++ b/components/connectivity-adapter/internal/appregistry/service/fixtures_test.go
@@ -31,7 +31,7 @@ paths:
                   type: string`
 
 	return model.API{
-		Spec: spec,
+		Spec: ptrSpecResponse(model.SpecResponse(spec)),
 	}
 }
 
@@ -106,7 +106,7 @@ func fixAPIOpenAPIJSON() model.API {
 }`
 
 	return model.API{
-		Spec: spec,
+		Spec: ptrSpecResponse(model.SpecResponse(spec)),
 	}
 }
 
@@ -273,7 +273,7 @@ func fixAPIODataXML() model.API {
 </edmx:Edmx>`
 
 	return model.API{
-		Spec:    spec,
+		Spec:    ptrSpecResponse(model.SpecResponse(spec)),
 		ApiType: "odata",
 	}
 }
@@ -312,7 +312,7 @@ components:
           type: string`
 
 	return model.Events{
-		Spec: spec,
+		Spec: ptrSpecResponse(model.SpecResponse(spec)),
 	}
 }
 
@@ -342,7 +342,7 @@ func fixEventsAsyncAPIJSON() model.Events {
 }`
 
 	return model.Events{
-		Spec: spec,
+		Spec: ptrSpecResponse(model.SpecResponse(spec)),
 	}
 }
 

--- a/components/connectivity-adapter/internal/appregistry/service/validation/servicedetailsvalidation_test.go
+++ b/components/connectivity-adapter/internal/appregistry/service/validation/servicedetailsvalidation_test.go
@@ -55,7 +55,7 @@ func TestServiceDetailsValidator(t *testing.T) {
 			Provider:    "provider",
 			Description: "description",
 			Events: &model.Events{
-				Spec: string(eventsRawSpec),
+				Spec: ptrSpecResponse(model.SpecResponse(eventsRawSpec)),
 			},
 		}
 
@@ -78,7 +78,7 @@ func TestServiceDetailsValidator(t *testing.T) {
 				TargetUrl: "http://target.com",
 			},
 			Events: &model.Events{
-				Spec: string(eventsRawSpec),
+				Spec: ptrSpecResponse(model.SpecResponse(eventsRawSpec)),
 			},
 		}
 
@@ -632,4 +632,8 @@ func TestServiceDetailsValidator_Specification_Basic(t *testing.T) {
 		assert.Error(t, err)
 		assert.Equal(t, apperrors.CodeWrongInput, err.Code())
 	})
+}
+
+func ptrSpecResponse(in model.SpecResponse) *model.SpecResponse {
+	return &in
 }

--- a/components/connectivity-adapter/internal/appregistry/service/validation/servicedetailsvalidation_test.go
+++ b/components/connectivity-adapter/internal/appregistry/service/validation/servicedetailsvalidation_test.go
@@ -8,6 +8,8 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/kyma-incubator/compass/components/director/pkg/graphql"
+
 	"github.com/kyma-incubator/compass/components/connectivity-adapter/pkg/apperrors"
 	"github.com/kyma-incubator/compass/components/connectivity-adapter/pkg/model"
 
@@ -55,7 +57,7 @@ func TestServiceDetailsValidator(t *testing.T) {
 			Provider:    "provider",
 			Description: "description",
 			Events: &model.Events{
-				Spec: eventsRawSpec,
+				Spec: ptrClob(graphql.CLOB(eventsRawSpec)),
 			},
 		}
 
@@ -78,7 +80,7 @@ func TestServiceDetailsValidator(t *testing.T) {
 				TargetUrl: "http://target.com",
 			},
 			Events: &model.Events{
-				Spec: eventsRawSpec,
+				Spec: ptrClob(graphql.CLOB(eventsRawSpec)),
 			},
 		}
 
@@ -632,4 +634,8 @@ func TestServiceDetailsValidator_Specification_Basic(t *testing.T) {
 		assert.Error(t, err)
 		assert.Equal(t, apperrors.CodeWrongInput, err.Code())
 	})
+}
+
+func ptrClob(in graphql.CLOB) *graphql.CLOB {
+	return &in
 }

--- a/components/connectivity-adapter/internal/appregistry/service/validation/servicedetailsvalidation_test.go
+++ b/components/connectivity-adapter/internal/appregistry/service/validation/servicedetailsvalidation_test.go
@@ -8,8 +8,6 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/kyma-incubator/compass/components/director/pkg/graphql"
-
 	"github.com/kyma-incubator/compass/components/connectivity-adapter/pkg/apperrors"
 	"github.com/kyma-incubator/compass/components/connectivity-adapter/pkg/model"
 
@@ -57,7 +55,7 @@ func TestServiceDetailsValidator(t *testing.T) {
 			Provider:    "provider",
 			Description: "description",
 			Events: &model.Events{
-				Spec: ptrClob(graphql.CLOB(eventsRawSpec)),
+				Spec: string(eventsRawSpec),
 			},
 		}
 
@@ -80,7 +78,7 @@ func TestServiceDetailsValidator(t *testing.T) {
 				TargetUrl: "http://target.com",
 			},
 			Events: &model.Events{
-				Spec: ptrClob(graphql.CLOB(eventsRawSpec)),
+				Spec: string(eventsRawSpec),
 			},
 		}
 
@@ -634,8 +632,4 @@ func TestServiceDetailsValidator_Specification_Basic(t *testing.T) {
 		assert.Error(t, err)
 		assert.Equal(t, apperrors.CodeWrongInput, err.Code())
 	})
-}
-
-func ptrClob(in graphql.CLOB) *graphql.CLOB {
-	return &in
 }

--- a/components/connectivity-adapter/internal/connectorservice/connector.go
+++ b/components/connectivity-adapter/internal/connectorservice/connector.go
@@ -4,9 +4,10 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/kyma-incubator/compass/components/connectivity-adapter/internal/connectorservice/api/middlewares"
+
 	"github.com/gorilla/mux"
 	"github.com/kyma-incubator/compass/components/connectivity-adapter/internal/connectorservice/api"
-	"github.com/kyma-incubator/compass/components/connectivity-adapter/internal/connectorservice/api/middlewares"
 	"github.com/kyma-incubator/compass/components/connectivity-adapter/internal/connectorservice/connector"
 	"github.com/kyma-incubator/compass/components/connectivity-adapter/internal/connectorservice/director"
 	"github.com/kyma-incubator/compass/components/connectivity-adapter/pkg/model"

--- a/components/connectivity-adapter/pkg/model/model.go
+++ b/components/connectivity-adapter/pkg/model/model.go
@@ -1,7 +1,5 @@
 package model
 
-import "github.com/kyma-incubator/compass/components/director/pkg/graphql"
-
 const (
 	TokenFormat                       = "?token=%s"
 	CertsEndpoint                     = "/v1/applications/certificates"
@@ -40,7 +38,7 @@ type CreateServiceResponse struct {
 type API struct {
 	TargetUrl                      string               `json:"targetUrl" valid:"url,required~targetUrl field cannot be empty."`
 	Credentials                    *CredentialsWithCSRF `json:"credentials,omitempty"`
-	Spec                           *graphql.CLOB        `json:"spec,omitempty"`
+	Spec                           string               `json:"spec,omitempty"`
 	SpecificationUrl               string               `json:"specificationUrl,omitempty"`
 	ApiType                        string               `json:"apiType,omitempty"`
 	RequestParameters              *RequestParameters   `json:"requestParameters,omitempty"`
@@ -103,7 +101,7 @@ type CertificateGenWithCSRF struct {
 }
 
 type Events struct {
-	Spec *graphql.CLOB `json:"spec" valid:"required~spec cannot be empty"`
+	Spec string `json:"spec" valid:"required~spec cannot be empty"`
 }
 
 type Documentation struct {

--- a/components/connectivity-adapter/pkg/model/model.go
+++ b/components/connectivity-adapter/pkg/model/model.go
@@ -1,6 +1,6 @@
 package model
 
-import "encoding/json"
+import "github.com/kyma-incubator/compass/components/director/pkg/graphql"
 
 const (
 	TokenFormat                       = "?token=%s"
@@ -40,7 +40,7 @@ type CreateServiceResponse struct {
 type API struct {
 	TargetUrl                      string               `json:"targetUrl" valid:"url,required~targetUrl field cannot be empty."`
 	Credentials                    *CredentialsWithCSRF `json:"credentials,omitempty"`
-	Spec                           json.RawMessage      `json:"spec,omitempty"`
+	Spec                           *graphql.CLOB        `json:"spec,omitempty"`
 	SpecificationUrl               string               `json:"specificationUrl,omitempty"`
 	ApiType                        string               `json:"apiType,omitempty"`
 	RequestParameters              *RequestParameters   `json:"requestParameters,omitempty"`
@@ -103,7 +103,7 @@ type CertificateGenWithCSRF struct {
 }
 
 type Events struct {
-	Spec json.RawMessage `json:"spec" valid:"required~spec cannot be empty"`
+	Spec *graphql.CLOB `json:"spec" valid:"required~spec cannot be empty"`
 }
 
 type Documentation struct {

--- a/components/connectivity-adapter/pkg/res/success.go
+++ b/components/connectivity-adapter/pkg/res/success.go
@@ -10,5 +10,7 @@ import (
 func WriteJSONResponse(writer http.ResponseWriter, res interface{}) error {
 	log.Infoln("returning response...")
 	writer.Header().Set(HeaderContentTypeKey, HeaderContentTypeValue)
-	return json.NewEncoder(writer).Encode(&res)
+	enc := json.NewEncoder(writer)
+	enc.SetEscapeHTML(false)
+	return enc.Encode(&res)
 }


### PR DESCRIPTION
**Description**
In the connectivity-adapter component, the spec field of API and Events is json.RawMessage and if the spec is e.g. XML this will result in json marshalling error

Changes proposed in this pull request:
- Change the Spec field type to string
- Add tests


- [x] Implementation
- [x] Unit tests
- [x] Integration tests
- [x] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
