### PR TITLE
Introduce disablement of tests for db-dump

### DIFF
--- a/chart/compass/templates/tests/system-fetcher/system-fetcher-test.yaml
+++ b/chart/compass/templates/tests/system-fetcher/system-fetcher-test.yaml
@@ -9,6 +9,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    disable-db-dump: "true"
   namespace: {{ .Values.global.tests.namespace }}
 spec:
   template:

--- a/installation/scripts/prow/deploy-and-test.sh
+++ b/installation/scripts/prow/deploy-and-test.sh
@@ -41,4 +41,10 @@ else
     sudo ${INSTALLATION_DIR}/cmd/run.sh
 fi
 
-sudo ARTIFACTS=${ARTIFACTS} ${INSTALLATION_DIR}/scripts/testing.sh
+if [[ ${DUMP_DB} ]]; then
+    sudo ARTIFACTS=${ARTIFACTS} ${INSTALLATION_DIR}/scripts/testing.sh --dump-db true
+else
+    sudo ARTIFACTS=${ARTIFACTS} ${INSTALLATION_DIR}/scripts/testing.sh --dump-db false
+fi
+
+


### PR DESCRIPTION
Some test will take too long when executed within a cluster which is populated from DB dump. This PR introduces a functionality using which we can disable the execution of particular tests when DB dump is used.

**Description**

Changes proposed in this pull request:
- Add db-dump command line parameter and change the label selector used in ClusterTestSuites accordingly in testing.sh 
- Add necessary labels to system-fetcher test in order to exclude it from executions with db-dump
- Minor changes in deploy-and-test.sh script

**Pull Request status**

- [X] Implementation
- [ ] Unit tests
- [ ] Integration tests
- [ ] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [ ] Mocks are regenerated, using the automated script
