### PR TITLE
Fix local installation with hyperkit failing

### DIFF
--- a/installation/resources/kyma/installer-overrides-kyma-minimal-config-local.yaml
+++ b/installation/resources/kyma/installer-overrides-kyma-minimal-config-local.yaml
@@ -97,6 +97,19 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
+  name: logging-overrides
+  namespace: kyma-installer
+  labels:
+    installer: overrides
+    component: logging
+    kyma-project.io/installation: ""
+data:
+  logui.resources.limits.cpu: 80m
+  logui.resources.limits.memory: 32Mi
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
   name: disable-legacy-connectivity-override
   namespace: kyma-installer
   labels:


### PR DESCRIPTION
**Description**
This PR fixes a bug with the local installation when hyperkit driver is used which gets stuck during the installation of the Kyma component **logui** because the deployment's resource limits are set too low. 

**Changes proposed in this pull request:**
- Add logging overrides for local installation.

**Pull Request status:**

- [X] Implementation
- [ ] Unit tests
- [ ] Integration tests
- [ ] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [ ] Mocks are regenerated, using the automated script
