### PR TITLE
Verify ORD Service

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -65,7 +65,7 @@ global:
       version: "PR-1820"
     ord_service:
       dir:
-      version: "PR-19"
+      version: "PR-20"
     schema_migrator:
       dir:
       version: "PR-1780"


### PR DESCRIPTION
**Description**
OpenJDK official images for [JRE 8](https://hub.docker.com/_/openjdk?tab=tags&page=1&ordering=last_updated&name=8-jre-alpine) are more than 2 years old. 
AdoptOpenJDK images are more frequently updated and their [alpine-jre](https://hub.docker.com/r/adoptopenjdk/openjdk8/tags?page=1&ordering=last_updated&name=alpine-jre) image is 2 days old. 

Verify the PR: https://github.com/kyma-incubator/ord-service/pull/20

Changes proposed in this pull request:
- Adopt fresh image from AdoptOpenJDK project based on Alpine and with JRE 8

**Pull Request status**
- [x] Implementation
- [x] Unit tests
- [x] Integration tests
- [x] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
