### PR TITLE
Use correct sql condition when listing clients for update

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -53,7 +53,7 @@ global:
       version: "PR-1808"
     director:
       dir:
-      version: "PR-1823"
+      version: "PR-1824"
     gateway:
       dir:
       version: "PR-1783"

--- a/components/director/internal/scopes_sync/service.go
+++ b/components/director/internal/scopes_sync/service.go
@@ -59,8 +59,9 @@ func (s *service) SynchronizeClientScopes(ctx context.Context) error {
 
 	areAllClientsUpdated := true
 	for _, auth := range auths {
+		log.C(ctx).Infof("Synchronizing oauth client of system auth with ID %s", auth.ID)
 		if auth.Value == nil || auth.Value.Credential.Oauth == nil {
-			log.C(ctx).Infof("System auth with ID %s should not be updated", auth.ID)
+			log.C(ctx).Infof("System auth with ID %s does not have oauth client for update", auth.ID)
 			continue
 		}
 

--- a/components/director/internal/scopes_sync/service_test.go
+++ b/components/director/internal/scopes_sync/service_test.go
@@ -20,7 +20,7 @@ func TestSyncService_UpdateClientScopes(t *testing.T) {
 
 	const clientID = "client-id"
 	selectCondition := repo.Conditions{
-		repo.NewNotNullCondition("(value -> 'Credential' -> 'Oauth')"),
+		repo.NewNotEqualCondition("(value -> 'Credential' -> 'Oauth')", "null"),
 	}
 
 	t.Run("fails when oauth service cannot list clients", func(t *testing.T) {
@@ -106,7 +106,7 @@ func TestSyncService_UpdateClientScopes(t *testing.T) {
 		// WHEN
 		err := scopeSyncSvc.SynchronizeClientScopes(context.TODO())
 		// THEN
-		assert.Error(t, err, "Not all clients were updated successfully")
+		assert.EqualError(t, err, "Not all clients were updated successfully")
 	})
 
 	t.Run("won't update client when getting client credentials scopes fails", func(t *testing.T) {
@@ -135,7 +135,7 @@ func TestSyncService_UpdateClientScopes(t *testing.T) {
 		// WHEN
 		err := scopeSyncSvc.SynchronizeClientScopes(context.TODO())
 		// THEN
-		assert.Error(t, err, "Not all clients were updated successfully")
+		assert.EqualError(t, err, "Not all clients were updated successfully")
 	})
 
 	t.Run("fails when client does not present in hydra", func(t *testing.T) {
@@ -199,6 +199,70 @@ func TestSyncService_UpdateClientScopes(t *testing.T) {
 		err := scopeSyncSvc.SynchronizeClientScopes(context.TODO())
 		// THEN
 		assert.Nil(t, err)
+	})
+
+	t.Run("won't update scopes when returned client is not for update", func(t *testing.T) {
+		// GIVEN
+		oauthSvc := &automock.OAuthService{}
+		systemAuthRepo := &automock.SystemAuthRepo{}
+		oauthSvc.On("ListClients").Return([]*models.OAuth2Client{
+			{
+				ClientID: clientID,
+				Scope:    "scope",
+			},
+		}, nil)
+		mockedTx, transactioner := txtest.NewTransactionContextGenerator(nil).ThatSucceeds()
+		systemAuthRepo.On("ListGlobalWithConditions", mock.Anything, selectCondition).Return([]model.SystemAuth{
+			{
+				AppID: str.Ptr("app-id"),
+				Value: &model.Auth{
+					Credential: model.CredentialData{},
+				},
+			},
+		}, nil)
+		defer mockedTx.AssertExpectations(t)
+		defer transactioner.AssertExpectations(t)
+		defer oauthSvc.AssertExpectations(t)
+		scopeSyncSvc := NewService(oauthSvc, transactioner, systemAuthRepo)
+		// WHEN
+		err := scopeSyncSvc.SynchronizeClientScopes(context.TODO())
+		// THEN
+		assert.Nil(t, err)
+	})
+
+	t.Run("fails when client update in Hydra fails", func(t *testing.T) {
+		// GIVEN
+		oauthSvc := &automock.OAuthService{}
+		systemAuthRepo := &automock.SystemAuthRepo{}
+		oauthSvc.On("ListClients").Return([]*models.OAuth2Client{
+			{
+				ClientID: clientID,
+				Scope:    "first",
+			},
+		}, nil)
+		oauthSvc.On("GetClientCredentialScopes", model.ApplicationReference).Return([]string{"first", "second"}, nil)
+		oauthSvc.On("UpdateClientScopes", mock.Anything, "client-id", model.ApplicationReference).Return(errors.New("fail"))
+		mockedTx, transactioner := txtest.NewTransactionContextGenerator(errors.New("error")).ThatSucceeds()
+		systemAuthRepo.On("ListGlobalWithConditions", mock.Anything, selectCondition).Return([]model.SystemAuth{
+			{
+				AppID: str.Ptr("app-id"),
+				Value: &model.Auth{
+					Credential: model.CredentialData{
+						Oauth: &model.OAuthCredentialData{
+							ClientID: clientID,
+						},
+					},
+				},
+			},
+		}, nil)
+		defer mockedTx.AssertExpectations(t)
+		defer transactioner.AssertExpectations(t)
+		defer oauthSvc.AssertExpectations(t)
+		scopeSyncSvc := NewService(oauthSvc, transactioner, systemAuthRepo)
+		// WHEN
+		err := scopeSyncSvc.SynchronizeClientScopes(context.TODO())
+		// THEN
+		assert.EqualError(t, err, "Not all clients were updated successfully")
 	})
 
 	t.Run("will update scopes successfully", func(t *testing.T) {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Due to one of the optimisations in the original PR, the executed SQL statement is not correct.
Statement before this PR that returns all system auths:
```
SELECT id, tenant_id, app_id, runtime_id, integration_system_id, value FROM public.system_auths WHERE (value -> 'Credential' -> 'Oauth') IS NOT NULL;
```

Statement now:
```
SELECT id, tenant_id, app_id, runtime_id, integration_system_id, value FROM public.system_auths WHERE (value -> 'Credential' -> 'Oauth') != 'null';
```

**Changes proposed in this pull request:**
- Fix the condition used for listing system auths with oauth clients

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- The deployment pipeline fails with the following error:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xaef257]

goroutine 1 [running]:
github.com/kyma-incubator/compass/components/director/internal/scopes_sync.(*service).SynchronizeClientScopes(0xc0003a2f60, 0xdeb9a0, 0xc00040bb30, 0x0, 0xd078aa)
	/go/src/github.com/kyma-incubator/compass/components/director/internal/scopes_sync/service.go:62 +0x197
main.main()
	/go/src/github.com/kyma-incubator/compass/components/director/cmd/scopessynchronizer/main.go:71 +0x96e
```

**Pull Request status**
<!-- Feel free to construct the checklist with whatever items seem most reasonable for your change. You could disassemble the Implementation part to even smaller separate checklist items if you're working on something big for example. But do make the effort to provide a checklist of some sort so that the core team as well as the community can have an idea about the progress of your Pull Request.
-->

- [x] Implementation
- [x] Unit tests
- [x] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
