### PR TITLE
Remove regional config for migration persistence volume

### DIFF
--- a/chart/compass/templates/migrator-pvc.yaml
+++ b/chart/compass/templates/migrator-pvc.yaml
@@ -3,10 +3,6 @@ kind: PersistentVolumeClaim
 metadata:
   name: {{ .Values.global.migratorJob.pvc.name }}
   namespace: {{ .Values.global.migratorJob.pvc.namespace }}
-  annotations:
-  {{- if eq .Values.global.migratorJob.pvc.regional true }}
-    topology.kubernetes.io/region: {{ .Values.global.migratorJob.pvc.region }}
-  {{- end }}
   labels:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app: {{ .Chart.Name }}

--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -479,7 +479,6 @@ global:
     pvc:
       name: "compass-director-migrations"
       namespace: "compass-system"
-      regional: false
       migrationsPath: "/compass-migrations"
 
 pairing-adapter:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**


According to this:

>A PV can specify node affinity to define constraints that limit what nodes this volume can be accessed from. Pods that use a PV will only be scheduled to nodes that are selected by the node affinity. To specify node affinity, set nodeAffinity in the .spec of a PV. The PersistentVolume API reference has more details on this field.
source: https://kubernetes.io/docs/concepts/storage/persistent-volumes/#node-affinity

and this:

>When persistent volumes are created, the PersistentVolumeLabel admission controller automatically adds zone labels to any PersistentVolumes that are linked to a specific zone. The scheduler then ensures, through its NoVolumeZoneConflict predicate, that pods which claim a given PersistentVolume are only placed into the same zone as that volume.
source: https://kubernetes.io/docs/setup/best-practices/multiple-zones/#storage-access-for-zones

there's no need for explicit node selectors for the migration jobs, they should be schaduled on the node where the PV is.


Changes proposed in this pull request:
- Remove PV regional config from chart
