### PR TITLE
Make WebhookInput's outputTemplate field mandatory for certain webhook types

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -53,7 +53,7 @@ global:
       version: "PR-1884"
     director:
       dir:
-      version: "PR-1883"
+      version: "PR-1891"
     gateway:
       dir:
       version: "PR-1884"

--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -85,7 +85,7 @@ global:
       version: "PR-33"
     e2e_tests:
       dir:
-      version: "PR-1878"
+      version: "PR-1891"
   isLocalEnv: false
   oauth2:
     host: oauth2

--- a/components/director/pkg/graphql/webhook_validation.go
+++ b/components/director/pkg/graphql/webhook_validation.go
@@ -84,11 +84,11 @@ func (i WebhookInput) Validate() error {
 }
 
 func isOutTemplateMandatory(webhookType WebhookType) bool {
-	outTmplMandatoryTypes := map[WebhookType]struct{}{
-		WebhookTypeRegisterApplication:   {},
-		WebhookTypeUnregisterApplication: {},
+	switch webhookType {
+	case WebhookTypeRegisterApplication,
+		WebhookTypeUnregisterApplication:
+		return true
+	default:
+		return false
 	}
-
-	_, ok := outTmplMandatoryTypes[webhookType]
-	return ok
 }

--- a/components/director/pkg/graphql/webhook_validation.go
+++ b/components/director/pkg/graphql/webhook_validation.go
@@ -49,6 +49,10 @@ func (i WebhookInput) Validate() error {
 		}
 	}
 
+	if i.OutputTemplate == nil && isOutTemplateMandatory(i.Type) {
+		return apperrors.NewInvalidDataError("outputTemplate is required for type: %v", i.Type)
+	}
+
 	var responseObject webhook.ResponseObject
 	if i.OutputTemplate != nil {
 		if _, err := responseObject.ParseOutputTemplate(i.OutputTemplate); err != nil {
@@ -77,4 +81,14 @@ func (i WebhookInput) Validate() error {
 		validation.Field(&i.Timeout, validation.Min(0)),
 		validation.Field(&i.Auth),
 	)
+}
+
+func isOutTemplateMandatory(webhookType WebhookType) bool {
+	outTmplMandatoryTypes := map[WebhookType]struct{}{
+		WebhookTypeRegisterApplication:   {},
+		WebhookTypeUnregisterApplication: {},
+	}
+
+	_, ok := outTmplMandatoryTypes[webhookType]
+	return ok
 }

--- a/components/director/pkg/graphql/webhook_validation_test.go
+++ b/components/director/pkg/graphql/webhook_validation_test.go
@@ -684,6 +684,51 @@ func TestWebhookInput_Validate_AsyncWebhook_MissingLocationInOutputTemplate_Shou
 	require.Error(t, err)
 }
 
