### PR TITLE
Handle same customer and account external tenants ID

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -75,7 +75,7 @@ global:
       version: "PR-2027"
     director:
       dir:
-      version: "PR-2048"
+      version: "PR-2052"
     gateway:
       dir:
       version: "PR-2034"
@@ -104,7 +104,7 @@ global:
       version: "PR-45"
     e2e_tests:
       dir:
-      version: "PR-2027"
+      version: "PR-2052"
   isLocalEnv: false
   oauth2:
     host: oauth2

--- a/components/director/internal/tenantfetchersvc/handler.go
+++ b/components/director/internal/tenantfetchersvc/handler.go
@@ -189,6 +189,10 @@ func (h *handler) getSubscriptionRequest(body []byte, region string) (*TenantSub
 		req.SubaccountTenantID = ""
 	}
 
+	if req.AccountTenantID == req.CustomerTenantID {
+		req.CustomerTenantID = ""
+	}
+
 	return req, nil
 }
 

--- a/tests/tenant-fetcher/tests/handler_test.go
+++ b/tests/tenant-fetcher/tests/handler_test.go
@@ -109,6 +109,23 @@ func TestOnboardingHandler(t *testing.T) {
 		assertTenant(t, tnt, tenant.TenantID, tenant.Subdomain)
 	})
 
+	t.Run("Successful account tenant creation with matching account and subaccount tenant IDs", func(t *testing.T) {
+		id := uuid.New().String()
+		tenant := Tenant{
+			CustomerID: id,
+			TenantID:     id,
+			Subdomain:    defaultSubdomain,
+		}
+
+		addTenantExpectStatusCode(t, tenant, http.StatusOK)
+
+		tnt, err := fixtures.GetTenantByExternalID(dexGraphQLClient, tenant.TenantID)
+		require.NoError(t, err)
+
+		// THEN
+		assertTenant(t, tnt, tenant.TenantID, tenant.Subdomain)
+	})
+
 	t.Run("Should not add already existing tenants", func(t *testing.T) {
 		tenantWithCustomer := Tenant{
 			TenantID:               uuid.New().String(),

--- a/tests/tenant-fetcher/tests/handler_test.go
+++ b/tests/tenant-fetcher/tests/handler_test.go
@@ -113,8 +113,8 @@ func TestOnboardingHandler(t *testing.T) {
 		id := uuid.New().String()
 		tenant := Tenant{
 			CustomerID: id,
-			TenantID:     id,
-			Subdomain:    defaultSubdomain,
+			TenantID:   id,
+			Subdomain:  defaultSubdomain,
 		}
 
 		addTenantExpectStatusCode(t, tenant, http.StatusOK)

--- a/tests/tenant-fetcher/tests/handler_test.go
+++ b/tests/tenant-fetcher/tests/handler_test.go
@@ -109,12 +109,13 @@ func TestOnboardingHandler(t *testing.T) {
 		assertTenant(t, tnt, tenant.TenantID, tenant.Subdomain)
 	})
 
-	t.Run("Successful account tenant creation with matching account and subaccount tenant IDs", func(t *testing.T) {
+	t.Run("Successful account tenant creation with matching customer and account tenant IDs", func(t *testing.T) {
 		id := uuid.New().String()
 		tenant := Tenant{
-			CustomerID: id,
-			TenantID:   id,
-			Subdomain:  defaultSubdomain,
+			CustomerID:             id,
+			TenantID:               id,
+			Subdomain:              defaultSubdomain,
+			SubscriptionProviderID: uuid.New().String(),
 		}
 
 		addTenantExpectStatusCode(t, tenant, http.StatusOK)


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:
- Support subscription requests for accounts with matching external ID and parent (customer) ID. Same as https://github.com/kyma-incubator/compass/pull/2019

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- https://github.com/kyma-incubator/compass/pull/2019

**Pull Request status**
<!-- Feel free to construct the checklist with whatever items seem most reasonable for your change. You could disassemble the Implementation part to even smaller separate checklist items if you're working on something big for example. But do make the effort to provide a checklist of some sort so that the core team as well as the community can have an idea about the progress of your Pull Request.
-->

- [x] Implementation
- [x] Unit tests
- [x] Integration tests
- [x] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
