### PR TITLE
Fix migration

### DIFF
--- a/components/schema-migrator/migrations/director/20210426104233_adopt_ord_rc2.up.sql
+++ b/components/schema-migrator/migrations/director/20210426104233_adopt_ord_rc2.up.sql
@@ -71,6 +71,7 @@ INSERT INTO bundle_references (
            bundle_id,
            target_url
     FROM api_definitions
+    WHERE bundle_id is not NULL
 );
 
 INSERT INTO bundle_references (
@@ -80,6 +81,7 @@ INSERT INTO bundle_references (
            bundle_id,
            NULL::varchar
     FROM event_api_definitions
+    WHERE bundle_id is not NULL
 );
 
 ALTER TABLE api_definitions


### PR DESCRIPTION
**Description**

Add additional check to skip apis/events with bundle_id = null when migrating them to the newly introduced many-to-many table between bundles and apis/events

**Pull Request status**

- [x] Implementation
- [ ] Unit tests
- [ ] Integration tests
- [ ] `chart/compass/values.yaml` is updated
