### PR TITLE
Fix ORD service test 2

### DIFF
--- a/chart/compass/templates/tests/ord-service/ord-service-test.yaml
+++ b/chart/compass/templates/tests/ord-service/ord-service-test.yaml
@@ -125,3 +125,9 @@ spec:
           {{- end }}
           {{end}}
       restartPolicy: Never
+      volumes:
+        {{if eq .Values.global.database.embedded.enabled false}}
+        - name: cloudsql-instance-credentials
+          secret:
+            secretName: cloudsql-instance-credentials
+        {{end}}


### PR DESCRIPTION
**Description**
In #1983 we forgot to add the volume to the test

Changes proposed in this pull request:
- Add missing volume to ord-service-test.yaml

- [X] Implementation
- [ ] Unit tests
- [ ] Integration tests
- [ ] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [ ] Mocks are regenerated, using the automated script
