### PR TITLE
Add check for Extra fields length in SystemAuth Provider matcher

### DIFF
--- a/components/director/internal/tenantmapping/system_auth_context_provider_test.go
+++ b/components/director/internal/tenantmapping/system_auth_context_provider_test.go
@@ -371,6 +371,27 @@ func TestSystemAuthContextProviderMatch(t *testing.T) {
 		require.Equal(t, clientID, authDetails.AuthID)
 	})
 
+	t.Run("returns nil when a client_id is specified in the Extra map of request body, but the extra fields are more than expected", func(t *testing.T) {
+		clientID := "de766a55-3abb-4480-8d4a-6d255990b159"
+		reqData := oathkeeper.ReqData{
+			Body: oathkeeper.ReqBody{
+				Extra: map[string]interface{}{
+					oathkeeper.ClientIDKey: clientID,
+					oathkeeper.ScopesKey: "application:read",
+					oathkeeper.UsernameKey: "test",
+					"extra-field": "extra",
+				},
+			},
+		}
+
+		provider := tenantmapping.NewSystemAuthContextProvider(nil, nil, nil)
+
+		match, _, err := provider.Match(context.TODO(), reqData)
+
+		require.False(t, match)
+		require.NoError(t, err)
+	})
+
 	t.Run("returns ID string and CertificateFlow when a client-id-from-certificate is specified in the Header map of request body", func(t *testing.T) {
 		clientID := "de766a55-3abb-4480-8d4a-6d255990b159"
 		provider := tenantmapping.NewSystemAuthContextProvider(nil, nil, nil)


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

For JWT tokens coming from external auth provider, which is not ORY Hydra, we also fall in the case where we have `client_id` in the JWT Extra fields, hence we try to provide auth context with SystemAuthObjectContextProvider, which results in SQL error. After that error, we're no longer able to execute DB requests, because the transaction is brokern. 

Possible fixes:
* Open a new transaction for each context provider. Looks like an overhead to me.
* Strip the `client_id` in the authenticator authnmappinghandler
* [current] Verify that the Extra attributes do not exceed 3 :) 
* [in progress] Strip configurable amount of extra fields in authnmappinghandler



Changes proposed in this pull request:
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- ...

**Pull Request status**
<!-- Feel free to construct the checklist with whatever items seem most reasonable for your change. You could disassemble the Implementation part to even smaller separate checklist items if you're working on something big for example. But do make the effort to provide a checklist of some sort so that the core team as well as the community can have an idea about the progress of your Pull Request.
-->

- [ ] Implementation
- [ ] Unit tests
- [ ] Integration tests
- [ ] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [ ] Mocks are regenerated, using the automated script
