### PR TITLE
Credentials rotation

### DIFF
--- a/chart/compass/charts/external-services-mock/templates/deployment.yaml
+++ b/chart/compass/charts/external-services-mock/templates/deployment.yaml
@@ -32,13 +32,13 @@ spec:
               - name: APP_CLIENT_ID
                 valueFrom:
                   secretKeyRef:
-                    name: {{ .Values.global.auditlog.secretName }}
-                    key: auditlog-client-id
+                    name: {{ .Values.global.auditlog.secret.name }}
+                    key: {{ .Values.global.auditlog.secret.clientIdKey }}
               - name: APP_CLIENT_SECRET
                 valueFrom:
                   secretKeyRef:
-                    name: {{ .Values.global.auditlog.secretName }}
-                    key: auditlog-client-secret
+                    name: {{ .Values.global.auditlog.secret.name }}
+                    key: {{ .Values.global.auditlog.secret.clientSecretKey }}
               {{- end }}
               - name: BASIC_USERNAME
                 valueFrom:

--- a/chart/compass/charts/external-services-mock/templates/oauth-credentials-secret.yaml
+++ b/chart/compass/charts/external-services-mock/templates/oauth-credentials-secret.yaml
@@ -14,13 +14,15 @@ data:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Values.global.ordAggregator.accessStrategies.cmpMtls.oauthSecret.name }}
+  name: {{ .Values.global.ordAggregator.accessStrategies.cmpMtls.secret.name }}
   namespace: {{ .Release.Namespace }}
 type: Opaque
 data:
-  {{ .Values.global.ordAggregator.accessStrategies.cmpMtls.oauthSecret.clientIdKey }}: {{ "client_id" | b64enc | quote }}
-  {{ .Values.global.ordAggregator.accessStrategies.cmpMtls.oauthSecret.clientSecretKey }}: {{ "client_secret" | b64enc | quote }}
-  {{ .Values.global.ordAggregator.accessStrategies.cmpMtls.oauthSecret.urlKey }}: {{ printf "http://compass-external-services-mock.%s.svc.cluster.local:%s" .Release.Namespace (.Values.service.port | toString) | b64enc | quote }}
+  {{ .Values.global.ordAggregator.accessStrategies.cmpMtls.secret.clientIdKey }}: {{ "client_id" | b64enc | quote }}
+  {{ .Values.global.ordAggregator.accessStrategies.cmpMtls.secret.clientSecretKey }}: {{ "client_secret" | b64enc | quote }}
+  {{ .Values.global.ordAggregator.accessStrategies.cmpMtls.secret.oauthUrlKey }}: {{ printf "http://compass-external-services-mock.%s.svc.cluster.local:%s" .Release.Namespace (.Values.service.port | toString) | b64enc | quote }}
+  {{ .Values.global.ordAggregator.accessStrategies.cmpMtls.secret.csrEndpointKey }}: {{ "http://compass-external-services-mock.compass-system.svc.cluster.local:8080" | b64enc | quote }}
+  {{ .Values.global.ordAggregator.accessStrategies.cmpMtls.secret.policyKey }}: {{ "compass-local-clients" | b64enc | quote }}
 ---
 apiVersion: v1
 kind: Secret

--- a/chart/compass/charts/external-services-mock/templates/oauth-credentials-secret.yaml
+++ b/chart/compass/charts/external-services-mock/templates/oauth-credentials-secret.yaml
@@ -2,13 +2,13 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Values.global.auditlog.secretName }}
+  name: {{ .Values.global.auditlog.secret.name }}
   namespace: {{ .Release.Namespace }}
 type: Opaque
 data:
