### PR TITLE
Add additional label to operations_near_reconciliation_timeout_count

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -59,7 +59,7 @@ global:
       version: "PR-1850"
     operations_controller:
       dir:
-      version: "PR-1859"
+      version: "PR-1863"
     tenant_fetcher:
       dir:
       version: "PR-1828"

--- a/components/operations-controller/controllers/operation_controller.go
+++ b/components/operations-controller/controllers/operation_controller.go
@@ -261,7 +261,7 @@ func (r *OperationReconciler) requeueUnlessTimeoutOrFatalError(ctx context.Conte
 
 func (r *OperationReconciler) finalizeStatus(ctx context.Context, operation *v1alpha1.Operation, errorMsg *string, webhook *graphql.Webhook) (ctrl.Result, error) {
 	if isCloseToTimeout(operation.Status.InitializedAt.Time, r.determineTimeout(webhook)) {
-		r.metricsCollector.RecordOperationInProgressNearTimeout(string(operation.Spec.OperationType))
+		r.metricsCollector.RecordOperationInProgressNearTimeout(string(operation.Spec.OperationType), operation.ObjectMeta.Name)
 	}
 
 	if errorMsg != nil && *errorMsg != "" {
@@ -290,7 +290,7 @@ func (r *OperationReconciler) finalizeStatus(ctx context.Context, operation *v1a
 
 func (r *OperationReconciler) finalizeStatusSuccess(ctx context.Context, operation *v1alpha1.Operation, webhook *graphql.Webhook) (ctrl.Result, error) {
 	if isCloseToTimeout(operation.Status.InitializedAt.Time, r.determineTimeout(webhook)) {
-		r.metricsCollector.RecordOperationInProgressNearTimeout(string(operation.Spec.OperationType))
+		r.metricsCollector.RecordOperationInProgressNearTimeout(string(operation.Spec.OperationType), operation.ObjectMeta.Name)
 	}
 
 	if err := r.directorClient.UpdateOperation(ctx, prepareDirectorRequest(operation)); err != nil {
@@ -311,7 +311,7 @@ func (r *OperationReconciler) finalizeStatusSuccess(ctx context.Context, operati
 
 func (r *OperationReconciler) finalizeStatusWithError(ctx context.Context, operation *v1alpha1.Operation, opErr error, webhook *graphql.Webhook) (ctrl.Result, error) {
 	if operation != nil && isCloseToTimeout(operation.Status.InitializedAt.Time, r.determineTimeout(webhook)) {
-		r.metricsCollector.RecordOperationInProgressNearTimeout(string(operation.Spec.OperationType))
+		r.metricsCollector.RecordOperationInProgressNearTimeout(string(operation.Spec.OperationType), operation.ObjectMeta.Name)
 	}
 
 	r.metricsCollector.RecordError(operation.ObjectMeta.Name,

--- a/components/operations-controller/internal/metrics/collector.go
+++ b/components/operations-controller/internal/metrics/collector.go
@@ -35,7 +35,7 @@ func NewCollector() *Collector {
 			Subsystem: Subsystem,
 			Name:      "operations_near_reconciliation_timeout_count",
 			Help:      "Count of Operations succeeded/failed which were InProgress close to reconciliation timeout.",
-		}, []string{"type"}),
+		}, []string{"type", "name"}),
 	}
 }
 
@@ -59,6 +59,6 @@ func (c *Collector) RecordError(name, correlationID, operationType, category, re
 	c.operationErrorCount.WithLabelValues(name, correlationID, operationType, category, requestObject, error).Inc()
 }
 
-func (c *Collector) RecordOperationInProgressNearTimeout(operationType string) {
-	c.operationNearTimeoutCount.WithLabelValues(operationType).Inc()
+func (c *Collector) RecordOperationInProgressNearTimeout(operationType, operationName string) {
+	c.operationNearTimeoutCount.WithLabelValues(operationType, operationName).Inc()
 }


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:
- add label `name` to `operations_near_reconciliation_timeout_count` metric