### PR TITLE
Fix authenticator rule path

### DIFF
--- a/chart/compass/charts/gateway/templates/oathkeeper-authenticator-rules.yaml
+++ b/chart/compass/charts/gateway/templates/oathkeeper-authenticator-rules.yaml
@@ -11,7 +11,7 @@ spec:
     url: "http://{{ $config.upstreamComponent }}.{{ $.Release.Namespace }}.svc.cluster.local:{{ $.Values.global.gateway.port }}"
   match:
     methods: ["GET", "POST", "OPTIONS", "PUT", "DELETE"]
-    url: <http|https>://{{ $config.gatewayHost }}.{{ $.Values.global.ingress.domainName }}<(:(80|443))?>/{{ $config.path }}
+    url: <http|https>://{{ $config.gatewayHost }}.{{ $.Values.global.ingress.domainName }}<(:(80|443))?>{{ $config.path }}
   authenticators:
   - handler: noop
   authorizer:

--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -468,7 +468,7 @@ global:
       gatewayHost: "compass-gateway"
       trusted_issuers: '[{"domain_url": "compass-system.svc.cluster.local:8080", "scope_prefix": "prefix.", "protocol": "http"}]'
       attributes: '{"uniqueAttribute": { "key": "test", "value": "tenant-fetcher" }, "tenant": { "key": "tenant" }, "identity": { "key": "identity" } }'
-      path: tenants/<.*>
+      path: /tenants/<.*>
       upstreamComponent: "compass-tenant-fetcher"
 
   externalServicesMock:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Currently, if we want the authenticator path to start with a slash, the oathkeeper rule will be broken and will contain two slashes.

Changes proposed in this pull request:
- Unify configuration in oathkeeper rules and virtual services for authenticators:
![image](https://user-images.githubusercontent.com/9128192/133208547-cecb63e6-a04b-4a19-9df4-6dd8275b6149.png)
![image](https://user-images.githubusercontent.com/9128192/133208608-8c781bf4-c5ec-4035-a773-4a8bb7c2613e.png)

Currently, if we want the config to start with a slash, the oathkeeper rule will be broken and will contain two slashes.

**Pull Request status**
<!-- Feel free to construct the checklist with whatever items seem most reasonable for your change. You could disassemble the Implementation part to even smaller separate checklist items if you're working on something big for example. But do make the effort to provide a checklist of some sort so that the core team as well as the community can have an idea about the progress of your Pull Request.
-->

- [x] Implementation