### PR TITLE
Delete eventing label

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -75,7 +75,7 @@ global:
       version: "PR-1939"
     director:
       dir:
-      version: "PR-1958"
+      version: "PR-1960"
     gateway:
       dir:
       version: "PR-1939"

--- a/components/director/internal/domain/eventing/service.go
+++ b/components/director/internal/domain/eventing/service.go
@@ -334,7 +334,7 @@ func (s *service) getRuntimeForApplicationScenarios(ctx context.Context, tenantI
 	}
 
 	if !hasScenarios {
-		return nil, false, apperrors.NewInternalError("application does not belong to scenarios")
+		return nil, false, nil
 	}
 
 	runtime, err := s.runtimeRepo.GetByFiltersAndID(ctx, tenantID, runtimeID.String(), runtimeScenariosFilter)


### PR DESCRIPTION
-Delete default eventing label, when removing from formation

- [x] Implementation
- [x] Unit tests
- [x] Integration tests
- [x] `chart/compass/values.yaml` is updated
- [x] Mocks are regenerated, using the automated script
