### PR TITLE
Extend current oauth-clients-scopes-sync job

### DIFF
--- a/chart/compass/charts/director/templates/oauth-clients-scopes-sync-job.yaml
+++ b/chart/compass/charts/director/templates/oauth-clients-scopes-sync-job.yaml
@@ -12,7 +12,7 @@ metadata:
   name: {{ $jobName }}
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ .Chart.Name }}
+    app: {{ $jobName }}
     release: {{ .Release.Name }}
   annotations:
     "helm.sh/hook": post-install,post-upgrade

--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -53,7 +53,7 @@ global:
       version: "PR-1808"
     director:
       dir:
-      version: "PR-1811"
+      version: "PR-1821"
     gateway:
       dir:
       version: "PR-1783"

--- a/components/director/cmd/scopessynchronizer/main.go
+++ b/components/director/cmd/scopessynchronizer/main.go
@@ -68,13 +68,8 @@ func main() {
 	authConverter := auth.NewConverter()
 	systemAuthConverter := systemauth.NewConverter(authConverter)
 	syncService := scopes_sync.NewService(oAuth20Svc, transact, systemauth.NewRepository(systemAuthConverter))
-	err, areAllClientsUpdated := syncService.SynchronizeClientScopes(ctx)
-
+	err = syncService.SynchronizeClientScopes(ctx)
 	exitOnError(ctx, err, "Error while updating client scopes")
-	if !areAllClientsUpdated {
-		log.C(ctx).WithError(err).Errorf("Not all clients were updated")
-		os.Exit(1)
-	}
 }
 
 func exitOnError(ctx context.Context, err error, context string) {

--- a/components/director/cmd/scopessynchronizer/main.go
+++ b/components/director/cmd/scopessynchronizer/main.go
@@ -68,8 +68,13 @@ func main() {
 	authConverter := auth.NewConverter()
 	systemAuthConverter := systemauth.NewConverter(authConverter)
 	syncService := scopes_sync.NewService(oAuth20Svc, transact, systemauth.NewRepository(systemAuthConverter))
-	err = syncService.SynchronizeClientScopes(ctx)
+	err, areAllClientsUpdated := syncService.SynchronizeClientScopes(ctx)
+
 	exitOnError(ctx, err, "Error while updating client scopes")
+	if !areAllClientsUpdated {
+		log.C(ctx).WithError(err).Errorf("Not all clients were updated")
+		os.Exit(1)
+	}
 }
 
 func exitOnError(ctx context.Context, err error, context string) {

--- a/components/director/internal/scopes_sync/service_test.go
+++ b/components/director/internal/scopes_sync/service_test.go
@@ -29,9 +29,8 @@ func TestSyncService_UpdateClientScopes(t *testing.T) {
 		oauthSvc.On("ListClients").Return(nil, errors.New("error"))
 		scopeSyncSvc := NewService(oauthSvc, nil, &automock.SystemAuthRepo{})
 		// WHEN
-		err, areAllClientsUpdated := scopeSyncSvc.SynchronizeClientScopes(context.TODO())
+		err := scopeSyncSvc.SynchronizeClientScopes(context.TODO())
 		// THEN
-		assert.False(t, areAllClientsUpdated)
 		assert.Error(t, err, "while listing clients from hydra")
 	})
 
@@ -45,9 +44,8 @@ func TestSyncService_UpdateClientScopes(t *testing.T) {
 		defer oauthSvc.AssertExpectations(t)
 		scopeSyncSvc := NewService(oauthSvc, transactioner, &automock.SystemAuthRepo{})
 		// WHEN
-		err, areAllClientsUpdated := scopeSyncSvc.SynchronizeClientScopes(context.TODO())
+		err := scopeSyncSvc.SynchronizeClientScopes(context.TODO())
 		// THEN
-		assert.False(t, areAllClientsUpdated)
 		assert.Error(t, err, "while opening database transaction")
 	})
 
