### PR TITLE
Improve schema-migrator

### DIFF
--- a/installation/cmd/run.sh
+++ b/installation/cmd/run.sh
@@ -127,8 +127,10 @@ if [[ ${DUMP_DB} ]]; then
 
     if [ "$(uname)" == "Darwin" ]; then #  this is the case when the script is ran on local Mac OSX machines, reference issue: https://stackoverflow.com/questions/4247068/sed-command-with-i-option-failing-on-mac-but-works-on-linux
         sed -i '' 's/image\:.*compass-schema-migrator.*/image\: compass-schema-migrator\:'$DUMP_IMAGE_TAG'/' ${ROOT_PATH}/chart/compass/templates/migrator-job.yaml
+        sed -i '' 's/image\:.*compass-schema-migrator.*/image\: compass-schema-migrator\:'$DUMP_IMAGE_TAG'/' ${ROOT_PATH}/chart/compass/templates/update-expected-schema-version-job.yaml
     else # this is the case when the script is ran on non-Mac OSX machines, ex. as part of remote PR jobs
         sed -i 's/image\:.*compass-schema-migrator.*/image\: compass-schema-migrator\:'$DUMP_IMAGE_TAG'/' ${ROOT_PATH}/chart/compass/templates/migrator-job.yaml
+        sed -i '' 's/image\:.*compass-schema-migrator.*/image\: compass-schema-migrator\:'$DUMP_IMAGE_TAG'/' ${ROOT_PATH}/chart/compass/templates/update-expected-schema-version-job.yaml
     fi
 
 


### PR DESCRIPTION
**Description**
In our PR if we try to use the schema-migrator version(PR-XX) from another PR and we run local installation with DB_DUMP without adding the new "migrations" in our local setup the director won't start because of the readiness probe. That happens because we have two jobs - compass-migration and update-expected-schema-version. The second one will use the image of the "remote" PR but the image of the compass-migration job will be build/created in the run.sh of the director during local installation using the migrations currently present in the local setup. So the two versions of the migrations in the jobs will be different and the readiness probe won't be successful.

Changes proposed in this pull request:
- Update the image of the update-expected-schema-version job in case we use DB_DUMP option. So we can have same migrations in the both jobs

- [ ] Implementation
- [ ] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
