### PR TITLE
Enable System Broker deployment resource configuration

### DIFF
--- a/chart/compass/charts/system-broker/templates/deployment.yaml
+++ b/chart/compass/charts/system-broker/templates/deployment.yaml
@@ -45,7 +45,7 @@ spec:
               containerPort: {{ .Values.metrics.port }}
               protocol: TCP
           resources:
-            {{- toYaml .Values.resources | nindent 12 }}
+            {{- toYaml .Values.deployment.resources | nindent 12 }}
           {{- with .Values.deployment.securityContext }}
           securityContext:
 {{ toYaml . | indent 12 }}


### PR DESCRIPTION
# Enable System Broker deployment resource configuration

**Description**

When the System Broker was originally introduced a broken deployment resource reference link looks to have been added.
This fix would be necessary if proper autoscaling is to be expected.

**Pull Request status**
<!-- Feel free to construct the checklist with whatever items seem most reasonable for your change. You could disassemble the Implementation part to even smaller separate checklist items if you're working on something big for example. But do make the effort to provide a checklist of some sort so that the core team as well as the community can have an idea about the progress of your Pull Request.
-->

- [N/A] Implementation
- [N/A] Unit tests
- [N/A] Integration tests
- [N/A] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
