### PR TITLE
Increase director TestDefinition memory

### DIFF
--- a/chart/compass/templates/tests/director/director-test.yaml
+++ b/chart/compass/templates/tests/director/director-test.yaml
@@ -34,6 +34,9 @@ spec:
           imagePullPolicy: IfNotPresent
           command: ["/bin/sh"]
           args: ["-c", "/director.test -test.v; exit_code=$?; echo code is $exit_code; echo 'killing pilot-agent...'; curl -XPOST http://127.0.0.1:15020/quitquitquit; sleep 4; exit $exit_code;"]
+          resources:
+            limits:
+              memory: "256Mi"
           env:
             - name: DIRECTOR_URL
               value: "https://{{ .Values.global.gateway.tls.host }}.{{ .Values.global.ingress.domainName }}{{ .Values.global.director.prefix }}"


### PR DESCRIPTION
**Description**

This PR increases the memory limit of the director TestDefinition because when `pre-main-compass-integration job` is executed the tests fail with OOM. That resulted in `object not unique` errors in `QueryTenants` tests because when the first execution of the tests fails with OOM, the cleanup is not executed leading to a failure of the second one.