### PR TITLE
Attach retry envoy filter on GW

### DIFF
--- a/chart/compass/templates/filters/disable-istio-retries-filter.yaml
+++ b/chart/compass/templates/filters/disable-istio-retries-filter.yaml
@@ -7,7 +7,7 @@ spec:
   configPatches:
     - applyTo: HTTP_FILTER
       match:
-        context: SIDECAR_OUTBOUND
+        context: ANY
         listener:
           filterChain:
             filter:

--- a/chart/compass/templates/filters/disable-istio-retries-filter.yaml
+++ b/chart/compass/templates/filters/disable-istio-retries-filter.yaml
@@ -1,8 +1,8 @@
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
-  name: disable-retries-filter
-  namespace: istio-system
+  name: {{ .Chart.Name }}-disable-retries-filter
+  namespace: {{ .Values.global.istio.namespace }}
 spec:
   configPatches:
     - applyTo: HTTP_FILTER


### PR DESCRIPTION
Retry envoy filter has to be attached on the ingress gw as well, otherwise calls coming from the ingress are still retried 2 times.