### PR TITLE
Infer API Protocol for non-ORD compliant systems

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -87,7 +87,7 @@ global:
       version: "PR-39"
     schema_migrator:
       dir:
-      version: "PR-2003"
+      version: "PR-2005"
     system_broker:
       dir:
       version: "PR-2003"
@@ -104,7 +104,7 @@ global:
       version: "PR-41"
     e2e_tests:
       dir:
-      version: "PR-2003"
+      version: "PR-2005"
   isLocalEnv: false
   oauth2:
     host: oauth2

--- a/components/schema-migrator/migrations/director/20210902160202_infer_api_protocol.down.sql
+++ b/components/schema-migrator/migrations/director/20210902160202_infer_api_protocol.down.sql
@@ -1,0 +1,26 @@
+BEGIN;
+
+CREATE OR REPLACE VIEW tenants_apis  AS
+SELECT DISTINCT t_apps.tenant_id, apis.id, apis.app_id, apis.name, apis.description, apis.group_name, apis.default_auth,
+                apis.version_value, apis.version_deprecated, apis.version_deprecated_since, apis.version_for_removal,
+                apis.ord_id, apis.short_description, apis.system_instance_aware, apis.api_protocol, apis.tags,
+                apis.countries, apis.links, apis.api_resource_links, apis.release_status, apis.sunset_date,
+                apis.changelog_entries, apis.labels, apis.package_id, apis.visibility, apis.disabled, apis.part_of_products,
+                apis.line_of_business, apis.industry, apis.ready, apis.created_at, apis.updated_at, apis.deleted_at, apis.error,
+                apis.implementation_standard, apis.custom_implementation_standard, apis.custom_implementation_standard_description,
+                apis.target_urls, apis.extensible, apis.successors, apis.resource_hash
+FROM api_definitions AS apis
+         INNER JOIN (
+--  select GAs
+    SELECT a1.id, a1.tenant_id FROM applications AS a1
+    UNION ALL
+--  select CRM
+    SELECT a.id, t.parent as tenant_id FROM applications AS a
+                                                INNER JOIN  business_tenant_mappings AS t ON t.id = a.tenant_id WHERE t.parent IS NOT NULL
+    UNION ALL
+--  select SA
+    SELECT l.app_id as id, asa.selector_value::uuid as tenant_id FROM labels AS l
+                                                                          INNER JOIN automatic_scenario_assignments AS asa ON asa.tenant_id = l.tenant_id AND l.value ? asa.scenario AND asa.selector_key='global_subaccount_id'
+    WHERE l.app_id IS NOT NULL AND l.key = 'scenarios') AS t_apps ON apis.app_id = t_apps.id;
+
+COMMIT;

--- a/components/schema-migrator/migrations/director/20210902160202_infer_api_protocol.up.sql
+++ b/components/schema-migrator/migrations/director/20210902160202_infer_api_protocol.up.sql
@@ -1,0 +1,32 @@
+BEGIN;
+
+CREATE OR REPLACE VIEW tenants_apis  AS
+SELECT DISTINCT t_apps.tenant_id, apis.id, apis.app_id, apis.name, apis.description, apis.group_name, apis.default_auth,
+                apis.version_value, apis.version_deprecated, apis.version_deprecated_since, apis.version_for_removal,
+                apis.ord_id, apis.short_description, apis.system_instance_aware,
+                CASE
+                    WHEN specs.api_spec_type::text = 'ODATA' THEN 'odata-v2'::api_protocol
+                    WHEN specs.api_spec_type::text = 'OPEN_API' THEN 'rest'::api_protocol
+                    ELSE apis.api_protocol
+                    END                                            AS api_protocol,
+                apis.tags, apis.countries, apis.links, apis.api_resource_links, apis.release_status, apis.sunset_date,
+                apis.changelog_entries, apis.labels, apis.package_id, apis.visibility, apis.disabled, apis.part_of_products,
+                apis.line_of_business, apis.industry, apis.ready, apis.created_at, apis.updated_at, apis.deleted_at, apis.error,
+                apis.implementation_standard, apis.custom_implementation_standard, apis.custom_implementation_standard_description,
+                apis.target_urls, apis.extensible, apis.successors, apis.resource_hash
+FROM api_definitions AS apis
+         INNER JOIN (
+--  select GAs
+    SELECT a1.id, a1.tenant_id FROM applications AS a1
+    UNION ALL
+--  select CRM
+    SELECT a.id, t.parent as tenant_id FROM applications AS a
+                                                INNER JOIN  business_tenant_mappings AS t ON t.id = a.tenant_id WHERE t.parent IS NOT NULL
+    UNION ALL
+--  select SA
+    SELECT l.app_id as id, asa.selector_value::uuid as tenant_id FROM labels AS l
+                                                                          INNER JOIN automatic_scenario_assignments AS asa ON asa.tenant_id = l.tenant_id AND l.value ? asa.scenario AND asa.selector_key='global_subaccount_id'
+    WHERE l.app_id IS NOT NULL AND l.key = 'scenarios') AS t_apps ON apis.app_id = t_apps.id
+         LEFT JOIN specifications as specs on apis.id = specs.api_def_id;
+
+COMMIT;

