### PR TITLE
Use XDS v3 API in EnvoyFilters

### DIFF
--- a/chart/compass/templates/oathkeeper-timeout-filter.yaml
+++ b/chart/compass/templates/oathkeeper-timeout-filter.yaml
@@ -22,7 +22,7 @@ spec:
         value:
           name: envoy.lua
           typed_config:
-            "@type": "type.googleapis.com/envoy.config.filter.http.lua.v2.Lua"
+            "@type": "type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua"
             inlineCode: |
               function envoy_on_request(request_handle)
                 request_handle:headers():add("x-envoy-upstream-rq-timeout-ms", "{{ .Values.global.oathkeeper.timeout_ms }}")

--- a/chart/compass/templates/rewrite-client-cert-filter.yaml
+++ b/chart/compass/templates/rewrite-client-cert-filter.yaml
@@ -22,7 +22,7 @@ spec:
         value:
           name: envoy.lua
           typed_config:
-            "@type": "type.googleapis.com/envoy.config.filter.http.lua.v2.Lua"
+            "@type": "type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua"
             inlineCode: |
               function envoy_on_request(request_handle)
                 local headers = request_handle:headers()

--- a/chart/compass/templates/rewrite-correlation-headers-filter.yaml
+++ b/chart/compass/templates/rewrite-correlation-headers-filter.yaml
@@ -20,7 +20,7 @@ spec:
         value:
           name: envoy.lua
           typed_config:
-            "@type": "type.googleapis.com/envoy.config.filter.http.lua.v2.Lua"
+            "@type": "type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua"
             inlineCode: |
               function expectedCorrelationHeaders()
                 local headers = {}

--- a/chart/compass/templates/rewrite-token-filter.yaml
+++ b/chart/compass/templates/rewrite-token-filter.yaml
@@ -22,7 +22,7 @@ spec:
         value:
           name: envoy.lua
           typed_config:
-            "@type": "type.googleapis.com/envoy.config.filter.http.lua.v2.Lua"
+            "@type": "type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua"
             inlineCode: |
               function envoy_on_request(request_handle)
                 function urldecode(s)


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:
- Use XDS v3 APIs instead of v2 in `EnvoyFilters` - the change is safe - v3 is supported by Istio 1.8.
Reference - https://istio.io/latest/news/releases/1.9.x/announcing-1.9/upgrade-notes/#envoyfilter-xds-v2-removal

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- Failing upgrade of Kyma (v1.22 has Istio 1.9) in https://github.com/kyma-project/control-plane/pull/782
