### PR TITLE
Increase memory limits for connectivity-adapter and tenant-fetcher components

### DIFF
--- a/chart/compass/templates/tests/connectivity-adapter/connectivity-adapter-test.yaml
+++ b/chart/compass/templates/tests/connectivity-adapter/connectivity-adapter-test.yaml
@@ -33,6 +33,9 @@ spec:
           imagePullPolicy: IfNotPresent
           command: ["/bin/sh"]
           args: ["-c", "/connectivity-adapter.test -test.v; exit_code=$?; echo code is $exit_code; echo 'killing pilot-agent...'; curl -XPOST http://127.0.0.1:15020/quitquitquit; sleep 4; exit $exit_code;"]
+          resources:
+            limits:
+              memory: "256Mi"
           env:
             - name: APP_CONNECTIVITY_ADAPTER_URL
               value: {{ .Values.global.tests.connectivityAdapterFQDN }}:{{ .Values.global.connectivity_adapter.port }}

--- a/chart/compass/templates/tests/tenant-fetcher/tenant-fetcher-test.yaml
+++ b/chart/compass/templates/tests/tenant-fetcher/tenant-fetcher-test.yaml
@@ -30,6 +30,9 @@ spec:
           imagePullPolicy: IfNotPresent
           command: ["/bin/sh"]
           args: ["-c", "./tenant-fetcher.test -test.v; exit_code=$?; echo code is $exit_code; echo 'killing pilot-agent...'; curl -XPOST http://127.0.0.1:15020/quitquitquit; sleep 4; exit $exit_code;"]
+          resources:
+            limits:
+              memory: "256Mi"
           env:
             - name: APP_TENANT_PROVIDER_TENANT_ID_PROPERTY
               value: {{ .Values.global.tenantFetcher.tenantProvider.tenantIdProperty }}


### PR DESCRIPTION
**Description**
The E2E tests fail due to OOM error

Changes proposed in this pull request:
- Increase memory limits of connectivity-adapter and tenant-fetcher components


- [x] Implementation
- [x] Unit tests
- [x] Integration tests
