### PR TITLE
Make authenticator config in ORY Rule overridable

### DIFF
--- a/chart/compass/charts/gateway/templates/oathkeeper-authenticator-rules.yaml
+++ b/chart/compass/charts/gateway/templates/oathkeeper-authenticator-rules.yaml
@@ -18,7 +18,12 @@ spec:
     handler: allow
   mutators:
   - handler: hydrator
-{{ toYaml $value.cfg| indent 4 }}
+    config:
+      api:
+        url: {{ $value.cfg.config.api.url }}
+        retry:
+          give_up_after: {{ $value.cfg.config.api.retry.give_up_after | default "6s" }}
+          max_delay: {{ $value.cfg.config.api.retry.max_delay | default "2000ms" }}
   - handler: hydrator
 {{ toYaml $.Values.global.oathkeeper.mutators.tenantMappingService | indent 4 }}
   - handler: id_token


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

It is not possible to override the values of the authenticator config with its current structure.

Changes proposed in this pull request:
- Make ORY rule configurable for different authenticators

**Related PR(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- https://github.com/kyma-incubator/compass/pull/2050
