### PR TITLE
Expose cert info

### DIFF
--- a/chart/compass/charts/director/templates/deployment.yaml
+++ b/chart/compass/charts/director/templates/deployment.yaml
@@ -145,6 +145,12 @@ spec:
               value: "https://{{ .Values.global.connectivity_adapter.tls.host }}.{{ .Values.global.ingress.domainName }}/v1/applications/signingRequests/info"
             - name: APP_SUGGEST_TOKEN_HTTP_HEADER
               value: {{ .Values.global.director.suggestTokenHeaderKey }}
+            - name: APP_INFO_API_ENDPOINT
+              value: {{ .Values.global.director.info.path }}
+            - name: APP_INFO_CERT_SUBJECT
+              value: {{ .Values.global.director.info.certSubject }}
+            - name: APP_INFO_CERT_ISSUER
+              value: {{ .Values.global.director.info.certIssuer }}
             {{- if .Values.deployment.pairingAdapterConfigMap }}
             - name: APP_PAIRING_ADAPTER_SRC
               value: /pairing-adapters/config.json

--- a/chart/compass/charts/director/templates/virtual-service.yaml
+++ b/chart/compass/charts/director/templates/virtual-service.yaml
@@ -18,6 +18,8 @@ spec:
     - match:
         - uri:
             exact: /healthz
+        - uri:
+            exact: {{ .Values.global.director.info.path }}
       route:
         - destination:
             port:

--- a/chart/compass/templates/internal-communication-policies.yaml
+++ b/chart/compass/templates/internal-communication-policies.yaml
@@ -30,6 +30,11 @@ spec:
             methods:
               - GET
             paths:
+              - {{ .Values.global.director.info.path }}
+        - operation:
+            methods:
+              - GET
+            paths:
               - /readyz*
         - operation:
             methods:

--- a/chart/compass/templates/tests/director/director-test.yaml
+++ b/chart/compass/templates/tests/director/director-test.yaml
@@ -104,6 +104,12 @@ spec:
               value: "{{.Values.global.tests.token.server.enabled}}"
             - name: APP_ADDRESS
               value: "0.0.0.0:{{.Values.global.tests.token.server.port}}"
+            - name: APP_INFO_API_ENDPOINT
+              value: {{ .Values.global.director.info.path }}
+            - name: APP_INFO_CERT_SUBJECT
+              value: {{ .Values.global.director.info.certSubject }}
+            - name: APP_INFO_CERT_ISSUER
+              value: {{ .Values.global.director.info.certIssuer }}
           {{ if .Values.global.isLocalEnv }}
           volumeMounts:
             - mountPath: "/src/github.com/kyma-incubator/compass/components/director/examples"

--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -136,6 +136,10 @@ global:
       port: 3002
       path: "/operation"
       lastOperationPath: "/last_operation"
+    info:
+      path: "/v1/info"
+      certIssuer: "C=BG, L=Local, O=CMP, OU=Local, CN=CMP"
+      certSubject: "C=BG, O=CMP, OU=Local, L=Local, CN=local-clients"
 
     clientIDHeaderKey: client_user
     suggestTokenHeaderKey: suggest_token

