### PR TITLE
Ord rc3 adaptation

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -53,7 +53,7 @@ global:
       version: "PR-1828"
     director:
       dir:
-      version: "PR-1845"
+      version: "PR-1858"
     gateway:
       dir:
       version: "PR-1850"
@@ -65,10 +65,10 @@ global:
       version: "PR-1828"
     ord_service:
       dir:
-      version: "PR-21"
+      version: "PR-24"
     schema_migrator:
       dir:
-      version: "PR-1845"
+      version: "PR-1858"
     system_broker:
       dir:
       version: "PR-1839"
@@ -79,7 +79,7 @@ global:
       version: "0a651695"
     external_services_mock:
       dir:
-      version: "PR-1845"
+      version: "PR-1858"
     console:
       dir:
       version: "PR-31"

--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -65,7 +65,7 @@ global:
       version: "PR-1828"
     ord_service:
       dir:
-      version: "PR-24"
+      version: "PR-25"
     schema_migrator:
       dir:
       version: "PR-1858"

--- a/components/director/internal/domain/api/converter.go
+++ b/components/director/internal/domain/api/converter.go
@@ -162,6 +162,7 @@ func (c *converter) FromEntity(entity Entity) model.APIDefinition {
 		CustomImplementationStandard:            repo.StringPtrFromNullableString(entity.CustomImplementationStandard),
 		CustomImplementationStandardDescription: repo.StringPtrFromNullableString(entity.CustomImplementationStandardDescription),
 		Version:                                 c.version.FromEntity(entity.Version),
+		Extensible:                              repo.JSONRawMessageFromNullableString(entity.Extensible),
 		BaseEntity: &model.BaseEntity{
 			ID:        entity.ID,
 			Ready:     entity.Ready,
@@ -204,6 +205,7 @@ func (c *converter) ToEntity(apiModel model.APIDefinition) *Entity {
 		CustomImplementationStandard:            repo.NewNullableString(apiModel.CustomImplementationStandard),
 		CustomImplementationStandardDescription: repo.NewNullableString(apiModel.CustomImplementationStandardDescription),
 		Version:                                 c.convertVersionToEntity(apiModel.Version),
+		Extensible:                              repo.NewNullableStringFromJSONRawMessage(apiModel.Extensible),
 		BaseEntity: &repo.BaseEntity{
 			ID:        apiModel.ID,
 			Ready:     apiModel.Ready,

--- a/components/director/internal/domain/api/entity.go
+++ b/components/director/internal/domain/api/entity.go
@@ -36,6 +36,8 @@ type Entity struct {
 	ImplementationStandard                  sql.NullString `db:"implementation_standard"`
 	CustomImplementationStandard            sql.NullString `db:"custom_implementation_standard"`
 	CustomImplementationStandardDescription sql.NullString `db:"custom_implementation_standard_description"`
+	Extensible                              sql.NullString `db:"extensible"`
+
 	*repo.BaseEntity
 	version.Version
 }

--- a/components/director/internal/domain/api/fixtures_test.go
+++ b/components/director/internal/domain/api/fixtures_test.go
@@ -27,6 +27,7 @@ const (
 	packageID        = "ppppppppp-pppp-pppp-pppp-pppppppppppp"
 	appID            = "aaaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
 	ordID            = "com.compass.ord.v1"
+	extensible       = `{"supported":"automatic","description":"Please find the extensibility documentation"}`
 )
 
 var fixedTimestamp = time.Now()
@@ -99,6 +100,7 @@ func fixFullAPIDefinitionModel(placeholder string) (model.APIDefinition, model.S
 		CustomImplementationStandard:            str.Ptr("customImplementationStandard"),
 		CustomImplementationStandardDescription: str.Ptr("customImplementationStandardDescription"),
 		Version:                                 v,
+		Extensible:                              json.RawMessage(extensible),
 		BaseEntity: &model.BaseEntity{
 			ID:        apiDefID,
 			Ready:     true,
@@ -249,6 +251,7 @@ func fixFullEntityAPIDefinition(apiDefID, placeholder string) api.Entity {
 		ImplementationStandard:                  repo.NewValidNullableString("implementationStandard"),
 		CustomImplementationStandard:            repo.NewValidNullableString("customImplementationStandard"),
 		CustomImplementationStandardDescription: repo.NewValidNullableString("customImplementationStandardDescription"),
+		Extensible:                              repo.NewValidNullableString(extensible),
 		Version: version.Version{
 			Value:           repo.NewNullableString(str.Ptr("v1.1")),
 			Deprecated:      repo.NewValidNullableBool(false),
@@ -270,7 +273,7 @@ func fixAPIDefinitionColumns() []string {
 	return []string{"id", "tenant_id", "app_id", "package_id", "name", "description", "group_name", "ord_id",
 		"short_description", "system_instance_aware", "api_protocol", "tags", "countries", "links", "api_resource_links", "release_status",
 		"sunset_date", "successor", "changelog_entries", "labels", "visibility", "disabled", "part_of_products", "line_of_business",
-		"industry", "version_value", "version_deprecated", "version_deprecated_since", "version_for_removal", "ready", "created_at", "updated_at", "deleted_at", "error", "implementation_standard", "custom_implementation_standard", "custom_implementation_standard_description", "target_urls"}
+		"industry", "version_value", "version_deprecated", "version_deprecated_since", "version_for_removal", "ready", "created_at", "updated_at", "deleted_at", "error", "implementation_standard", "custom_implementation_standard", "custom_implementation_standard_description", "target_urls", "extensible"}
 }
 
 func fixAPIDefinitionRow(id, placeholder string) []driver.Value {
@@ -278,7 +281,7 @@ func fixAPIDefinitionRow(id, placeholder string) []driver.Value {
 	return []driver.Value{id, tenantID, appID, packageID, placeholder, "desc_" + placeholder, "group_" + placeholder,
 		ordID, "shortDescription", &boolVar, "apiProtocol", repo.NewValidNullableString("[]"),
 		repo.NewValidNullableString("[]"), repo.NewValidNullableString("[]"), repo.NewValidNullableString("[]"), "releaseStatus", "sunsetDate", "successor", repo.NewValidNullableString("[]"), repo.NewValidNullableString("[]"), "visibility", &boolVar,
-		repo.NewValidNullableString("[]"), repo.NewValidNullableString("[]"), repo.NewValidNullableString("[]"), "v1.1", false, "v1.0", false, true, fixedTimestamp, time.Time{}, time.Time{}, nil, "implementationStandard", "customImplementationStandard", "customImplementationStandardDescription", repo.NewValidNullableString(`["` + fmt.Sprintf("https://%s.com", placeholder) + `"]`)}
+		repo.NewValidNullableString("[]"), repo.NewValidNullableString("[]"), repo.NewValidNullableString("[]"), "v1.1", false, "v1.0", false, true, fixedTimestamp, time.Time{}, time.Time{}, nil, "implementationStandard", "customImplementationStandard", "customImplementationStandardDescription", repo.NewValidNullableString(`["` + fmt.Sprintf("https://%s.com", placeholder) + `"]`), extensible}
 }
 
 func fixAPICreateArgs(id string, apiDef *model.APIDefinition) []driver.Value {
@@ -287,7 +290,7 @@ func fixAPICreateArgs(id string, apiDef *model.APIDefinition) []driver.Value {
 		repo.NewNullableStringFromJSONRawMessage(apiDef.Links), repo.NewNullableStringFromJSONRawMessage(apiDef.APIResourceLinks),
 		apiDef.ReleaseStatus, apiDef.SunsetDate, apiDef.Successor, repo.NewNullableStringFromJSONRawMessage(apiDef.ChangeLogEntries), repo.NewNullableStringFromJSONRawMessage(apiDef.Labels), apiDef.Visibility,
 		apiDef.Disabled, repo.NewNullableStringFromJSONRawMessage(apiDef.PartOfProducts), repo.NewNullableStringFromJSONRawMessage(apiDef.LineOfBusiness), repo.NewNullableStringFromJSONRawMessage(apiDef.Industry),
-		apiDef.Version.Value, apiDef.Version.Deprecated, apiDef.Version.DeprecatedSince, apiDef.Version.ForRemoval, apiDef.Ready, apiDef.CreatedAt, apiDef.UpdatedAt, apiDef.DeletedAt, apiDef.Error, apiDef.ImplementationStandard, apiDef.CustomImplementationStandard, apiDef.CustomImplementationStandardDescription, repo.NewNullableStringFromJSONRawMessage(apiDef.TargetURLs)}
+		apiDef.Version.Value, apiDef.Version.Deprecated, apiDef.Version.DeprecatedSince, apiDef.Version.ForRemoval, apiDef.Ready, apiDef.CreatedAt, apiDef.UpdatedAt, apiDef.DeletedAt, apiDef.Error, apiDef.ImplementationStandard, apiDef.CustomImplementationStandard, apiDef.CustomImplementationStandardDescription, repo.NewNullableStringFromJSONRawMessage(apiDef.TargetURLs), extensible}
 }
 
 func fixModelFetchRequest(id, url string, timestamp time.Time) *model.FetchRequest {

--- a/components/director/internal/domain/api/repository.go
+++ b/components/director/internal/domain/api/repository.go
@@ -21,12 +21,12 @@ var (
 	apiDefColumns = []string{"id", "tenant_id", "app_id", "package_id", "name", "description", "group_name", "ord_id",
 		"short_description", "system_instance_aware", "api_protocol", "tags", "countries", "links", "api_resource_links", "release_status",
 		"sunset_date", "successor", "changelog_entries", "labels", "visibility", "disabled", "part_of_products", "line_of_business",
-		"industry", "version_value", "version_deprecated", "version_deprecated_since", "version_for_removal", "ready", "created_at", "updated_at", "deleted_at", "error", "implementation_standard", "custom_implementation_standard", "custom_implementation_standard_description", "target_urls"}
+		"industry", "version_value", "version_deprecated", "version_deprecated_since", "version_for_removal", "ready", "created_at", "updated_at", "deleted_at", "error", "implementation_standard", "custom_implementation_standard", "custom_implementation_standard_description", "target_urls", "extensible"}
 	idColumns        = []string{"id"}
 	updatableColumns = []string{"package_id", "name", "description", "group_name", "ord_id",
 		"short_description", "system_instance_aware", "api_protocol", "tags", "countries", "links", "api_resource_links", "release_status",
 		"sunset_date", "successor", "changelog_entries", "labels", "visibility", "disabled", "part_of_products", "line_of_business",
-		"industry", "version_value", "version_deprecated", "version_deprecated_since", "version_for_removal", "ready", "created_at", "updated_at", "deleted_at", "error", "implementation_standard", "custom_implementation_standard", "custom_implementation_standard_description", "target_urls"}
+		"industry", "version_value", "version_deprecated", "version_deprecated_since", "version_for_removal", "ready", "created_at", "updated_at", "deleted_at", "error", "implementation_standard", "custom_implementation_standard", "custom_implementation_standard_description", "target_urls", "extensible"}
 )
 
 //go:generate mockery --name=APIDefinitionConverter --output=automock --outpkg=automock --case=underscore

--- a/components/director/internal/domain/api/repository_test.go
+++ b/components/director/internal/domain/api/repository_test.go
@@ -209,7 +209,7 @@ func TestPgRepository_Update(t *testing.T) {
 	updateQuery := regexp.QuoteMeta(`UPDATE "public"."api_definitions" SET package_id = ?, name = ?, description = ?, group_name = ?, ord_id = ?,
 		short_description = ?, system_instance_aware = ?, api_protocol = ?, tags = ?, countries = ?, links = ?, api_resource_links = ?, release_status = ?,
 		sunset_date = ?, successor = ?, changelog_entries = ?, labels = ?, visibility = ?, disabled = ?, part_of_products = ?, line_of_business = ?,
-		industry = ?, version_value = ?, version_deprecated = ?, version_deprecated_since = ?, version_for_removal = ?, ready = ?, created_at = ?, updated_at = ?, deleted_at = ?, error = ?, implementation_standard = ?, custom_implementation_standard = ?, custom_implementation_standard_description = ?, target_urls = ? WHERE tenant_id = ? AND id = ?`)
+		industry = ?, version_value = ?, version_deprecated = ?, version_deprecated_since = ?, version_for_removal = ?, ready = ?, created_at = ?, updated_at = ?, deleted_at = ?, error = ?, implementation_standard = ?, custom_implementation_standard = ?, custom_implementation_standard_description = ?, target_urls = ?, extensible = ? WHERE tenant_id = ? AND id = ?`)
 
 	t.Run("success", func(t *testing.T) {
 		sqlxDB, sqlMock := testdb.MockDatabase(t)
@@ -225,7 +225,7 @@ func TestPgRepository_Update(t *testing.T) {
 			WithArgs(entity.PackageID, entity.Name, entity.Description, entity.Group,
 				entity.OrdID, entity.ShortDescription, entity.SystemInstanceAware, entity.ApiProtocol, entity.Tags, entity.Countries,
 				entity.Links, entity.APIResourceLinks, entity.ReleaseStatus, entity.SunsetDate, entity.Successor, entity.ChangeLogEntries, entity.Labels, entity.Visibility,
-				entity.Disabled, entity.PartOfProducts, entity.LineOfBusiness, entity.Industry, entity.Version.Value, entity.Version.Deprecated, entity.Version.DeprecatedSince, entity.Version.ForRemoval, entity.Ready, entity.CreatedAt, entity.UpdatedAt, entity.DeletedAt, entity.Error, entity.ImplementationStandard, entity.CustomImplementationStandard, entity.CustomImplementationStandardDescription, entity.TargetURLs, tenantID, entity.ID).
+				entity.Disabled, entity.PartOfProducts, entity.LineOfBusiness, entity.Industry, entity.Version.Value, entity.Version.Deprecated, entity.Version.DeprecatedSince, entity.Version.ForRemoval, entity.Ready, entity.CreatedAt, entity.UpdatedAt, entity.DeletedAt, entity.Error, entity.ImplementationStandard, entity.CustomImplementationStandard, entity.CustomImplementationStandardDescription, entity.TargetURLs, entity.Extensible, tenantID, entity.ID).
 			WillReturnResult(sqlmock.NewResult(-1, 1))
 
 		pgRepository := api.NewRepository(convMock)

--- a/components/director/internal/domain/eventdef/converter.go
+++ b/components/director/internal/domain/eventdef/converter.go
@@ -148,6 +148,7 @@ func (c *converter) FromEntity(entity Entity) model.EventDefinition {
 		LineOfBusiness:      repo.JSONRawMessageFromNullableString(entity.LineOfBusiness),
 		Industry:            repo.JSONRawMessageFromNullableString(entity.Industry),
 		Version:             c.vc.FromEntity(entity.Version),
+		Extensible:          repo.JSONRawMessageFromNullableString(entity.Extensible),
 		BaseEntity: &model.BaseEntity{
 			ID:        entity.ID,
 			Ready:     entity.Ready,
@@ -184,6 +185,7 @@ func (c *converter) ToEntity(eventModel model.EventDefinition) Entity {
 		LineOfBusiness:      repo.NewNullableStringFromJSONRawMessage(eventModel.LineOfBusiness),
 		Industry:            repo.NewNullableStringFromJSONRawMessage(eventModel.Industry),
 		Version:             c.convertVersionToEntity(eventModel.Version),
+		Extensible:          repo.NewNullableStringFromJSONRawMessage(eventModel.Extensible),
 		BaseEntity: &repo.BaseEntity{
 			ID:        eventModel.ID,
 			Ready:     eventModel.Ready,

--- a/components/director/internal/domain/eventdef/entity.go
+++ b/components/director/internal/domain/eventdef/entity.go
@@ -30,6 +30,7 @@ type Entity struct {
 	PartOfProducts      sql.NullString `db:"part_of_products"`
 	LineOfBusiness      sql.NullString `db:"line_of_business"`
 	Industry            sql.NullString `db:"industry"`
+	Extensible          sql.NullString `db:"extensible"`
 	version.Version
 
 	*repo.BaseEntity

--- a/components/director/internal/domain/eventdef/fixtures_test.go
+++ b/components/director/internal/domain/eventdef/fixtures_test.go
@@ -25,6 +25,7 @@ const (
 	packageID        = "ppppppppp-pppp-pppp-pppp-pppppppppppp"
 	appID            = "aaaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
 	ordID            = "com.compass.ord.v1"
+	extensible       = `{"supported":"automatic","description":"Please find the extensibility documentation"}`
 )
 
 var fixedTimestamp = time.Now()
@@ -88,6 +89,7 @@ func fixFullEventDefinitionModel(placeholder string) (model.EventDefinition, mod
 		PartOfProducts:      json.RawMessage("[]"),
 		LineOfBusiness:      json.RawMessage("[]"),
 		Industry:            json.RawMessage("[]"),
+		Extensible:          json.RawMessage(extensible),
 		Version:             v,
 		BaseEntity: &model.BaseEntity{
 			ID:        eventID,
@@ -229,6 +231,7 @@ func fixFullEntityEventDefinition(eventID, placeholder string) event.Entity {
 		PartOfProducts:      repo.NewValidNullableString("[]"),
 		LineOfBusiness:      repo.NewValidNullableString("[]"),
 		Industry:            repo.NewValidNullableString("[]"),
+		Extensible:          repo.NewValidNullableString(extensible),
 		Version: version.Version{
 			Value:           repo.NewNullableString(str.Ptr("v1.1")),
 			Deprecated:      repo.NewValidNullableBool(false),
@@ -250,14 +253,14 @@ func fixEventDefinitionColumns() []string {
 	return []string{"id", "tenant_id", "app_id", "package_id", "name", "description", "group_name", "ord_id",
 		"short_description", "system_instance_aware", "changelog_entries", "links", "tags", "countries", "release_status",
 		"sunset_date", "successor", "labels", "visibility", "disabled", "part_of_products", "line_of_business", "industry", "version_value", "version_deprecated", "version_deprecated_since",
-		"version_for_removal", "ready", "created_at", "updated_at", "deleted_at", "error"}
+		"version_for_removal", "ready", "created_at", "updated_at", "deleted_at", "error", "extensible"}
 }
 
 func fixEventDefinitionRow(id, placeholder string) []driver.Value {
 	boolVar := false
 	return []driver.Value{id, tenantID, appID, packageID, placeholder, "desc_" + placeholder, "group_" + placeholder, ordID, "shortDescription", &boolVar,
 		repo.NewValidNullableString("[]"), repo.NewValidNullableString("[]"), repo.NewValidNullableString("[]"), repo.NewValidNullableString("[]"), "releaseStatus", "sunsetDate", "successor", repo.NewValidNullableString("[]"), "visibility", &boolVar,
-		repo.NewValidNullableString("[]"), repo.NewValidNullableString("[]"), repo.NewValidNullableString("[]"), "v1.1", false, "v1.0", false, true, fixedTimestamp, time.Time{}, time.Time{}, nil}
+		repo.NewValidNullableString("[]"), repo.NewValidNullableString("[]"), repo.NewValidNullableString("[]"), "v1.1", false, "v1.0", false, true, fixedTimestamp, time.Time{}, time.Time{}, nil, repo.NewValidNullableString(extensible)}
 }
 
 func fixEventCreateArgs(id string, event *model.EventDefinition) []driver.Value {
@@ -266,7 +269,7 @@ func fixEventCreateArgs(id string, event *model.EventDefinition) []driver.Value 
 		repo.NewNullableStringFromJSONRawMessage(event.Tags), repo.NewNullableStringFromJSONRawMessage(event.Countries), event.ReleaseStatus, event.SunsetDate, event.Successor,
 		repo.NewNullableStringFromJSONRawMessage(event.Labels), event.Visibility,
 		event.Disabled, repo.NewNullableStringFromJSONRawMessage(event.PartOfProducts), repo.NewNullableStringFromJSONRawMessage(event.LineOfBusiness), repo.NewNullableStringFromJSONRawMessage(event.Industry),
-		event.Version.Value, event.Version.Deprecated, event.Version.DeprecatedSince, event.Version.ForRemoval, event.Ready, event.CreatedAt, event.UpdatedAt, event.DeletedAt, event.Error}
+		event.Version.Value, event.Version.Deprecated, event.Version.DeprecatedSince, event.Version.ForRemoval, event.Ready, event.CreatedAt, event.UpdatedAt, event.DeletedAt, event.Error, repo.NewNullableStringFromJSONRawMessage(event.Extensible)}
 }
 
 func fixModelFetchRequest(id, url string, timestamp time.Time) *model.FetchRequest {

--- a/components/director/internal/domain/eventdef/repository.go
+++ b/components/director/internal/domain/eventdef/repository.go
@@ -26,12 +26,12 @@ var (
 	eventDefColumns = []string{idColumn, tenantColumn, appColumn, "package_id", "name", "description", "group_name", "ord_id",
 		"short_description", "system_instance_aware", "changelog_entries", "links", "tags", "countries", "release_status",
 		"sunset_date", "successor", "labels", "visibility", "disabled", "part_of_products", "line_of_business", "industry", "version_value", "version_deprecated", "version_deprecated_since",
-		"version_for_removal", "ready", "created_at", "updated_at", "deleted_at", "error"}
+		"version_for_removal", "ready", "created_at", "updated_at", "deleted_at", "error", "extensible"}
 	idColumns        = []string{idColumn}
 	updatableColumns = []string{"package_id", "name", "description", "group_name", "ord_id",
 		"short_description", "system_instance_aware", "changelog_entries", "links", "tags", "countries", "release_status",
 		"sunset_date", "successor", "labels", "visibility", "disabled", "part_of_products", "line_of_business", "industry", "version_value", "version_deprecated", "version_deprecated_since",
-		"version_for_removal", "ready", "created_at", "updated_at", "deleted_at", "error"}
+		"version_for_removal", "ready", "created_at", "updated_at", "deleted_at", "error", "extensible"}
 )
 
 //go:generate mockery --name=EventAPIDefinitionConverter --output=automock --outpkg=automock --case=underscore

--- a/components/director/internal/domain/eventdef/repository_test.go
+++ b/components/director/internal/domain/eventdef/repository_test.go
@@ -208,7 +208,7 @@ func TestPgRepository_Update(t *testing.T) {
 	updateQuery := regexp.QuoteMeta(`UPDATE "public"."event_api_definitions" SET package_id = ?, name = ?, description = ?, group_name = ?, ord_id = ?,
 		short_description = ?, system_instance_aware = ?, changelog_entries = ?, links = ?, tags = ?, countries = ?, release_status = ?,
 		sunset_date = ?, successor = ?, labels = ?, visibility = ?, disabled = ?, part_of_products = ?, line_of_business = ?, industry = ?, version_value = ?, version_deprecated = ?, version_deprecated_since = ?,
-		version_for_removal = ?, ready = ?, created_at = ?, updated_at = ?, deleted_at = ?, error = ? WHERE tenant_id = ? AND id = ?`)
+		version_for_removal = ?, ready = ?, created_at = ?, updated_at = ?, deleted_at = ?, error = ?, extensible = ? WHERE tenant_id = ? AND id = ?`)
 
 	t.Run("success", func(t *testing.T) {
 		sqlxDB, sqlMock := testdb.MockDatabase(t)
@@ -223,7 +223,7 @@ func TestPgRepository_Update(t *testing.T) {
 		sqlMock.ExpectExec(updateQuery).
 			WithArgs(entity.PackageID, entity.Name, entity.Description, entity.GroupName, entity.OrdID, entity.ShortDescription, entity.SystemInstanceAware, entity.ChangeLogEntries, entity.Links,
 				entity.Tags, entity.Countries, entity.ReleaseStatus, entity.SunsetDate, entity.Successor, entity.Labels, entity.Visibility,
-				entity.Disabled, entity.PartOfProducts, entity.LineOfBusiness, entity.Industry, entity.Version.Value, entity.Version.Deprecated, entity.Version.DeprecatedSince, entity.Version.ForRemoval, entity.Ready, entity.CreatedAt, entity.UpdatedAt, entity.DeletedAt, entity.Error, tenantID, entity.ID).
+				entity.Disabled, entity.PartOfProducts, entity.LineOfBusiness, entity.Industry, entity.Version.Value, entity.Version.Deprecated, entity.Version.DeprecatedSince, entity.Version.ForRemoval, entity.Ready, entity.CreatedAt, entity.UpdatedAt, entity.DeletedAt, entity.Error, entity.Extensible, tenantID, entity.ID).
 			WillReturnResult(sqlmock.NewResult(-1, 1))
 
 		pgRepository := event.NewRepository(convMock)

--- a/components/director/internal/domain/ordvendor/converter.go
+++ b/components/director/internal/domain/ordvendor/converter.go
@@ -24,7 +24,7 @@ func (c *converter) ToEntity(in *model.Vendor) *Entity {
 		TenantID:      in.TenantID,
 		ApplicationID: in.ApplicationID,
 		Title:         in.Title,
-		SapPartner:    repo.NewNullableBool(in.SapPartner),
+		Partners:      repo.NewNullableStringFromJSONRawMessage(in.Partners),
 		Labels:        repo.NewNullableStringFromJSONRawMessage(in.Labels),
 	}
 
@@ -41,7 +41,7 @@ func (c *converter) FromEntity(entity *Entity) (*model.Vendor, error) {
 		TenantID:      entity.TenantID,
 		ApplicationID: entity.ApplicationID,
 		Title:         entity.Title,
-		SapPartner:    repo.BoolPtrFromNullableBool(entity.SapPartner),
+		Partners:      repo.JSONRawMessageFromNullableString(entity.Partners),
 		Labels:        repo.JSONRawMessageFromNullableString(entity.Labels),
 	}
 

--- a/components/director/internal/domain/ordvendor/entity.go
+++ b/components/director/internal/domain/ordvendor/entity.go
@@ -9,6 +9,6 @@ type Entity struct {
 	TenantID      string         `db:"tenant_id"`
 	ApplicationID string         `db:"app_id"`
 	Title         string         `db:"title"`
-	SapPartner    sql.NullBool   `db:"sap_partner"`
+	Partners      sql.NullString `db:"partners"`
 	Labels        sql.NullString `db:"labels"`
 }

--- a/components/director/internal/domain/ordvendor/fixtures_test.go
+++ b/components/director/internal/domain/ordvendor/fixtures_test.go
@@ -15,9 +15,8 @@ const (
 	appID            = "appID"
 	ordID            = "com.compass.v1"
 	externalTenantID = "externalTenantID"
+	partners         = `["microsoft:vendor:Microsoft:"]`
 )
-
-var boolPtr = true
 
 func fixEntityVendor() *ordvendor.Entity {
 	return &ordvendor.Entity{
@@ -25,7 +24,7 @@ func fixEntityVendor() *ordvendor.Entity {
 		TenantID:      tenantID,
 		ApplicationID: appID,
 		Title:         "title",
-		SapPartner:    repo.NewNullableBool(&boolPtr),
+		Partners:      repo.NewValidNullableString(partners),
 		Labels:        repo.NewValidNullableString("{}"),
 	}
 }
@@ -36,28 +35,29 @@ func fixVendorModel() *model.Vendor {
 		TenantID:      tenantID,
 		ApplicationID: appID,
 		Title:         "title",
-		SapPartner:    &boolPtr,
+		Partners:      json.RawMessage(partners),
 		Labels:        json.RawMessage("{}"),
 	}
 }
 
 func fixVendorModelInput() *model.VendorInput {
 	return &model.VendorInput{
-		OrdID:      ordID,
-		Title:      "title",
-		SapPartner: &boolPtr,
-		Labels:     json.RawMessage("{}"),
+		OrdID:    ordID,
+		Title:    "title",
+		Partners: json.RawMessage(partners),
+		Labels:   json.RawMessage("{}"),
 	}
 }
 
 func fixVendorColumns() []string {
-	return []string{"ord_id", "tenant_id", "app_id", "title", "labels", "sap_partner"}
+	return []string{"ord_id", "tenant_id", "app_id", "title", "labels", "partners"}
 }
 
 func fixVendorRow() []driver.Value {
-	return []driver.Value{ordID, tenantID, appID, "title", repo.NewValidNullableString("{}"), repo.NewNullableBool(&boolPtr)}
+	return []driver.Value{ordID, tenantID, appID, "title", repo.NewValidNullableString("{}"), repo.NewValidNullableString(partners)}
 }
 
+/**/
 func fixVendorUpdateArgs() []driver.Value {
-	return []driver.Value{"title", repo.NewValidNullableString("{}"), repo.NewNullableBool(&boolPtr)}
+	return []driver.Value{"title", repo.NewValidNullableString("{}"), repo.NewValidNullableString(partners)}
 }

--- a/components/director/internal/domain/ordvendor/repository.go
+++ b/components/director/internal/domain/ordvendor/repository.go
@@ -15,8 +15,8 @@ const vendorTable string = `public.vendors`
 
 var (
 	tenantColumn     = "tenant_id"
-	vendorColumns    = []string{"ord_id", tenantColumn, "app_id", "title", "labels", "sap_partner"}
-	updatableColumns = []string{"title", "labels", "sap_partner"}
+	vendorColumns    = []string{"ord_id", tenantColumn, "app_id", "title", "labels", "partners"}
+	updatableColumns = []string{"title", "labels", "partners"}
 )
 
 //go:generate mockery --name=EntityConverter --output=automock --outpkg=automock --case=underscore

--- a/components/director/internal/domain/ordvendor/repository_test.go
+++ b/components/director/internal/domain/ordvendor/repository_test.go
@@ -55,7 +55,7 @@ func TestPgRepository_Create(t *testing.T) {
 }
 
 func TestPgRepository_Update(t *testing.T) {
-	updateQuery := regexp.QuoteMeta(`UPDATE public.vendors SET title = ?, labels = ?, sap_partner = ? WHERE tenant_id = ? AND ord_id = ?`)
+	updateQuery := regexp.QuoteMeta(`UPDATE public.vendors SET title = ?, labels = ?, partners = ? WHERE tenant_id = ? AND ord_id = ?`)
 
 	t.Run("success", func(t *testing.T) {
 		sqlxDB, sqlMock := testdb.MockDatabase(t)

--- a/components/director/internal/model/api.go
+++ b/components/director/internal/model/api.go
@@ -42,6 +42,7 @@ type APIDefinition struct {
 	CustomImplementationStandard            *string
 	CustomImplementationStandardDescription *string
 	Version                                 *Version
+	Extensible                              json.RawMessage
 	*BaseEntity
 }
 
@@ -50,36 +51,36 @@ func (_ *APIDefinition) GetType() resource.Type {
 }
 
 type APIDefinitionInput struct {
-	OrdPackageID                            *string         `json:"partOfPackage"`
-	Tenant                                  string          `json:",omitempty"`
-	Name                                    string          `json:"title"`
-	Description                             *string         `json:"description"`
-	TargetURLs                              json.RawMessage `json:"entryPoints"`
-	Group                                   *string         `json:",omitempty"` //  group allows you to find the same API but in different version
-	OrdID                                   *string         `json:"ordId"`
-	ShortDescription                        *string         `json:"shortDescription"`
-	SystemInstanceAware                     *bool           `json:"systemInstanceAware"`
-	ApiProtocol                             *string         `json:"apiProtocol"`
-	Tags                                    json.RawMessage `json:"tags"`
-	Countries                               json.RawMessage `json:"countries"`
-	Links                                   json.RawMessage `json:"links"`
-	APIResourceLinks                        json.RawMessage `json:"apiResourceLinks"`
-	ReleaseStatus                           *string         `json:"releaseStatus"`
-	SunsetDate                              *string         `json:"sunsetDate"`
-	Successor                               *string         `json:"successor"`
-	ChangeLogEntries                        json.RawMessage `json:"changelogEntries"`
-	Labels                                  json.RawMessage `json:"labels"`
-	Visibility                              *string         `json:"visibility"`
-	Disabled                                *bool           `json:"disabled"`
-	PartOfProducts                          json.RawMessage `json:"partOfProducts"`
-	LineOfBusiness                          json.RawMessage `json:"lineOfBusiness"`
-	Industry                                json.RawMessage `json:"industry"`
-	ImplementationStandard                  *string         `json:"implementationStandard"`
-	CustomImplementationStandard            *string         `json:"customImplementationStandard"`
-	CustomImplementationStandardDescription *string         `json:"customImplementationStandardDescription"`
-
-	ResourceDefinitions      []*APIResourceDefinition      `json:"resourceDefinitions"`
-	PartOfConsumptionBundles []*ConsumptionBundleReference `json:"partOfConsumptionBundles"`
+	OrdPackageID                            *string                       `json:"partOfPackage"`
+	Tenant                                  string                        `json:",omitempty"`
+	Name                                    string                        `json:"title"`
+	Description                             *string                       `json:"description"`
+	TargetURLs                              json.RawMessage               `json:"entryPoints"`
+	Group                                   *string                       `json:",omitempty"` //  group allows you to find the same API but in different version
+	OrdID                                   *string                       `json:"ordId"`
+	ShortDescription                        *string                       `json:"shortDescription"`
+	SystemInstanceAware                     *bool                         `json:"systemInstanceAware"`
+	ApiProtocol                             *string                       `json:"apiProtocol"`
+	Tags                                    json.RawMessage               `json:"tags"`
+	Countries                               json.RawMessage               `json:"countries"`
+	Links                                   json.RawMessage               `json:"links"`
+	APIResourceLinks                        json.RawMessage               `json:"apiResourceLinks"`
+	ReleaseStatus                           *string                       `json:"releaseStatus"`
+	SunsetDate                              *string                       `json:"sunsetDate"`
+	Successor                               *string                       `json:"successor"`
+	ChangeLogEntries                        json.RawMessage               `json:"changelogEntries"`
+	Labels                                  json.RawMessage               `json:"labels"`
+	Visibility                              *string                       `json:"visibility"`
+	Disabled                                *bool                         `json:"disabled"`
+	PartOfProducts                          json.RawMessage               `json:"partOfProducts"`
+	LineOfBusiness                          json.RawMessage               `json:"lineOfBusiness"`
+	Industry                                json.RawMessage               `json:"industry"`
+	ImplementationStandard                  *string                       `json:"implementationStandard"`
+	CustomImplementationStandard            *string                       `json:"customImplementationStandard"`
+	CustomImplementationStandardDescription *string                       `json:"customImplementationStandardDescription"`
+	Extensible                              json.RawMessage               `json:"extensible"`
+	ResourceDefinitions                     []*APIResourceDefinition      `json:"resourceDefinitions"`
+	PartOfConsumptionBundles                []*ConsumptionBundleReference `json:"partOfConsumptionBundles"`
 
 	*VersionInput
 }
@@ -184,6 +185,7 @@ func (a *APIDefinitionInput) ToAPIDefinition(id, appID string, packageID *string
 		PartOfProducts:      a.PartOfProducts,
 		LineOfBusiness:      a.LineOfBusiness,
 		Industry:            a.Industry,
+		Extensible:          a.Extensible,
 		Version:             a.VersionInput.ToVersion(),
 		BaseEntity: &BaseEntity{
 			ID:    id,

--- a/components/director/internal/model/eventapi.go
+++ b/components/director/internal/model/eventapi.go
@@ -33,6 +33,7 @@ type EventDefinition struct {
 	PartOfProducts      json.RawMessage
 	LineOfBusiness      json.RawMessage
 	Industry            json.RawMessage
+	Extensible          json.RawMessage
 
 	Version *Version
 	*BaseEntity
@@ -51,27 +52,27 @@ type EventDefinitionPage struct {
 func (EventDefinitionPage) IsPageable() {}
 
 type EventDefinitionInput struct {
-	OrdPackageID        *string         `json:"partOfPackage"`
-	Name                string          `json:"title"`
-	Description         *string         `json:"description"`
-	Group               *string         `json:",omitempty"`
-	OrdID               *string         `json:"ordId"`
-	ShortDescription    *string         `json:"shortDescription"`
-	SystemInstanceAware *bool           `json:"systemInstanceAware"`
-	ChangeLogEntries    json.RawMessage `json:"changelogEntries"`
-	Links               json.RawMessage `json:"links"`
-	Tags                json.RawMessage `json:"tags"`
-	Countries           json.RawMessage `json:"countries"`
-	ReleaseStatus       *string         `json:"releaseStatus"`
-	SunsetDate          *string         `json:"sunsetDate"`
-	Successor           *string         `json:"successor"`
-	Labels              json.RawMessage `json:"labels"`
-	Visibility          *string         `json:"visibility"`
-	Disabled            *bool           `json:"disabled"`
-	PartOfProducts      json.RawMessage `json:"partOfProducts"`
-	LineOfBusiness      json.RawMessage `json:"lineOfBusiness"`
-	Industry            json.RawMessage `json:"industry"`
-
+	OrdPackageID             *string                       `json:"partOfPackage"`
+	Name                     string                        `json:"title"`
+	Description              *string                       `json:"description"`
+	Group                    *string                       `json:",omitempty"`
+	OrdID                    *string                       `json:"ordId"`
+	ShortDescription         *string                       `json:"shortDescription"`
+	SystemInstanceAware      *bool                         `json:"systemInstanceAware"`
+	ChangeLogEntries         json.RawMessage               `json:"changelogEntries"`
+	Links                    json.RawMessage               `json:"links"`
+	Tags                     json.RawMessage               `json:"tags"`
+	Countries                json.RawMessage               `json:"countries"`
+	ReleaseStatus            *string                       `json:"releaseStatus"`
+	SunsetDate               *string                       `json:"sunsetDate"`
+	Successor                *string                       `json:"successor"`
+	Labels                   json.RawMessage               `json:"labels"`
+	Visibility               *string                       `json:"visibility"`
+	Disabled                 *bool                         `json:"disabled"`
+	PartOfProducts           json.RawMessage               `json:"partOfProducts"`
+	LineOfBusiness           json.RawMessage               `json:"lineOfBusiness"`
+	Industry                 json.RawMessage               `json:"industry"`
+	Extensible               json.RawMessage               `json:"extensible"`
 	ResourceDefinitions      []*EventResourceDefinition    `json:"resourceDefinitions"`
 	PartOfConsumptionBundles []*ConsumptionBundleReference `json:"partOfConsumptionBundles"`
 
@@ -143,6 +144,7 @@ func (e *EventDefinitionInput) ToEventDefinition(id, appID string, packageID *st
 		LineOfBusiness:      e.LineOfBusiness,
 		Industry:            e.Industry,
 		Version:             e.VersionInput.ToVersion(),
+		Extensible:          e.Extensible,
 		BaseEntity: &BaseEntity{
 			ID:    id,
 			Ready: true,

--- a/components/director/internal/model/vendor.go
+++ b/components/director/internal/model/vendor.go
@@ -9,15 +9,15 @@ type Vendor struct {
 	TenantID      string
 	ApplicationID string
 	Title         string
-	SapPartner    *bool
+	Partners      json.RawMessage
 	Labels        json.RawMessage
 }
 
 type VendorInput struct {
-	OrdID      string          `json:"ordId"`
-	Title      string          `json:"title"`
-	SapPartner *bool           `json:"sapPartner"`
-	Labels     json.RawMessage `json:"labels"`
+	OrdID    string          `json:"ordId"`
+	Title    string          `json:"title"`
+	Partners json.RawMessage `json:"partners"`
+	Labels   json.RawMessage `json:"labels"`
 }
 
 func (i *VendorInput) ToVendor(tenantID, appID string) *Vendor {
@@ -30,13 +30,13 @@ func (i *VendorInput) ToVendor(tenantID, appID string) *Vendor {
 		TenantID:      tenantID,
 		ApplicationID: appID,
 		Title:         i.Title,
-		SapPartner:    i.SapPartner,
+		Partners:      i.Partners,
 		Labels:        i.Labels,
 	}
 }
 
 func (p *Vendor) SetFromUpdateInput(update VendorInput) {
 	p.Title = update.Title
-	p.SapPartner = update.SapPartner
+	p.Partners = update.Partners
 	p.Labels = update.Labels
 }

--- a/components/director/internal/model/vendor_test.go
+++ b/components/director/internal/model/vendor_test.go
@@ -12,7 +12,7 @@ func TestVendorInput_ToVendor(t *testing.T) {
 	// given
 	id := "foo"
 	appID := "bar"
-	isPartner := true
+	partners := json.RawMessage(`["microsoft:vendor:Microsoft:"]`)
 	name := "sample"
 	tenant := "tenant"
 	labels := json.RawMessage("{}")
@@ -25,17 +25,17 @@ func TestVendorInput_ToVendor(t *testing.T) {
 		{
 			Name: "All properties given",
 			Input: &model.VendorInput{
-				OrdID:      id,
-				Title:      name,
-				SapPartner: &isPartner,
-				Labels:     labels,
+				OrdID:    id,
+				Title:    name,
+				Partners: partners,
+				Labels:   labels,
 			},
 			Expected: &model.Vendor{
 				OrdID:         id,
 				TenantID:      tenant,
 				ApplicationID: appID,
 				Title:         name,
-				SapPartner:    &isPartner,
+				Partners:      partners,
 				Labels:        labels,
 			},
 		},

--- a/components/director/internal/open_resource_discovery/fixtures_test.go
+++ b/components/director/internal/open_resource_discovery/fixtures_test.go
@@ -40,6 +40,7 @@ const (
 	policyLevel               = "sap"
 	apiImplementationStandard = "cff:open-service-broker:v2"
 	correlationIds            = `["foo.bar.baz:123456","foo.bar.baz:654321"]`
+	partners                  = `["microsoft:vendor:Microsoft:"]`
 )
 
 var (
@@ -195,7 +196,7 @@ func fixSanitizedORDDocument() *open_resource_discovery.Document {
 func fixORDDocumentWithBaseURL(baseUrl string) *open_resource_discovery.Document {
 	return &open_resource_discovery.Document{
 		Schema:                "./spec/v1/generated/Document.schema.json",
-		OpenResourceDiscovery: "1.0-rc.2",
+		OpenResourceDiscovery: "1.0-rc.3",
 		Description:           "Test Document",
 		DescribedSystemInstance: &model.Application{
 			BaseURL: str.Ptr(baseURL),
@@ -271,6 +272,7 @@ func fixORDDocumentWithBaseURL(baseUrl string) *open_resource_discovery.Document
 				ImplementationStandard:                  str.Ptr(apiImplementationStandard),
 				CustomImplementationStandard:            nil,
 				CustomImplementationStandardDescription: nil,
+				Extensible:                              json.RawMessage(`{"supported":"automatic","description":"Please find the extensibility documentation"}`),
 				ResourceDefinitions: []*model.APIResourceDefinition{
 					{
 						Type:      "openapi-v3",
@@ -292,6 +294,16 @@ func fixORDDocumentWithBaseURL(baseUrl string) *open_resource_discovery.Document
 							},
 						},
 					},
+					{
+						Type:      "edmx",
+						MediaType: "application/xml",
+						URL:       "https://TEST:443//odata/$metadata",
+						AccessStrategy: []model.AccessStrategy{
+							{
+								Type: "open",
+							},
+						},
+					},
 				},
 				PartOfConsumptionBundles: []*model.ConsumptionBundleReference{
 					{
@@ -304,6 +316,7 @@ func fixORDDocumentWithBaseURL(baseUrl string) *open_resource_discovery.Document
 				},
 			},
 			{
+				Extensible:                              json.RawMessage(`{"supported":"automatic","description":"Please find the extensibility documentation"}`),
 				OrdID:                                   str.Ptr(api2ORDID),
 				OrdPackageID:                            str.Ptr(packageORDID),
 				Name:                                    "Gateway Sample Service",
@@ -334,6 +347,16 @@ func fixORDDocumentWithBaseURL(baseUrl string) *open_resource_discovery.Document
 						Type:      "edmx",
 						MediaType: "application/xml",
 						URL:       "https://TEST:443//odata/$metadata",
+						AccessStrategy: []model.AccessStrategy{
+							{
+								Type: "open",
+							},
+						},
+					},
+					{
+						Type:      "openapi-v3",
+						MediaType: "application/json",
+						URL:       fmt.Sprintf("%s/odata/1.0/catalog.svc/$value?type=json", baseURL),
 						AccessStrategy: []model.AccessStrategy{
 							{
 								Type: "open",
@@ -372,6 +395,7 @@ func fixORDDocumentWithBaseURL(baseUrl string) *open_resource_discovery.Document
 				PartOfProducts:      json.RawMessage(fmt.Sprintf(`["%s"]`, productORDID)),
 				LineOfBusiness:      json.RawMessage(`["lineOfBusiness2"]`),
 				Industry:            json.RawMessage(`["automotive","test"]`),
+				Extensible:          json.RawMessage(`{"supported":"automatic","description":"Please find the extensibility documentation"}`),
 				ResourceDefinitions: []*model.EventResourceDefinition{
 					{
 						Type:      "asyncapi-v2",
@@ -413,6 +437,7 @@ func fixORDDocumentWithBaseURL(baseUrl string) *open_resource_discovery.Document
 				PartOfProducts:      json.RawMessage(fmt.Sprintf(`["%s"]`, productORDID)),
 				LineOfBusiness:      json.RawMessage(`["lineOfBusiness2"]`),
 				Industry:            json.RawMessage(`["automotive","test"]`),
+				Extensible:          json.RawMessage(`{"supported":"automatic","description":"Please find the extensibility documentation"}`),
 				ResourceDefinitions: []*model.EventResourceDefinition{
 					{
 						Type:      "asyncapi-v2",
@@ -443,10 +468,10 @@ func fixORDDocumentWithBaseURL(baseUrl string) *open_resource_discovery.Document
 		},
 		Vendors: []*model.VendorInput{
 			{
-				OrdID:      vendorORDID,
-				Title:      "SAP",
-				SapPartner: &boolPtr,
-				Labels:     json.RawMessage(labels),
+				OrdID:    vendorORDID,
+				Title:    "SAP",
+				Partners: json.RawMessage(partners),
+				Labels:   json.RawMessage(labels),
 			},
 		},
 	}
@@ -492,7 +517,7 @@ func fixVendors() []*model.Vendor {
 			TenantID:      tenantID,
 			ApplicationID: appID,
 			Title:         "SAP",
-			SapPartner:    &boolPtr,
+			Partners:      json.RawMessage(partners),
 			Labels:        json.RawMessage(labels),
 		},
 	}
@@ -736,11 +761,12 @@ func fixEvents() []*model.EventDefinition {
 }
 
 func fixApi1SpecInputs() []*model.SpecInput {
-	apiType := model.APISpecTypeOpenAPIV3
+	openApiType := model.APISpecTypeOpenAPIV3
+	edmxAPIType := model.APISpecTypeEDMX
 	return []*model.SpecInput{
 		{
 			Format:     "application/json",
-			APIType:    &apiType,
+			APIType:    &openApiType,
 			CustomType: str.Ptr(""),
 			FetchRequest: &model.FetchRequestInput{
 				URL: baseURL + "/odata/1.0/catalog.svc/$value?type=json",
@@ -748,24 +774,41 @@ func fixApi1SpecInputs() []*model.SpecInput {
 		},
 		{
 			Format:     "text/yaml",
-			APIType:    &apiType,
+			APIType:    &openApiType,
 			CustomType: str.Ptr(""),
 			FetchRequest: &model.FetchRequestInput{
 				URL: "https://test.com/odata/1.0/catalog",
+			},
+		},
+		{
+			Format:     "application/xml",
+			APIType:    &edmxAPIType,
+			CustomType: str.Ptr(""),
+			FetchRequest: &model.FetchRequestInput{
+				URL: "https://TEST:443//odata/$metadata",
 			},
 		},
 	}
 }
 
 func fixApi2SpecInputs() []*model.SpecInput {
-	apiType := model.APISpecTypeEDMX
+	edmxAPIType := model.APISpecTypeEDMX
+	openApiType := model.APISpecTypeOpenAPIV3
 	return []*model.SpecInput{
 		{
 			Format:     "application/xml",
-			APIType:    &apiType,
+			APIType:    &edmxAPIType,
 			CustomType: str.Ptr(""),
 			FetchRequest: &model.FetchRequestInput{
 				URL: "https://TEST:443//odata/$metadata",
+			},
+		},
+		{
+			Format:     "application/json",
+			APIType:    &openApiType,
+			CustomType: str.Ptr(""),
+			FetchRequest: &model.FetchRequestInput{
+				URL: baseURL + "/odata/1.0/catalog.svc/$value?type=json",
 			},
 		},
 	}

--- a/components/director/internal/open_resource_discovery/service_test.go
+++ b/components/director/internal/open_resource_discovery/service_test.go
@@ -136,8 +136,10 @@ func TestService_SyncORDDocuments(t *testing.T) {
 		specSvc.On("DeleteByReferenceObjectID", txtest.CtxWithDBMatcher(), model.APISpecReference, api1ID).Return(nil).Once()
 		specSvc.On("CreateByReferenceObjectID", txtest.CtxWithDBMatcher(), *fixApi1SpecInputs()[0], model.APISpecReference, api1ID).Return("", nil).Once()
 		specSvc.On("CreateByReferenceObjectID", txtest.CtxWithDBMatcher(), *fixApi1SpecInputs()[1], model.APISpecReference, api1ID).Return("", nil).Once()
+		specSvc.On("CreateByReferenceObjectID", txtest.CtxWithDBMatcher(), *fixApi2SpecInputs()[0], model.APISpecReference, api1ID).Return("", nil).Once()
 		specSvc.On("DeleteByReferenceObjectID", txtest.CtxWithDBMatcher(), model.APISpecReference, api2ID).Return(nil).Once()
 		specSvc.On("CreateByReferenceObjectID", txtest.CtxWithDBMatcher(), *fixApi2SpecInputs()[0], model.APISpecReference, api2ID).Return("", nil).Once()
+		specSvc.On("CreateByReferenceObjectID", txtest.CtxWithDBMatcher(), *fixApi1SpecInputs()[0], model.APISpecReference, api2ID).Return("", nil).Once()
 
 		specSvc.On("DeleteByReferenceObjectID", txtest.CtxWithDBMatcher(), model.EventSpecReference, event1ID).Return(nil).Once()
 		specSvc.On("CreateByReferenceObjectID", txtest.CtxWithDBMatcher(), *fixEvent1SpecInputs()[0], model.EventSpecReference, event1ID).Return("", nil).Once()
@@ -151,8 +153,11 @@ func TestService_SyncORDDocuments(t *testing.T) {
 		specSvc.On("DeleteByReferenceObjectID", txtest.CtxWithDBMatcher(), model.APISpecReference, api1ID).Return(nil).Once()
 		specSvc.On("CreateByReferenceObjectID", txtest.CtxWithDBMatcher(), *fixApi1SpecInputs()[0], model.APISpecReference, api1ID).Return("", nil).Once()
 		specSvc.On("CreateByReferenceObjectID", txtest.CtxWithDBMatcher(), *fixApi1SpecInputs()[1], model.APISpecReference, api1ID).Return("", nil).Once()
+		specSvc.On("CreateByReferenceObjectID", txtest.CtxWithDBMatcher(), *fixApi2SpecInputs()[0], model.APISpecReference, api1ID).Return("", nil).Once()
 		specSvc.On("DeleteByReferenceObjectID", txtest.CtxWithDBMatcher(), model.APISpecReference, api2ID).Return(nil).Once()
 		specSvc.On("CreateByReferenceObjectID", txtest.CtxWithDBMatcher(), *fixApi2SpecInputs()[0], model.APISpecReference, api2ID).Return("", nil).Once()
+		specSvc.On("CreateByReferenceObjectID", txtest.CtxWithDBMatcher(), *fixApi1SpecInputs()[0], model.APISpecReference, api2ID).Return("", nil).Once()
+
 		return specSvc
 	}
 
@@ -727,9 +732,10 @@ func TestService_SyncORDDocuments(t *testing.T) {
 				specSvc.On("DeleteByReferenceObjectID", txtest.CtxWithDBMatcher(), model.APISpecReference, api1ID).Return(nil).Once()
 				specSvc.On("CreateByReferenceObjectID", txtest.CtxWithDBMatcher(), *fixApi1SpecInputs()[0], model.APISpecReference, api1ID).Return("", nil).Once()
 				specSvc.On("CreateByReferenceObjectID", txtest.CtxWithDBMatcher(), *fixApi1SpecInputs()[1], model.APISpecReference, api1ID).Return("", nil).Once()
+				specSvc.On("CreateByReferenceObjectID", txtest.CtxWithDBMatcher(), *fixApi2SpecInputs()[0], model.APISpecReference, api1ID).Return("", nil).Once()
 				specSvc.On("DeleteByReferenceObjectID", txtest.CtxWithDBMatcher(), model.APISpecReference, api2ID).Return(nil).Once()
 				specSvc.On("CreateByReferenceObjectID", txtest.CtxWithDBMatcher(), *fixApi2SpecInputs()[0], model.APISpecReference, api2ID).Return("", nil).Once()
-
+				specSvc.On("CreateByReferenceObjectID", txtest.CtxWithDBMatcher(), *fixApi1SpecInputs()[0], model.APISpecReference, api2ID).Return("", nil).Once()
 				specSvc.On("DeleteByReferenceObjectID", txtest.CtxWithDBMatcher(), model.EventSpecReference, event1ID).Return(testErr).Once()
 				return specSvc
 			},
@@ -757,8 +763,11 @@ func TestService_SyncORDDocuments(t *testing.T) {
 				specSvc.On("DeleteByReferenceObjectID", txtest.CtxWithDBMatcher(), model.APISpecReference, api1ID).Return(nil).Once()
 				specSvc.On("CreateByReferenceObjectID", txtest.CtxWithDBMatcher(), *fixApi1SpecInputs()[0], model.APISpecReference, api1ID).Return("", nil).Once()
 				specSvc.On("CreateByReferenceObjectID", txtest.CtxWithDBMatcher(), *fixApi1SpecInputs()[1], model.APISpecReference, api1ID).Return("", nil).Once()
+				specSvc.On("CreateByReferenceObjectID", txtest.CtxWithDBMatcher(), *fixApi2SpecInputs()[0], model.APISpecReference, api1ID).Return("", nil).Once()
+
 				specSvc.On("DeleteByReferenceObjectID", txtest.CtxWithDBMatcher(), model.APISpecReference, api2ID).Return(nil).Once()
 				specSvc.On("CreateByReferenceObjectID", txtest.CtxWithDBMatcher(), *fixApi2SpecInputs()[0], model.APISpecReference, api2ID).Return("", nil).Once()
+				specSvc.On("CreateByReferenceObjectID", txtest.CtxWithDBMatcher(), *fixApi1SpecInputs()[0], model.APISpecReference, api2ID).Return("", nil).Once()
 
 				specSvc.On("DeleteByReferenceObjectID", txtest.CtxWithDBMatcher(), model.EventSpecReference, event1ID).Return(nil).Once()
 				specSvc.On("CreateByReferenceObjectID", txtest.CtxWithDBMatcher(), *fixEvent1SpecInputs()[0], model.EventSpecReference, event1ID).Return("", testErr).Once()

--- a/components/director/internal/open_resource_discovery/validation_test.go
+++ b/components/director/internal/open_resource_discovery/validation_test.go
@@ -2342,9 +2342,9 @@ func TestDocuments_ValidateAPI(t *testing.T) {
 			Name: "Valid `WSDL V1` and `WSDL V2` definitions when APIResources has policyLevel `sap` and apiProtocol is `soap-inbound`",
 			DocumentProvider: func() []*open_resource_discovery.Document {
 				doc := fixORDDocument()
-				doc.Packages[0].PolicyLevel = "sap"
-				*doc.APIResources[0].ApiProtocol = "soap-inbound"
-				*doc.APIResources[1].ApiProtocol = "soap-inbound"
+				doc.Packages[0].PolicyLevel = open_resource_discovery.PolicyLevelSap
+				*doc.APIResources[0].ApiProtocol = open_resource_discovery.ApiProtocolSoapInbound
+				*doc.APIResources[1].ApiProtocol = open_resource_discovery.ApiProtocolSoapInbound
 				doc.APIResources[0].ResourceDefinitions[0].Type = model.APISpecTypeWsdlV1
 				doc.APIResources[0].ResourceDefinitions[0].MediaType = model.SpecFormatApplicationXML
 				doc.APIResources[0].ResourceDefinitions[1].Type = model.APISpecTypeWsdlV1
@@ -2359,9 +2359,9 @@ func TestDocuments_ValidateAPI(t *testing.T) {
 			Name: "Valid `WSDL V1` and `WSDL V2` definitions when APIResources has policyLevel `sap-partner` and apiProtocol is `soap-inbound`",
 			DocumentProvider: func() []*open_resource_discovery.Document {
 				doc := fixORDDocument()
-				doc.Packages[0].PolicyLevel = "sap-partner"
-				*doc.APIResources[0].ApiProtocol = "soap-inbound"
-				*doc.APIResources[1].ApiProtocol = "soap-inbound"
+				doc.Packages[0].PolicyLevel = open_resource_discovery.PolicyLevelSapPartner
+				*doc.APIResources[0].ApiProtocol = open_resource_discovery.ApiProtocolSoapInbound
+				*doc.APIResources[1].ApiProtocol = open_resource_discovery.ApiProtocolSoapInbound
 				doc.APIResources[0].ResourceDefinitions[0].Type = model.APISpecTypeWsdlV1
 				doc.APIResources[0].ResourceDefinitions[0].MediaType = model.SpecFormatApplicationXML
 				doc.APIResources[0].ResourceDefinitions[1].Type = model.APISpecTypeWsdlV1
@@ -2376,9 +2376,9 @@ func TestDocuments_ValidateAPI(t *testing.T) {
 			Name: "Valid `WSDL V1` and `WSDL V2` definitions when APIResources has policyLevel `sap` and apiProtocol is `soap-outbound`",
 			DocumentProvider: func() []*open_resource_discovery.Document {
 				doc := fixORDDocument()
-				doc.Packages[0].PolicyLevel = "sap"
-				*doc.APIResources[0].ApiProtocol = "soap-outbound"
-				*doc.APIResources[1].ApiProtocol = "soap-outbound"
+				doc.Packages[0].PolicyLevel = open_resource_discovery.PolicyLevelSap
+				*doc.APIResources[0].ApiProtocol = open_resource_discovery.ApiProtocolSoapOutbound
+				*doc.APIResources[1].ApiProtocol = open_resource_discovery.ApiProtocolSoapOutbound
 				doc.APIResources[0].ResourceDefinitions[0].Type = model.APISpecTypeWsdlV1
 				doc.APIResources[0].ResourceDefinitions[0].MediaType = model.SpecFormatApplicationXML
 				doc.APIResources[0].ResourceDefinitions[1].Type = model.APISpecTypeWsdlV1
@@ -2393,9 +2393,9 @@ func TestDocuments_ValidateAPI(t *testing.T) {
 			Name: "Missing `WSDL V1` or `WSDL V2` definition when APIResources has policyLevel `sap` and apiProtocol is `soap-inbound`",
 			DocumentProvider: func() []*open_resource_discovery.Document {
 				doc := fixORDDocument()
-				doc.Packages[0].PolicyLevel = "sap"
-				*doc.APIResources[0].ApiProtocol = "soap-inbound"
-				*doc.APIResources[1].ApiProtocol = "soap-inbound"
+				doc.Packages[0].PolicyLevel = open_resource_discovery.PolicyLevelSap
+				*doc.APIResources[0].ApiProtocol = open_resource_discovery.ApiProtocolSoapInbound
+				*doc.APIResources[1].ApiProtocol = open_resource_discovery.ApiProtocolSoapInbound
 				doc.APIResources[0].ResourceDefinitions[0].Type = model.APISpecTypeOpenAPIV2
 				doc.APIResources[0].ResourceDefinitions[0].MediaType = model.SpecFormatApplicationJSON
 				doc.APIResources[0].ResourceDefinitions[1].Type = model.APISpecTypeRaml
@@ -2409,9 +2409,9 @@ func TestDocuments_ValidateAPI(t *testing.T) {
 			Name: "Missing `WSDL V1` or `WSDL V2` definition when APIResources has policyLevel `sap-partner` and apiProtocol is `soap-inbound`",
 			DocumentProvider: func() []*open_resource_discovery.Document {
 				doc := fixORDDocument()
-				doc.Packages[0].PolicyLevel = "sap-partner"
-				*doc.APIResources[0].ApiProtocol = "soap-inbound"
-				*doc.APIResources[1].ApiProtocol = "soap-inbound"
+				doc.Packages[0].PolicyLevel = open_resource_discovery.PolicyLevelSapPartner
+				*doc.APIResources[0].ApiProtocol = open_resource_discovery.ApiProtocolSoapInbound
+				*doc.APIResources[1].ApiProtocol = open_resource_discovery.ApiProtocolSoapInbound
 				doc.APIResources[0].ResourceDefinitions[0].Type = model.APISpecTypeOpenAPIV2
 				doc.APIResources[0].ResourceDefinitions[0].MediaType = model.SpecFormatApplicationJSON
 				doc.APIResources[0].ResourceDefinitions[1].Type = model.APISpecTypeRaml
@@ -2425,9 +2425,9 @@ func TestDocuments_ValidateAPI(t *testing.T) {
 			Name: "Missing `WSDL V1` or `WSDL V2` definition when APIResources has policyLevel `sap` and apiProtocol is `soap-outbound`",
 			DocumentProvider: func() []*open_resource_discovery.Document {
 				doc := fixORDDocument()
-				doc.Packages[0].PolicyLevel = "sap"
-				*doc.APIResources[0].ApiProtocol = "soap-outbound"
-				*doc.APIResources[1].ApiProtocol = "soap-outbound"
+				doc.Packages[0].PolicyLevel = open_resource_discovery.PolicyLevelSap
+				*doc.APIResources[0].ApiProtocol = open_resource_discovery.ApiProtocolSoapOutbound
+				*doc.APIResources[1].ApiProtocol = open_resource_discovery.ApiProtocolSoapOutbound
 				doc.APIResources[0].ResourceDefinitions[0].Type = model.APISpecTypeOpenAPIV2
 				doc.APIResources[0].ResourceDefinitions[0].MediaType = model.SpecFormatApplicationJSON
 				doc.APIResources[0].ResourceDefinitions[1].Type = model.APISpecTypeRaml
@@ -2441,9 +2441,9 @@ func TestDocuments_ValidateAPI(t *testing.T) {
 			Name: "Missing `WSDL V1` or `WSDL V2` definition when APIResources has policyLevel `sap-partner` and apiProtocol is `soap-outbound`",
 			DocumentProvider: func() []*open_resource_discovery.Document {
 				doc := fixORDDocument()
-				doc.Packages[0].PolicyLevel = "sap-partner"
-				*doc.APIResources[0].ApiProtocol = "soap-outbound"
-				*doc.APIResources[1].ApiProtocol = "soap-outbound"
+				doc.Packages[0].PolicyLevel = open_resource_discovery.PolicyLevelSapPartner
+				*doc.APIResources[0].ApiProtocol = open_resource_discovery.ApiProtocolSoapOutbound
+				*doc.APIResources[1].ApiProtocol = open_resource_discovery.ApiProtocolSoapOutbound
 				doc.APIResources[0].ResourceDefinitions[0].Type = model.APISpecTypeOpenAPIV2
 				doc.APIResources[0].ResourceDefinitions[0].MediaType = model.SpecFormatApplicationJSON
 				doc.APIResources[0].ResourceDefinitions[1].Type = model.APISpecTypeRaml
@@ -2457,8 +2457,8 @@ func TestDocuments_ValidateAPI(t *testing.T) {
 			Name: "Missing `OpenAPI` and `EDMX` definitions when APIResources has policyLevel `sap` and apiProtocol is `odata-v2`",
 			DocumentProvider: func() []*open_resource_discovery.Document {
 				doc := fixORDDocument()
-				doc.Packages[0].PolicyLevel = "sap"
-				*doc.APIResources[0].ApiProtocol = "odata-v2"
+				doc.Packages[0].PolicyLevel = open_resource_discovery.PolicyLevelSap
+				*doc.APIResources[0].ApiProtocol = open_resource_discovery.ApiProtocolODataV2
 				doc.APIResources[0].ResourceDefinitions[0].Type = model.APISpecTypeOpenAPIV2
 				doc.APIResources[0].ResourceDefinitions[0].MediaType = model.SpecFormatApplicationJSON
 				doc.APIResources[0].ResourceDefinitions[1].Type = model.APISpecTypeRaml
@@ -2471,8 +2471,8 @@ func TestDocuments_ValidateAPI(t *testing.T) {
 			Name: "Missing `OpenAPI` and `EDMX` definitions when APIResources has policyLevel `sap-partner` and apiProtocol is `odata-v2`",
 			DocumentProvider: func() []*open_resource_discovery.Document {
 				doc := fixORDDocument()
-				doc.Packages[0].PolicyLevel = "sap-partner"
-				*doc.APIResources[0].ApiProtocol = "odata-v2"
+				doc.Packages[0].PolicyLevel = open_resource_discovery.PolicyLevelSapPartner
+				*doc.APIResources[0].ApiProtocol = open_resource_discovery.ApiProtocolODataV2
 				doc.APIResources[0].ResourceDefinitions[0].Type = model.APISpecTypeOpenAPIV2
 				doc.APIResources[0].ResourceDefinitions[0].MediaType = model.SpecFormatApplicationJSON
 				doc.APIResources[0].ResourceDefinitions[1].Type = model.APISpecTypeRaml
@@ -2485,8 +2485,8 @@ func TestDocuments_ValidateAPI(t *testing.T) {
 			Name: "Missing `OpenAPI` and `EDMX` definitions when APIResources has policyLevel `sap` and apiProtocol is `odata-v4`",
 			DocumentProvider: func() []*open_resource_discovery.Document {
 				doc := fixORDDocument()
-				doc.Packages[0].PolicyLevel = "sap"
-				*doc.APIResources[0].ApiProtocol = "odata-v4"
+				doc.Packages[0].PolicyLevel = open_resource_discovery.PolicyLevelSap
+				*doc.APIResources[0].ApiProtocol = open_resource_discovery.ApiProtocolODataV4
 				doc.APIResources[0].ResourceDefinitions[0].Type = model.APISpecTypeOpenAPIV2
 				doc.APIResources[0].ResourceDefinitions[0].MediaType = model.SpecFormatApplicationJSON
 				doc.APIResources[0].ResourceDefinitions[1].Type = model.APISpecTypeRaml
@@ -2499,8 +2499,8 @@ func TestDocuments_ValidateAPI(t *testing.T) {
 			Name: "Missing `OpenAPI` and `EDMX` definitions when APIResources has policyLevel `sap-partner` and apiProtocol is `odata-v4`",
 			DocumentProvider: func() []*open_resource_discovery.Document {
 				doc := fixORDDocument()
-				doc.Packages[0].PolicyLevel = "sap-partner"
-				*doc.APIResources[0].ApiProtocol = "odata-v4"
+				doc.Packages[0].PolicyLevel = open_resource_discovery.PolicyLevelSapPartner
+				*doc.APIResources[0].ApiProtocol = open_resource_discovery.ApiProtocolODataV4
 				doc.APIResources[0].ResourceDefinitions[0].Type = model.APISpecTypeOpenAPIV2
 				doc.APIResources[0].ResourceDefinitions[0].MediaType = model.SpecFormatApplicationJSON
 				doc.APIResources[0].ResourceDefinitions[1].Type = model.APISpecTypeRaml

--- a/components/director/internal/open_resource_discovery/validation_test.go
+++ b/components/director/internal/open_resource_discovery/validation_test.go
@@ -140,6 +140,17 @@ var (
   		]
 	}`
 
+	invalidPartnersWhenValueIsNotArray = `{
+  		"partner-key-1": "partner-value-1"
+	}`
+
+	invalidPartnersWhenValuesAreNotArrayOfStrings = `{
+  		"partners-key-1": [
+    	  "partners-value-1",
+    	  112
+  		]
+	}`
+
 	invalidCountriesElement          = `["DE", "wrongCountry"]`
 	invalidCountriesNonStringElement = `["DE", 992]`
 
@@ -302,6 +313,12 @@ var (
 	invalidEntryPointURI               = `["invalidUrl"]`
 	invalidEntryPointsDueToDuplicates  = `["/test/v1", "/test/v1"]`
 	invalidEntryPointsNonStringElement = `["/test/v1", 992]`
+
+	invalidExtensibleDueToInvalidSupportedType                       = `{"supported":true}`
+	invalidExtensibleDueToNoSupportedProperty                        = `{"description":"Please find the extensibility documentation"}`
+	invalidExtensibleDueToInvalidSupportedValue                      = `{"supported":"invalid"}`
+	invalidExtensibleDueToSupportedAutomaticAndNoDescriptionProperty = `{"supported":"automatic"}`
+	invalidExtensibleDueToSupportedManualAndNoDescriptionProperty    = `{"supported":"manual"}`
 )
 
 func TestDocuments_ValidateSystemInstance(t *testing.T) {
@@ -2276,7 +2293,222 @@ func TestDocuments_ValidateAPI(t *testing.T) {
 				return []*open_resource_discovery.Document{doc}
 			},
 		},
+		{
+			Name: "Missing `supported` field in the `extensible` object for API",
+			DocumentProvider: func() []*open_resource_discovery.Document {
+				doc := fixORDDocument()
+				doc.APIResources[0].Extensible = json.RawMessage(invalidExtensibleDueToNoSupportedProperty)
 
+				return []*open_resource_discovery.Document{doc}
+			},
+		},
+		{
+			Name: "Invalid `supported` field type in the `extensible` object for API",
+			DocumentProvider: func() []*open_resource_discovery.Document {
+				doc := fixORDDocument()
+				doc.APIResources[0].Extensible = json.RawMessage(invalidExtensibleDueToInvalidSupportedType)
+
+				return []*open_resource_discovery.Document{doc}
+			},
+		},
+		{
+			Name: "Invalid `supported` field value in the `extensible` object for API",
+			DocumentProvider: func() []*open_resource_discovery.Document {
+				doc := fixORDDocument()
+				doc.APIResources[0].Extensible = json.RawMessage(invalidExtensibleDueToInvalidSupportedValue)
+
+				return []*open_resource_discovery.Document{doc}
+			},
+		},
+		{
+			Name: "Missing `description` field when `supported` has an `automatic` value",
+			DocumentProvider: func() []*open_resource_discovery.Document {
+				doc := fixORDDocument()
+				doc.APIResources[0].Extensible = json.RawMessage(invalidExtensibleDueToSupportedAutomaticAndNoDescriptionProperty)
+
+				return []*open_resource_discovery.Document{doc}
+			},
+		},
+		{
+			Name: "Missing `description` field when `supported` has a `manual` value",
+			DocumentProvider: func() []*open_resource_discovery.Document {
+				doc := fixORDDocument()
+				doc.APIResources[0].Extensible = json.RawMessage(invalidExtensibleDueToSupportedManualAndNoDescriptionProperty)
+
+				return []*open_resource_discovery.Document{doc}
+			},
+		},
+		{
+			Name: "Valid `WSDL V1` and `WSDL V2` definitions when APIResources has policyLevel `sap` and apiProtocol is `soap-inbound`",
+			DocumentProvider: func() []*open_resource_discovery.Document {
+				doc := fixORDDocument()
+				doc.Packages[0].PolicyLevel = "sap"
+				*doc.APIResources[0].ApiProtocol = "soap-inbound"
+				*doc.APIResources[1].ApiProtocol = "soap-inbound"
+				doc.APIResources[0].ResourceDefinitions[0].Type = model.APISpecTypeWsdlV1
+				doc.APIResources[0].ResourceDefinitions[0].MediaType = model.SpecFormatApplicationXML
+				doc.APIResources[0].ResourceDefinitions[1].Type = model.APISpecTypeWsdlV1
+				doc.APIResources[0].ResourceDefinitions[1].MediaType = model.SpecFormatApplicationXML
+				doc.APIResources[1].ResourceDefinitions[0].Type = model.APISpecTypeWsdlV2
+				doc.APIResources[1].ResourceDefinitions[0].MediaType = model.SpecFormatApplicationXML
+				return []*open_resource_discovery.Document{doc}
+			},
+			ExpectedToBeValid: true,
+		},
+		{
+			Name: "Valid `WSDL V1` and `WSDL V2` definitions when APIResources has policyLevel `sap-partner` and apiProtocol is `soap-inbound`",
+			DocumentProvider: func() []*open_resource_discovery.Document {
+				doc := fixORDDocument()
+				doc.Packages[0].PolicyLevel = "sap-partner"
+				*doc.APIResources[0].ApiProtocol = "soap-inbound"
+				*doc.APIResources[1].ApiProtocol = "soap-inbound"
+				doc.APIResources[0].ResourceDefinitions[0].Type = model.APISpecTypeWsdlV1
+				doc.APIResources[0].ResourceDefinitions[0].MediaType = model.SpecFormatApplicationXML
+				doc.APIResources[0].ResourceDefinitions[1].Type = model.APISpecTypeWsdlV1
+				doc.APIResources[0].ResourceDefinitions[1].MediaType = model.SpecFormatApplicationXML
+				doc.APIResources[1].ResourceDefinitions[0].Type = model.APISpecTypeWsdlV2
+				doc.APIResources[1].ResourceDefinitions[0].MediaType = model.SpecFormatApplicationXML
+				return []*open_resource_discovery.Document{doc}
+			},
+			ExpectedToBeValid: true,
+		},
+		{
+			Name: "Valid `WSDL V1` and `WSDL V2` definitions when APIResources has policyLevel `sap` and apiProtocol is `soap-outbound`",
+			DocumentProvider: func() []*open_resource_discovery.Document {
+				doc := fixORDDocument()
+				doc.Packages[0].PolicyLevel = "sap"
+				*doc.APIResources[0].ApiProtocol = "soap-outbound"
+				*doc.APIResources[1].ApiProtocol = "soap-outbound"
+				doc.APIResources[0].ResourceDefinitions[0].Type = model.APISpecTypeWsdlV1
+				doc.APIResources[0].ResourceDefinitions[0].MediaType = model.SpecFormatApplicationXML
+				doc.APIResources[0].ResourceDefinitions[1].Type = model.APISpecTypeWsdlV1
+				doc.APIResources[0].ResourceDefinitions[1].MediaType = model.SpecFormatApplicationXML
+				doc.APIResources[1].ResourceDefinitions[0].Type = model.APISpecTypeWsdlV2
+				doc.APIResources[1].ResourceDefinitions[0].MediaType = model.SpecFormatApplicationXML
+				return []*open_resource_discovery.Document{doc}
+			},
+			ExpectedToBeValid: true,
+		},
+		{
+			Name: "Missing `WSDL V1` or `WSDL V2` definition when APIResources has policyLevel `sap` and apiProtocol is `soap-inbound`",
+			DocumentProvider: func() []*open_resource_discovery.Document {
+				doc := fixORDDocument()
+				doc.Packages[0].PolicyLevel = "sap"
+				*doc.APIResources[0].ApiProtocol = "soap-inbound"
+				*doc.APIResources[1].ApiProtocol = "soap-inbound"
+				doc.APIResources[0].ResourceDefinitions[0].Type = model.APISpecTypeOpenAPIV2
+				doc.APIResources[0].ResourceDefinitions[0].MediaType = model.SpecFormatApplicationJSON
+				doc.APIResources[0].ResourceDefinitions[1].Type = model.APISpecTypeRaml
+				doc.APIResources[0].ResourceDefinitions[1].MediaType = model.SpecFormatTextYAML
+				doc.APIResources[1].ResourceDefinitions[0].Type = model.APISpecTypeEDMX
+				doc.APIResources[1].ResourceDefinitions[0].MediaType = model.SpecFormatApplicationXML
+				return []*open_resource_discovery.Document{doc}
+			},
+		},
+		{
+			Name: "Missing `WSDL V1` or `WSDL V2` definition when APIResources has policyLevel `sap-partner` and apiProtocol is `soap-inbound`",
+			DocumentProvider: func() []*open_resource_discovery.Document {
+				doc := fixORDDocument()
+				doc.Packages[0].PolicyLevel = "sap-partner"
+				*doc.APIResources[0].ApiProtocol = "soap-inbound"
+				*doc.APIResources[1].ApiProtocol = "soap-inbound"
+				doc.APIResources[0].ResourceDefinitions[0].Type = model.APISpecTypeOpenAPIV2
+				doc.APIResources[0].ResourceDefinitions[0].MediaType = model.SpecFormatApplicationJSON
+				doc.APIResources[0].ResourceDefinitions[1].Type = model.APISpecTypeRaml
+				doc.APIResources[0].ResourceDefinitions[1].MediaType = model.SpecFormatTextYAML
+				doc.APIResources[1].ResourceDefinitions[0].Type = model.APISpecTypeEDMX
+				doc.APIResources[1].ResourceDefinitions[0].MediaType = model.SpecFormatApplicationXML
+				return []*open_resource_discovery.Document{doc}
+			},
+		},
+		{
+			Name: "Missing `WSDL V1` or `WSDL V2` definition when APIResources has policyLevel `sap` and apiProtocol is `soap-outbound`",
+			DocumentProvider: func() []*open_resource_discovery.Document {
+				doc := fixORDDocument()
+				doc.Packages[0].PolicyLevel = "sap"
+				*doc.APIResources[0].ApiProtocol = "soap-outbound"
+				*doc.APIResources[1].ApiProtocol = "soap-outbound"
+				doc.APIResources[0].ResourceDefinitions[0].Type = model.APISpecTypeOpenAPIV2
+				doc.APIResources[0].ResourceDefinitions[0].MediaType = model.SpecFormatApplicationJSON
+				doc.APIResources[0].ResourceDefinitions[1].Type = model.APISpecTypeRaml
+				doc.APIResources[0].ResourceDefinitions[1].MediaType = model.SpecFormatTextYAML
+				doc.APIResources[1].ResourceDefinitions[0].Type = model.APISpecTypeEDMX
+				doc.APIResources[1].ResourceDefinitions[0].MediaType = model.SpecFormatApplicationXML
+				return []*open_resource_discovery.Document{doc}
+			},
+		},
+		{
+			Name: "Missing `WSDL V1` or `WSDL V2` definition when APIResources has policyLevel `sap-partner` and apiProtocol is `soap-outbound`",
+			DocumentProvider: func() []*open_resource_discovery.Document {
+				doc := fixORDDocument()
+				doc.Packages[0].PolicyLevel = "sap-partner"
+				*doc.APIResources[0].ApiProtocol = "soap-outbound"
+				*doc.APIResources[1].ApiProtocol = "soap-outbound"
+				doc.APIResources[0].ResourceDefinitions[0].Type = model.APISpecTypeOpenAPIV2
+				doc.APIResources[0].ResourceDefinitions[0].MediaType = model.SpecFormatApplicationJSON
+				doc.APIResources[0].ResourceDefinitions[1].Type = model.APISpecTypeRaml
+				doc.APIResources[0].ResourceDefinitions[1].MediaType = model.SpecFormatTextYAML
+				doc.APIResources[1].ResourceDefinitions[0].Type = model.APISpecTypeEDMX
+				doc.APIResources[1].ResourceDefinitions[0].MediaType = model.SpecFormatApplicationXML
+				return []*open_resource_discovery.Document{doc}
+			},
+		},
+		{
+			Name: "Missing `OpenAPI` and `EDMX` definitions when APIResources has policyLevel `sap` and apiProtocol is `odata-v2`",
+			DocumentProvider: func() []*open_resource_discovery.Document {
+				doc := fixORDDocument()
+				doc.Packages[0].PolicyLevel = "sap"
+				*doc.APIResources[0].ApiProtocol = "odata-v2"
+				doc.APIResources[0].ResourceDefinitions[0].Type = model.APISpecTypeOpenAPIV2
+				doc.APIResources[0].ResourceDefinitions[0].MediaType = model.SpecFormatApplicationJSON
+				doc.APIResources[0].ResourceDefinitions[1].Type = model.APISpecTypeRaml
+				doc.APIResources[0].ResourceDefinitions[1].MediaType = model.SpecFormatTextYAML
+				doc.APIResources[0].ResourceDefinitions[2] = &model.APIResourceDefinition{}
+				return []*open_resource_discovery.Document{doc}
+			},
+		},
+		{
+			Name: "Missing `OpenAPI` and `EDMX` definitions when APIResources has policyLevel `sap-partner` and apiProtocol is `odata-v2`",
+			DocumentProvider: func() []*open_resource_discovery.Document {
+				doc := fixORDDocument()
+				doc.Packages[0].PolicyLevel = "sap-partner"
+				*doc.APIResources[0].ApiProtocol = "odata-v2"
+				doc.APIResources[0].ResourceDefinitions[0].Type = model.APISpecTypeOpenAPIV2
+				doc.APIResources[0].ResourceDefinitions[0].MediaType = model.SpecFormatApplicationJSON
+				doc.APIResources[0].ResourceDefinitions[1].Type = model.APISpecTypeRaml
+				doc.APIResources[0].ResourceDefinitions[1].MediaType = model.SpecFormatTextYAML
+				doc.APIResources[0].ResourceDefinitions[2] = &model.APIResourceDefinition{}
+				return []*open_resource_discovery.Document{doc}
+			},
+		},
+		{
+			Name: "Missing `OpenAPI` and `EDMX` definitions when APIResources has policyLevel `sap` and apiProtocol is `odata-v4`",
+			DocumentProvider: func() []*open_resource_discovery.Document {
+				doc := fixORDDocument()
+				doc.Packages[0].PolicyLevel = "sap"
+				*doc.APIResources[0].ApiProtocol = "odata-v4"
+				doc.APIResources[0].ResourceDefinitions[0].Type = model.APISpecTypeOpenAPIV2
+				doc.APIResources[0].ResourceDefinitions[0].MediaType = model.SpecFormatApplicationJSON
+				doc.APIResources[0].ResourceDefinitions[1].Type = model.APISpecTypeRaml
+				doc.APIResources[0].ResourceDefinitions[1].MediaType = model.SpecFormatTextYAML
+				doc.APIResources[0].ResourceDefinitions[2] = &model.APIResourceDefinition{}
+				return []*open_resource_discovery.Document{doc}
+			},
+		},
+		{
+			Name: "Missing `OpenAPI` and `EDMX` definitions when APIResources has policyLevel `sap-partner` and apiProtocol is `odata-v4`",
+			DocumentProvider: func() []*open_resource_discovery.Document {
+				doc := fixORDDocument()
+				doc.Packages[0].PolicyLevel = "sap-partner"
+				*doc.APIResources[0].ApiProtocol = "odata-v4"
+				doc.APIResources[0].ResourceDefinitions[0].Type = model.APISpecTypeOpenAPIV2
+				doc.APIResources[0].ResourceDefinitions[0].MediaType = model.SpecFormatApplicationJSON
+				doc.APIResources[0].ResourceDefinitions[1].Type = model.APISpecTypeRaml
+				doc.APIResources[0].ResourceDefinitions[1].MediaType = model.SpecFormatTextYAML
+				doc.APIResources[0].ResourceDefinitions[2] = &model.APIResourceDefinition{}
+				return []*open_resource_discovery.Document{doc}
+			},
+		},
 		// Test invalid entity relations
 
 		{
@@ -3005,6 +3237,51 @@ func TestDocuments_ValidateEvent(t *testing.T) {
 				return []*open_resource_discovery.Document{doc}
 			},
 		},
+		{
+			Name: "Missing `supported` field in the `extensible` object for API",
+			DocumentProvider: func() []*open_resource_discovery.Document {
+				doc := fixORDDocument()
+				doc.EventResources[0].Extensible = json.RawMessage(invalidExtensibleDueToNoSupportedProperty)
+
+				return []*open_resource_discovery.Document{doc}
+			},
+		},
+		{
+			Name: "Invalid `supported` field type in the `extensible` object for API",
+			DocumentProvider: func() []*open_resource_discovery.Document {
+				doc := fixORDDocument()
+				doc.EventResources[0].Extensible = json.RawMessage(invalidExtensibleDueToInvalidSupportedType)
+
+				return []*open_resource_discovery.Document{doc}
+			},
+		},
+		{
+			Name: "Invalid `supported` field value in the `extensible` object for API",
+			DocumentProvider: func() []*open_resource_discovery.Document {
+				doc := fixORDDocument()
+				doc.EventResources[0].Extensible = json.RawMessage(invalidExtensibleDueToInvalidSupportedValue)
+
+				return []*open_resource_discovery.Document{doc}
+			},
+		},
+		{
+			Name: "Missing `description` field when `supported` has an `automatic` value",
+			DocumentProvider: func() []*open_resource_discovery.Document {
+				doc := fixORDDocument()
+				doc.EventResources[0].Extensible = json.RawMessage(invalidExtensibleDueToSupportedAutomaticAndNoDescriptionProperty)
+
+				return []*open_resource_discovery.Document{doc}
+			},
+		},
+		{
+			Name: "Missing `description` field when `supported` has a `manual` value",
+			DocumentProvider: func() []*open_resource_discovery.Document {
+				doc := fixORDDocument()
+				doc.EventResources[0].Extensible = json.RawMessage(invalidExtensibleDueToSupportedManualAndNoDescriptionProperty)
+
+				return []*open_resource_discovery.Document{doc}
+			},
+		},
 
 		// Test invalid entity relations
 
@@ -3303,6 +3580,31 @@ func TestDocuments_ValidateVendor(t *testing.T) {
 			DocumentProvider: func() []*open_resource_discovery.Document {
 				doc := fixORDDocument()
 				doc.Vendors[0].Labels = json.RawMessage(invalidLabelsWhenKeyIsWrong)
+
+				return []*open_resource_discovery.Document{doc}
+			},
+		},
+		{
+			Name: "Invalid JSON object `Partners` field for Vendor",
+			DocumentProvider: func() []*open_resource_discovery.Document {
+				doc := fixORDDocument()
+				doc.Vendors[0].Partners = json.RawMessage(`[]`)
+
+				return []*open_resource_discovery.Document{doc}
+			},
+		}, {
+			Name: "`Partners` values are not array for Vendor",
+			DocumentProvider: func() []*open_resource_discovery.Document {
+				doc := fixORDDocument()
+				doc.Vendors[0].Labels = json.RawMessage(invalidPartnersWhenValueIsNotArray)
+
+				return []*open_resource_discovery.Document{doc}
+			},
+		}, {
+			Name: "`Partners` values are not array of strings for Vendor",
+			DocumentProvider: func() []*open_resource_discovery.Document {
+				doc := fixORDDocument()
+				doc.Vendors[0].Labels = json.RawMessage(invalidPartnersWhenValuesAreNotArrayOfStrings)
 
 				return []*open_resource_discovery.Document{doc}
 			},

--- a/components/external-services-mock/internal/ord-aggregator/template.go
+++ b/components/external-services-mock/internal/ord-aggregator/template.go
@@ -23,387 +23,471 @@ const ordConfig = `{
 
 // This document is based on marshalling (and optionally enhancing) the returned document from the fixture fixORDDocumentWithBaseURL located in: /compass/components/director/internal/open_resource_discovery/fixtures_test.go
 // If any breaking/validation change is applied to the fixture's Document structure, it must be applied here and in the constants used in the e2e test (/compass/tests/ord-aggregator/tests/handler_test.go) as well. Otherwise, the aggregator e2e test will fail.
+// describedSystemInstance.baseUrl should be the same as the url of external services mock in the cluster
 const ordDocument = `{
 	"$schema": "./spec/v1/generated/Document.schema.json",
-	"openResourceDiscovery": "1.0-rc.2",
-	"description": "Test Document",
-	"describedSystemInstance": {
-		"ProviderName": null,
-		"Tenant": "",
-		"Name": "",
-		"Description": null,
-		"Status": null,
-		"HealthCheckURL": null,
-		"IntegrationSystemID": null,
-		"ApplicationTemplateID": null,
-		"baseUrl": "http://compass-external-services-mock.compass-system.svc.cluster.local:8080",
+	"apiResources": [{
+		"apiProtocol": "odata-v2",
+		"apiResourceLinks": [{
+			"type": "console",
+			"url": "https://example.com/shell/discover"
+		},
+		{
+			"type": "console",
+			"url": "/shell/discover/relative"
+		}],
+		"changelogEntries": [{
+			"date": "2020-04-29",
+			"description": "loremipsumdolorsitamet",
+			"releaseStatus": "active",
+			"url": "https://example.com/changelog/v1",
+			"version": "1.0.0"
+		}],
+		"countries": ["BG", "US"],
+		"customImplementationStandard": null,
+		"customImplementationStandardDescription": null,
+		"description": "lorem ipsum dolor sit amet",
+		"disabled": true,
+		"entryPoints": ["https://exmaple.com/test/v1", "https://exmaple.com/test/v2"],
+		"extensible": {
+			"description": "Please find the extensibility documentation",
+			"supported": "automatic"
+		},
+		"implementationStandard": "cff:open-service-broker:v2",
+		"industry": ["automotive","test"],
 		"labels": {
 			"label-key-1": ["label-value-1", "label-value-2"]
-		}
-	},
-	"providerSystemInstance": null,
-	"packages": [{
-		"ordId": "ns:package:PACKAGE_ID:v1",
-		"vendor": "ns:vendor:id:",
-		"title": "PACKAGE 1 TITLE",
-		"shortDescription": "lorem ipsum",
-		"description": "lorem ipsum dolor set",
-		"version": "1.1.2",
-		"packageLinks": [{
-			"type": "terms-of-service",
-			"url": "https://example.com/en/legal/terms-of-use.html"
-		}, {
-			"type": "client-registration",
-			"url": "/ui/public/showRegisterForm"
-		}],
+		},
+		"lineOfBusiness": ["lineOfBusiness2"],
 		"links": [{
 			"description": "loremipsumdolornem",
 			"title": "LinkTitle",
 			"url": "https://example.com/2018/04/11/testing/"
-		}, {
+		},
+		{
 			"description": "loremipsumdolornem",
 			"title": "LinkTitle",
 			"url": "/testing/relative"
 		}],
-		"licenseType": "licence",
-		"tags": ["testTag"],
+		"ordId": "ns:apiResource:API_ID:v2",
+		"partOfConsumptionBundles": [{
+			"defaultEntryPoint": "https://exmaple.com/test/v1",
+			"ordId": "ns:consumptionBundle:BUNDLE_ID:v1"
+		},
+		{
+			"defaultEntryPoint": "https://exmaple.com/test/v1",
+			"ordId": "ns:consumptionBundle:BUNDLE_ID:v2"
+		}],
+		"partOfPackage": "ns:package:PACKAGE_ID:v1",
+		"partOfProducts": ["ns:product:id:"],
+		"releaseStatus": "active",
+		"resourceDefinitions": [{
+			"accessStrategies": [{
+				"customDescription": "",
+				"customType": "",
+				"type": "open"
+			}],
+			"customType": "",
+			"mediaType": "application/json",
+			"type": "openapi-v3",
+			"url": "http://localhost:8080/odata/1.0/catalog.svc/$value?type=json"
+		},
+		{
+			"accessStrategies": [{
+				"customDescription": "",
+				"customType": "",
+				"type": "open"
+			}],
+			"customType": "",
+			"mediaType": "text/yaml",
+			"type": "openapi-v3",
+			"url": "https://test.com/odata/1.0/catalog"
+		},
+		{
+			"accessStrategies": [{
+				"customDescription": "",
+				"customType": "",
+				"type": "open"
+			}],
+			"customType": "",
+			"mediaType": "application/xml",
+			"type": "edmx",
+			"url": "https://TEST:443//odata/$metadata"
+		}],
+		"shortDescription": "lorem ipsum",
+		"successor": null,
+		"sunsetDate": null,
+		"systemInstanceAware": true,
+		"tags": ["apiTestTag"],
+		"title": "API TITLE",
+		"version": "2.1.2",
+		"visibility": "public"
+	},
+	{
+		"apiProtocol": "odata-v2",
+		"apiResourceLinks": [{
+			"type": "console",
+			"url": "https://example.com/shell/discover"
+		},
+		{
+			"type": "console",
+			"url": "/shell/discover/relative"
+		}],
+		"changelogEntries": [{
+			"date": "2020-04-29",
+			"description": "loremipsumdolorsitamet",
+			"releaseStatus": "active",
+			"url": "https://example.com/changelog/v1",
+			"version": "1.0.0"
+		}],
+		"countries": ["BR"],
+		"customImplementationStandard": null,
+		"customImplementationStandardDescription": null,
+		"description": "lorem ipsum dolor sit amet",
+		"disabled": null,
+		"entryPoints": ["http://localhost:8080/some-api/v1"],
+		"extensible": {
+			"description": "Please find the extensibility documentation",
+			"supported": "automatic"
+		},
+		"implementationStandard": "cff:open-service-broker:v2",
+		"industry": ["automotive","test"],
+		"labels": {
+			"label-key-1": ["label-value-1", "label-value-2"]
+		},
+		"lineOfBusiness": ["lineOfBusiness2"],
+		"links": [{
+			"description": "loremipsumdolornem",
+			"title": "LinkTitle",
+			"url": "https://example.com/2018/04/11/testing/"
+		},
+		{
+			"description": "loremipsumdolornem",
+			"title": "LinkTitle",
+			"url": "/testing/relative"
+		}],
+		"ordId": "ns:apiResource:API_ID2:v1",
+		"partOfConsumptionBundles": [{
+			"defaultEntryPoint": "",
+			"ordId": "ns:consumptionBundle:BUNDLE_ID:v1"
+		},
+ 		{
+			"ordId": "ns:consumptionBundle:BUNDLE_ID:v2",
+			"defaultEntryPoint": ""
+		}],
+		"partOfPackage": "ns:package:PACKAGE_ID:v1",
+		"partOfProducts": ["ns:product:id:"],
+		"releaseStatus": "deprecated",
+		"resourceDefinitions": [{
+			"accessStrategies": [{
+				"customDescription": "",
+				"customType": "",
+				"type": "open"
+			}],
+			"customType": "",
+			"mediaType": "application/xml",
+			"type": "edmx",
+			"url": "https://TEST:443//odata/$metadata"
+		},
+		{
+			"accessStrategies": [{
+				"customDescription": "",
+				"customType": "",
+				"type": "open"
+			}],
+			"customType": "",
+			"mediaType": "application/json",
+			"type": "openapi-v3",
+			"url": "http://localhost:8080/odata/1.0/catalog.svc/$value?type=json"
+		}],
+		"shortDescription": "lorem ipsum",
+		"successor": "ns:apiResource:API_ID:v2",
+		"sunsetDate": "2020-12-08T15:47:04+0000",
+		"systemInstanceAware": true,
+		"tags": ["ZGWSAMPLE"],
+		"title": "Gateway Sample Service",
+		"version": "1.1.0",
+		"visibility": "public"
+	}],
+	"consumptionBundles":[
+        {
+            "credentialExchangeStrategies":[
+                {
+                    "callbackUrl":"/credentials/relative",
+                    "customType":"ns:credential-exchange:v1",
+                    "type":"custom"
+                },
+                {
+                    "callbackUrl":"http://example.com/credentials",
+                    "customType":"ns:credential-exchange2:v3",
+                    "type":"custom"
+                }
+            ],
+            "description":"lorem ipsum dolor nsq sme",
+            "labels":{
+                "label-key-1":[
+                    "label-value-1",
+                    "label-value-2"
+                ]
+            },
+            "links":[
+                {
+                    "description":"loremipsumdolornem",
+                    "title":"LinkTitle",
+                    "url":"https://example.com/2018/04/11/testing/"
+                },
+                {
+                    "description":"loremipsumdolornem",
+                    "title":"LinkTitle",
+                    "url":"/testing/relative"
+                }
+            ],
+            "ordId":"ns:consumptionBundle:BUNDLE_ID:v1",
+            "shortDescription":"lorem ipsum",
+            "title":"BUNDLE TITLE"
+        },
+        {
+            "title":"BUNDLE TITLE 2",
+            "description":"foo bar",
+            "ordId":"ns:consumptionBundle:BUNDLE_ID:v2",
+            "shortDescription":"foo",
+            "links":[
+                {
+                    "description":"loremipsumdolornem",
+                    "title":"LinkTitle",
+                    "url":"https://example.com/2018/04/11/testing/"
+                },
+                {
+                    "description":"loremipsumdolornem",
+                    "title":"LinkTitle",
+                    "url":"/testing/relative"
+                }
+            ],
+            "labels":{
+                "label-key-1":[
+                    "label-value-1",
+                    "label-value-2"
+                ]
+            },
+            "credentialExchangeStrategies":[
+                {
+                    "callbackUrl":"/credentials/relative",
+                    "customType":"ns:credential-exchange:v1",
+                    "type":"custom"
+                },
+                {
+                    "callbackUrl":"http://example.com/credentials",
+                    "customType":"ns:credential-exchange2:v3",
+                    "type":"custom"
+                }
+            ]
+        }
+    ],
+	"describedSystemInstance": {
+		"ApplicationTemplateID": null,
+		"baseUrl": "http://compass-external-services-mock.compass-system.svc.cluster.local:8080",
+		"Description": null,
+		"HealthCheckURL": null,
+		"IntegrationSystemID": null,
+		"labels": {
+			"label-key-1": ["label-value-1", "label-value-2"]
+		},
+		"Name": "",
+		"ProviderName": null,
+		"Status": null,
+		"Tenant": ""
+	},
+	"description": "Test Document",
+	"eventResources": [{
+		"changelogEntries": [{
+			"date": "2020-04-29",
+			"description": "loremipsumdolorsitamet",
+			"releaseStatus": "active",
+			"url": "https://example.com/changelog/v1",
+			"version": "1.0.0"
+		}],
+		"countries": ["BG", "US"],
+		"description": "lorem ipsum dolor sit amet",
+		"disabled": true,
+		"extensible": {
+			"description": "Please find the extensibility documentation",
+			"supported": "automatic"
+		},
+		"industry": ["automotive", "test"],
+		"labels": {
+			"label-key-1": ["label-value-1", "label-value-2"]
+		},
+		"lineOfBusiness": ["lineOfBusiness2"],
+		"links": [{
+			"description": "loremipsumdolornem",
+			"title": "LinkTitle",
+			"url": "https://example.com/2018/04/11/testing/"
+		},
+		{
+			"description": "loremipsumdolornem",
+			"title": "LinkTitle",
+			"url": "/testing/relative"
+		}],
+		"ordId": "ns:eventResource:EVENT_ID:v1",
+		"partOfConsumptionBundles": [{
+			"defaultEntryPoint": "",
+			"ordId": "ns:consumptionBundle:BUNDLE_ID:v1"
+		},
+		{
+			"defaultEntryPoint": "",
+			"ordId": "ns:consumptionBundle:BUNDLE_ID:v2"
+		}],
+		"partOfPackage": "ns:package:PACKAGE_ID:v1",
+		"partOfProducts": ["ns:product:id:"],
+		"releaseStatus": "active",
+		"resourceDefinitions": [{
+			"accessStrategies": [{
+				"customDescription": "",
+				"customType": "",
+				"type": "open"
+			}],
+			"customType": "",
+			"mediaType": "application/json",
+			"type": "asyncapi-v2",
+			"url": "http://localhost:8080/asyncApi2.json"
+		}],
+		"shortDescription": "lorem ipsum",
+		"successor": null,
+		"sunsetDate": null,
+		"systemInstanceAware": true,
+		"tags": ["eventTestTag"],
+		"title": "EVENT TITLE",
+		"version": "2.1.2",
+		"visibility": "public"
+	},
+	{
+		"changelogEntries": [{
+			"date": "2020-04-29",
+			"description": "loremipsumdolorsitamet",
+			"releaseStatus": "active",
+			"url": "https://example.com/changelog/v1",
+			"version": "1.0.0"
+		}],
+		"countries": ["BR"],
+		"description": "lorem ipsum dolor sit amet",
+		"disabled": null,
+		"extensible": {
+			"description": "Please find the extensibility documentation",
+			"supported": "automatic"
+		},
+		"industry": ["automotive", "test"],
+		"labels": {
+			"label-key-1": ["label-value-1", "label-value-2"]
+		},
+		"lineOfBusiness": ["lineOfBusiness2"],
+		"links": [{
+			"description": "loremipsumdolornem",
+			"title": "LinkTitle",
+			"url": "https://example.com/2018/04/11/testing/"
+		},
+		{
+			"description": "loremipsumdolornem",
+			"title": "LinkTitle",
+			"url": "/testing/relative"
+		}],
+		"ordId": "ns2:eventResource:EVENT_ID:v1",
+		"partOfConsumptionBundles": [{
+			"defaultEntryPoint": "",
+			"ordId": "ns:consumptionBundle:BUNDLE_ID:v1"
+		},
+		{
+			"defaultEntryPoint": "",
+			"ordId": "ns:consumptionBundle:BUNDLE_ID:v2"
+		}],
+		"partOfPackage": "ns:package:PACKAGE_ID:v1",
+		"partOfProducts": ["ns:product:id:"],
+		"releaseStatus": "deprecated",
+		"resourceDefinitions": [{
+			"accessStrategies": [{
+				"customDescription": "",
+				"customType": "",
+				"type": "open"
+			}],
+			"customType": "",
+			"mediaType": "application/json",
+			"type": "asyncapi-v2",
+			"url": "http://localhost:8080/api/eventCatalog.json"
+		}],
+		"shortDescription": "lorem ipsum",
+		"successor": "ns2:eventResource:EVENT_ID:v1",
+		"sunsetDate": "2020-12-08T15:47:04+0000",
+		"systemInstanceAware": true,
+		"tags": ["eventTestTag2"],
+		"title": "EVENT TITLE 2",
+		"version": "1.1.0",
+		"visibility": "public"
+	}],
+	"openResourceDiscovery": "1.0-rc.3",
+	"packages": [{
 		"countries": ["BG", "EN"],
+		"customPolicyLevel": null,
+		"description": "lorem ipsum dolor set",
+		"industry": ["automotive", "finance"],
 		"labels": {
 			"label-key-1": ["label-val"],
 			"pkg-label": ["label-val"]
 		},
-		"policyLevel": "sap",
-		"customPolicyLevel": null,
-		"partOfProducts": ["ns:product:id:"],
+		"licenseType": "licence",
 		"lineOfBusiness": ["lineOfBusiness"],
-		"industry": ["automotive", "finance"]
-	}],
-	"consumptionBundles": [{
-		"title": "BUNDLE TITLE",
-		"description": "lorem ipsum dolor nsq sme",
-		"ordId": "ns:consumptionBundle:BUNDLE_ID:v1",
+		"links": [{
+			"description": "loremipsumdolornem",
+			"title": "LinkTitle",
+			"url": "https://example.com/2018/04/11/testing/"
+		},
+		{
+			"description": "loremipsumdolornem",
+			"title": "LinkTitle",
+			"url": "/testing/relative"
+		}],
+		"ordId": "ns:package:PACKAGE_ID:v1",
+		"packageLinks": [{
+			"type": "terms-of-service",
+			"url": "https://example.com/en/legal/terms-of-use.html"
+		},
+		{
+			"type": "client-registration",
+			"url": "/ui/public/showRegisterForm"
+		}],
+		"partOfProducts": ["ns:product:id:"],
+		"policyLevel": "sap",
 		"shortDescription": "lorem ipsum",
-		"links": [{
-			"description": "loremipsumdolornem",
-			"title": "LinkTitle",
-			"url": "https://example.com/2018/04/11/testing/"
-		}, {
-			"description": "loremipsumdolornem",
-			"title": "LinkTitle",
-			"url": "/testing/relative"
-		}],
-		"labels": {
-			"label-key-1": ["label-value-1", "label-value-2"]
-		},
-		"credentialExchangeStrategies": [{
-			"callbackUrl": "/credentials/relative",
-			"customType": "ns:credential-exchange:v1",
-			"type": "custom"
-		}, {
-			"callbackUrl": "http://example.com/credentials",
-			"customType": "ns:credential-exchange2:v3",
-			"type": "custom"
-		}]
-	}, {
-		"title": "BUNDLE TITLE 2",
-		"description": "foo bar",
-		"ordId": "ns:consumptionBundle:BUNDLE_ID:v2",
-		"shortDescription": "foo",
-		"links": [{
-			"description": "loremipsumdolornem",
-			"title": "LinkTitle",
-			"url": "https://example.com/2018/04/11/testing/"
-		}, {
-			"description": "loremipsumdolornem",
-			"title": "LinkTitle",
-			"url": "/testing/relative"
-		}],
-		"labels": {
-			"label-key-1": ["label-value-1", "label-value-2"]
-		},
-		"credentialExchangeStrategies": [{
-			"callbackUrl": "/credentials/relative",
-			"customType": "ns:credential-exchange:v1",
-			"type": "custom"
-		}, {
-			"callbackUrl": "http://example.com/credentials",
-			"customType": "ns:credential-exchange2:v3",
-			"type": "custom"
-		}]
+		"tags": ["testTag"],
+		"title": "PACKAGE 1 TITLE",
+		"vendor": "ns:vendor:id:",
+		"version": "1.1.2"
 	}],
 	"products": [{
+		"correlationIds": [
+			"foo.bar.baz:123456",
+			"foo.bar.baz:654321"
+		],
+		"labels": {
+			"label-key-1": ["label-value-1", "label-value-2"]
+		},
 		"ordId": "ns:product:id:",
-		"title": "PRODUCT TITLE",
-		"shortDescription": "lorem ipsum",
-		"vendor": "ns:vendor:id:",
 		"parent": "ns:product:id2:",
-		"correlationIds": ["foo.bar.baz:123456", "foo.bar.baz:654321"],
-		"labels": {
-			"label-key-1": ["label-value-1", "label-value-2"]
-		}
+		"shortDescription": "lorem ipsum",
+		"title": "PRODUCT TITLE",
+		"vendor": "ns:vendor:id:"
 	}],
-	"apiResources": [{
-		"partOfPackage": "ns:package:PACKAGE_ID:v1",
-		"title": "API TITLE",
-		"description": "lorem ipsum dolor sit amet",
-		"entryPoints": ["https://exmaple.com/test/v1", "https://exmaple.com/test/v2"],
-		"ordId": "ns:apiResource:API_ID:v2",
-		"shortDescription": "lorem ipsum",
-		"systemInstanceAware": true,
-		"apiProtocol": "odata-v2",
-		"tags": ["apiTestTag"],
-		"countries": ["BG", "US"],
-		"links": [{
-			"description": "loremipsumdolornem",
-			"title": "LinkTitle",
-			"url": "https://example.com/2018/04/11/testing/"
-		}, {
-			"description": "loremipsumdolornem",
-			"title": "LinkTitle",
-			"url": "/testing/relative"
-		}],
-		"apiResourceLinks": [{
-			"type": "console",
-			"url": "https://example.com/shell/discover"
-		}, {
-			"type": "console",
-			"url": "/shell/discover/relative"
-		}],
-		"releaseStatus": "active",
-		"sunsetDate": null,
-		"successor": null,
-		"changelogEntries": [{
-			"date": "2020-04-29",
-			"description": "loremipsumdolorsitamet",
-			"releaseStatus": "active",
-			"url": "https://example.com/changelog/v1",
-			"version": "1.0.0"
-		}],
-		"labels": {
-			"label-key-1": ["label-value-1", "label-value-2"]
-		},
-		"visibility": "public",
-		"disabled": true,
-		"partOfProducts": ["ns:product:id:"],
-		"lineOfBusiness": ["lineOfBusiness2"],
-		"industry": ["automotive", "test"],
-		"implementationStandard": "cff:open-service-broker:v2",
-		"customImplementationStandard": null,
-		"customImplementationStandardDescription": null,
-		"resourceDefinitions": [{
-			"type": "openapi-v3",
-			"customType": "",
-			"mediaType": "application/json",
-			"url": "http://localhost:8080/odata/1.0/catalog.svc/$value?type=json",
-			"accessStrategies": [{
-				"type": "open",
-				"customType": "",
-				"customDescription": ""
-			}]
-		}, {
-			"type": "openapi-v3",
-			"customType": "",
-			"mediaType": "text/yaml",
-			"url": "https://test.com/odata/1.0/catalog",
-			"accessStrategies": [{
-				"type": "open",
-				"customType": "",
-				"customDescription": ""
-			}]
-		}],
-		"partOfConsumptionBundles": [{
-			"ordId": "ns:consumptionBundle:BUNDLE_ID:v1",
-			"defaultEntryPoint": "https://exmaple.com/test/v1"
-		}, {
-			"ordId": "ns:consumptionBundle:BUNDLE_ID:v2",
-			"defaultEntryPoint": "https://exmaple.com/test/v2"
-		}],
-		"version": "2.1.2"
-	}, {
-		"partOfPackage": "ns:package:PACKAGE_ID:v1",
-		"title": "Gateway Sample Service",
-		"description": "lorem ipsum dolor sit amet",
-		"entryPoints": ["http://localhost:8080/some-api/v1"],
-		"ordId": "ns:apiResource:API_ID2:v1",
-		"shortDescription": "lorem ipsum",
-		"systemInstanceAware": true,
-		"apiProtocol": "odata-v2",
-		"tags": ["ZGWSAMPLE"],
-		"countries": ["BR"],
-		"links": [{
-			"description": "loremipsumdolornem",
-			"title": "LinkTitle",
-			"url": "https://example.com/2018/04/11/testing/"
-		}, {
-			"description": "loremipsumdolornem",
-			"title": "LinkTitle",
-			"url": "/testing/relative"
-		}],
-		"apiResourceLinks": [{
-			"type": "console",
-			"url": "https://example.com/shell/discover"
-		}, {
-			"type": "console",
-			"url": "/shell/discover/relative"
-		}],
-		"releaseStatus": "deprecated",
-		"sunsetDate": "2020-12-08T15:47:04+0000",
-		"successor": "ns:apiResource:API_ID:v2",
-		"changelogEntries": [{
-			"date": "2020-04-29",
-			"description": "loremipsumdolorsitamet",
-			"releaseStatus": "active",
-			"url": "https://example.com/changelog/v1",
-			"version": "1.0.0"
-		}],
-		"labels": {
-			"label-key-1": ["label-value-1", "label-value-2"]
-		},
-		"visibility": "public",
-		"disabled": null,
-		"partOfProducts": ["ns:product:id:"],
-		"lineOfBusiness": ["lineOfBusiness2"],
-		"industry": ["automotive", "test"],
-		"implementationStandard": "cff:open-service-broker:v2",
-		"customImplementationStandard": null,
-		"customImplementationStandardDescription": null,
-		"resourceDefinitions": [{
-			"type": "edmx",
-			"customType": "",
-			"mediaType": "application/xml",
-			"url": "https://TEST:443//odata/$metadata",
-			"accessStrategies": [{
-				"type": "open",
-				"customType": "",
-				"customDescription": ""
-			}]
-		}],
-		"partOfConsumptionBundles": [{
-			"ordId": "ns:consumptionBundle:BUNDLE_ID:v1",
-			"defaultEntryPoint": ""
-		}, {
-			"ordId": "ns:consumptionBundle:BUNDLE_ID:v2",
-			"defaultEntryPoint": ""
-		}],
-		"version": "1.1.0"
-	}],
-	"eventResources": [{
-		"partOfPackage": "ns:package:PACKAGE_ID:v1",
-		"title": "EVENT TITLE",
-		"description": "lorem ipsum dolor sit amet",
-		"ordId": "ns:eventResource:EVENT_ID:v1",
-		"shortDescription": "lorem ipsum",
-		"systemInstanceAware": true,
-		"changelogEntries": [{
-			"date": "2020-04-29",
-			"description": "loremipsumdolorsitamet",
-			"releaseStatus": "active",
-			"url": "https://example.com/changelog/v1",
-			"version": "1.0.0"
-		}],
-		"links": [{
-			"description": "loremipsumdolornem",
-			"title": "LinkTitle",
-			"url": "https://example.com/2018/04/11/testing/"
-		}, {
-			"description": "loremipsumdolornem",
-			"title": "LinkTitle",
-			"url": "/testing/relative"
-		}],
-		"tags": ["eventTestTag"],
-		"countries": ["BG", "US"],
-		"releaseStatus": "active",
-		"sunsetDate": null,
-		"successor": null,
-		"labels": {
-			"label-key-1": ["label-value-1", "label-value-2"]
-		},
-		"visibility": "public",
-		"disabled": true,
-		"partOfProducts": ["ns:product:id:"],
-		"lineOfBusiness": ["lineOfBusiness2"],
-		"industry": ["automotive", "test"],
-		"resourceDefinitions": [{
-			"type": "asyncapi-v2",
-			"customType": "",
-			"mediaType": "application/json",
-			"url": "http://localhost:8080/asyncApi2.json",
-			"accessStrategies": [{
-				"type": "open",
-				"customType": "",
-				"customDescription": ""
-			}]
-		}],
-		"partOfConsumptionBundles": [{
-			"ordId": "ns:consumptionBundle:BUNDLE_ID:v1"
-		}, {
-			"ordId": "ns:consumptionBundle:BUNDLE_ID:v2"	
-		}],
-		"version": "2.1.2"
-	}, {
-		"partOfPackage": "ns:package:PACKAGE_ID:v1",
-		"title": "EVENT TITLE 2",
-		"description": "lorem ipsum dolor sit amet",
-		"ordId": "ns2:eventResource:EVENT_ID:v1",
-		"shortDescription": "lorem ipsum",
-		"systemInstanceAware": true,
-		"changelogEntries": [{
-			"date": "2020-04-29",
-			"description": "loremipsumdolorsitamet",
-			"releaseStatus": "active",
-			"url": "https://example.com/changelog/v1",
-			"version": "1.0.0"
-		}],
-		"links": [{
-			"description": "loremipsumdolornem",
-			"title": "LinkTitle",
-			"url": "https://example.com/2018/04/11/testing/"
-		}, {
-			"description": "loremipsumdolornem",
-			"title": "LinkTitle",
-			"url": "/testing/relative"
-		}],
-		"tags": ["eventTestTag2"],
-		"countries": ["BR"],
-		"releaseStatus": "deprecated",
-		"sunsetDate": "2020-12-08T15:47:04+0000",
-		"successor": "ns2:eventResource:EVENT_ID:v1",
-		"labels": {
-			"label-key-1": ["label-value-1", "label-value-2"]
-		},
-		"visibility": "public",
-		"disabled": null,
-		"partOfProducts": ["ns:product:id:"],
-		"lineOfBusiness": ["lineOfBusiness2"],
-		"industry": ["automotive", "test"],
-		"resourceDefinitions": [{
-			"type": "asyncapi-v2",
-			"customType": "",
-			"mediaType": "application/json",
-			"url": "http://localhost:8080/api/eventCatalog.json",
-			"accessStrategies": [{
-				"type": "open",
-				"customType": "",
-				"customDescription": ""
-			}]
-		}],
-		"partOfConsumptionBundles": [{
-			"ordId": "ns:consumptionBundle:BUNDLE_ID:v1"
-		}, {
-			"ordId": "ns:consumptionBundle:BUNDLE_ID:v2"
-		}],
-		"version": "1.1.0"
-	}],
+	"providerSystemInstance": null,
 	"tombstones": [{
 		"ordId": "ns:apiResource:API_ID2:v1",
 		"removalDate": "2020-12-02T14:12:59Z"
 	}],
 	"vendors": [{
-		"ordId": "ns:vendor:id:",
-		"title": "SAP",
-		"sapPartner": true,
 		"labels": {
 			"label-key-1": ["label-value-1", "label-value-2"]
-		}
+		},
+		"ordId": "ns:vendor:id:",
+		"partners": [
+		"microsoft:vendor:Microsoft:"
+		],
+		"title": "SAP"
 	}]
 }`

--- a/components/schema-migrator/migrations/director/20210512130350_adapt_ord_rc3.down.sql
+++ b/components/schema-migrator/migrations/director/20210512130350_adapt_ord_rc3.down.sql
@@ -1,0 +1,19 @@
+BEGIN;
+
+DROP VIEW partners;
+
+DROP VIEW api_definition_extensible;
+
+DROP VIEW event_api_definition_extensible;
+
+ALTER TABLE vendors
+    ADD COLUMN sap_partner BOOLEAN,
+    DROP COLUMN partners;
+
+ALTER TABLE api_definitions
+    DROP COLUMN extensible;
+
+ALTER TABLE event_api_definitions
+    DROP COLUMN extensible;
+
+COMMIT;

--- a/components/schema-migrator/migrations/director/20210512130350_adapt_ord_rc3.up.sql
+++ b/components/schema-migrator/migrations/director/20210512130350_adapt_ord_rc3.up.sql
@@ -1,0 +1,33 @@
+BEGIN;
+
+ALTER TABLE vendors
+    DROP COLUMN sap_partner,
+    ADD COLUMN partners JSONB;
+
+ALTER TABLE api_definitions
+    ADD COLUMN extensible JSONB;
+
+ALTER TABLE event_api_definitions
+    ADD COLUMN extensible JSONB;
+
+CREATE VIEW partners AS
+SELECT vendors.ord_id AS vendor_id,
+       elements.value AS value
+FROM vendors,
+     jsonb_array_elements_text(vendors.partners) AS elements;
+
+CREATE VIEW api_definition_extensible AS
+SELECT id                  AS api_definition_id,
+       actions.supported   AS supported,
+       actions.description AS description
+FROM api_definitions,
+     jsonb_to_record(api_definitions.extensible) AS actions(supported TEXT, description TEXT);
+
+CREATE VIEW event_api_definitions_extensible AS
+SELECT id                  AS event_definition_id,
+       actions.supported   AS supported,
+       actions.description AS description
+FROM event_api_definitions,
+     jsonb_to_record(event_api_definitions.extensible) AS actions(supported TEXT, description TEXT);
+
+COMMIT;

--- a/components/schema-migrator/migrations/director/20210512130350_adapt_ord_rc3.up.sql
+++ b/components/schema-migrator/migrations/director/20210512130350_adapt_ord_rc3.up.sql
@@ -23,7 +23,7 @@ SELECT id                  AS api_definition_id,
 FROM api_definitions,
      jsonb_to_record(api_definitions.extensible) AS actions(supported TEXT, description TEXT);
 
-CREATE VIEW event_api_definitions_extensible AS
+CREATE VIEW event_api_definition_extensible AS
 SELECT id                  AS event_definition_id,
        actions.supported   AS supported,
        actions.description AS description


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:
 - Validation when the ORD docs have APIResources of policyLevel='sap' or 'sap-partner' and with apiProtocol='soap-inbound' or 'soap-outbound', then it is mandatory to provide either WSDL V2 or WSDL V1 definitions.
 - Validation when the ORD docs have APIResources of policyLevel='sap' or 'sap-partner' and with apiProtocol='odata-v2' or 'odata-v4', then it is mandatory to not only provide edmx definitions, but also OpenAPI definitions.
- Replaced Vendor.sapPartner property with a more generic Vendor.partners property
- Renamed PackageLink.type enum value licence to license


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- ...

**Pull Request status**
<!-- Feel free to construct the checklist with whatever items seem most reasonable for your change. You could disassemble the Implementation part to even smaller separate checklist items if you're working on something big for example. But do make the effort to provide a checklist of some sort so that the core team as well as the community can have an idea about the progress of your Pull Request.
-->

- [x] Implementation
- [x] Unit tests
- [ ] Integration tests
- [x] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
