### PR TITLE
Fix timeout check in Operations Controller

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -75,7 +75,7 @@ global:
       version: "PR-2027"
     director:
       dir:
-      version: "PR-2068"
+      version: "PR-2071"
     gateway:
       dir:
       version: "PR-2050"

--- a/components/operations-controller/api/v1alpha1/operation_types.go
+++ b/components/operations-controller/api/v1alpha1/operation_types.go
@@ -175,7 +175,7 @@ func (in *Operation) NextPollTime(retryInterval *int, timeLayout string) (time.D
 // based on the creation timestamp of the Operation and the provided
 // timeout duration variable.
 func (in *Operation) TimeoutReached(timeout time.Duration) bool {
-	operationEndTime := in.ObjectMeta.CreationTimestamp.Time.Add(timeout)
+	operationEndTime := in.Status.InitializedAt.Time.Add(timeout)
 
 	return time.Now().After(operationEndTime)
 }


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
When we try to retrigger a failed async delete operation the operations-controller sets the state as "Failed" immediately, instead of actually retrying to delete the resource.
That happens when you retry an operation that was created <timeout> minutes before now.
 
Changes proposed in this pull request:
- Use `InitializedAt` status field for checking if the operation is timed-out or not

**Pull Request status**
<!-- Feel free to construct the checklist with whatever items seem most reasonable for your change. You could disassemble the Implementation part to even smaller separate checklist items if you're working on something big for example. But do make the effort to provide a checklist of some sort so that the core team as well as the community can have an idea about the progress of your Pull Request.
-->

- [x] Implementation
- [ ] Unit tests
- [ ] Integration tests
- [ ] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [ ] Mocks are regenerated, using the automated script