--- a/components/director/cmd/director/main.go
+++ b/components/director/cmd/director/main.go
@@ -139,7 +139,7 @@ type config struct {
 
 	ReadyConfig healthz.ReadyConfig
 
-	CertInfoConfig info.Config
+	InfoConfig info.Config
 
 	DataloaderMaxBatch int           `envconfig:"default=200"`
 	DataloaderWait     time.Duration `envconfig:"default=10ms"`
@@ -331,7 +331,7 @@ func main() {
 	mainRouter.HandleFunc("/healthz", healthz.NewHealthHandler(health))
 
 	logger.Infof("Registering info endpoint...")
-	mainRouter.HandleFunc(cfg.CertInfoConfig.APIEndpoint, info.NewInfoHandler(ctx, cfg.CertInfoConfig))
+	mainRouter.HandleFunc(cfg.InfoConfig.APIEndpoint, info.NewInfoHandler(ctx, cfg.InfoConfig))
 
 	examplesServer := http.FileServer(http.Dir("./examples/"))
 	mainRouter.PathPrefix("/examples/").Handler(http.StripPrefix("/examples/", examplesServer))

--- a/components/director/cmd/director/main.go
+++ b/components/director/cmd/director/main.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/kyma-incubator/compass/components/director/internal/cert_info"
+	"github.com/kyma-incubator/compass/components/director/internal/info"
 
 	gqlgen "github.com/99designs/gqlgen/graphql"
 	"github.com/99designs/gqlgen/graphql/handler"
@@ -139,7 +139,7 @@ type config struct {
 
 	ReadyConfig healthz.ReadyConfig
 
-	CertInfoConfig cert_info.Config
+	CertInfoConfig info.Config
 
 	DataloaderMaxBatch int           `envconfig:"default=200"`
 	DataloaderWait     time.Duration `envconfig:"default=10ms"`
@@ -330,8 +330,8 @@ func main() {
 	health.RegisterIndicator(healthz.NewIndicator(healthz.DBIndicatorName, healthz.NewDBIndicatorFunc(transact))).Start()
 	mainRouter.HandleFunc("/healthz", healthz.NewHealthHandler(health))
 
-	logger.Infof("Registering certificate info endpoint...")
-	mainRouter.HandleFunc(cfg.CertInfoConfig.APIEndpoint, cert_info.NewCertInfoHandler(ctx, cfg.CertInfoConfig))
+	logger.Infof("Registering info endpoint...")
+	mainRouter.HandleFunc(cfg.CertInfoConfig.APIEndpoint, info.NewInfoHandler(ctx, cfg.CertInfoConfig))
 
 	examplesServer := http.FileServer(http.Dir("./examples/"))
 	mainRouter.PathPrefix("/examples/").Handler(http.StripPrefix("/examples/", examplesServer))

--- a/components/director/internal/info/handler.go
+++ b/components/director/internal/info/handler.go
@@ -1,0 +1,25 @@
+package info
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/kyma-incubator/compass/components/director/pkg/httputils"
+)
+
+type Config struct {
+	APIEndpoint string `envconfig:"APP_INFO_API_ENDPOINT,default=/v1/info" json:"-"`
+	Issuer      string `envconfig:"APP_INFO_CERT_ISSUER" json:"certIssuer"`
+	Subject     string `envconfig:"APP_INFO_CERT_SUBJECT" json:"certSubject"`
+}
+
+// NewInfoHandler returns handler returns an endpoint which gives information about the CMP client certificate
+func NewInfoHandler(ctx context.Context, c Config) func(writer http.ResponseWriter, request *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		httputils.RespondWithBody(ctx, w, http.StatusOK, c)
+	}
+}

--- a/components/director/pkg/httputils/response.go
+++ b/components/director/pkg/httputils/response.go
@@ -8,7 +8,7 @@ import (
 	"github.com/kyma-incubator/compass/components/director/pkg/log"
 )
 
-// RespondWithBody missing godoc
+// RespondWithBody writes a http response using with the JSON encoded data as payload
 func RespondWithBody(ctx context.Context, w http.ResponseWriter, status int, data interface{}) {
 	w.Header().Add(HeaderContentType, ContentTypeApplicationJSON)
 	w.WriteHeader(status)
@@ -18,7 +18,7 @@ func RespondWithBody(ctx context.Context, w http.ResponseWriter, status int, dat
 	}
 }
 
-// RespondWithError missing godoc
+// RespondWithError writes a http response using with the JSON encoded error wrapped in an Error struct
 func RespondWithError(ctx context.Context, w http.ResponseWriter, status int, err error) {
 	log.C(ctx).WithError(err).Errorf("Responding with error: %v", err)
 	w.Header().Add(HeaderContentType, ContentTypeApplicationJSON)

--- a/components/director/run.sh
+++ b/components/director/run.sh
@@ -195,6 +195,8 @@ export APP_HEALTH_CONFIG_INDICATORS="{database,5s,1s,1s,3}"
 export APP_SUGGEST_TOKEN_HTTP_HEADER=suggest_token
 export APP_SCHEMA_MIGRATION_VERSION=$(ls -lr ${ROOT_PATH}/../schema-migrator/migrations/director | head -n 2 | tail -n 1 | tr -s ' ' | cut -d ' ' -f9 | cut -d '_' -f1)
 export APP_ALLOW_JWT_SIGNING_NONE=true
+export APP_CERT_SUBJECT="C=BG, O=CMP, OU=Local, L=Local, CN=local-clients"
+export APP_CERT_ISSUER="C=BG, L=Local, O=CMP, OU=Local, CN=CMP"
 
 # Tenant Fetcher properties
 export APP_SUBSCRIPTION_CALLBACK_SCOPE=Callback

--- a/components/director/run.sh
+++ b/components/director/run.sh
@@ -195,8 +195,8 @@ export APP_HEALTH_CONFIG_INDICATORS="{database,5s,1s,1s,3}"
 export APP_SUGGEST_TOKEN_HTTP_HEADER=suggest_token
 export APP_SCHEMA_MIGRATION_VERSION=$(ls -lr ${ROOT_PATH}/../schema-migrator/migrations/director | head -n 2 | tail -n 1 | tr -s ' ' | cut -d ' ' -f9 | cut -d '_' -f1)
 export APP_ALLOW_JWT_SIGNING_NONE=true
-export APP_CERT_SUBJECT="C=BG, O=CMP, OU=Local, L=Local, CN=local-clients"
-export APP_CERT_ISSUER="C=BG, L=Local, O=CMP, OU=Local, CN=CMP"
+export APP_INFO_CERT_ISSUER="C=BG, L=Local, O=CMP, OU=Local, CN=CMP"
+export APP_INFO_CERT_SUBJECT="C=BG, O=CMP, OU=Local, L=Local, CN=local-clients"
 
 # Tenant Fetcher properties
 export APP_SUBSCRIPTION_CALLBACK_SCOPE=Callback

--- a/tests/director/tests/info_api_test.go
+++ b/tests/director/tests/info_api_test.go
@@ -1,0 +1,35 @@
+package tests
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetInfo(t *testing.T) {
+	get, err := http.DefaultClient.Get(conf.InfoUrl)
+	require.NoError(t, err)
+
+	info := struct {
+		Subject string `json:"certSubject"`
+		Issuer  string `json:"certIssuer"`
+	}{}
+
+	err = json.NewDecoder(get.Body).Decode(&info)
+	require.NoError(t, err)
+
+	require.Equal(t, conf.CertSubject, info.Subject)
+	require.Equal(t, conf.CertIssuer, info.Issuer)
+}
+
+func TestCallingInfoEndpointFailForMethodsOtherThanGet(t *testing.T) {
+	req, err := http.NewRequest(http.MethodPost, conf.InfoUrl, strings.NewReader("{}"))
+	require.NoError(t, err)
+	get, err := http.DefaultClient.Do(req)
+
+	require.NoError(t, err)
+	require.Equal(t, http.StatusMethodNotAllowed, get.StatusCode)
+}

--- a/tests/pkg/config/director.go
+++ b/tests/pkg/config/director.go
@@ -3,6 +3,9 @@ package config
 type DirectorConfig struct {
 	HealthUrl                  string `envconfig:"default=https://director.kyma.local/healthz"`
 	WebhookUrl                 string `envconfig:"default=https://kyma-project.io"`
+	InfoUrl                    string `envconfig:"APP_INFO_API_ENDPOINT"`
+	CertIssuer                 string `envconfig:"APP_INFO_CERT_ISSUER"`
+	CertSubject                string `envconfig:"APP_INFO_CERT_SUBJECT"`
 	DefaultScenario            string `envconfig:"default=DEFAULT"`
 	DefaultScenarioEnabled     bool   `envconfig:"default=true"`
 	DefaultNormalizationPrefix string `envconfig:"default=mp-"`


### PR DESCRIPTION
**Description**
This PR introduces a new unsecured endpoint on which information about client certificates used in compass can be found. 

Changes proposed in this pull request:
- Introduce new endpoint in director
- Add configuration in values.yaml
- Adjust director deployment with the new necessary envvars
- Add e2e test and adjust test definition

**Pull Request status**

- [X Implementation
- [ ] Unit tests
- [X] Integration tests
- [ ] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [ ] Mocks are regenerated, using the automated script
