### PR TITLE
Introduce automatic vendor assignment

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -53,7 +53,7 @@ global:
       version: "PR-1884"
     director:
       dir:
-      version: "PR-1883"
+      version: "PR-1894"
     gateway:
       dir:
       version: "PR-1884"

--- a/components/director/internal/open_resource_discovery/service.go
+++ b/components/director/internal/open_resource_discovery/service.go
@@ -133,6 +133,12 @@ func (s *Service) processApp(ctx context.Context, app *model.Application) error 
 }
 
 func (s *Service) processDocuments(ctx context.Context, appID string, baseURL string, documents Documents) error {
+	// TODO: Currently it isn't mandatory Vendor resources to be declared in the Documents because there is a concept of a central registry from where Vendors will be fetched once.
+	// However, until this registry concept is production ready, we should make sure that if no SAP Vendor resource is explicitly declared across all Documents of a System Instance to
+	// assign it once for it so that all resources referencing that SAP Vendor will not fail.
+	// NOTE: to be deleted once the concept of central registry for Vendors fetching is productive
+	assignSAPVendor(documents)
+
 	if err := documents.Validate(baseURL); err != nil {
 		return errors.Wrap(err, "invalid documents")
 	}
@@ -586,6 +592,29 @@ func extractBundleReferencesForDeletion(allBundleIDsForAPI []string, defaultTarg
 	}
 
 	return bundleIDsToBeDeleted, nil
+}
+
+func assignSAPVendor(documents Documents) {
+	isSAPVendorFound := false
+	for _, doc := range documents {
+		for _, vendor := range doc.Vendors {
+			if vendor.OrdID == SapVendor {
+				isSAPVendorFound = true
+				break
+			}
+		}
+		if isSAPVendorFound {
+			break
+		}
+	}
+
+	if !isSAPVendorFound {
+		sapVendor := model.VendorInput{
+			OrdID: SapVendor,
+			Title: SapTitle,
+		}
+		documents[0].Vendors = append(documents[0].Vendors, &sapVendor)
+	}
 }
 
 func equalStrings(first, second *string) bool {

--- a/components/director/internal/open_resource_discovery/service.go
+++ b/components/director/internal/open_resource_discovery/service.go
@@ -595,26 +595,19 @@ func extractBundleReferencesForDeletion(allBundleIDsForAPI []string, defaultTarg
 }
 
 func assignSAPVendor(documents Documents) {
-	isSAPVendorFound := false
 	for _, doc := range documents {
 		for _, vendor := range doc.Vendors {
 			if vendor.OrdID == SapVendor {
-				isSAPVendorFound = true
-				break
+				return
 			}
-		}
-		if isSAPVendorFound {
-			break
 		}
 	}
 
-	if !isSAPVendorFound {
-		sapVendor := model.VendorInput{
-			OrdID: SapVendor,
-			Title: SapTitle,
-		}
-		documents[0].Vendors = append(documents[0].Vendors, &sapVendor)
+	sapVendor := model.VendorInput{
+		OrdID: SapVendor,
+		Title: SapTitle,
 	}
+	documents[0].Vendors = append(documents[0].Vendors, &sapVendor)
 }
 
 func equalStrings(first, second *string) bool {

--- a/components/director/internal/open_resource_discovery/service_test.go
+++ b/components/director/internal/open_resource_discovery/service_test.go
@@ -22,7 +22,6 @@ func TestService_SyncORDDocuments(t *testing.T) {
 	sanitizedDoc := fixSanitizedORDDocument()
 	var nilSpecInput *model.SpecInput
 	var nilBundleID *string
-	sapVendorTitle := "SAP SE"
 
 	secondTransactionNotCommited := func() (*persistenceautomock.PersistenceTx, *persistenceautomock.Transactioner) {
 		persistTx := &persistenceautomock.PersistenceTx{}
@@ -96,16 +95,16 @@ func TestService_SyncORDDocuments(t *testing.T) {
 	successfulSAPVendorUpdate := func() *automock.VendorService {
 		vendorSvc := &automock.VendorService{}
 		sapVendor := model.VendorInput{
-			OrdID: vendorORDID,
-			Title: sapVendorTitle,
+			OrdID: open_resource_discovery.SapVendor,
+			Title: open_resource_discovery.SapTitle,
 		}
 
 		modelVendor := []*model.Vendor{
 			{
-				OrdID:         vendorORDID,
+				OrdID:         open_resource_discovery.SapVendor,
 				TenantID:      tenantID,
 				ApplicationID: appID,
-				Title:         sapVendorTitle,
+				Title:         open_resource_discovery.SapTitle,
 			}}
 
 		vendorSvc.On("ListByApplicationID", txtest.CtxWithDBMatcher(), appID).Return(modelVendor, nil).Once()
@@ -126,16 +125,16 @@ func TestService_SyncORDDocuments(t *testing.T) {
 	successfulSAPVendorCreate := func() *automock.VendorService {
 		vendorSvc := &automock.VendorService{}
 		sapVendor := model.VendorInput{
-			OrdID: vendorORDID,
-			Title: sapVendorTitle,
+			OrdID: open_resource_discovery.SapVendor,
+			Title: open_resource_discovery.SapTitle,
 		}
 
 		modelVendor := []*model.Vendor{
 			{
-				OrdID:         vendorORDID,
+				OrdID:         open_resource_discovery.SapVendor,
 				TenantID:      tenantID,
 				ApplicationID: appID,
-				Title:         sapVendorTitle,
+				Title:         open_resource_discovery.SapTitle,
 			}}
 
 		vendorSvc.On("ListByApplicationID", txtest.CtxWithDBMatcher(), appID).Return(nil, nil).Once()
@@ -1103,7 +1102,7 @@ func TestService_SyncORDDocuments(t *testing.T) {
 		},
 		// TODO: Delete the two tests below after the concept of central registry for Vendors fetching is productive
 		{
-			Name: "Success when resources are not in db and no Vendor is declared in Documents should Create them",
+			Name: "Success when resources are not in db and no SAP Vendor is declared in Documents should Create them",
 			TransactionerFn: func() (*persistenceautomock.PersistenceTx, *persistenceautomock.Transactioner) {
 				return txGen.ThatSucceedsMultipleTimes(2)
 			},
@@ -1139,7 +1138,7 @@ func TestService_SyncORDDocuments(t *testing.T) {
 			},
 		},
 		{
-			Name: "Success when resources are already in db and no Vendor is declared in Documents should Update them",
+			Name: "Success when resources are already in db and no SAP Vendor is declared in Documents should Update them",
 			TransactionerFn: func() (*persistenceautomock.PersistenceTx, *persistenceautomock.Transactioner) {
 				return txGen.ThatSucceedsMultipleTimes(2)
 			},

--- a/components/director/internal/open_resource_discovery/service_test.go
+++ b/components/director/internal/open_resource_discovery/service_test.go
@@ -22,6 +22,7 @@ func TestService_SyncORDDocuments(t *testing.T) {
 	sanitizedDoc := fixSanitizedORDDocument()
 	var nilSpecInput *model.SpecInput
 	var nilBundleID *string
+	sapVendorTitle := "SAP SE"
 
 	secondTransactionNotCommited := func() (*persistenceautomock.PersistenceTx, *persistenceautomock.Transactioner) {
 		persistTx := &persistenceautomock.PersistenceTx{}
@@ -92,12 +93,54 @@ func TestService_SyncORDDocuments(t *testing.T) {
 		return vendorSvc
 	}
 
+	successfulSAPVendorUpdate := func() *automock.VendorService {
+		vendorSvc := &automock.VendorService{}
+		sapVendor := model.VendorInput{
+			OrdID: vendorORDID,
+			Title: sapVendorTitle,
+		}
+
+		modelVendor := []*model.Vendor{
+			{
+				OrdID:         vendorORDID,
+				TenantID:      tenantID,
+				ApplicationID: appID,
+				Title:         sapVendorTitle,
+			}}
+
+		vendorSvc.On("ListByApplicationID", txtest.CtxWithDBMatcher(), appID).Return(modelVendor, nil).Once()
+		vendorSvc.On("Update", txtest.CtxWithDBMatcher(), vendorORDID, sapVendor).Return(nil).Once()
+		vendorSvc.On("ListByApplicationID", txtest.CtxWithDBMatcher(), appID).Return(modelVendor, nil).Once()
+		return vendorSvc
+	}
+
 	successfulVendorCreate := func() *automock.VendorService {
 		vendorSvc := &automock.VendorService{}
 		vendorSvc.On("ListByApplicationID", txtest.CtxWithDBMatcher(), appID).Return(nil, nil).Once()
 		vendorSvc.On("Create", txtest.CtxWithDBMatcher(), appID, *sanitizedDoc.Vendors[0]).Return("", nil).Once()
 		vendorSvc.On("Create", txtest.CtxWithDBMatcher(), appID, *sanitizedDoc.Vendors[1]).Return("", nil).Once()
 		vendorSvc.On("ListByApplicationID", txtest.CtxWithDBMatcher(), appID).Return(fixVendors(), nil).Once()
+		return vendorSvc
+	}
+
+	successfulSAPVendorCreate := func() *automock.VendorService {
+		vendorSvc := &automock.VendorService{}
+		sapVendor := model.VendorInput{
+			OrdID: vendorORDID,
+			Title: sapVendorTitle,
+		}
+
+		modelVendor := []*model.Vendor{
+			{
+				OrdID:         vendorORDID,
+				TenantID:      tenantID,
+				ApplicationID: appID,
+				Title:         sapVendorTitle,
+			}}
+
+		vendorSvc.On("ListByApplicationID", txtest.CtxWithDBMatcher(), appID).Return(nil, nil).Once()
+		vendorSvc.On("Create", txtest.CtxWithDBMatcher(), appID, sapVendor).Return("", nil).Once()
+		vendorSvc.On("ListByApplicationID", txtest.CtxWithDBMatcher(), appID).Return(modelVendor, nil).Once()
 		return vendorSvc
 	}
 
@@ -1054,6 +1097,81 @@ func TestService_SyncORDDocuments(t *testing.T) {
 				client := &automock.Client{}
 				doc := fixORDDocument()
 				doc.Tombstones[0].OrdID = bundleORDID
+				client.On("FetchOpenResourceDiscoveryDocuments", txtest.CtxWithDBMatcher(), baseURL).Return(open_resource_discovery.Documents{doc}, nil)
+				return client
+			},
+		},
+		// TODO: Delete the two tests below after the concept of central registry for Vendors fetching is productive
+		{
+			Name: "Success when resources are not in db and no Vendor is declared in Documents should Create them",
+			TransactionerFn: func() (*persistenceautomock.PersistenceTx, *persistenceautomock.Transactioner) {
+				return txGen.ThatSucceedsMultipleTimes(2)
+			},
+			appSvcFn:     successfulAppList,
+			webhookSvcFn: successfulWebhookList,
+			bundleSvcFn:  successfulBundleCreate,
+			apiSvcFn: func() *automock.APIService {
+				apiSvc := &automock.APIService{}
+				apiSvc.On("ListByApplicationID", txtest.CtxWithDBMatcher(), appID).Return(nil, nil).Once()
+				apiSvc.On("Create", txtest.CtxWithDBMatcher(), appID, nilBundleID, str.Ptr(packageID), *sanitizedDoc.APIResources[0], fixApi1SpecInputs(), map[string]string{bundleID: sanitizedDoc.APIResources[0].PartOfConsumptionBundles[0].DefaultTargetURL}).Return("", nil).Once()
+				apiSvc.On("Create", txtest.CtxWithDBMatcher(), appID, nilBundleID, str.Ptr(packageID), *sanitizedDoc.APIResources[1], fixApi2SpecInputs(), map[string]string{bundleID: "http://localhost:8080/some-api/v1"}).Return("", nil).Once()
+				apiSvc.On("ListByApplicationID", txtest.CtxWithDBMatcher(), appID).Return(fixAPIs(), nil).Once()
+				apiSvc.On("Delete", txtest.CtxWithDBMatcher(), api2ID).Return(nil).Once()
+				return apiSvc
+			},
+			eventSvcFn:   successfulEventCreate,
+			packageSvcFn: successfulPackageCreate,
+			productSvcFn: successfulProductCreate,
+			vendorSvcFn:  successfulSAPVendorCreate,
+			tombstoneSvcFn: func() *automock.TombstoneService {
+				tombstoneSvc := &automock.TombstoneService{}
+				tombstoneSvc.On("ListByApplicationID", txtest.CtxWithDBMatcher(), appID).Return(nil, nil).Once()
+				tombstoneSvc.On("Create", txtest.CtxWithDBMatcher(), appID, *sanitizedDoc.Tombstones[0]).Return("", nil).Once()
+				tombstoneSvc.On("ListByApplicationID", txtest.CtxWithDBMatcher(), appID).Return(fixTombstones(), nil).Once()
+				return tombstoneSvc
+			},
+			clientFn: func() *automock.Client {
+				client := &automock.Client{}
+				doc := fixORDDocument()
+				doc.Vendors = nil
+				client.On("FetchOpenResourceDiscoveryDocuments", txtest.CtxWithDBMatcher(), baseURL).Return(open_resource_discovery.Documents{doc}, nil)
+				return client
+			},
+		},
+		{
+			Name: "Success when resources are already in db and no Vendor is declared in Documents should Update them",
+			TransactionerFn: func() (*persistenceautomock.PersistenceTx, *persistenceautomock.Transactioner) {
+				return txGen.ThatSucceedsMultipleTimes(2)
+			},
+			appSvcFn:       successfulAppList,
+			webhookSvcFn:   successfulWebhookList,
+			bundleSvcFn:    successfulBundleUpdate,
+			bundleRefSvcFn: successfulBundleReferenceFetchingOfBundleIDs,
+			apiSvcFn: func() *automock.APIService {
+				apiSvc := &automock.APIService{}
+				apiSvc.On("ListByApplicationID", txtest.CtxWithDBMatcher(), appID).Return(fixAPIs(), nil).Once()
+				apiSvc.On("UpdateInManyBundles", txtest.CtxWithDBMatcher(), api1ID, *sanitizedDoc.APIResources[0], nilSpecInput, map[string]string{bundleID: sanitizedDoc.APIResources[0].PartOfConsumptionBundles[0].DefaultTargetURL}, map[string]string{}, []string{}).Return(nil).Once()
+				apiSvc.On("UpdateInManyBundles", txtest.CtxWithDBMatcher(), api2ID, *sanitizedDoc.APIResources[1], nilSpecInput, map[string]string{bundleID: "http://localhost:8080/some-api/v1"}, map[string]string{}, []string{}).Return(nil).Once()
+				apiSvc.On("ListByApplicationID", txtest.CtxWithDBMatcher(), appID).Return(fixAPIs(), nil).Once()
+				apiSvc.On("Delete", txtest.CtxWithDBMatcher(), api2ID).Return(nil).Once()
+				return apiSvc
+			},
+			eventSvcFn:   successfulEventUpdate,
+			specSvcFn:    successfulSpecUpdate,
+			packageSvcFn: successfulPackageUpdate,
+			productSvcFn: successfulProductUpdate,
+			vendorSvcFn:  successfulSAPVendorUpdate,
+			tombstoneSvcFn: func() *automock.TombstoneService {
+				tombstoneSvc := &automock.TombstoneService{}
+				tombstoneSvc.On("ListByApplicationID", txtest.CtxWithDBMatcher(), appID).Return(fixTombstones(), nil).Once()
+				tombstoneSvc.On("Update", txtest.CtxWithDBMatcher(), sanitizedDoc.Tombstones[0].OrdID, *sanitizedDoc.Tombstones[0]).Return(nil).Once()
+				tombstoneSvc.On("ListByApplicationID", txtest.CtxWithDBMatcher(), appID).Return(fixTombstones(), nil).Once()
+				return tombstoneSvc
+			},
+			clientFn: func() *automock.Client {
+				client := &automock.Client{}
+				doc := fixORDDocument()
+				doc.Vendors = nil
 				client.On("FetchOpenResourceDiscoveryDocuments", txtest.CtxWithDBMatcher(), baseURL).Return(open_resource_discovery.Documents{doc}, nil)
 				return client
 			},

--- a/components/director/internal/open_resource_discovery/validation.go
+++ b/components/director/internal/open_resource_discovery/validation.go
@@ -62,6 +62,7 @@ const (
 	ApiImplementationStandardCsnExposure   string = "sap:csn-exposure:v1"
 	ApiImplementationStandardCustom        string = "custom"
 
+	SapTitle      = "SAP SE"
 	SapVendor     = "sap:vendor:SAP:"
 	PartnerVendor = "partner:vendor:SAP:"
 )


### PR DESCRIPTION
**Description**

Currently it isn't mandatory Vendor resources to be declared in the Documents because there is a concept of a central registry from where Vendors will be fetched once. However, until this registry concept is production ready, we should make sure that if no SAP Vendor resource is explicitly declared across all Documents of a System Instance to assign it once for it so that all resources referencing that SAP Vendor will not fail.

**Pull Request status**

- [x] Implementation
- [x] Unit tests
- [ ] Integration tests
- [x] `chart/compass/values.yaml` is updated 
