### PR TITLE
Adopt ORD changes after v1

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -75,7 +75,7 @@ global:
       version: "PR-2027"
     director:
       dir:
-      version: "PR-2038"
+      version: "PR-2042"
     gateway:
       dir:
       version: "PR-2034"
@@ -98,7 +98,7 @@ global:
       version: "0a651695"
     external_services_mock:
       dir:
-      version: "PR-2027"
+      version: "PR-2042"
     console:
       dir:
       version: "PR-45"

--- a/components/director/internal/model/api.go
+++ b/components/director/internal/model/api.go
@@ -103,7 +103,7 @@ type APIResourceDefinition struct { // This is the place from where the specific
 
 // Validate missing godoc
 func (rd *APIResourceDefinition) Validate() error {
-	const CustomTypeRegex = "^([a-z0-9.]+):([a-zA-Z0-9._\\-]+):v([0-9]+)$"
+	const CustomTypeRegex = "^([a-z0-9-]+(?:[.][a-z0-9-]+)*):([a-zA-Z0-9._\\-]+):v([0-9]+)$"
 	return validation.ValidateStruct(rd,
 		validation.Field(&rd.Type, validation.Required, validation.In(APISpecTypeOpenAPIV2, APISpecTypeOpenAPIV3, APISpecTypeRaml, APISpecTypeEDMX,
 			APISpecTypeCsdl, APISpecTypeWsdlV1, APISpecTypeWsdlV2, APISpecTypeRfcMetadata, APISpecTypeCustom), validation.When(rd.CustomType != "", validation.In(APISpecTypeCustom))),
@@ -142,9 +142,10 @@ type AccessStrategy struct {
 
 // Validate missing godoc
 func (as AccessStrategy) Validate() error {
+	const CustomTypeRegex = "^([a-z0-9-]+(?:[.][a-z0-9-]+)*):([a-zA-Z0-9._\\-]+):v([0-9]+)$"
 	return validation.ValidateStruct(&as,
-		validation.Field(&as.Type, validation.Required, validation.In("open", "custom")),
-		validation.Field(&as.CustomType, validation.When(as.Type != "custom", validation.Empty)),
+		validation.Field(&as.Type, validation.Required, validation.In("open", "custom"), validation.When(as.CustomType != "", validation.In("custom"))),
+		validation.Field(&as.CustomType, validation.When(as.CustomType != "", validation.Match(regexp.MustCompile(CustomTypeRegex)))),
 		validation.Field(&as.CustomDescription, validation.When(as.Type != "custom", validation.Empty)),
 	)
 }

--- a/components/director/internal/model/eventapi.go
+++ b/components/director/internal/model/eventapi.go
@@ -98,7 +98,7 @@ type EventResourceDefinition struct { // This is the place from where the specif
 
 // Validate missing godoc
 func (rd *EventResourceDefinition) Validate() error {
-	const CustomTypeRegex = "^([a-z0-9.]+):([a-zA-Z0-9._\\-]+):v([0-9]+)$"
+	const CustomTypeRegex = "^([a-z0-9-]+(?:[.][a-z0-9-]+)*):([a-zA-Z0-9._\\-]+):v([0-9]+)$"
 	return validation.ValidateStruct(rd,
 		validation.Field(&rd.Type, validation.Required, validation.In(EventSpecTypeAsyncAPIV2, EventSpecTypeCustom), validation.When(rd.CustomType != "", validation.In(EventSpecTypeCustom))),
 		validation.Field(&rd.CustomType, validation.When(rd.CustomType != "", validation.Match(regexp.MustCompile(CustomTypeRegex)))),

--- a/components/director/internal/open_resource_discovery/access_strategy.go
+++ b/components/director/internal/open_resource_discovery/access_strategy.go
@@ -1,24 +1,24 @@
 package ord
 
-// AccessStrategy missing godoc
+// AccessStrategy is an ORD object
 type AccessStrategy struct {
 	Type              AccessStrategyType `json:"type"`
 	CustomType        AccessStrategyType `json:"customType"`
 	CustomDescription string             `json:"customDescription"`
 }
 
-// AccessStrategyType missing godoc
+// AccessStrategyType represents the possible type of the AccessStrategy
 type AccessStrategyType string
 
-// IsSupported missing godoc
+// IsSupported checks if the given AccessStrategy is supported by CMP
 func (a AccessStrategyType) IsSupported() bool {
 	return supportedAccessStrategies[a]
 }
 
 const (
-	// OpenAccessStrategy missing godoc
+	// OpenAccessStrategy is one of the available AccessStrategy types
 	OpenAccessStrategy AccessStrategyType = "open"
-	// CustomAccessStrategy missing godoc
+	// CustomAccessStrategy is one of the available AccessStrategy types
 	CustomAccessStrategy AccessStrategyType = "custom"
 )
 
@@ -26,7 +26,7 @@ var supportedAccessStrategies = map[AccessStrategyType]bool{
 	OpenAccessStrategy: true,
 }
 
-// AccessStrategies missing godoc
+// AccessStrategies is a slice of AccessStrategy objects
 type AccessStrategies []AccessStrategy
 
 // GetSupported returns the first AccessStrategy in the slice that is supported by CMP

--- a/components/director/internal/open_resource_discovery/fixtures_test.go
+++ b/components/director/internal/open_resource_discovery/fixtures_test.go
@@ -53,7 +53,7 @@ const (
 	cursor                    = "cursor"
 	policyLevel               = "sap:core:v1"
 	apiImplementationStandard = "cff:open-service-broker:v2"
-	correlationIDs            = `["foo.bar.baz:123456","foo.bar.baz:654321"]`
+	correlationIDs            = `["foo.bar.baz:foo:123456","foo.bar.baz:bar:654321"]`
 	partners                  = `["microsoft:vendor:Microsoft:"]`
 )
 

--- a/components/director/internal/open_resource_discovery/interfaces.go
+++ b/components/director/internal/open_resource_discovery/interfaces.go
@@ -6,19 +6,19 @@ import (
 	"github.com/kyma-incubator/compass/components/director/internal/model"
 )
 
-// WebhookService missing godoc
+// WebhookService is responsible for the service-layer Webhook operations.
 //go:generate mockery --name=WebhookService --output=automock --outpkg=automock --case=underscore
 type WebhookService interface {
 	ListForApplication(ctx context.Context, applicationID string) ([]*model.Webhook, error)
 }
 
-// ApplicationService missing godoc
+// ApplicationService is responsible for the service-layer Application operations.
 //go:generate mockery --name=ApplicationService --output=automock --outpkg=automock --case=underscore
 type ApplicationService interface {
 	ListGlobal(ctx context.Context, pageSize int, cursor string) (*model.ApplicationPage, error)
 }
 
-// BundleService missing godoc
+// BundleService is responsible for the service-layer Bundle operations.
 //go:generate mockery --name=BundleService --output=automock --outpkg=automock --case=underscore
 type BundleService interface {
 	Create(ctx context.Context, applicationID string, in model.BundleCreateInput) (string, error)
@@ -27,13 +27,13 @@ type BundleService interface {
 	ListByApplicationIDNoPaging(ctx context.Context, appID string) ([]*model.Bundle, error)
 }
 
-// BundleReferenceService missing godoc
+// BundleReferenceService is responsible for the service-layer BundleReference operations.
 //go:generate mockery --name=BundleReferenceService --output=automock --outpkg=automock --case=underscore
 type BundleReferenceService interface {
 	GetBundleIDsForObject(ctx context.Context, objectType model.BundleReferenceObjectType, objectID *string) ([]string, error)
 }
 
-// APIService missing godoc
+// APIService is responsible for the service-layer API operations.
 //go:generate mockery --name=APIService --output=automock --outpkg=automock --case=underscore
 type APIService interface {
 	Create(ctx context.Context, appID string, bundleID, packageID *string, in model.APIDefinitionInput, spec []*model.SpecInput, targetURLsPerBundle map[string]string, apiHash uint64) (string, error)
@@ -42,7 +42,7 @@ type APIService interface {
 	ListByApplicationID(ctx context.Context, appID string) ([]*model.APIDefinition, error)
 }
 
-// EventService missing godoc
+// EventService is responsible for the service-layer Event operations.
 //go:generate mockery --name=EventService --output=automock --outpkg=automock --case=underscore
 type EventService interface {
 	Create(ctx context.Context, appID string, bundleID, packageID *string, in model.EventDefinitionInput, specs []*model.SpecInput, bundleIDs []string, eventHash uint64) (string, error)
@@ -51,7 +51,7 @@ type EventService interface {
 	ListByApplicationID(ctx context.Context, appID string) ([]*model.EventDefinition, error)
 }
 
-// SpecService missing godoc
+// SpecService is responsible for the service-layer Specification operations.
 //go:generate mockery --name=SpecService --output=automock --outpkg=automock --case=underscore
 type SpecService interface {
 	CreateByReferenceObjectID(ctx context.Context, in model.SpecInput, objectType model.SpecReferenceObjectType, objectID string) (string, error)
@@ -61,7 +61,7 @@ type SpecService interface {
 	RefetchSpec(ctx context.Context, id string) (*model.Spec, error)
 }
 
-// PackageService missing godoc
+// PackageService is responsible for the service-layer Package operations.
 //go:generate mockery --name=PackageService --output=automock --outpkg=automock --case=underscore
 type PackageService interface {
 	Create(ctx context.Context, applicationID string, in model.PackageInput, pkgHash uint64) (string, error)
@@ -70,7 +70,7 @@ type PackageService interface {
 	ListByApplicationID(ctx context.Context, appID string) ([]*model.Package, error)
 }
 
-// ProductService missing godoc
+// ProductService is responsible for the service-layer Product operations.
 //go:generate mockery --name=ProductService --output=automock --outpkg=automock --case=underscore
 type ProductService interface {
 	Create(ctx context.Context, applicationID string, in model.ProductInput) (string, error)
@@ -79,7 +79,7 @@ type ProductService interface {
 	ListByApplicationID(ctx context.Context, appID string) ([]*model.Product, error)
 }
 
-// VendorService missing godoc
+// VendorService is responsible for the service-layer Vendor operations.
 //go:generate mockery --name=VendorService --output=automock --outpkg=automock --case=underscore
 type VendorService interface {
 	Create(ctx context.Context, applicationID string, in model.VendorInput) (string, error)
@@ -88,7 +88,7 @@ type VendorService interface {
 	ListByApplicationID(ctx context.Context, appID string) ([]*model.Vendor, error)
 }
 
-// TombstoneService missing godoc
+// TombstoneService is responsible for the service-layer Tombstone operations.
 //go:generate mockery --name=TombstoneService --output=automock --outpkg=automock --case=underscore
 type TombstoneService interface {
 	Create(ctx context.Context, applicationID string, in model.TombstoneInput) (string, error)

--- a/components/director/internal/open_resource_discovery/ord_document.go
+++ b/components/director/internal/open_resource_discovery/ord_document.go
@@ -10,21 +10,21 @@ import (
 	"github.com/tidwall/sjson"
 )
 
-// WellKnownEndpoint missing godoc
+// WellKnownEndpoint is the single entry point for the discovery.
 const WellKnownEndpoint = "/.well-known/open-resource-discovery"
 
-// WellKnownConfig missing godoc
+// WellKnownConfig represents the whole config object
 type WellKnownConfig struct {
 	Schema                  string                  `json:"$schema"`
 	OpenResourceDiscoveryV1 OpenResourceDiscoveryV1 `json:"openResourceDiscoveryV1"`
 }
 
-// OpenResourceDiscoveryV1 missing godoc
+// OpenResourceDiscoveryV1 contains all Documents' details
 type OpenResourceDiscoveryV1 struct {
 	Documents []DocumentDetails `json:"documents"`
 }
 
-// DocumentDetails missing godoc
+// DocumentDetails contains fields related to the fetching of each Document
 type DocumentDetails struct {
 	URL string `json:"url"`
 	// TODO: Currently we cannot differentiate between system instance types reliably, therefore we cannot make use of the systemInstanceAware optimization (store it once per system type and reuse it for each system instance of that type).
@@ -34,7 +34,7 @@ type DocumentDetails struct {
 	AccessStrategies    AccessStrategies `json:"accessStrategies"`
 }
 
-// Document missing godoc
+// Document represents an ORD Document
 type Document struct {
 	Schema                string `json:"$schema"`
 	OpenResourceDiscovery string `json:"openResourceDiscovery"`
@@ -53,7 +53,7 @@ type Document struct {
 	Vendors            []*model.VendorInput          `json:"vendors"`
 }
 
-// Documents missing godoc
+// Documents is a slice of Document objects
 type Documents []*Document
 
 // Validate validates all the documents for a system instance

--- a/components/director/internal/open_resource_discovery/service.go
+++ b/components/director/internal/open_resource_discovery/service.go
@@ -14,7 +14,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-// Service missing godoc
+// Service consists of various resource services responsible for service-layer ORD operations.
 type Service struct {
 	transact persistence.Transactioner
 
@@ -33,7 +33,7 @@ type Service struct {
 	ordClient Client
 }
 
-// NewAggregatorService missing godoc
+// NewAggregatorService returns a new object responsible for service-layer ORD operations.
 func NewAggregatorService(transact persistence.Transactioner, appSvc ApplicationService, webhookSvc WebhookService, bundleSvc BundleService, bundleReferenceSvc BundleReferenceService, apiSvc APIService, eventSvc EventService, specSvc SpecService, packageSvc PackageService, productSvc ProductService, vendorSvc VendorService, tombstoneSvc TombstoneService, client Client) *Service {
 	return &Service{
 		transact:           transact,

--- a/components/director/internal/open_resource_discovery/validation.go
+++ b/components/director/internal/open_resource_discovery/validation.go
@@ -24,97 +24,97 @@ import (
 
 // Disclaimer: All regexes below are provided by the ORD spec itself.
 const (
-	// SemVerRegex missing godoc
+	// SemVerRegex represents the valid structure of the field
 	SemVerRegex = "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$"
-	// PackageOrdIDRegex missing godoc
-	PackageOrdIDRegex = "^([a-zA-Z0-9._\\-]+):(package):([a-zA-Z0-9._\\-]+):(alpha|beta|v[0-9]+)$"
-	// VendorOrdIDRegex missing godoc
-	VendorOrdIDRegex = "^([a-zA-Z0-9._\\-]+):(vendor):([a-zA-Z0-9._\\-]+):()$"
-	// ProductOrdIDRegex missing godoc
-	ProductOrdIDRegex = "^([a-zA-Z0-9._\\-]+):(product):([a-zA-Z0-9._\\-]+):()$"
-	// BundleOrdIDRegex missing godoc
-	BundleOrdIDRegex = "^([a-zA-Z0-9._\\-]+):(consumptionBundle):([a-zA-Z0-9._\\-]+):(alpha|beta|v[0-9]+)$"
-	// TombstoneOrdIDRegex missing godoc
-	TombstoneOrdIDRegex = "^([a-zA-Z0-9._\\-]+):(package|consumptionBundle|product|vendor|apiResource|eventResource):([a-zA-Z0-9._\\-]+):(alpha|beta|v[0-9]+|)$"
+	// PackageOrdIDRegex represents the valid structure of the ordID of the Package
+	PackageOrdIDRegex = "^([a-z0-9-]+(?:[.][a-z0-9-]+)*):(package):([a-zA-Z0-9._\\-]+):(alpha|beta|v[0-9]+)$"
+	// VendorOrdIDRegex represents the valid structure of the ordID of the Vendor
+	VendorOrdIDRegex = "^([a-z0-9-]+(?:[.][a-z0-9-]+)*):(vendor):([a-zA-Z0-9._\\-]+):()$"
+	// ProductOrdIDRegex represents the valid structure of the ordID of the Product
+	ProductOrdIDRegex = "^([a-z0-9-]+(?:[.][a-z0-9-]+)*):(product):([a-zA-Z0-9._\\-]+):()$"
+	// BundleOrdIDRegex represents the valid structure of the ordID of the ConsumptionBundle
+	BundleOrdIDRegex = "^([a-z0-9-]+(?:[.][a-z0-9-]+)*):(consumptionBundle):([a-zA-Z0-9._\\-]+):(alpha|beta|v[0-9]+)$"
+	// TombstoneOrdIDRegex represents the valid structure of the ordID of the Tombstone
+	TombstoneOrdIDRegex = "^([a-z0-9-]+(?:[.][a-z0-9-]+)*):(package|consumptionBundle|product|vendor|apiResource|eventResource):([a-zA-Z0-9._\\-]+):(alpha|beta|v[0-9]+|)$"
 
-	// SystemInstanceBaseURLRegex missing godoc
+	// SystemInstanceBaseURLRegex represents the valid structure of the field
 	SystemInstanceBaseURLRegex = "^http[s]?:\\/\\/[^:\\/\\s]+\\.[^:\\/\\s\\.]+(:\\d+)?$"
-	// StringArrayElementRegex missing godoc
+	// StringArrayElementRegex represents the valid structure of the field
 	StringArrayElementRegex = "^[a-zA-Z0-9-_.\\/ ]*$"
-	// CountryRegex missing godoc
+	// CountryRegex represents the valid structure of the field
 	CountryRegex = "^[A-Z]{2}$"
-	// APIOrdIDRegex missing godoc
-	APIOrdIDRegex = "^([a-zA-Z0-9._\\-]+):(apiResource):([a-zA-Z0-9._\\-]+):(alpha|beta|v[0-9]+)$"
-	// EventOrdIDRegex missing godoc
-	EventOrdIDRegex = "^([a-zA-Z0-9._\\-]+):(eventResource):([a-zA-Z0-9._\\-]+):(alpha|beta|v[0-9]+)$"
-	// CorrelationIDsRegex missing godoc
-	CorrelationIDsRegex = "^([a-zA-Z0-9._\\-]+):([a-zA-Z0-9._\\-\\/]+)$"
-	// LabelsKeyRegex missing godoc
+	// APIOrdIDRegex represents the valid structure of the ordID of the API
+	APIOrdIDRegex = "^([a-z0-9-]+(?:[.][a-z0-9-]+)*):(apiResource):([a-zA-Z0-9._\\-]+):(alpha|beta|v[0-9]+)$"
+	// EventOrdIDRegex represents the valid structure of the ordID of the Event
+	EventOrdIDRegex = "^([a-z0-9-]+(?:[.][a-z0-9-]+)*):(eventResource):([a-zA-Z0-9._\\-]+):(alpha|beta|v[0-9]+)$"
+	// CorrelationIDsRegex represents the valid structure of the field
+	CorrelationIDsRegex = "^([a-z0-9-]+(?:[.][a-z0-9-]+)*):([a-zA-Z0-9._\\-\\/]+):([a-zA-Z0-9._\\-\\/]+)$"
+	// LabelsKeyRegex represents the valid structure of the field
 	LabelsKeyRegex = "^[a-zA-Z0-9-_.]*$"
-	// CustomImplementationStandardRegex missing godoc
-	CustomImplementationStandardRegex = "^([a-z0-9.]+):([a-zA-Z0-9._\\-]+):v([0-9]+)$"
-	// VendorPartnersRegex missing godoc
-	VendorPartnersRegex = "^([a-zA-Z0-9._\\-]+):(vendor):([a-zA-Z0-9._\\-]+):()$"
-	// CustomPolicyLevelRegex missing godoc
-	CustomPolicyLevelRegex = "^([a-z0-9.]+):([a-zA-Z0-9._\\-]+):v([0-9]+)$"
+	// CustomImplementationStandardRegex represents the valid structure of the field
+	CustomImplementationStandardRegex = "^([a-z0-9-]+(?:[.][a-z0-9-]+)*):([a-zA-Z0-9._\\-]+):v([0-9]+)$"
+	// VendorPartnersRegex represents the valid structure of the field
+	VendorPartnersRegex = "^([a-z0-9-]+(?:[.][a-z0-9-]+)*):(vendor):([a-zA-Z0-9._\\-]+):()$"
+	// CustomPolicyLevelRegex represents the valid structure of the field
+	CustomPolicyLevelRegex = "^([a-z0-9-]+(?:[.][a-z0-9-]+)*):([a-zA-Z0-9._\\-]+):v([0-9]+)$"
 )
 
 const (
 	custom string = "custom"
 
-	// PolicyLevelSap missing godoc
+	// PolicyLevelSap is one of the available policy options
 	PolicyLevelSap string = "sap:core:v1"
-	// PolicyLevelSapPartner missing godoc
+	// PolicyLevelSapPartner is one of the available policy options
 	PolicyLevelSapPartner string = "sap:partner:v1"
-	// PolicyLevelCustom missing godoc
+	// PolicyLevelCustom is one of the available policy options
 	PolicyLevelCustom = custom
 
-	// ReleaseStatusBeta missing godoc
+	// ReleaseStatusBeta is one of the available release status options
 	ReleaseStatusBeta string = "beta"
-	// ReleaseStatusActive missing godoc
+	// ReleaseStatusActive is one of the available release status options
 	ReleaseStatusActive string = "active"
-	// ReleaseStatusDeprecated missing godoc
+	// ReleaseStatusDeprecated is one of the available release status options
 	ReleaseStatusDeprecated string = "deprecated"
 
-	// APIProtocolODataV2 missing godoc
+	// APIProtocolODataV2 is one of the available api protocol options
 	APIProtocolODataV2 string = "odata-v2"
-	// APIProtocolODataV4 missing godoc
+	// APIProtocolODataV4 is one of the available api protocol options
 	APIProtocolODataV4 string = "odata-v4"
-	// APIProtocolSoapInbound missing godoc
+	// APIProtocolSoapInbound is one of the available api protocol options
 	APIProtocolSoapInbound string = "soap-inbound"
-	// APIProtocolSoapOutbound missing godoc
+	// APIProtocolSoapOutbound is one of the available api protocol options
 	APIProtocolSoapOutbound string = "soap-outbound"
-	// APIProtocolRest missing godoc
+	// APIProtocolRest is one of the available api protocol options
 	APIProtocolRest string = "rest"
-	// APIProtocolSapRfc missing godoc
+	// APIProtocolSapRfc is one of the available api protocol options
 	APIProtocolSapRfc string = "sap-rfc"
 
-	// APIVisibilityPublic missing godoc
+	// APIVisibilityPublic is one of the available api visibility options
 	APIVisibilityPublic string = "public"
-	// APIVisibilityPrivate missing godoc
+	// APIVisibilityPrivate is one of the available api visibility options
 	APIVisibilityPrivate string = "private"
-	// APIVisibilityInternal missing godoc
+	// APIVisibilityInternal is one of the available api visibility options
 	APIVisibilityInternal string = "internal"
 
-	// APIImplementationStandardDocumentAPI missing godoc
+	// APIImplementationStandardDocumentAPI is one of the available api implementation standard options
 	APIImplementationStandardDocumentAPI string = "sap:ord-document-api:v1"
-	// APIImplementationStandardServiceBroker missing godoc
+	// APIImplementationStandardServiceBroker is one of the available api implementation standard options
 	APIImplementationStandardServiceBroker string = "cff:open-service-broker:v2"
-	// APIImplementationStandardCsnExposure missing godoc
+	// APIImplementationStandardCsnExposure is one of the available api implementation standard options
 	APIImplementationStandardCsnExposure string = "sap:csn-exposure:v1"
-	// APIImplementationStandardCustom missing godoc
+	// APIImplementationStandardCustom is one of the available api implementation standard options
 	APIImplementationStandardCustom = custom
 
-	// SapTitle missing godoc
+	// SapTitle is a valid SAP title
 	SapTitle = "SAP SE"
-	// SapVendor missing godoc
+	// SapVendor is a valid Vendor ordID
 	SapVendor = "sap:vendor:SAP:"
-	// PartnerVendor missing godoc
+	// PartnerVendor is a valid partner Vendor ordID
 	PartnerVendor = "partner:vendor:SAP:"
 )
 
 var (
-	// LineOfBusinesses missing godoc
+	// LineOfBusinesses contain all valid values for this field from the spec
 	LineOfBusinesses = map[string]bool{
 		"Asset Management":                 true,
 		"Commerce":                         true,
@@ -133,7 +133,7 @@ var (
 		"Plant Operations and Maintenance": true,
 		"Maintenance and Engineering":      true,
 	}
-	// Industries missing godoc
+	// Industries contain all valid values for this field from the spec
 	Industries = map[string]bool{
 		"Aerospace and Defense": true,
 		"Automotive":            true,
@@ -171,7 +171,7 @@ var descriptionRules = []validation.Rule{
 	validation.Required, validation.Length(1, 255), validation.NewStringRule(noNewLines, "description should not contain line breaks"),
 }
 
-// ValidateSystemInstanceInput missing godoc
+// ValidateSystemInstanceInput validates the given SystemInstance
 func ValidateSystemInstanceInput(app *model.Application) error {
 	return validation.ValidateStruct(app,
 		validation.Field(&app.CorrelationIDs, validation.By(func(value interface{}) error {
@@ -1099,7 +1099,7 @@ func validateExtensibleInnerFields(el gjson.Result) error {
 	return nil
 }
 
-// HashObject missing godoc
+// HashObject hashes the given object
 func HashObject(obj interface{}) (uint64, error) {
 	hash, err := hashstructure.Hash(obj, hashstructure.FormatV2, &hashstructure.HashOptions{SlicesAsSets: true})
 	if err != nil {

--- a/components/director/internal/open_resource_discovery/validation_test.go
+++ b/components/director/internal/open_resource_discovery/validation_test.go
@@ -2133,6 +2133,33 @@ func TestDocuments_ValidateAPI(t *testing.T) {
 				return []*ord.Document{doc}
 			},
 		}, {
+			Name: "Invalid field `customType` when field `type` is `custom` for `accessStrategies` of `resourceDefinitions` field for API",
+			DocumentProvider: func() []*ord.Document {
+				doc := fixORDDocument()
+				doc.APIResources[0].ResourceDefinitions[0].AccessStrategy[0].Type = "custom"
+				doc.APIResources[0].ResourceDefinitions[0].AccessStrategy[0].CustomType = invalidCustomType
+
+				return []*ord.Document{doc}
+			},
+		}, {
+			Name: "Field `type` is not `custom` when `customType` is valid for `accessStrategies` of `resourceDefinitions` field for API",
+			DocumentProvider: func() []*ord.Document {
+				doc := fixORDDocument()
+				doc.APIResources[0].ResourceDefinitions[0].AccessStrategy[0].Type = "open"
+				doc.APIResources[0].ResourceDefinitions[0].AccessStrategy[0].CustomType = "sap:custom-definition-format:v1"
+
+				return []*ord.Document{doc}
+			},
+		}, {
+			Name: "Invalid `customType` value when field `type` has value `custom` for `accessStrategies` field for API",
+			DocumentProvider: func() []*ord.Document {
+				doc := fixORDDocument()
+				doc.APIResources[0].ResourceDefinitions[0].Type = "custom"
+				doc.APIResources[0].ResourceDefinitions[0].CustomType = invalidCustomType
+
+				return []*ord.Document{doc}
+			},
+		}, {
 			Name: "Invalid field `customDescription` when field `type` is not `custom` for `accessStrategies` of `resourceDefinitions` field for API",
 			DocumentProvider: func() []*ord.Document {
 				doc := fixORDDocument()
@@ -3492,6 +3519,24 @@ func TestDocuments_ValidateEvent(t *testing.T) {
 				return []*ord.Document{doc}
 			},
 		}, {
+			Name: "Invalid field `customType` when field `type` is `custom` for `accessStrategies` of `resourceDefinitions` field for Event",
+			DocumentProvider: func() []*ord.Document {
+				doc := fixORDDocument()
+				doc.EventResources[0].ResourceDefinitions[0].AccessStrategy[0].Type = "custom"
+				doc.EventResources[0].ResourceDefinitions[0].AccessStrategy[0].CustomType = invalidCustomType
+
+				return []*ord.Document{doc}
+			},
+		}, {
+			Name: "Field `type` is not `custom` when `customType` is valid for `accessStrategies` of `resourceDefinitions` field for Event",
+			DocumentProvider: func() []*ord.Document {
+				doc := fixORDDocument()
+				doc.EventResources[0].ResourceDefinitions[0].AccessStrategy[0].Type = "open"
+				doc.EventResources[0].ResourceDefinitions[0].AccessStrategy[0].CustomType = "sap:custom-definition-format:v1"
+
+				return []*ord.Document{doc}
+			},
+		}, {
 			Name: "Invalid field `customDescription` when field `type` is not `custom` for `accessStrategies` of `resourceDefinitions` field for Event",
 			DocumentProvider: func() []*ord.Document {
 				doc := fixORDDocument()
@@ -4003,7 +4048,7 @@ func TestDocuments_ValidateProduct(t *testing.T) {
 			DocumentProvider: func() []*ord.Document {
 				doc := fixORDDocument()
 				doc.Products = append(doc.Products, &model.ProductInput{
-					OrdID:            "sap.product-valid_value:product:id:",
+					OrdID:            "sap:product:test:",
 					Title:            "title",
 					ShortDescription: "Description",
 					Vendor:           ord.SapVendor,

--- a/components/external-services-mock/internal/ord-aggregator/template.go
+++ b/components/external-services-mock/internal/ord-aggregator/template.go
@@ -189,8 +189,8 @@ const ordDocument = `{
          "vendor":"sap:vendor:SAP:",
          "parent":"ns:product:id2:",
          "correlationIds":[
-            "foo.bar.baz:123456",
-            "foo.bar.baz:654321"
+            "foo.bar.baz:foo:123456",
+            "foo.bar.baz:bar:654321"
          ],
          "labels":{
             "label-key-1":[


### PR DESCRIPTION
**Description**

This PR adopts the latest changes from the ORD spec - mainly changed regexes for various fields across the spec.

**Pull Request status**

- [x] Implementation
- [x] Unit tests
- [ ] Integration tests
- [x] `chart/compass/values.yaml` is updated 
- [ ] Mocks are regenerated, using the automated script
