### PR TITLE
Fix empty JWKS cache

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -62,7 +62,7 @@ global:
       version: "PR-1884"
     tenant_fetcher:
       dir:
-      version: "PR-1884"
+      version: "PR-1907"
     ord_service:
       dir:
       version: "PR-29"

--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -53,7 +53,7 @@ global:
       version: "PR-1884"
     director:
       dir:
-      version: "PR-1889"
+      version: "PR-1907"
     gateway:
       dir:
       version: "PR-1884"

--- a/components/director/internal/authenticator/middleware.go
+++ b/components/director/internal/authenticator/middleware.go
@@ -159,18 +159,23 @@ func (a *Authenticator) contextWithClaims(ctx context.Context, claims Claims) co
 
 func (a *Authenticator) getKeyFunc(ctx context.Context) func(token *jwt.Token) (interface{}, error) {
 	return func(token *jwt.Token) (interface{}, error) {
+		a.mux.RLock()
+		defer a.mux.RUnlock()
+
 		unsupportedErr := fmt.Errorf("unexpected signing method: %v", token.Method.Alg())
 
 		switch token.Method.Alg() {
 		case jwt.SigningMethodRS256.Name:
-			a.mux.RLock()
-			keys := a.cachedJWKS
-			a.mux.RUnlock()
-
 			keyID, err := a.getKeyID(*token)
 			if err != nil {
 				log.C(ctx).WithError(err).Errorf("An error occurred while getting the token signing key ID: %v", err)
 				return nil, errors.Wrap(err, "while getting the key ID")
+			}
+
+			if a.cachedJWKS == nil {
+				log.C(ctx).Debugf("Empty JWKS cache... Signing key %s is not found", keyID)
+				return nil, apperrors.NewKeyDoesNotExistError(keyID)
+
 			}
 
 			keyIterator := &authenticator.JWTKeyIterator{
@@ -182,13 +187,13 @@ func (a *Authenticator) getKeyFunc(ctx context.Context) func(token *jwt.Token) (
 				},
 			}
 
-			if err := arrayiter.Walk(ctx, keys, keyIterator); err != nil {
+			if err := arrayiter.Walk(ctx, a.cachedJWKS, keyIterator); err != nil {
 				log.C(ctx).WithError(err).Errorf("An error occurred while walking through the JWKS: %v", err)
 				return nil, err
 			}
 
 			if keyIterator.ResultingKey == nil {
-				log.C(ctx).Debug("Signing key is not found")
+				log.C(ctx).Debugf("Signing key %s is not found", keyID)
 				return nil, apperrors.NewKeyDoesNotExistError(keyID)
 			}
 

--- a/components/director/internal/authenticator/middleware.go
+++ b/components/director/internal/authenticator/middleware.go
@@ -175,7 +175,6 @@ func (a *Authenticator) getKeyFunc(ctx context.Context) func(token *jwt.Token) (
 			if a.cachedJWKS == nil {
 				log.C(ctx).Debugf("Empty JWKS cache... Signing key %s is not found", keyID)
 				return nil, apperrors.NewKeyDoesNotExistError(keyID)
-
 			}
 
 			keyIterator := &authenticator.JWTKeyIterator{

--- a/components/tenant-fetcher/internal/authenticator/middleware.go
+++ b/components/tenant-fetcher/internal/authenticator/middleware.go
@@ -155,7 +155,6 @@ func (a *Authenticator) getKeyFunc(ctx context.Context) func(token *jwt.Token) (
 			if a.cachedJWKS == nil {
 				log.C(ctx).Debugf("Empty JWKS cache... Signing key %s is not found", keyID)
 				return nil, apperrors.NewKeyDoesNotExistError(keyID)
-
 			}
 
 			keyIterator := &authenticator.JWTKeyIterator{

--- a/components/tenant-fetcher/internal/authenticator/middleware.go
+++ b/components/tenant-fetcher/internal/authenticator/middleware.go
@@ -139,18 +139,23 @@ func (a *Authenticator) parseClaimsWithRetry(ctx context.Context, bearerToken st
 
 func (a *Authenticator) getKeyFunc(ctx context.Context) func(token *jwt.Token) (interface{}, error) {
 	return func(token *jwt.Token) (interface{}, error) {
+		a.mux.RLock()
+		defer a.mux.RUnlock()
+
 		unsupportedErr := apperrors.NewInternalError("unexpected signing method: %s", token.Method.Alg())
 
 		switch token.Method.Alg() {
 		case jwt.SigningMethodRS256.Name:
-			a.mux.RLock()
-			keys := a.cachedJWKS
-			a.mux.RUnlock()
-
 			keyID, err := a.getKeyID(*token)
 			if err != nil {
 				log.C(ctx).WithError(err).Errorf("An error occurred while getting the token signing key ID: %v", err)
 				return nil, errors.Wrap(err, "while getting the key ID")
+			}
+
+			if a.cachedJWKS == nil {
+				log.C(ctx).Debugf("Empty JWKS cache... Signing key %s is not found", keyID)
+				return nil, apperrors.NewKeyDoesNotExistError(keyID)
+
 			}
 
 			keyIterator := &authenticator.JWTKeyIterator{
@@ -162,13 +167,13 @@ func (a *Authenticator) getKeyFunc(ctx context.Context) func(token *jwt.Token) (
 				},
 			}
 
-			if err := arrayiter.Walk(ctx, keys, keyIterator); err != nil {
+			if err := arrayiter.Walk(ctx, a.cachedJWKS, keyIterator); err != nil {
 				log.C(ctx).WithError(err).Errorf("An error occurred while walking through the jwks: %v", err)
 				return nil, err
 			}
 
 			if keyIterator.ResultingKey == nil {
-				log.C(ctx).Debug("Signing key is not found")
+				log.C(ctx).Debugf("Signing key %s is not found", keyID)
 				return nil, apperrors.NewKeyDoesNotExistError(keyID)
 			}
 


### PR DESCRIPTION
### Description

When JWKs synchronization fails on bootstrap we panic with nil pointer until the next JWKs sync.

This is the reason why the director does not initialize properly without oathkeeper.