### PR TITLE
Skip tenant events that contain invalid data

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -53,7 +53,7 @@ global:
       version: "PR-1828"
     director:
       dir:
-      version: "PR-1832"
+      version: "PR-1844"
     gateway:
       dir:
       version: "PR-1828"

--- a/components/director/internal/tenantfetcher/event_page.go
+++ b/components/director/internal/tenantfetcher/event_page.go
@@ -40,7 +40,8 @@ func (ep eventsPage) getMovedRuntimes() ([]model.MovedRuntimeByLabelMappingInput
 	for _, detail := range eds {
 		mapping, err := ep.eventDataToMovedRuntime(detail)
 		if err != nil {
-			return nil, err
+			log.D().Warnf("Error: %s. Could not convert tenant: %s", err.Error(), string(detail))
+			continue
 		}
 
 		mappings = append(mappings, *mapping)
@@ -55,7 +56,8 @@ func (ep eventsPage) getTenantMappings(eventsType EventsType) ([]model.BusinessT
 	for _, detail := range eds {
 		mapping, err := ep.eventDataToTenant(eventsType, detail)
 		if err != nil {
-			return nil, err
+			log.D().Warnf("Error: %s. Could not convert tenant: %s", err.Error(), string(detail))
+			continue
 		}
 
 		tenants = append(tenants, *mapping)

--- a/components/director/internal/tenantfetcher/service_test.go
+++ b/components/director/internal/tenantfetcher/service_test.go
@@ -815,7 +815,7 @@ func TestService_SyncTenants(t *testing.T) {
 			ExpectedError: testErr,
 		},
 		{
-			Name:            "Error when receiving event with wrong format",
+			Name:            "Skip event when receiving event with wrong format",
 			TransactionerFn: txGen.ThatDoesntStartTransaction,
 			APIClientFn: func() *automock.EventAPIClient {
 				client := &automock.EventAPIClient{}
@@ -825,6 +825,7 @@ func TestService_SyncTenants(t *testing.T) {
 				}
 				wrongTenantEvents := eventsToJsonArray(fixEvent("4", "qux", wrongFieldMApping))
 				client.On("FetchTenantEventsPage", tenantfetcher.CreatedEventsType, pageOneQueryParams).Return(fixTenantEventsResponse(wrongTenantEvents, 1, 1), nil).Once()
+				attachNoResponseOnFirstPage(client, tenantfetcher.UpdatedEventsType, tenantfetcher.DeletedEventsType, tenantfetcher.MovedRuntimeByLabelEventsType)
 				return client
 			},
 			LabelDefSvcFn:       UnusedLabelLabelSvc,
@@ -836,7 +837,6 @@ func TestService_SyncTenants(t *testing.T) {
 				client.AssertNotCalled(t, "UpdateTenantFetcherConfigMapData")
 				return client
 			},
-			ExpectedError: errors.New("invalid format"),
 		},
 	}
 


### PR DESCRIPTION
**Tenant mapping job fails because of not valid tenant events**

Changes proposed in this pull request:
- Only log errors for invalid tenant event, and proceed with other events

**Pull Request status**
- [x] Implementation
- [x] Unit tests
- [ ] Integration tests
- [x] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