+func TestWebhookInput_Validate_MissingOutputTemplateForCertainTypes(t *testing.T) {
+	testCases := []struct {
+		Name          string
+		Type          graphql.WebhookType
+		ExpectedValid bool
+	}{
+		{
+			Name:          "Success when missing for type: OPEN_RESOURCE_DISCOVERY",
+			ExpectedValid: true,
+			Type:          graphql.WebhookTypeOpenResourceDiscovery,
+		},
+		{
+			Name:          "Success when missing for type: CONFIGURATION_CHANGED",
+			ExpectedValid: true,
+			Type:          graphql.WebhookTypeConfigurationChanged,
+		},
+		{
+			Name:          "Fails when missing for type: UNREGISTER_APPLICATION",
+			ExpectedValid: false,
+			Type:          graphql.WebhookTypeUnregisterApplication,
+		},
+		{
+			Name:          "Fails when missing for type: REGISTER_APPLICATION",
+			ExpectedValid: false,
+			Type:          graphql.WebhookTypeRegisterApplication,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Name, func(t *testing.T) {
+			input := fixValidWebhookInput(inputvalidationtest.ValidURL)
+			input.OutputTemplate = nil
+			input.Type = testCase.Type
+
+			err := input.Validate()
+			if testCase.ExpectedValid {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+			}
+		})
+	}
+
+}
+
 func fixValidWebhookInput(url string) graphql.WebhookInput {
 	template := `{}`
 	outputTemplate := `{

--- a/tests/director/tests/application_api_test.go
+++ b/tests/director/tests/application_api_test.go
@@ -650,12 +650,13 @@ func TestUpdateApplicationParts(t *testing.T) {
 
 	t.Run("manage webhooks", func(t *testing.T) {
 		// add
-
+		outputTemplate := "{\"location\":\"{{.Headers.Location}}\",\"success_status_code\": 202,\"error\": \"{{.Body.error}}\"}"
 		url := "http://new-webhook.url"
 		urlUpdated := "http://updated-webhook.url"
 		webhookInStr, err := testctx.Tc.Graphqlizer.WebhookInputToGQL(&graphql.WebhookInput{
-			URL:  &url,
-			Type: graphql.WebhookTypeUnregisterApplication,
+			URL:            &url,
+			Type:           graphql.WebhookTypeUnregisterApplication,
+			OutputTemplate: &outputTemplate,
 		})
 
 		require.NoError(t, err)

--- a/tests/director/tests/application_api_test.go
+++ b/tests/director/tests/application_api_test.go
@@ -650,7 +650,7 @@ func TestUpdateApplicationParts(t *testing.T) {
 
 	t.Run("manage webhooks", func(t *testing.T) {
 		// add
-		outputTemplate := "{\"location\":\"{{.Headers.Location}}\",\"success_status_code\": 202,\"error\": \"{{.Body.error}}\"}"
+		outputTemplate := "{\\\"location\\\":\\\"{{.Headers.Location}}\\\",\\\"success_status_code\\\": 202,\\\"error\\\": \\\"{{.Body.error}}\\\"}"
 		url := "http://new-webhook.url"
 		urlUpdated := "http://updated-webhook.url"
 		webhookInStr, err := testctx.Tc.Graphqlizer.WebhookInputToGQL(&graphql.WebhookInput{
@@ -679,7 +679,7 @@ func TestUpdateApplicationParts(t *testing.T) {
 
 		// update
 		webhookInStr, err = testctx.Tc.Graphqlizer.WebhookInputToGQL(&graphql.WebhookInput{
-			URL: &urlUpdated, Type: graphql.WebhookTypeUnregisterApplication})
+			URL: &urlUpdated, Type: graphql.WebhookTypeUnregisterApplication, OutputTemplate: &outputTemplate})
 
 		require.NoError(t, err)
 		updateReq := fixtures.FixUpdateWebhookRequest(actualWebhook.ID, webhookInStr)

--- a/tests/director/tests/application_templates_api_test.go
+++ b/tests/director/tests/application_templates_api_test.go
@@ -245,7 +245,7 @@ func TestAddWebhookToApplicationTemplate(t *testing.T) {
 	// add
 	url := "http://new-webhook.url"
 	urlUpdated := "http://updated-webhook.url"
-	outputTemplate := "{\"location\":\"{{.Headers.Location}}\",\"success_status_code\": 202,\"error\": \"{{.Body.error}}\"}"
+	outputTemplate := "{\\\"location\\\":\\\"{{.Headers.Location}}\\\",\\\"success_status_code\\\": 202,\\\"error\\\": \\\"{{.Body.error}}\\\"}"
 
 	webhookInStr, err := testctx.Tc.Graphqlizer.WebhookInputToGQL(&graphql.WebhookInput{
 		URL:            &url,

--- a/tests/director/tests/application_templates_api_test.go
+++ b/tests/director/tests/application_templates_api_test.go
@@ -245,9 +245,12 @@ func TestAddWebhookToApplicationTemplate(t *testing.T) {
 	// add
 	url := "http://new-webhook.url"
 	urlUpdated := "http://updated-webhook.url"
+	outputTemplate := "{\"location\":\"{{.Headers.Location}}\",\"success_status_code\": 202,\"error\": \"{{.Body.error}}\"}"
+
 	webhookInStr, err := testctx.Tc.Graphqlizer.WebhookInputToGQL(&graphql.WebhookInput{
-		URL:  &url,
-		Type: graphql.WebhookTypeUnregisterApplication,
+		URL:            &url,
+		Type:           graphql.WebhookTypeUnregisterApplication,
+		OutputTemplate: &outputTemplate,
 	})
 
 	require.NoError(t, err)
@@ -278,7 +281,9 @@ func TestAddWebhookToApplicationTemplate(t *testing.T) {
 	assert.Len(t, updatedAppTemplate.Webhooks, 1)
 
 	webhookInStr, err = testctx.Tc.Graphqlizer.WebhookInputToGQL(&graphql.WebhookInput{
-		URL: &urlUpdated, Type: graphql.WebhookTypeUnregisterApplication,
+		URL:            &urlUpdated,
+		Type:           graphql.WebhookTypeUnregisterApplication,
+		OutputTemplate: &outputTemplate,
 	})
 	require.NoError(t, err)
 

--- a/tests/director/tests/sensitive_data_strip_test.go
+++ b/tests/director/tests/sensitive_data_strip_test.go
@@ -237,7 +237,7 @@ func gqlClient(t *testing.T, creds *graphql.OAuthCredentialData, scopes string) 
 
 func appWithAPIsAndEvents(name string) graphql.ApplicationRegisterInput {
 	webhookURL := "http://test-url.com"
-	webhookOutputTemplate := "{\"location\":\"{{.Headers.Location}}\",\"success_status_code\": 202,\"error\": \"{{.Body.error}}\"}"
+	webhookOutputTemplate := "{\\\"location\\\":\\\"{{.Headers.Location}}\\\",\\\"success_status_code\\\": 202,\\\"error\\\": \\\"{{.Body.error}}\\\"}"
 	auth := &graphql.AuthInput{
 		Credential: &graphql.CredentialDataInput{
 			Basic: &graphql.BasicCredentialDataInput{

--- a/tests/director/tests/sensitive_data_strip_test.go
+++ b/tests/director/tests/sensitive_data_strip_test.go
@@ -237,6 +237,7 @@ func gqlClient(t *testing.T, creds *graphql.OAuthCredentialData, scopes string) 
 
 func appWithAPIsAndEvents(name string) graphql.ApplicationRegisterInput {
 	webhookURL := "http://test-url.com"
+	webhookOutputTemplate := "{\"location\":\"{{.Headers.Location}}\",\"success_status_code\": 202,\"error\": \"{{.Body.error}}\"}"
 	auth := &graphql.AuthInput{
 		Credential: &graphql.CredentialDataInput{
 			Basic: &graphql.BasicCredentialDataInput{
@@ -282,9 +283,10 @@ func appWithAPIsAndEvents(name string) graphql.ApplicationRegisterInput {
 			}},
 		}},
 		Webhooks: []*graphql.WebhookInput{{
-			Type: graphql.WebhookTypeUnregisterApplication,
-			URL:  &webhookURL,
-			Auth: auth,
+			Type:           graphql.WebhookTypeUnregisterApplication,
+			URL:            &webhookURL,
+			Auth:           auth,
+			OutputTemplate: &webhookOutputTemplate,
 		}},
 	}
 }


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:
- Currently it is possible to register/unregister resource in `ASYNC` mode with REGISTER_APPLICATION / UNREGISTER_APPLICATION webhook type. The WebhookInput field `outputTemplate` should be mandatory. `operations-controller` expect it to be available.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- ...

**Pull Request status**
<!-- Feel free to construct the checklist with whatever items seem most reasonable for your change. You could disassemble the Implementation part to even smaller separate checklist items if you're working on something big for example. But do make the effort to provide a checklist of some sort so that the core team as well as the community can have an idea about the progress of your Pull Request.
-->

- [x] Implementation
- [x] Unit tests
- [ ] Integration tests
- [x] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
