### PR TITLE
Fix foreign keys issue for cascade deletion

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -37,7 +37,7 @@ global:
       version: "PR-15"
     schema_migrator:
       dir:
-      version: "PR-1743"
+      version: "PR-1774"
     system_broker:
       dir:
       version: "PR-1750"

--- a/components/schema-migrator/migrations/director/20210311180909_add_application_ready_delete_cascase.down.sql
+++ b/components/schema-migrator/migrations/director/20210311180909_add_application_ready_delete_cascase.down.sql
@@ -1,0 +1,23 @@
+BEGIN;
+
+ALTER TABLE bundles DROP CONSTRAINT bundles_applications_ready_fk;
+ALTER TABLE bundles
+    ADD CONSTRAINT bundles_applications_ready_fk
+        FOREIGN KEY (app_id, ready) REFERENCES applications (id, ready) ON UPDATE CASCADE;
+
+ALTER TABLE api_definitions DROP CONSTRAINT api_definitions_bundles_ready_fk;
+ALTER TABLE api_definitions
+    ADD CONSTRAINT api_definitions_bundles_ready_fk
+        FOREIGN KEY (bundle_id, ready) REFERENCES bundles (id, ready) ON UPDATE CASCADE;
+
+ALTER TABLE event_api_definitions DROP CONSTRAINT event_api_definitions_bundles_ready_fk;
+ALTER TABLE event_api_definitions
+    ADD CONSTRAINT event_api_definitions_bundles_ready_fk
+        FOREIGN KEY (bundle_id, ready) REFERENCES bundles (id, ready) ON UPDATE CASCADE;
+
+ALTER TABLE documents DROP CONSTRAINT documents_bundles_ready_fk;
+ALTER TABLE documents
+    ADD CONSTRAINT documents_bundles_ready_fk
+        FOREIGN KEY (bundle_id, ready) REFERENCES bundles (id, ready) ON UPDATE CASCADE;
+
+COMMIT;

--- a/components/schema-migrator/migrations/director/20210311180909_add_application_ready_delete_cascase.up.sql
+++ b/components/schema-migrator/migrations/director/20210311180909_add_application_ready_delete_cascase.up.sql
@@ -1,0 +1,23 @@
+BEGIN;
+
+ALTER TABLE bundles DROP CONSTRAINT bundles_applications_ready_fk;
+ALTER TABLE bundles
+    ADD CONSTRAINT bundles_applications_ready_fk
+        FOREIGN KEY (app_id, ready) REFERENCES applications (id, ready) ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE api_definitions DROP CONSTRAINT api_definitions_bundles_ready_fk;
+ALTER TABLE api_definitions
+    ADD CONSTRAINT api_definitions_bundles_ready_fk
+        FOREIGN KEY (bundle_id, ready) REFERENCES bundles (id, ready) ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE event_api_definitions DROP CONSTRAINT event_api_definitions_bundles_ready_fk;
+ALTER TABLE event_api_definitions
+    ADD CONSTRAINT event_api_definitions_bundles_ready_fk
+        FOREIGN KEY (bundle_id, ready) REFERENCES bundles (id, ready) ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE documents DROP CONSTRAINT documents_bundles_ready_fk;
+ALTER TABLE documents
+    ADD CONSTRAINT documents_bundles_ready_fk
+        FOREIGN KEY (bundle_id, ready) REFERENCES bundles (id, ready) ON DELETE CASCADE ON UPDATE CASCADE;
+
+COMMIT;


### PR DESCRIPTION
**Description**
Due to missing delete cascade we cannot delete applications with bundles and API/Event Definition

Changes proposed in this pull request:
- Add DB migration with cascade deletion

- [x] Implementation
- [x] Unit tests
- [x] Integration tests
- [x] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
