### PR TITLE
Fix all system auths are assumed to be OneTimeTokens

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -75,7 +75,7 @@ global:
       version: "PR-2027"
     director:
       dir:
-      version: "PR-2043"
+      version: "PR-2045"
     gateway:
       dir:
       version: "PR-2034"

--- a/components/director/internal/domain/application/resolver.go
+++ b/components/director/internal/domain/application/resolver.go
@@ -553,25 +553,27 @@ func (r *Resolver) Auths(ctx context.Context, obj *graphql.Application) ([]*grap
 
 	out := make([]*graphql.AppSystemAuth, 0, len(sysAuths))
 	for _, sa := range sysAuths {
-		isTokenType := r.sysAuthSvc.IsSystemAuthOneTimeTokenType(&sa)
-		if _, err := r.oneTimeTokenSvc.IsTokenValid(&sa); isTokenType && err != nil {
-			log.C(ctx).WithError(err).Errorf("skipping one-time token due to its expiration or usage")
-			continue
-		}
-
 		c, err := r.sysAuthConv.ToGraphQL(&sa)
 		if err != nil {
 			return nil, err
 		}
 
-		if sa.Value.OneTimeToken != nil && sa.Value.OneTimeToken.Type == tokens.ApplicationToken {
-			oneTimeTokenForApplication, err := r.oneTimeTokenConv.ToGraphQLForApplication(*sa.Value.OneTimeToken)
-			if err != nil {
-				return nil, errors.Wrap(err, "while converting one-time token to graphql")
+		if r.sysAuthSvc.IsSystemAuthOneTimeTokenType(&sa) {
+			if valid, err := r.oneTimeTokenSvc.IsTokenValid(&sa); !valid {
+				log.C(ctx).WithError(err).Errorf("skipping one-time token due to its expiration or usage")
+				continue
 			}
 
-			c.(*graphql.AppSystemAuth).Auth.OneTimeToken = &oneTimeTokenForApplication
+			if sa.Value.OneTimeToken.Type == tokens.ApplicationToken {
+				oneTimeTokenForApplication, err := r.oneTimeTokenConv.ToGraphQLForApplication(*sa.Value.OneTimeToken)
+				if err != nil {
+					return nil, errors.Wrap(err, "while converting one-time token to graphql")
+				}
+
+				c.(*graphql.AppSystemAuth).Auth.OneTimeToken = &oneTimeTokenForApplication
+			}
 		}
+
 		out = append(out, c.(*graphql.AppSystemAuth))
 	}
 

--- a/components/director/internal/domain/systemauth/service.go
+++ b/components/director/internal/domain/systemauth/service.go
@@ -192,8 +192,11 @@ func (s *service) DeleteByIDForObject(ctx context.Context, objectType model.Syst
 
 // IsSystemAuthOneTimeTokenType missing godoc
 func (s *service) IsSystemAuthOneTimeTokenType(systemAuth *model.SystemAuth) bool {
-	if (systemAuth != nil && systemAuth.Value != nil) &&
-		(systemAuth.Value.Credential.Basic != nil || systemAuth.Value.Credential.Oauth != nil || systemAuth.Value.RequestAuth != nil) {
+	if systemAuth == nil || systemAuth.Value == nil {
+		return false
+	}
+
+	if systemAuth.Value.Credential.Basic != nil || systemAuth.Value.Credential.Oauth != nil || systemAuth.Value.RequestAuth != nil {
 		return false
 	}
 

--- a/components/director/pkg/graphql/one_time_token.go
+++ b/components/director/pkg/graphql/one_time_token.go
@@ -13,7 +13,7 @@ type OneTimeTokenForApplication struct {
 }
 
 // IsOneTimeToken missing godoc
-func (OneTimeTokenForApplication) IsOneTimeToken() {}
+func (t *OneTimeTokenForApplication) IsOneTimeToken() {}
 
 // OneTimeTokenForRuntime missing godoc
 type OneTimeTokenForRuntime struct {

--- a/components/director/pkg/graphql/schema_gen.go
+++ b/components/director/pkg/graphql/schema_gen.go
@@ -22670,8 +22670,6 @@ func (ec *executionContext) _OneTimeToken(ctx context.Context, sel ast.Selection
 	switch obj := (obj).(type) {
 	case nil:
 		return graphql.Null
-	case OneTimeTokenForApplication:
-		return ec._OneTimeTokenForApplication(ctx, sel, &obj)
 	case *OneTimeTokenForApplication:
 		if obj == nil {
 			return graphql.Null


### PR DESCRIPTION
There is an issue with OneTimeToken validation. Certificate system auths has nil Value and this is mistakenly assumed to be OneTimeToken.

In addition, if this was not the case a nil pointer dereference panic happens a few lines below since we access sa.Value.OneTimeToken, but Value is nil for certificates.