-  auditlog-client-id: {{ "client_id" | b64enc | quote }}
-  auditlog-client-secret: {{ "client_secret" | b64enc | quote }}
-  auditlog-oauth-url: {{ printf "http://compass-external-services-mock.%s.svc.cluster.local:%s/audit-log/v2/oauth/token" .Release.Namespace (.Values.service.port | toString) | b64enc | quote }}
+  {{ .Values.global.auditlog.secret.clientIdKey }}: {{ "client_id" | b64enc | quote }}
+  {{ .Values.global.auditlog.secret.clientSecretKey }}: {{ "client_secret" | b64enc | quote }}
+    {{ .Values.global.auditlog.secret.urlKey }}: {{ printf "http://compass-external-services-mock.%s.svc.cluster.local:%s/audit-log/v2" .Release.Namespace (.Values.service.port | toString) | b64enc | quote }}
 {{end}}
 ---
 apiVersion: v1

--- a/chart/compass/charts/gateway/templates/deployment.yaml
+++ b/chart/compass/charts/gateway/templates/deployment.yaml
@@ -55,12 +55,12 @@ spec:
             - name: APP_AUDITLOG_USER
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.global.auditlog.secretName }}
+                  name: {{ .Values.global.auditlog.secret.name }}
                   key: auditlog-user
             - name: APP_AUDITLOG_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.global.auditlog.secretName }}
+                  name: {{ .Values.global.auditlog.secret.name }}
                   key: auditlog-password
             - name: APP_AUDITLOG_TENANT
               valueFrom:
@@ -73,18 +73,20 @@ spec:
             - name: APP_AUDITLOG_CLIENT_ID
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.global.auditlog.secretName }}
-                  key: auditlog-client-id
+                  name: {{ .Values.global.auditlog.secret.name }}
+                  key: {{ .Values.global.auditlog.secret.clientIdKey }}
             - name: APP_AUDITLOG_CLIENT_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.global.auditlog.secretName }}
-                  key: auditlog-client-secret
+                  name: {{ .Values.global.auditlog.secret.name }}
+                  key: {{ .Values.global.auditlog.secret.clientSecretKey }}
             - name: APP_AUDITLOG_OAUTH_URL
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.global.auditlog.secretName }}
-                  key: auditlog-oauth-url
+                  name: {{ .Values.global.auditlog.secret.name }}
+                  key: {{ .Values.global.auditlog.secret.urlKey }}
+            - name: APP_AUDITLOG_TOKEN_PATH
+              value: {{ .Values.global.auditlog.tokenPath }}
             - name: APP_AUDITLOG_OAUTH_USER
               valueFrom:
                 configMapKeyRef:

--- a/chart/compass/templates/ord-aggregator-job.yaml
+++ b/chart/compass/templates/ord-aggregator-job.yaml
@@ -85,24 +85,30 @@ spec:
                 - name: ACCESS_STRATEGY_SAP_CMP_MTLS_V1_LOCALITY
                   value: {{ $.Values.global.mtlsClient.locality }}
                 - name: ACCESS_STRATEGY_SAP_CMP_MTLS_V1_POLICY
-                  value: {{ $.Values.global.ordAggregator.accessStrategies.cmpMtls.policy }}
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ $.Values.global.ordAggregator.accessStrategies.cmpMtls.secret.name }}
+                      key: {{ $.Values.global.ordAggregator.accessStrategies.cmpMtls.secret.policyKey }}
                 - name: ACCESS_STRATEGY_SAP_CMP_MTLS_V1_CSR_ENDPOINT
-                  value: {{ $.Values.global.ordAggregator.accessStrategies.cmpMtls.csrEndpoint }}
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ $.Values.global.ordAggregator.accessStrategies.cmpMtls.secret.name }}
+                      key: {{ $.Values.global.ordAggregator.accessStrategies.cmpMtls.secret.csrEndpointKey }}
                 - name: ACCESS_STRATEGY_SAP_CMP_MTLS_V1_CLIENT_ID
                   valueFrom:
                     secretKeyRef:
-                      name: {{ $.Values.global.ordAggregator.accessStrategies.cmpMtls.oauthSecret.name }}
-                      key: {{ $.Values.global.ordAggregator.accessStrategies.cmpMtls.oauthSecret.clientIdKey }}
+                      name: {{ $.Values.global.ordAggregator.accessStrategies.cmpMtls.secret.name }}
+                      key: {{ $.Values.global.ordAggregator.accessStrategies.cmpMtls.secret.clientIdKey }}
                 - name: ACCESS_STRATEGY_SAP_CMP_MTLS_V1_CLIENT_SECRET
                   valueFrom:
                     secretKeyRef:
