### PR TITLE
Retry AuditLog operation if fails

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -78,7 +78,7 @@ global:
       version: "PR-2027"
     gateway:
       dir:
-      version: "PR-2027"
+      version: "PR-2034"
     operations_controller:
       dir:
       version: "PR-2027"

--- a/components/gateway/go.mod
+++ b/components/gateway/go.mod
@@ -33,3 +33,5 @@ require (
 	gopkg.in/check.v1 v1.0.0-20200902074654-038fdea0a05b // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )
+
+require github.com/avast/retry-go v3.0.0+incompatible // indirect

--- a/components/gateway/go.mod
+++ b/components/gateway/go.mod
@@ -4,6 +4,7 @@ go 1.17
 
 require (
 	github.com/99designs/gqlgen v0.11.0 // indirect
+	github.com/avast/retry-go v3.0.0+incompatible // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.1.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
@@ -33,5 +34,3 @@ require (
 	gopkg.in/check.v1 v1.0.0-20200902074654-038fdea0a05b // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )
-
-require github.com/avast/retry-go v3.0.0+incompatible // indirect

--- a/components/gateway/go.sum
+++ b/components/gateway/go.sum
@@ -108,6 +108,7 @@ github.com/asaskevich/govalidator v0.0.0-20200108200545-475eaeb16496/go.mod h1:o
 github.com/asaskevich/govalidator v0.0.0-20200428143746-21a406dcc535/go.mod h1:oGkLhpf+kjZl6xBf758TQhh5XrAeiJv/7FRz/2spLIg=
 github.com/asaskevich/govalidator v0.0.0-20200907205600-7a23bdc65eef/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
 github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
+github.com/avast/retry-go v3.0.0+incompatible h1:4SOWQ7Qs+oroOTQOYnAHqelpCO0biHSxpiH9JdtuBj0=
 github.com/avast/retry-go v3.0.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=
 github.com/aws/aws-lambda-go v1.13.3/go.mod h1:4UKl9IzQMoD+QF79YdCuzCwp8VbmG4VAQwij/eHl5CU=
 github.com/aws/aws-sdk-go v1.27.0/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=

--- a/components/gateway/internal/auditlog/client.go
+++ b/components/gateway/internal/auditlog/client.go
@@ -76,22 +76,37 @@ func (c *Client) LogSecurityEvent(ctx context.Context, event model.SecurityEvent
 
 func (c *Client) sendAuditLog(ctx context.Context, req *http.Request) error {
 	logger := log.C(ctx)
+	responseStatusCode, err := c.sendAuditLogInternal(ctx, req)
+	if responseStatusCode != http.StatusCreated || err != nil {
+		logger.Infof("Will retry auditlog request.")
+		responseStatusCode, err = c.sendAuditLogInternal(ctx, req)
+		if responseStatusCode != http.StatusCreated || err != nil {
+			return errors.Wrapf(err, "Write to auditlog failed with status code: %d", responseStatusCode)
+		}
+	}
+	return nil
+}
+
+func (c *Client) sendAuditLogInternal(ctx context.Context, req *http.Request) (int, error) {
+	logger := log.C(ctx)
+	var err error = nil
 	response, err := c.httpClient.Do(req)
 	if err != nil {
-		return errors.Wrapf(err, "while sending auditlog to: %s", req.URL.String())
+		return 0, errors.Wrapf(err, "while sending auditlog to: %s", req.URL.String())
 	}
 	defer httpcommon.CloseBody(ctx, response.Body)
 
 	if response.StatusCode != http.StatusCreated {
+		var output []byte = nil
 		logger.Infof("Got different status code: %d\n", response.StatusCode)
-		output, err := ioutil.ReadAll(response.Body)
+		output, err = ioutil.ReadAll(response.Body)
 		if err != nil {
-			return errors.Wrap(err, "while reading response from auditlog")
+			return response.StatusCode, errors.Wrap(err, "while reading response from auditlog")
 		}
 		logger.Infoln(string(output))
-		return errors.Errorf("Write to auditlog failed with status code: %d", response.StatusCode)
+		err = errors.Errorf("Write to auditlog failed with status code: %d", response.StatusCode)
 	}
-	return nil
+	return response.StatusCode, err
 }
 
 func createURL(auditlogURL, urlPath string) (url.URL, error) {

--- a/components/gateway/internal/auditlog/client.go
+++ b/components/gateway/internal/auditlog/client.go
@@ -8,6 +8,9 @@ import (
 	"net/http"
 	"net/url"
 	"path"
+	"time"
+
+	"github.com/avast/retry-go"
 
 	"github.com/kyma-incubator/compass/components/director/pkg/log"
 	"github.com/kyma-incubator/compass/components/gateway/pkg/httpcommon"
@@ -27,6 +30,11 @@ type Client struct {
 	configChangeURL  string
 	securityEventURL string
 }
+
+const (
+	retryAttempts          = 2
+	retryDelayMilliseconds = 100
+)
 
 func NewClient(cfg Config, httpClient HttpClient) (*Client, error) {
 	configChangeURL, err := createURL(cfg.URL, cfg.ConfigPath)
@@ -52,12 +60,7 @@ func (c *Client) LogConfigurationChange(ctx context.Context, change model.Config
 		return errors.Wrap(err, "while marshaling auditlog payload")
 	}
 
-	req, err := http.NewRequestWithContext(ctx, "POST", c.configChangeURL, bytes.NewBuffer(payload))
-	if err != nil {
-		return errors.Wrap(err, "while creating request")
-	}
-
-	return c.sendAuditLog(ctx, req)
+	return c.sendAuditLogWithRetry(ctx, c.configChangeURL, payload)
 }
 
 func (c *Client) LogSecurityEvent(ctx context.Context, event model.SecurityEvent) error {
@@ -66,47 +69,41 @@ func (c *Client) LogSecurityEvent(ctx context.Context, event model.SecurityEvent
 		return errors.Wrap(err, "while marshaling auditlog payload")
 	}
 
-	req, err := http.NewRequestWithContext(ctx, "POST", c.securityEventURL, bytes.NewBuffer(payload))
-	if err != nil {
-		return errors.Wrap(err, "while creating request")
-	}
-
-	return c.sendAuditLog(ctx, req)
+	return c.sendAuditLogWithRetry(ctx, c.securityEventURL, payload)
 }
 
-func (c *Client) sendAuditLog(ctx context.Context, req *http.Request) error {
+func (c *Client) sendAuditLogWithRetry(ctx context.Context, url string, payload []byte) error {
 	logger := log.C(ctx)
-	responseStatusCode, err := c.sendAuditLogInternal(ctx, req)
-	if responseStatusCode != http.StatusCreated || err != nil {
-		logger.Infof("Will retry auditlog request.")
-		responseStatusCode, err = c.sendAuditLogInternal(ctx, req)
-		if responseStatusCode != http.StatusCreated || err != nil {
-			return errors.Wrapf(err, "Write to auditlog failed with status code: %d", responseStatusCode)
+	err := retry.Do(func() error {
+		buf := bytes.NewBuffer(payload)
+		request, err := http.NewRequestWithContext(ctx, http.MethodPost, url, buf)
+		if err != nil {
+			return errors.Wrap(err, "while creating request")
 		}
+
+		response, err := c.httpClient.Do(request)
+		if err != nil {
+			return errors.Wrapf(err, "while sending auditlog to: %s", request.URL.String())
+		}
+
+		defer httpcommon.CloseBody(ctx, response.Body)
+
+		if response.StatusCode != http.StatusCreated {
+			logger.Infof("Got different status code: %d\n", response.StatusCode)
+			output, err := ioutil.ReadAll(response.Body)
+			if err != nil {
+				return errors.Wrap(err, "while reading response from auditlog")
+			}
+			logger.Infoln(string(output))
+			return errors.Errorf("Write to auditlog failed with status code: %d", response.StatusCode)
+		}
+		return nil
+	}, retry.Attempts(retryAttempts), retry.Delay(retryDelayMilliseconds*time.Millisecond))
+
+	if err != nil {
+		return err
 	}
 	return nil
-}
-
-func (c *Client) sendAuditLogInternal(ctx context.Context, req *http.Request) (int, error) {
-	logger := log.C(ctx)
-	var err error = nil
-	response, err := c.httpClient.Do(req)
-	if err != nil {
-		return 0, errors.Wrapf(err, "while sending auditlog to: %s", req.URL.String())
-	}
-	defer httpcommon.CloseBody(ctx, response.Body)
-
-	if response.StatusCode != http.StatusCreated {
-		var output []byte = nil
-		logger.Infof("Got different status code: %d\n", response.StatusCode)
-		output, err = ioutil.ReadAll(response.Body)
-		if err != nil {
-			return response.StatusCode, errors.Wrap(err, "while reading response from auditlog")
-		}
-		logger.Infoln(string(output))
-		err = errors.Errorf("Write to auditlog failed with status code: %d", response.StatusCode)
-	}
-	return response.StatusCode, err
 }
 
 func createURL(auditlogURL, urlPath string) (url.URL, error) {

--- a/components/gateway/internal/auditlog/client_test.go
+++ b/components/gateway/internal/auditlog/client_test.go
@@ -75,7 +75,7 @@ func TestClient_LogConfigurationChange(t *testing.T) {
 
 		//THEN
 		require.Error(t, err)
-		assert.EqualError(t, err, "Write to auditlog failed with status code: 403")
+		assert.EqualError(t, err, "Write to auditlog failed with status code: 403: Write to auditlog failed with status code: 403")
 	})
 }
 
@@ -148,7 +148,7 @@ func TestClient_LogSecurityEvent(t *testing.T) {
 
 		//THEN
 		require.Error(t, err)
-		assert.EqualError(t, err, "Write to auditlog failed with status code: 403")
+		assert.EqualError(t, err, "Write to auditlog failed with status code: 403: Write to auditlog failed with status code: 403")
 	})
 
 	t.Run("http client return error", func(t *testing.T) {
@@ -167,7 +167,7 @@ func TestClient_LogSecurityEvent(t *testing.T) {
 
 		//THEN
 		require.Error(t, err)
-		assert.EqualError(t, err, fmt.Sprintf("while sending auditlog to: %s: %s", "localhost:8080", testErr.Error()))
+		assert.EqualError(t, err, fmt.Sprintf("Write to auditlog failed with status code: 0: while sending auditlog to: %s: %s", "localhost:8080", testErr.Error()))
 	})
 }
 

--- a/components/gateway/internal/auditlog/client_test.go
+++ b/components/gateway/internal/auditlog/client_test.go
@@ -75,7 +75,7 @@ func TestClient_LogConfigurationChange(t *testing.T) {
 
 		//THEN
 		require.Error(t, err)
-		assert.EqualError(t, err, "Write to auditlog failed with status code: 403: Write to auditlog failed with status code: 403")
+		assert.EqualError(t, err, "All attempts fail:\n#1: Write to auditlog failed with status code: 403\n#2: Write to auditlog failed with status code: 403")
 	})
 }
 
@@ -148,7 +148,7 @@ func TestClient_LogSecurityEvent(t *testing.T) {
 
 		//THEN
 		require.Error(t, err)
-		assert.EqualError(t, err, "Write to auditlog failed with status code: 403: Write to auditlog failed with status code: 403")
+		assert.EqualError(t, err, "All attempts fail:\n#1: Write to auditlog failed with status code: 403\n#2: Write to auditlog failed with status code: 403")
 	})
 
 	t.Run("http client return error", func(t *testing.T) {
@@ -167,7 +167,7 @@ func TestClient_LogSecurityEvent(t *testing.T) {
 
 		//THEN
 		require.Error(t, err)
-		assert.EqualError(t, err, fmt.Sprintf("Write to auditlog failed with status code: 0: while sending auditlog to: %s: %s", "localhost:8080", testErr.Error()))
+		assert.EqualError(t, err, fmt.Sprintf("All attempts fail:\n#1: while sending auditlog to: %s: %s\n#2: while sending auditlog to: %s: %s", "localhost:8080", testErr.Error(), "localhost:8080", testErr.Error()))
 	})
 }
 


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:
- Retry AL operation if fails

**Related issue(s)**
- Sporadically the AL operations fails, and pass upon retry. We are going to retry the operations in case they are failing on first attempt.

**Pull Request status**

- [x] Implementation
- [x] Unit tests
- [x] Integration tests
- [x] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [ ] Mocks are regenerated, using the automated script
