### PR TITLE
Strip configurable extra fields in authenticator

### DIFF
--- a/chart/compass/charts/director/templates/deployment.yaml
+++ b/chart/compass/charts/director/templates/deployment.yaml
@@ -163,6 +163,8 @@ spec:
               value: {{ $config.authenticator.trusted_issuers | quote }}
             - name: APP_{{ $config.authenticator.name }}_AUTHENTICATOR_ATTRIBUTES
               value: {{ $config.authenticator.attributes | quote }}
+            - name: APP_{{ $config.authenticator.name }}_AUTHENTICATOR_STRIP_EXTRA_FIELDS
+              value: {{ $config.authenticator.strip_extra_fields | quote }}
             {{- end }}
             {{- end }}
             - name: APP_HEALTH_CONFIG_INDICATORS

--- a/chart/compass/charts/external-services-mock/templates/oauth-credentials-secret.yaml
+++ b/chart/compass/charts/external-services-mock/templates/oauth-credentials-secret.yaml
@@ -9,7 +9,8 @@ data:
   auditlog-client-id: {{ "client_id" | b64enc | quote }}
   auditlog-client-secret: {{ "client_secret" | b64enc | quote }}
   auditlog-oauth-url: {{ printf "http://compass-external-services-mock.%s.svc.cluster.local:%s/audit-log/v2/oauth/token" .Release.Namespace (.Values.service.port | toString) | b64enc | quote }}
-{{end}}
+{{- end }}
+{{- if eq .Values.global.ordAggregator.accessStrategies.cmpMtls.oauthSecret.manage true }}
 ---
 apiVersion: v1
 kind: Secret
@@ -21,6 +22,7 @@ data:
   {{ .Values.global.ordAggregator.accessStrategies.cmpMtls.oauthSecret.clientIdKey }}: {{ "client_id" | b64enc | quote }}
   {{ .Values.global.ordAggregator.accessStrategies.cmpMtls.oauthSecret.clientSecretKey }}: {{ "client_secret" | b64enc | quote }}
   {{ .Values.global.ordAggregator.accessStrategies.cmpMtls.oauthSecret.urlKey }}: {{ printf "http://compass-external-services-mock.%s.svc.cluster.local:%s" .Release.Namespace (.Values.service.port | toString) | b64enc | quote }}
+{{- end }}
 ---
 apiVersion: v1
 kind: Secret

--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -75,7 +75,7 @@ global:
       version: "PR-2027"
     director:
       dir:
-      version: "PR-2068"
+      version: "PR-2075"
     gateway:
       dir:
       version: "PR-2050"

--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -331,6 +331,7 @@ global:
             gatewayHost: "compass-gateway"
             trusted_issuers: '[{"domain_url": "compass-system.svc.cluster.local:8080", "scope_prefix": "prefix.", "protocol": "http"}]'
             attributes: '{"uniqueAttribute": { "key": "test", "value": "tenant-fetcher" }, "tenant": { "key": "tenant" }, "identity": { "key": "identity" } }'
+            strip_extra_fields: '["test"]'
             path: /tenants/<.*>
             upstreamComponent: "compass-tenant-fetcher"
         subscriber:
@@ -428,6 +429,7 @@ global:
         tokenPath: "/secured/oauth/token"
         oauthSecret:
           name: cert-svc-oauth-secret
+          manage: true
           urlKey: url
           clientIdKey: client-id
           clientSecretKey: client-secret

--- a/components/director/internal/authnmappinghandler/handler.go
+++ b/components/director/internal/authnmappinghandler/handler.go
@@ -157,6 +157,11 @@ func (h *Handler) ServeHTTP(writer http.ResponseWriter, req *http.Request) {
 	}
 	reqData.Body.Extra[authenticator.CoordinatesKey] = authCoordinates
 
+	config := h.authenticators[authCoordinates.Index]
+	for _, f := range config.StripExtraFields {
+		delete(reqData.Body.Extra, f)
+	}
+
 	h.respond(ctx, writer, reqData.Body)
 }
 

--- a/components/director/pkg/authenticator/types.go
+++ b/components/director/pkg/authenticator/types.go
@@ -28,9 +28,10 @@ const HeaderName = "X-Authenticator-Name"
 
 // Config holds all configuration related to an additional authenticator provided to the Director
 type Config struct {
-	Name           string          `json:"name"`
-	TrustedIssuers []TrustedIssuer `json:"trusted_issuers"`
-	Attributes     Attributes      `json:"attributes"`
+	Name             string          `json:"name"`
+	TrustedIssuers   []TrustedIssuer `json:"trusted_issuers"`
+	Attributes       Attributes      `json:"attributes"`
+	StripExtraFields []string        `json:"strip_extra_fields"`
 }
 
 // TrustedIssuer missing godoc


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

For JWT tokens coming from external auth provider, which is not ORY Hydra, we also fall in the case where we have `client_id` in the JWT Extra fields, hence we try to provide auth context with SystemAuthObjectContextProvider, which results in SQL error. After that error, we're no longer able to execute DB requests, because the transaction is brokern. 

Possible fixes:
* Open a new transaction for each context provider. Looks like an overhead to me.
* Strip the `client_id` in the authenticator authnmappinghandler
* Verify that the Extra attributes do not exceed 3 :) 
* [preferred] Strip configurable amount of extra fields in authnmappinghandler



Changes proposed in this pull request:
- Strip configurable amount of extra fields in authnmappinghandler
- Create certificate service oauth client secret conditionally

**Related PR(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- https://github.com/kyma-incubator/compass/pull/2050

**Pull Request status**
<!-- Feel free to construct the checklist with whatever items seem most reasonable for your change. You could disassemble the Implementation part to even smaller separate checklist items if you're working on something big for example. But do make the effort to provide a checklist of some sort so that the core team as well as the community can have an idea about the progress of your Pull Request.
-->

- [x] Implementation
- [ ] Unit tests
- [ ] Integration tests - I'm not sure how that would happen
- [x] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