-                      name: {{ $.Values.global.ordAggregator.accessStrategies.cmpMtls.oauthSecret.name }}
-                      key: {{ $.Values.global.ordAggregator.accessStrategies.cmpMtls.oauthSecret.clientSecretKey }}
+                      name: {{ $.Values.global.ordAggregator.accessStrategies.cmpMtls.secret.name }}
+                      key: {{ $.Values.global.ordAggregator.accessStrategies.cmpMtls.secret.clientSecretKey }}
                 - name: ACCESS_STRATEGY_SAP_CMP_MTLS_V1_OAUTHURL
                   valueFrom:
                     secretKeyRef:
-                      name: {{ $.Values.global.ordAggregator.accessStrategies.cmpMtls.oauthSecret.name }}
-                      key: {{ $.Values.global.ordAggregator.accessStrategies.cmpMtls.oauthSecret.urlKey }}
+                      name: {{ $.Values.global.ordAggregator.accessStrategies.cmpMtls.secret.name }}
+                      key: {{ $.Values.global.ordAggregator.accessStrategies.cmpMtls.secret.oauthUrlKey }}
                 - name: ACCESS_STRATEGY_SAP_CMP_MTLS_V1_TOKEN_PATH
                   value: {{ $.Values.global.ordAggregator.accessStrategies.cmpMtls.tokenPath }}
                 - name: ACCESS_STRATEGY_SAP_CMP_MTLS_V1_CERT_SVC_API_PATH

--- a/chart/compass/templates/system-fetcher-job.yaml
+++ b/chart/compass/templates/system-fetcher-job.yaml
@@ -1,6 +1,4 @@
 {{if .Values.global.systemFetcher.enabled }}
-{{ $configmapName := printf "%s-%s-config" $.Chart.Name .Values.global.systemFetcher.name }}
-{{ $secretName := printf "%s-%s-secret" $.Chart.Name .Values.global.systemFetcher.name }}
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
@@ -71,18 +69,22 @@ spec:
                 - name: APP_OAUTH_CLIENT_ID
                   valueFrom:
                     secretKeyRef:
-                      name: "{{ $secretName }}"
-                      key: oauth-client-id
+                      name: {{ .Values.global.systemFetcher.secret.name }}
+                      key: {{ .Values.global.systemFetcher.secret.clientIdKey }}
                 - name: APP_OAUTH_CLIENT_SECRET
                   valueFrom:
                     secretKeyRef:
-                      name: "{{ $secretName }}"
-                      key: oauth-client-secret
-                - name: APP_OAUTH_TOKEN_ENDPOINT_PATTERN
+                      name: {{ .Values.global.systemFetcher.secret.name }}
+                      key: {{ .Values.global.systemFetcher.secret.clientSecretKey }}
+                - name: APP_OAUTH_TOKEN_BASE_URL
                   valueFrom:
                     secretKeyRef:
-                      name: "{{ $secretName }}"
-                      key: oauth-token-endpoint-pattern
+                      name: {{ .Values.global.systemFetcher.secret.name }}
+                      key: {{ .Values.global.systemFetcher.secret.oauthUrlKey }}
+                - name: APP_OAUTH_TOKEN_PATH
+                  value: {{ .Values.global.systemFetcher.oauth.tokenPath }}
+                - name: APP_OAUTH_TOKEN_ENDPOINT_PROTOCOL
+                  value: {{ .Values.global.systemFetcher.oauth.tokenEndpointProtocol }}
                 - name: APP_DB_USER
                   valueFrom:
                     secretKeyRef:
@@ -155,11 +157,11 @@ spec:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ $secretName }}
+  name: {{ .Values.global.systemFetcher.secret.name }}
   namespace: {{ .Release.Namespace }}
 data:
