### PR TITLE
Fix tenant type in tenant-fetcher job

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -71,7 +71,7 @@ global:
       version: "PR-1910"
     director:
       dir:
-      version: "PR-1927"
+      version: "PR-1935"
     gateway:
       dir:
       version: "PR-1910"

--- a/components/director/internal/tenantfetcher/event_page.go
+++ b/components/director/internal/tenantfetcher/event_page.go
@@ -3,6 +3,7 @@ package tenantfetcher
 import (
 	"github.com/kyma-incubator/compass/components/director/internal/model"
 	"github.com/kyma-incubator/compass/components/director/pkg/log"
+	"github.com/kyma-incubator/compass/components/director/pkg/tenant"
 	"github.com/pkg/errors"
 	"github.com/tidwall/gjson"
 )
@@ -115,5 +116,6 @@ func (ep eventsPage) eventDataToTenant(eventType EventsType, eventData []byte) (
 		Name:           name,
 		ExternalTenant: id,
 		Provider:       ep.providerName,
+		Type:           string(tenant.Account),
 	}, nil
 }

--- a/components/director/internal/tenantfetcher/event_page_test.go
+++ b/components/director/internal/tenantfetcher/event_page_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"text/template"
 
+	"github.com/kyma-incubator/compass/components/director/pkg/tenant"
+
 	"github.com/kyma-incubator/compass/components/director/internal/model"
 	"github.com/stretchr/testify/assert"
 )
@@ -151,6 +153,7 @@ func Test_getTenantMappings(t *testing.T) {
 	expectedTenantMapping := model.BusinessTenantMappingInput{
 		ExternalTenant: id,
 		Name:           name,
+		Type:           string(tenant.Account),
 		Provider:       providerName,
 	}
 

--- a/components/director/internal/tenantfetcher/fixtures_test.go
+++ b/components/director/internal/tenantfetcher/fixtures_test.go
@@ -3,6 +3,8 @@ package tenantfetcher_test
 import (
 	"fmt"
 
+	"github.com/kyma-incubator/compass/components/director/pkg/tenant"
+
 	"github.com/google/uuid"
 
 	"github.com/kyma-incubator/compass/components/director/internal/model"
@@ -51,6 +53,7 @@ func fixBusinessTenantMappingInput(name, externalTenant, provider string) model.
 	return model.BusinessTenantMappingInput{
 		Name:           name,
 		ExternalTenant: externalTenant,
+		Type:           string(tenant.Account),
 		Provider:       provider,
 	}
 }

--- a/components/director/internal/tenantfetcher/service_test.go
+++ b/components/director/internal/tenantfetcher/service_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/kyma-incubator/compass/components/director/pkg/tenant"
+
 	"github.com/kyma-incubator/compass/components/director/internal/labelfilter"
 	"github.com/kyma-incubator/compass/components/director/pkg/apperrors"
 	"github.com/kyma-incubator/compass/components/director/pkg/resource"
@@ -308,6 +310,7 @@ func TestService_SyncTenants(t *testing.T) {
 				receivedTenants := []model.BusinessTenantMappingInput{{
 					Name:           "updated-name",
 					ExternalTenant: busTenant1.ExternalTenant,
+					Type:           string(tenant.Account),
 					Provider:       busTenant1.Provider,
 				}}
 


### PR DESCRIPTION
Currently tenant-fetcher job does not work because type field is missing but has NOT NULL constraint in DB.