### PR TITLE
Remove api and event definitions cascade deletion

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -37,7 +37,7 @@ global:
       version: "PR-15"
     schema_migrator:
       dir:
-      version: "PR-1774"
+      version: "PR-1780"
     system_broker:
       dir:
       version: "PR-1750"

--- a/components/schema-migrator/create_migration.sh
+++ b/components/schema-migrator/create_migration.sh
@@ -12,7 +12,7 @@ for var in COMPONENT NAME; do
     fi
 done
 
-DATE="$(date +%Y%m%d%H%M)"
+DATE="$(date +%Y%m%d%H%M%S)"
 MIGRATIONS_DIR="${DIR}/migrations"
 TRANSACTION_STR=$'BEGIN;\nCOMMIT;'
 

--- a/components/schema-migrator/migrations/director/20210319170212_remove-api-and-event-delete-cascade.down.sql
+++ b/components/schema-migrator/migrations/director/20210319170212_remove-api-and-event-delete-cascade.down.sql
@@ -1,0 +1,13 @@
+BEGIN;
+
+ALTER TABLE api_definitions DROP CONSTRAINT api_definitions_bundles_ready_fk;
+ALTER TABLE api_definitions
+    ADD CONSTRAINT api_definitions_bundles_ready_fk
+        FOREIGN KEY (bundle_id, ready) REFERENCES bundles (id, ready) ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE event_api_definitions DROP CONSTRAINT event_api_definitions_bundles_ready_fk;
+ALTER TABLE event_api_definitions
+    ADD CONSTRAINT event_api_definitions_bundles_ready_fk
+        FOREIGN KEY (bundle_id, ready) REFERENCES bundles (id, ready) ON DELETE CASCADE ON UPDATE CASCADE;
+
+COMMIT;

--- a/components/schema-migrator/migrations/director/20210319170212_remove-api-and-event-delete-cascade.up.sql
+++ b/components/schema-migrator/migrations/director/20210319170212_remove-api-and-event-delete-cascade.up.sql
@@ -1,0 +1,13 @@
+BEGIN;
+
+ALTER TABLE api_definitions DROP CONSTRAINT api_definitions_bundles_ready_fk;
+ALTER TABLE api_definitions
+    ADD CONSTRAINT api_definitions_bundles_ready_fk
+        FOREIGN KEY (bundle_id, ready) REFERENCES bundles (id, ready) ON UPDATE CASCADE;
+
+ALTER TABLE event_api_definitions DROP CONSTRAINT event_api_definitions_bundles_ready_fk;
+ALTER TABLE event_api_definitions
+    ADD CONSTRAINT event_api_definitions_bundles_ready_fk
+        FOREIGN KEY (bundle_id, ready) REFERENCES bundles (id, ready) ON UPDATE CASCADE;
+
+COMMIT;


### PR DESCRIPTION
**Description**
Due to the delete cascade hotfix on prod, we need to remove the cascade from api and event definition we've introduced because they will break an existing cascade merged in master

Changes proposed in this pull request:
- Remove cascade deletion from api and event definition

**Related issue(s)**
- #1774 
- #1776 


- [x] Implementation
- [x] Unit tests
- [x] Integration tests
- [x] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
