### PR TITLE
Support account creation with matching child ID

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -75,7 +75,7 @@ global:
       version: "PR-2003"
     director:
       dir:
-      version: "PR-1993"
+      version: "PR-2019"
     gateway:
       dir:
       version: "PR-2003"
@@ -104,7 +104,7 @@ global:
       version: "PR-42"
     e2e_tests:
       dir:
-      version: "PR-2007"
+      version: "PR-2019"
   isLocalEnv: false
   oauth2:
     host: oauth2

--- a/components/director/internal/tenantfetchersvc/handler.go
+++ b/components/director/internal/tenantfetchersvc/handler.go
@@ -150,13 +150,19 @@ func (h *handler) getProvisioningRequest(body []byte, region string) (*TenantPro
 		return nil, err
 	}
 
-	return &TenantProvisioningRequest{
+	req := &TenantProvisioningRequest{
 		AccountTenantID:    properties[h.config.TenantIDProperty],
 		SubaccountTenantID: properties[h.config.SubaccountTenantIDProperty],
 		CustomerTenantID:   properties[h.config.CustomerIDProperty],
 		Subdomain:          properties[h.config.SubdomainProperty],
 		Region:             region,
-	}, nil
+	}
+
+	if req.AccountTenantID == req.SubaccountTenantID {
+		req.SubaccountTenantID = ""
+	}
+
+	return req, nil
 }
 
 func (h *handler) provisionTenants(ctx context.Context, request *TenantProvisioningRequest, region string) error {

--- a/tests/tenant-fetcher/tests/handler_test.go
+++ b/tests/tenant-fetcher/tests/handler_test.go
@@ -85,6 +85,23 @@ func TestOnboardingHandler(t *testing.T) {
 		assertTenant(t, tnt, tenant.TenantID, tenant.Subdomain)
 	})
 
+	t.Run("Successful account tenant creation with matching account and subaccount tenant IDs", func(t *testing.T) {
+		id := uuid.New().String()
+		tenant := Tenant{
+			TenantID:     id,
+			SubaccountID: id,
+			Subdomain:    defaultSubdomain,
+		}
+
+		addTenantExpectStatusCode(t, tenant, http.StatusOK)
+
+		tnt, err := fixtures.GetTenantByExternalID(dexGraphQLClient, tenant.TenantID)
+		require.NoError(t, err)
+
+		// THEN
+		assertTenant(t, tnt, tenant.TenantID, tenant.Subdomain)
+	})
+
 	t.Run("Should not add already existing tenants", func(t *testing.T) {
 		tenantWithCustomer := Tenant{
 			TenantID:   uuid.New().String(),


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:
- Add graceful handling for requests with matching account and subaccount tenant ID based on the assumption that the created tenant should be only one, and of type "account"


**Pull Request status**
<!-- Feel free to construct the checklist with whatever items seem most reasonable for your change. You could disassemble the Implementation part to even smaller separate checklist items if you're working on something big for example. But do make the effort to provide a checklist of some sort so that the core team as well as the community can have an idea about the progress of your Pull Request.
-->

- [x] Implementation
- [x] Unit tests
- [x] Integration tests
- [x] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->