-  oauth-client-id: {{ .Values.global.systemFetcher.oauth.client | b64enc | quote }}
-  oauth-client-secret: {{ .Values.global.systemFetcher.oauth.secret | b64enc | quote }}
-  oauth-token-endpoint-pattern: {{ .Values.global.systemFetcher.oauth.tokenURLPattern | b64enc | quote }}
+  {{ .Values.global.systemFetcher.secret.clientIdKey }}: {{ .Values.global.systemFetcher.oauth.client | b64enc | quote }}
+  {{ .Values.global.systemFetcher.secret.clientSecretKey }}: {{ .Values.global.systemFetcher.oauth.secret | b64enc | quote }}
+  {{ .Values.global.systemFetcher.secret.oauthUrlKey }}: {{ .Values.global.systemFetcher.oauth.tokenBaseUrl | b64enc | quote }}
 {{ end }}
 {{ end }}

--- a/chart/compass/templates/tenant-fetcher-job.yaml
+++ b/chart/compass/templates/tenant-fetcher-job.yaml
@@ -94,18 +94,20 @@ spec:
               - name: APP_CLIENT_ID
                 valueFrom:
                   secretKeyRef:
-                    name: compass-tenant-fetcher-secret-{{ $tenantFetcherName }}
-                    key: oauth-client
+                    name: {{ $config.secret.name }}
+                    key: {{ $config.secret.clientIdKey }}
               - name: APP_CLIENT_SECRET
                 valueFrom:
                   secretKeyRef:
-                    name: compass-tenant-fetcher-secret-{{ $tenantFetcherName }}
-                    key: oauth-secret
+                    name: {{ $config.secret.name }}
+                    key: {{ $config.secret.clientSecretKey }}
               - name: APP_OAUTH_TOKEN_ENDPOINT
                 valueFrom:
                   secretKeyRef:
-                    name: compass-tenant-fetcher-secret-{{ $tenantFetcherName }}
-                    key: oauth-token-endpoint
+                    name: {{ $config.secret.name }}
+                    key: {{ $config.secret.oauthUrlKey }}
+              - name: APP_OAUTH_TOKEN_PATH
+                value: {{ $config.oauth.tokenPath }}
               - name: APP_LAST_EXECUTION_TIME_CONFIG_MAP_NAME
                 value: {{ $configmapName }}
               - name: APP_CONFIGMAP_NAMESPACE

--- a/chart/compass/templates/tenant-fetcher-secret.yaml
+++ b/chart/compass/templates/tenant-fetcher-secret.yaml
@@ -5,11 +5,11 @@ apiVersion: v1
 kind: Secret
 type: Opaque
 metadata:
-  name: "compass-tenant-fetcher-secret-{{ $tenantFetcherName }}"
+  name: {{ $config.secret.name }}
   namespace: {{ $.Release.Namespace }}
 data:
-  oauth-client: {{ $config.oauth.client | b64enc | quote }}
-  oauth-secret: {{ $config.oauth.secret | b64enc | quote }}
-  oauth-token-endpoint: {{ $config.oauth.tokenURL | b64enc | quote }}
+  {{ $config.secret.clientIdKey }}: {{ $config.oauth.client | b64enc | quote }}
+  {{ $config.secret.clientSecretKey }}: {{ $config.oauth.secret | b64enc | quote }}
+  {{ $config.secret.oauthUrlKey }}: {{ $config.oauth.tokenURL | b64enc | quote }}
 {{- end -}}
 {{ end }}

--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -145,9 +145,12 @@ global:
 
   auditlog:
     configMapName: "compass-gateway-auditlog-config"
-    secretName: "compass-gateway-auditlog-secret"
-    script:
-      configMapName: "auditlog-script"
+    tokenPath: "/oauth/token"
+    secret:
+      name: "compass-gateway-auditlog-secret"
+      urlKey: url
+      clientIdKey: client-id
+      clientSecretKey: client-secret
 
   log:
     format: "kibana"

--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -398,15 +398,15 @@ global:
     securedApplicationTypes: "sample-app-type" # comma-separated values are used for specifying multiple application types
     accessStrategies:
       cmpMtls:
