### PR TITLE
Better error message when runtime lists application

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -53,7 +53,7 @@ global:
       version: "PR-1808"
     director:
       dir:
-      version: "PR-1827"
+      version: "PR-1835"
     gateway:
       dir:
       version: "PR-1783"

--- a/components/director/pkg/scenario/directive.go
+++ b/components/director/pkg/scenario/directive.go
@@ -157,6 +157,9 @@ func (d *directive) extractCommonScenarios(ctx context.Context, runtimeID, appli
 func (d *directive) getObjectScenarios(ctx context.Context, tenantID string, objectType model.LabelableObject, objectID string) ([]string, error) {
 	scenariosLabel, err := d.labelRepo.GetByKey(ctx, tenantID, objectType, objectID, model.ScenariosKey)
 	if err != nil {
+		if apperrors.IsNotFoundError(err) {
+			return make([]string, 0), nil
+		}
 		return nil, errors.Wrapf(err, "while fetching scenarios for object with id: %s and type: %s", objectID, objectType)
 	}
 	return label.ValueToStringsSlice(scenariosLabel.Value)

--- a/components/director/pkg/scenario/directive_test.go
+++ b/components/director/pkg/scenario/directive_test.go
@@ -92,17 +92,18 @@ func TestHasScenario(t *testing.T) {
 			idField       = "id"
 			tenantID      = "42"
 			applicationID = "24"
+			runtimeID     = "23"
 		)
 
 		lblRepo := &lbl_mock.LabelRepository{}
 		defer lblRepo.AssertExpectations(t)
 
-		mockedTx, mockedTransactioner := txtest.NewTransactionContextGenerator(nil).ThatDoesntExpectCommit()
+		mockedTx, mockedTransactioner := txtest.NewTransactionContextGenerator(nil).ThatSucceeds()
 		defer mockedTx.AssertExpectations(t)
 		defer mockedTransactioner.AssertExpectations(t)
 
 		directive := scenario.NewDirective(mockedTransactioner, lblRepo, nil, nil)
-		ctx := context.WithValue(context.TODO(), consumer.ConsumerKey, consumer.Consumer{ConsumerType: consumer.Runtime})
+		ctx := context.WithValue(context.TODO(), consumer.ConsumerKey, consumer.Consumer{ConsumerType: consumer.Runtime, ConsumerID: runtimeID})
 		ctx = context.WithValue(ctx, tenant.TenantContextKey, tenant.TenantCtx{InternalID: tenantID})
 		rCtx := &graphql.FieldContext{
 			Object:   "Application",
@@ -115,6 +116,7 @@ func TestHasScenario(t *testing.T) {
 
 		notFoundErr := apperrors.NewNotFoundError(resource.Label, model.ScenariosKey)
 		lblRepo.On("GetByKey", ctxWithTx, tenantID, model.ApplicationLabelableObject, applicationID, model.ScenariosKey).Return(nil, notFoundErr)
+		lblRepo.On("GetByKey", ctxWithTx, tenantID, model.RuntimeLabelableObject, runtimeID, model.ScenariosKey).Return(nil, notFoundErr)
 		// WHEN
 		res, err := directive.HasScenario(ctx, nil, nil, scenario.GetApplicationID, idField)
 		// THEN

--- a/scripts/generic_make_go.mk
+++ b/scripts/generic_make_go.mk
@@ -180,5 +180,6 @@ exec:
 
 # Sets locally built image for a given component in Minikube cluster 
 deploy-on-minikube: build-to-minikube
+	kubectl config use-context minikube
 	kubectl set image -n $(NAMESPACE) deployment/$(DEPLOYMENT_NAME) $(COMPONENT_NAME)=$(DEPLOYMENT_NAME):latest
 	kubectl rollout restart -n $(NAMESPACE) deployment/$(DEPLOYMENT_NAME)


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:
- When getting an application with runtime authentication and the runtime or app is not in a scenario, the returned error is now meaningful


**Pull Request status**

- [x] Implementation
- [x] Unit tests
- [ ] Integration tests
- [x] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