--- a/components/schema-migrator/migrations/director/20210902160202_infer_api_protocol.up.sql
+++ b/components/schema-migrator/migrations/director/20210902160202_infer_api_protocol.up.sql
@@ -5,8 +5,8 @@ SELECT DISTINCT t_apps.tenant_id, apis.id, apis.app_id, apis.name, apis.descript
                 apis.version_value, apis.version_deprecated, apis.version_deprecated_since, apis.version_for_removal,
                 apis.ord_id, apis.short_description, apis.system_instance_aware,
                 CASE
-                    WHEN specs.api_spec_type::text = 'ODATA' THEN 'odata-v2'::api_protocol
-                    WHEN specs.api_spec_type::text = 'OPEN_API' THEN 'rest'::api_protocol
+                    WHEN apis.api_protocol IS NULL AND specs.api_spec_type::text = 'ODATA' THEN 'odata-v2'::api_protocol
+                    WHEN apis.api_protocol IS NULL AND specs.api_spec_type::text = 'OPEN_API' THEN 'rest'::api_protocol
                     ELSE apis.api_protocol
                     END                                            AS api_protocol,
                 apis.tags, apis.countries, apis.links, apis.api_resource_links, apis.release_status, apis.sunset_date,

--- a/tests/ord-service/tests/api_test.go
+++ b/tests/ord-service/tests/api_test.go
@@ -325,6 +325,16 @@ func TestORDService(stdT *testing.T) {
 					panic(errors.New(fmt.Sprintf("Unknown release status: %s", releaseStatus)))
 				}
 
+				apiProtocol := gjson.Get(respBody, fmt.Sprintf("value.%d.apiProtocol", i)).String()
+				switch apiProtocol {
+				case "odata-v2":
+					require.Equal(t, expectedAPI.Spec.Type, directorSchema.APISpecTypeOdata)
+				case "rest":
+					require.Equal(t, expectedAPI.Spec.Type, directorSchema.APISpecTypeOpenAPI)
+				default:
+					t.Log(fmt.Sprintf("API Protocol for API %s is %s. It does not match a predefined spec type.", name, apiProtocol))
+				}
+
 				specs := gjson.Get(respBody, fmt.Sprintf("value.%d.resourceDefinitions", i)).Array()
 				require.Equal(t, 1, len(specs))
 


### PR DESCRIPTION
# Infer API Protocol for non-ORD compliant systems

**Description**

Compass should fill in the API protocol field when exposing APIs via ORD Service for systems which were manually registered.

Introduce a new SQL view that fills in the apiProtocol field based on the spec type from the db:



Changes proposed in this pull request:
- Introduce a new SQL view that fills in the apiProtocol field based on the spec type from the db
  - if it's ODATA -->  fill in the apiProtocol field with value "odata-v2"
  - if it's OPEN_API --> fill in the apiProtocol field with value "rest"

**Pull Request status**
<!-- Feel free to construct the checklist with whatever items seem most reasonable for your change. You could disassemble the Implementation part to even smaller separate checklist items if you're working on something big for example. But do make the effort to provide a checklist of some sort so that the core team as well as the community can have an idea about the progress of your Pull Request.
-->

- [x] Implementation
- [x] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