-        policy: "compass-local-clients"
-        csrEndpoint: "http://compass-external-services-mock.compass-system.svc.cluster.local:8080"
         certSvcApiPath: "/cert"
         tokenPath: "/secured/oauth/token"
-        oauthSecret:
-          name: cert-svc-oauth-secret
-          urlKey: url
+        secret:
+          name: cert-svc-secret
+          oauthUrlKey: url
           clientIdKey: client-id
           clientSecretKey: client-secret
+          csrEndpointKey: csr-endpoint
+          policyKey: policy
 
   systemFetcher:
     enabled: false

--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -465,6 +465,12 @@ global:
         client: ""
         secret: ""
         tokenURL: ""
+        tokenPath: ""
+      secret:
+        name: "compass-tenant-fetcher-secret-job1"
+        clientIdKey: client-id
+        clientSecretKey: client-secret
+        oauthUrlKey: url
       endpoints:
         tenantCreated: "127.0.0.1/events?type=created"
         tenantDeleted: "127.0.0.1/events?type=deleted"

--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -361,7 +361,6 @@ global:
       subdomainProperty: "subdomain"
       name: "provider"
       subscriptionProviderIdProperty: "subscriptionProviderId"
-
     server:
       handlerEndpoint: "/v1/callback/{tenantId}"
       regionalHandlerEndpoint: "/v1/regional/{region}/callback/{tenantId}"
@@ -441,9 +440,16 @@ global:
     oauth:
       client: ""
       secret: ""
-      tokenURLPattern: ""
+      tokenEndpointProtocol: ""
+      tokenBaseUrl: ""
+      tokenPath: ""
       scopesClaim: ""
       tenantHeaderName: ""
+    secret:
+      name: "compass-system-fetcher-secret"
+      clientIdKey: client-id
+      clientSecretKey: client-secret
+      oauthUrlKey: url
     paging:
       pageSize: 200
       sizeParam: "$top"

