### PR TITLE
Improve benchmark test

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -85,7 +85,7 @@ global:
       version: "PR-31"
     e2e_tests:
       dir:
-      version: "PR-1860"
+      version: "PR-1874"
   isLocalEnv: false
   oauth2:
     host: oauth2


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:
- Exclude cleanup logic from the benchmark time.
- Do not use the retry library for benchmarked requests.

