### PR TITLE
Fix logging response writer

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -53,7 +53,7 @@ global:
       version: "PR-1868"
     director:
       dir:
-      version: "PR-1878"
+      version: "PR-1882"
     gateway:
       dir:
       version: "PR-1868"

--- a/components/director/pkg/log/logging_response_writer.go
+++ b/components/director/pkg/log/logging_response_writer.go
@@ -20,7 +20,8 @@ import "net/http"
 
 type responseWriter struct {
 	http.ResponseWriter
-	statusCode int
+	statusCode  int
+	wroteHeader bool
 }
 
 func newLoggingResponseWriter(w http.ResponseWriter) *responseWriter {
@@ -31,6 +32,9 @@ func newLoggingResponseWriter(w http.ResponseWriter) *responseWriter {
 }
 
 func (lrw *responseWriter) WriteHeader(code int) {
-	lrw.statusCode = code
-	lrw.ResponseWriter.WriteHeader(code)
+	if !lrw.wroteHeader {
+		lrw.statusCode = code
+		lrw.ResponseWriter.WriteHeader(code)
+		lrw.wroteHeader = true
+	}
 }


### PR DESCRIPTION
**Description**

Currently, in the gateway, we have both a timeout handler and a proxy.

When a timeout is reached timeout handler returns 503 status code and cancels the context.

Once the context is canceled the error handler of the gateway's reverse proxy kicks in and returns 502 status code.

However the user already received 503 status code with a timeout error, but the logging response writer will override it with 502 of the second execution and the log will be misleading.

The same happens with the error presenter and timeout handler in director. 503 is returned to the client and 200 is logged in the logs.