--- a/components/director/internal/systemfetcher/client.go
+++ b/components/director/internal/systemfetcher/client.go
@@ -18,11 +18,15 @@ import (
 
 // OAuth2Config missing godoc
 type OAuth2Config struct {
-	ClientID             string   `envconfig:"APP_OAUTH_CLIENT_ID"`
-	ClientSecret         string   `envconfig:"APP_OAUTH_CLIENT_SECRET"`
-	TokenEndpointPattern string   `envconfig:"APP_OAUTH_TOKEN_ENDPOINT_PATTERN"`
-	TenantHeaderName     string   `envconfig:"APP_OAUTH_TENANT_HEADER_NAME"`
-	ScopesClaim          []string `envconfig:"APP_OAUTH_SCOPES_CLAIM"`
+	ClientID              string   `envconfig:"APP_OAUTH_CLIENT_ID"`
+	TokenBaseURL          string   `envconfig:"APP_OAUTH_TOKEN_BASE_URL"`
+	TokenPath             string   `envconfig:"APP_OAUTH_TOKEN_PATH"`
+	TokenEndpointProtocol string   `envconfig:"APP_OAUTH_TOKEN_ENDPOINT_PROTOCOL"`
+	ClientSecret          string   `envconfig:"APP_OAUTH_CLIENT_SECRET"`
+	TenantHeaderName      string   `envconfig:"APP_OAUTH_TENANT_HEADER_NAME"`
+	ScopesClaim           []string `envconfig:"APP_OAUTH_SCOPES_CLAIM"`
+
+	TokenEndpointPattern string `envconfig:"-"`
 }
 
 // APIConfig missing godoc
@@ -50,7 +54,7 @@ func DefaultClientCreator(ctx context.Context, oAuth2Config OAuth2Config) *http.
 	cfg := clientcredentials.Config{
 		ClientID:     oAuth2Config.ClientID,
 		ClientSecret: oAuth2Config.ClientSecret,
-		TokenURL:     oAuth2Config.TokenEndpointPattern,
+		TokenURL:     oAuth2Config.TokenEndpointProtocol + "://" + oAuth2Config.TokenBaseURL + oAuth2Config.TokenPath,
 		Scopes:       oAuth2Config.ScopesClaim,
 	}
 

--- a/components/director/internal/tenantfetcher/client.go
+++ b/components/director/internal/tenantfetcher/client.go
@@ -27,6 +27,7 @@ type OAuth2Config struct {
 	ClientID           string `envconfig:"APP_CLIENT_ID"`
 	ClientSecret       string `envconfig:"APP_CLIENT_SECRET"`
 	OAuthTokenEndpoint string `envconfig:"APP_OAUTH_TOKEN_ENDPOINT"`
+	TokenPath          string `envconfig:"APP_OAUTH_TOKEN_PATH"`
 }
 
 // APIConfig missing godoc
@@ -66,7 +67,7 @@ func NewClient(oAuth2Config OAuth2Config, apiConfig APIConfig, timeout time.Dura
 	cfg := clientcredentials.Config{
 		ClientID:     oAuth2Config.ClientID,
 		ClientSecret: oAuth2Config.ClientSecret,
-		TokenURL:     oAuth2Config.OAuthTokenEndpoint,
+		TokenURL:     oAuth2Config.OAuthTokenEndpoint + oAuth2Config.TokenPath,
 	}
 
 	httpClient := cfg.Client(context.Background())

--- a/components/gateway/cmd/main.go
+++ b/components/gateway/cmd/main.go
@@ -253,7 +253,7 @@ func fillJWTCredentials(cfg auditlog.OAuthConfig) clientcredentials.Config {
 	return clientcredentials.Config{
 		ClientID:     cfg.ClientID,
 		ClientSecret: cfg.ClientSecret,
-		TokenURL:     cfg.OAuthURL,
+		TokenURL:     cfg.OAuthURL + cfg.TokenPath,
 		AuthStyle:    oauth2.AuthStyleAutoDetect,
 	}
 }

--- a/components/gateway/internal/auditlog/config.go
+++ b/components/gateway/internal/auditlog/config.go
@@ -25,6 +25,7 @@ type OAuthConfig struct {
 	OAuthURL     string `envconfig:"APP_AUDITLOG_OAUTH_URL"`
 	User         string `envconfig:"APP_AUDITLOG_OAUTH_USER,default=$USER"`
 	Tenant       string `envconfig:"APP_AUDITLOG_OAUTH_TENANT,default=$PROVIDER"`
+	TokenPath    string `envconfig:"APP_AUDITLOG_TOKEN_PATH"`
 }
 
 type AuthMode string

--- a/installation/resources/installer-config-local.yaml.tpl
+++ b/installation/resources/installer-config-local.yaml.tpl
@@ -47,7 +47,9 @@ data:
   global.systemFetcher.systemToTemplateMappings: '[{"Name": "temp1", "SourceKey": ["prop"], "SourceValue": ["val1"] }, {"Name": "temp2", "SourceKey": ["prop"], "SourceValue": ["val2"] }]'
   global.systemFetcher.oauth.client: "admin"
   global.systemFetcher.oauth.secret: "admin"
-  global.systemFetcher.oauth.tokenURLPattern: "http://compass-external-services-mock.compass-system.svc.cluster.local:8080/systemfetcher/oauth/token"
+  global.systemFetcher.oauth.tokenBaseUrl: "compass-external-services-mock.compass-system.svc.cluster.local:8080"
+  global.systemFetcher.oauth.tokenPath: "/systemfetcher/oauth/token"
+  global.systemFetcher.oauth.tokenEndpointProtocol: "http"
   global.systemFetcher.oauth.scopesClaim: "scopes"
   global.systemFetcher.oauth.tenantHeaderName: "x-zid"
   global.authenticators.tenant-fetcher.enabled: "true"


### PR DESCRIPTION
**Description**

We need to use secrets for our configuration for external services in order to enable credentials rotation.

Changes proposed in this pull request:
- Migrate external services configurations to secrets instead of overrides.