@@ -63,9 +61,8 @@ func TestSyncService_UpdateClientScopes(t *testing.T) {
 		defer oauthSvc.AssertExpectations(t)
 		scopeSyncSvc := NewService(oauthSvc, transactioner, systemAuthRepo)
 		// WHEN
-		err, areAllClientsUpdated := scopeSyncSvc.SynchronizeClientScopes(context.TODO())
+		err := scopeSyncSvc.SynchronizeClientScopes(context.TODO())
 		// THEN
-		assert.False(t, areAllClientsUpdated)
 		assert.Error(t, err, "error while listing systemAuths")
 	})
 	t.Run("fails when cannot commit transaction", func(t *testing.T) {
@@ -80,9 +77,8 @@ func TestSyncService_UpdateClientScopes(t *testing.T) {
 		defer oauthSvc.AssertExpectations(t)
 		scopeSyncSvc := NewService(oauthSvc, transactioner, systemAuthRepo)
 		// WHEN
-		err, areAllClientsUpdated := scopeSyncSvc.SynchronizeClientScopes(context.TODO())
+		err := scopeSyncSvc.SynchronizeClientScopes(context.TODO())
 		// THEN
-		assert.False(t, areAllClientsUpdated)
 		assert.Error(t, err, "while database transaction commit")
 	})
 
@@ -108,10 +104,9 @@ func TestSyncService_UpdateClientScopes(t *testing.T) {
 		defer oauthSvc.AssertExpectations(t)
 		scopeSyncSvc := NewService(oauthSvc, transactioner, systemAuthRepo)
 		// WHEN
-		err, areAllClientsUpdated := scopeSyncSvc.SynchronizeClientScopes(context.TODO())
+		err := scopeSyncSvc.SynchronizeClientScopes(context.TODO())
 		// THEN
-		assert.Nil(t, err)
-		assert.False(t, areAllClientsUpdated)
+		assert.Error(t, err, "Not all clients were updated successfully")
 	})
 
 	t.Run("won't update client when getting client credentials scopes fails", func(t *testing.T) {
@@ -138,10 +133,9 @@ func TestSyncService_UpdateClientScopes(t *testing.T) {
 		defer oauthSvc.AssertExpectations(t)
 		scopeSyncSvc := NewService(oauthSvc, transactioner, systemAuthRepo)
 		// WHEN
-		err, areAllClientsUpdated := scopeSyncSvc.SynchronizeClientScopes(context.TODO())
+		err := scopeSyncSvc.SynchronizeClientScopes(context.TODO())
 		// THEN
-		assert.Nil(t, err)
-		assert.False(t, areAllClientsUpdated)
+		assert.Error(t, err, "Not all clients were updated successfully")
 	})
 
 	t.Run("fails when client does not present in hydra", func(t *testing.T) {
@@ -168,10 +162,9 @@ func TestSyncService_UpdateClientScopes(t *testing.T) {
 		defer oauthSvc.AssertExpectations(t)
 		scopeSyncSvc := NewService(oauthSvc, transactioner, systemAuthRepo)
 		// WHEN
-		err, areAllClientsUpdated := scopeSyncSvc.SynchronizeClientScopes(context.TODO())
+		err := scopeSyncSvc.SynchronizeClientScopes(context.TODO())
 		// THEN
-		assert.Nil(t, err)
-		assert.False(t, areAllClientsUpdated)
+		assert.Error(t, err, "Not all clients were updated successfully")
 	})
 
 	t.Run("won't update scopes if not needed", func(t *testing.T) {
@@ -203,10 +196,9 @@ func TestSyncService_UpdateClientScopes(t *testing.T) {
 		defer oauthSvc.AssertExpectations(t)
 		scopeSyncSvc := NewService(oauthSvc, transactioner, systemAuthRepo)
 		// WHEN
-		err, areAllClientsUpdated := scopeSyncSvc.SynchronizeClientScopes(context.TODO())
+		err := scopeSyncSvc.SynchronizeClientScopes(context.TODO())
 		// THEN
 		assert.Nil(t, err)
-		assert.True(t, areAllClientsUpdated)
 	})
 
 	t.Run("will update scopes successfully", func(t *testing.T) {
@@ -239,9 +231,8 @@ func TestSyncService_UpdateClientScopes(t *testing.T) {
 		defer oauthSvc.AssertExpectations(t)
 		scopeSyncSvc := NewService(oauthSvc, transactioner, systemAuthRepo)
 		// WHEN
-		err, areAllClientsUpdated := scopeSyncSvc.SynchronizeClientScopes(context.TODO())
+		err := scopeSyncSvc.SynchronizeClientScopes(context.TODO())
 		// THEN
 		assert.Nil(t, err)
-		assert.True(t, areAllClientsUpdated)
 	})
 }

--- a/components/director/internal/scopes_sync/service_test.go
+++ b/components/director/internal/scopes_sync/service_test.go
@@ -29,8 +29,9 @@ func TestSyncService_UpdateClientScopes(t *testing.T) {
 		oauthSvc.On("ListClients").Return(nil, errors.New("error"))
 		scopeSyncSvc := NewService(oauthSvc, nil, &automock.SystemAuthRepo{})
 		// WHEN
-		err := scopeSyncSvc.SynchronizeClientScopes(context.TODO())
+		err, areAllClientsUpdated := scopeSyncSvc.SynchronizeClientScopes(context.TODO())
 		// THEN
+		assert.False(t, areAllClientsUpdated)
 		assert.Error(t, err, "while listing clients from hydra")
 	})
 
@@ -44,8 +45,9 @@ func TestSyncService_UpdateClientScopes(t *testing.T) {
 		defer oauthSvc.AssertExpectations(t)
 		scopeSyncSvc := NewService(oauthSvc, transactioner, &automock.SystemAuthRepo{})
 		// WHEN
-		err := scopeSyncSvc.SynchronizeClientScopes(context.TODO())
+		err, areAllClientsUpdated := scopeSyncSvc.SynchronizeClientScopes(context.TODO())
 		// THEN
+		assert.False(t, areAllClientsUpdated)
 		assert.Error(t, err, "while opening database transaction")
 	})
 
@@ -61,8 +63,9 @@ func TestSyncService_UpdateClientScopes(t *testing.T) {
 		defer oauthSvc.AssertExpectations(t)
 		scopeSyncSvc := NewService(oauthSvc, transactioner, systemAuthRepo)
 		// WHEN
-		err := scopeSyncSvc.SynchronizeClientScopes(context.TODO())
+		err, areAllClientsUpdated := scopeSyncSvc.SynchronizeClientScopes(context.TODO())
 		// THEN
+		assert.False(t, areAllClientsUpdated)
 		assert.Error(t, err, "error while listing systemAuths")
 	})
 	t.Run("fails when cannot commit transaction", func(t *testing.T) {
@@ -77,8 +80,9 @@ func TestSyncService_UpdateClientScopes(t *testing.T) {
 		defer oauthSvc.AssertExpectations(t)
 		scopeSyncSvc := NewService(oauthSvc, transactioner, systemAuthRepo)
 		// WHEN
-		err := scopeSyncSvc.SynchronizeClientScopes(context.TODO())
+		err, areAllClientsUpdated := scopeSyncSvc.SynchronizeClientScopes(context.TODO())
 		// THEN
+		assert.False(t, areAllClientsUpdated)
 		assert.Error(t, err, "while database transaction commit")
 	})
 
@@ -104,9 +108,10 @@ func TestSyncService_UpdateClientScopes(t *testing.T) {
 		defer oauthSvc.AssertExpectations(t)
 		scopeSyncSvc := NewService(oauthSvc, transactioner, systemAuthRepo)
 		// WHEN
-		err := scopeSyncSvc.SynchronizeClientScopes(context.TODO())
+		err, areAllClientsUpdated := scopeSyncSvc.SynchronizeClientScopes(context.TODO())
 		// THEN
 		assert.Nil(t, err)
+		assert.False(t, areAllClientsUpdated)
 	})
 
 	t.Run("won't update client when getting client credentials scopes fails", func(t *testing.T) {
@@ -133,9 +138,10 @@ func TestSyncService_UpdateClientScopes(t *testing.T) {
 		defer oauthSvc.AssertExpectations(t)
 		scopeSyncSvc := NewService(oauthSvc, transactioner, systemAuthRepo)
 		// WHEN
-		err := scopeSyncSvc.SynchronizeClientScopes(context.TODO())
+		err, areAllClientsUpdated := scopeSyncSvc.SynchronizeClientScopes(context.TODO())
 		// THEN
 		assert.Nil(t, err)
+		assert.False(t, areAllClientsUpdated)
 	})
 
 	t.Run("fails when client does not present in hydra", func(t *testing.T) {
@@ -162,9 +168,10 @@ func TestSyncService_UpdateClientScopes(t *testing.T) {
 		defer oauthSvc.AssertExpectations(t)
 		scopeSyncSvc := NewService(oauthSvc, transactioner, systemAuthRepo)
 		// WHEN
-		err := scopeSyncSvc.SynchronizeClientScopes(context.TODO())
+		err, areAllClientsUpdated := scopeSyncSvc.SynchronizeClientScopes(context.TODO())
 		// THEN
 		assert.Nil(t, err)
+		assert.False(t, areAllClientsUpdated)
 	})
 
 	t.Run("won't update scopes if not needed", func(t *testing.T) {
@@ -196,9 +203,10 @@ func TestSyncService_UpdateClientScopes(t *testing.T) {
 		defer oauthSvc.AssertExpectations(t)
 		scopeSyncSvc := NewService(oauthSvc, transactioner, systemAuthRepo)
 		// WHEN
-		err := scopeSyncSvc.SynchronizeClientScopes(context.TODO())
+		err, areAllClientsUpdated := scopeSyncSvc.SynchronizeClientScopes(context.TODO())
 		// THEN
 		assert.Nil(t, err)
+		assert.True(t, areAllClientsUpdated)
 	})
 
 	t.Run("will update scopes successfully", func(t *testing.T) {
@@ -231,8 +239,9 @@ func TestSyncService_UpdateClientScopes(t *testing.T) {
 		defer oauthSvc.AssertExpectations(t)
 		scopeSyncSvc := NewService(oauthSvc, transactioner, systemAuthRepo)
 		// WHEN
-		err := scopeSyncSvc.SynchronizeClientScopes(context.TODO())
+		err, areAllClientsUpdated := scopeSyncSvc.SynchronizeClientScopes(context.TODO())
 		// THEN
 		assert.Nil(t, err)
+		assert.True(t, areAllClientsUpdated)
 	})
 }


### PR DESCRIPTION
Extend current oauth-clients-scopes-sync job, so that it fails when not all clients are updated successfully