### PR TITLE
Improve application cleanup in benchmark tests

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -104,7 +104,7 @@ global:
       version: "PR-42"
     e2e_tests:
       dir:
-      version: "PR-2023"
+      version: "PR-2028"
   isLocalEnv: false
   oauth2:
     host: oauth2

--- a/tests/director/bench/application_api_test.go
+++ b/tests/director/bench/application_api_test.go
@@ -17,15 +17,11 @@ func BenchmarkApplicationsForRuntime(b *testing.B) {
 	tenantID := tenant.TestTenants.GetDefaultTenantID()
 
 	appsCount := 5
-	apps := make([]graphql.ApplicationRegisterInput, 0, appsCount)
 	for i := 0; i < appsCount; i++ {
-		apps = append(apps, fixtures.CreateApp(fmt.Sprintf("%d", i)))
-	}
-
-	for _, app := range apps {
+		app := fixtures.CreateApp(fmt.Sprintf("%d", i))
 		appResp, err := fixtures.RegisterApplicationFromInput(b, ctx, dexGraphQLClient, tenantID, app)
+		defer fixtures.CleanupApplication(b, ctx, dexGraphQLClient, tenantID, &appResp)
 		require.NoError(b, err)
-		defer fixtures.UnregisterApplication(b, ctx, dexGraphQLClient, tenantID, appResp.ID)
 	}
 
 	//create runtime without normalization

--- a/tests/ord-service/bench/system_bundles_test.go
+++ b/tests/ord-service/bench/system_bundles_test.go
@@ -27,7 +27,7 @@ func BenchmarkSystemBundles(b *testing.B) {
 	for i := 0; i < appsCount; i++ {
 		app := fixtures.CreateApp(fmt.Sprintf("%d", i))
 		appResp, err := fixtures.RegisterApplicationFromInput(b, ctx, dexGraphQLClient, defaultTestTenant, app)
-		defer fixtures.UnregisterApplication(b, ctx, dexGraphQLClient, defaultTestTenant, appResp.ID)
+		defer fixtures.CleanupApplication(b, ctx, dexGraphQLClient, defaultTestTenant, &appResp)
 		require.NoError(b, err)
 	}
 


### PR DESCRIPTION
Improve cleanup of applications used in benchmark tests

Related PRs:
- [Add benchmark test for ord-service](https://github.com/kyma-incubator/compass/pull/2022)
- [Introduce performance tests](https://github.com/kyma-incubator/compass/pull/1856)