### PR TITLE
Fix oathkeeper token cache

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -53,7 +53,7 @@ global:
       version: "PR-1884"
     director:
       dir:
-      version: "PR-1889"
+      version: "PR-1906"
     gateway:
       dir:
       version: "PR-1884"

--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -269,7 +269,8 @@ global:
     port: 4455
     timeout_ms: 120000
     idTokenConfig:
-      claims: '{"scopes": "{{ print .Extra.scope }}", "tenant": "{{ print .Extra.tenant }}", "externalTenant": "{{ print .Extra.externalTenant }}", "consumerID": "{{ print .Extra.consumerID}}", "consumerType": "{{ print .Extra.consumerType }}"}'
+      # nonce in claims is used to mitigate oathkeeper's token cache which will result in usage of invalid tokens on JWKS rotation (done by kyma on post-upgrade).
+      claims: '{"scopes": "{{ print .Extra.scope }}", "tenant": "{{ print .Extra.tenant }}", "externalTenant": "{{ print .Extra.externalTenant }}", "consumerID": "{{ print .Extra.consumerID}}", "consumerType": "{{ print .Extra.consumerType }}", "nonce": "{{ print .Extra.nonce }}"}'
     mutators:
       runtimeMappingService:
         config:

--- a/components/director/cmd/director/main.go
+++ b/components/director/cmd/director/main.go
@@ -205,13 +205,12 @@ func main() {
 
 	if cfg.JWKSSyncPeriod != 0 {
 		logger.Infof("JWKS synchronization enabled. Sync period: %v", cfg.JWKSSyncPeriod)
-		periodicExecutor := executor.NewPeriodic(cfg.JWKSSyncPeriod, func(ctx context.Context) {
+		executor.NewPeriodic(cfg.JWKSSyncPeriod, func(ctx context.Context) {
 			err := authMiddleware.SynchronizeJWKS(ctx)
 			if err != nil {
 				logger.WithError(err).Errorf("An error has occurred while synchronizing JWKS: %v", err)
 			}
-		})
-		go periodicExecutor.Run(ctx)
+		}).Run(ctx)
 	}
 
 	packageToBundlesMiddleware := packagetobundles.NewHandler(transact)

--- a/components/director/internal/tenantmapping/handler.go
+++ b/components/director/internal/tenantmapping/handler.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/kyma-incubator/compass/components/director/pkg/authenticator"
 
@@ -126,6 +127,7 @@ func (h Handler) processRequest(ctx context.Context, reqData oathkeeper.ReqData,
 	reqData.Body.Extra["scope"] = objCtx.Scopes
 	reqData.Body.Extra["consumerID"] = objCtx.ConsumerID
 	reqData.Body.Extra["consumerType"] = objCtx.ConsumerType
+	reqData.Body.Extra["nonce"] = time.Now().Unix() // nonce in claims is used to mitigate oathkeeper's token cache which will result in usage of invalid tokens on JWKS rotation (done by kyma on post-upgrade).
 
 	return reqData.Body
 }

--- a/components/director/internal/tenantmapping/handler_test.go
+++ b/components/director/internal/tenantmapping/handler_test.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/tidwall/sjson"
+
 	"github.com/kyma-incubator/compass/components/director/pkg/authenticator"
 
 	"github.com/kyma-incubator/compass/components/director/pkg/persistence/txtest"
@@ -80,6 +82,9 @@ func TestHandler(t *testing.T) {
 		resp := w.Result()
 		require.Equal(t, http.StatusOK, resp.StatusCode)
 		body, err := ioutil.ReadAll(resp.Body)
+		require.NoError(t, err)
+
+		body, err = sjson.DeleteBytes(body, "extra.nonce")
 		require.NoError(t, err)
 
 		require.Equal(t, expectedRespPayload, strings.TrimSpace(string(body)))
@@ -154,6 +159,9 @@ func TestHandler(t *testing.T) {
 		resp := w.Result()
 		require.Equal(t, http.StatusOK, resp.StatusCode)
 		body, err := ioutil.ReadAll(resp.Body)
+		require.NoError(t, err)
+
+		body, err = sjson.DeleteBytes(body, "extra.nonce")
 		require.NoError(t, err)
 
 		require.Equal(t, expectedRespPayload, strings.TrimSpace(string(body)))
@@ -232,6 +240,9 @@ func TestHandler(t *testing.T) {
 		body, err := ioutil.ReadAll(resp.Body)
 		require.NoError(t, err)
 
+		body, err = sjson.DeleteBytes(body, "extra.nonce")
+		require.NoError(t, err)
+
 		require.Equal(t, expectedRespPayload, strings.TrimSpace(string(body)))
 
 		mock.AssertExpectationsForObjects(t, reqDataParserMock, persist, transact, userMockContextProvider)
@@ -297,6 +308,9 @@ func TestHandler(t *testing.T) {
 		body, err := ioutil.ReadAll(resp.Body)
 		require.NoError(t, err)
 
+		body, err = sjson.DeleteBytes(body, "extra.nonce")
+		require.NoError(t, err)
+
 		require.Equal(t, expectedRespPayload, strings.TrimSpace(string(body)))
 
 		mock.AssertExpectationsForObjects(t, reqDataParserMock, persist, transact, userMockContextProvider)
@@ -343,6 +357,9 @@ func TestHandler(t *testing.T) {
 		resp := w.Result()
 		require.Equal(t, http.StatusOK, resp.StatusCode)
 		body, err := ioutil.ReadAll(resp.Body)
+		require.NoError(t, err)
+
+		body, err = sjson.DeleteBytes(body, "extra.nonce")
 		require.NoError(t, err)
 
 		require.Equal(t, expectedRespPayload, strings.TrimSpace(string(body)))
@@ -394,6 +411,9 @@ func TestHandler(t *testing.T) {
 		body, err := ioutil.ReadAll(resp.Body)
 		require.NoError(t, err)
 
+		body, err = sjson.DeleteBytes(body, "extra.nonce")
+		require.NoError(t, err)
+
 		require.Equal(t, expectedRespPayload, strings.TrimSpace(string(body)))
 
 		mock.AssertExpectationsForObjects(t, reqDataParserMock, persist, transact, systemAuthMockContextProvider)
@@ -441,6 +461,9 @@ func TestHandler(t *testing.T) {
 		resp := w.Result()
 		require.Equal(t, http.StatusOK, resp.StatusCode)
 		body, err := ioutil.ReadAll(resp.Body)
+		require.NoError(t, err)
+
+		body, err = sjson.DeleteBytes(body, "extra.nonce")
 		require.NoError(t, err)
 
 		require.Equal(t, expectedRespPayload, strings.TrimSpace(string(body)))


### PR DESCRIPTION
### Problem

id_token mutator from oathkeeper maintains a token cache: https://github.com/ory/oathkeeper/blob/d942c043aa2370b87e0dd822440ad39d809755f9/pipeline/mutate/mutator_id_token.go

With the previous release, we updated the TTL of the token to 1h in order to mitigate interference with all the retry chain bugs identified. However, it looks like that the oathkeeper uses the same TTL for the token cache.

In addition, kyma have a job - https://github.com/kyma-project/kyma/blob/main/resources/ory/charts/oathkeeper/templates/job.yaml which rotates all the JWKs keys on helm upgrade.

So what happens is:
Me as a customer (or a runtime agent) perform a call to CMP:
1. Oathkeeper performs tenant-mapping and auth-mapping and then crafts an id_token
2. Caches this id_token for ttl duration - 1h
3. CMP CD pipepline installs new compass version
4. JWKs are rotated by the kyma post-upgrade job
5. All the tokes cached for 1h with the same set of claims are invalid. Therefore all the calls for a given tenant of a given client are failing.

This is especially bad for the runtimes, since they periodically do some kind of resyncs. This way they always will have a token cached and will fail for up to 1h after upgrade.

### Solution

Add a nonce value in the claims. For example we can add the time.Now().UTC() in the claims in order to guarantee that each token will have unique claims effectively disabling the cache.