### PR TITLE
Use the correct unix timestamp format in requests

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -75,7 +75,7 @@ global:
       version: "PR-1956"
     director:
       dir:
-      version: "PR-1961"
+      version: "PR-1969"
     gateway:
       dir:
       version: "PR-1956"

--- a/components/director/internal/tenantfetcher/service.go
+++ b/components/director/internal/tenantfetcher/service.go
@@ -131,7 +131,7 @@ func (s Service) SyncTenants() error {
 	if shouldFullResync {
 		log.C(ctx).Infof("Last full resync was %s ago. Will perform a full resync.", s.fullResyncInterval)
 		lastConsumedTenantTimestamp = "1"
-		newLastResyncTimestamp = convertTimeToUnixNanoString(startTime)
+		newLastResyncTimestamp = convertTimeToUnixMilliSecondString(startTime)
 	}
 
 	tenantsToCreate, err := s.getTenantsToCreate(lastConsumedTenantTimestamp)
@@ -200,7 +200,7 @@ func (s Service) SyncTenants() error {
 	if err = tx.Commit(); err != nil {
 		return err
 	}
-	if err = s.kubeClient.UpdateTenantFetcherConfigMapData(ctx, convertTimeToUnixNanoString(startTime), newLastResyncTimestamp); err != nil {
+	if err = s.kubeClient.UpdateTenantFetcherConfigMapData(ctx, convertTimeToUnixMilliSecondString(startTime), newLastResyncTimestamp); err != nil {
 		return err
 	}
 
@@ -523,10 +523,10 @@ func (s Service) shouldFullResync(lastFullResyncTimestamp string) (bool, error) 
 	if err != nil {
 		return false, err
 	}
-	ts := time.Unix(0, i)
+	ts := time.Unix(i/1000, 0)
 	return time.Now().After(ts.Add(s.fullResyncInterval)), nil
 }
 
-func convertTimeToUnixNanoString(timestamp time.Time) string {
-	return strconv.FormatInt(timestamp.UnixNano(), 10)
+func convertTimeToUnixMilliSecondString(timestamp time.Time) string {
+	return strconv.FormatInt(timestamp.UnixNano()/int64(time.Millisecond), 10)
 }

--- a/components/director/internal/tenantfetcher/service_test.go
+++ b/components/director/internal/tenantfetcher/service_test.go
@@ -146,6 +146,8 @@ func TestService_SyncTenants(t *testing.T) {
 	testErr := errors.New("test error")
 	txGen := txtest.NewTransactionContextGenerator(testErr)
 
+	tNowInMillis := strconv.FormatInt(time.Now().UnixNano()/int64(time.Millisecond), 10)
+
 	testCases := []struct {
 		Name                string
 		TransactionerFn     func() (*persistenceautomock.PersistenceTx, *persistenceautomock.Transactioner)
@@ -568,7 +570,7 @@ func TestService_SyncTenants(t *testing.T) {
 			},
 			KubeClientFn: func() *automock.KubeClient {
 				client := &automock.KubeClient{}
-				client.On("GetTenantFetcherConfigMapData", mock.Anything).Return("1", strconv.FormatInt(time.Now().UnixNano(), 10), nil).Once()
+				client.On("GetTenantFetcherConfigMapData", mock.Anything).Return("1", tNowInMillis, nil).Once()
 				client.On("UpdateTenantFetcherConfigMapData", mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
 				return client
 			},


### PR DESCRIPTION
**Description**
Use the correct unix timestamp format in requests

Changes proposed in this pull request:
- Use milliseconds instead of nanoseconds

**Related issue(s)**
- https://github.com/kyma-incubator/compass/pull/1965


- [x] Implementation
- [x] Unit tests
- [x] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->

