### PR TITLE
Make subscription test skippable in E2E tests

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -104,7 +104,7 @@ global:
       version: "PR-45"
     e2e_tests:
       dir:
-      version: "PR-2060"
+      version: "PR-2079"
   isLocalEnv: false
   oauth2:
     host: oauth2

--- a/tests/ord-service/tests/subscription_flow_test.go
+++ b/tests/ord-service/tests/subscription_flow_test.go
@@ -41,7 +41,7 @@ import (
 
 func TestSubscriptionFlow(stdT *testing.T) {
 	t := testingx.NewT(stdT)
-	t.Run("Consuming provider resources after successful subscription", func(t *testing.T) {
+	t.Run("ConsumerProvider flow: calls with provider certificate and consumer token are successful when valid subscription exists", func(t *testing.T) {
 		ctx := context.Background()
 		defaultTenantId := tenant.TestTenants.GetDefaultTenantID()
 		secondaryTenant := tenant.TestTenants.GetIDByName(t, tenant.ApplicationsForRuntimeTenantName)

--- a/tests/ord-service/tests/subscription_flow_test.go
+++ b/tests/ord-service/tests/subscription_flow_test.go
@@ -39,7 +39,7 @@ import (
 	"github.com/tidwall/gjson"
 )
 
-func TestSubscriptionFlow(stdT *testing.T) {
+func TestConsumerProviderFlow(stdT *testing.T) {
 	t := testingx.NewT(stdT)
 	t.Run("ConsumerProvider flow: calls with provider certificate and consumer token are successful when valid subscription exists", func(t *testing.T) {
 		ctx := context.Background()

--- a/tests/ord-service/tests/subscription_flow_test.go
+++ b/tests/ord-service/tests/subscription_flow_test.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/kyma-incubator/compass/tests/pkg/testctx"
+	testingx "github.com/kyma-incubator/compass/tests/pkg/testing"
 
 	"github.com/google/uuid"
 
@@ -38,102 +39,105 @@ import (
 	"github.com/tidwall/gjson"
 )
 
-func TestSubscriptionFlow(t *testing.T) {
-	ctx := context.Background()
-	defaultTenantId := tenant.TestTenants.GetDefaultTenantID()
-	secondaryTenant := tenant.TestTenants.GetIDByName(t, tenant.ApplicationsForRuntimeTenantName)
-	accountID := uuid.New().String()
-	subscriptionProviderID := "xs-app-name"
-	subscriptionProviderSubaccountID := "f8075207-1478-4a80-bd26-24a4785a2bfd"
-	subscriptionConsumerSubaccountID := "1f538f34-30bf-4d3d-aeaa-02e69eef84ae"
+func TestSubscriptionFlow(stdT *testing.T) {
+	t := testingx.NewT(stdT)
+	t.Run("Consuming provider resources after successful subscription", func(t *testing.T) {
+		ctx := context.Background()
+		defaultTenantId := tenant.TestTenants.GetDefaultTenantID()
+		secondaryTenant := tenant.TestTenants.GetIDByName(t, tenant.ApplicationsForRuntimeTenantName)
+		accountID := uuid.New().String()
+		subscriptionProviderID := "xs-app-name"
+		subscriptionProviderSubaccountID := "f8075207-1478-4a80-bd26-24a4785a2bfd"
+		subscriptionConsumerSubaccountID := "1f538f34-30bf-4d3d-aeaa-02e69eef84ae"
 
-	runtimeInput := graphql.RuntimeInput{
-		Name:        "providerRuntime",
-		Description: ptr.String("providerRuntime-description"),
-		Labels:      graphql.Labels{testConfig.SubscriptionProviderLabelKey: subscriptionProviderID, tenantfetcher.RegionKey: tenantfetcher.RegionPathParamValue, selectorKey: subscriptionProviderSubaccountID},
-	}
+		runtimeInput := graphql.RuntimeInput{
+			Name:        "providerRuntime",
+			Description: ptr.String("providerRuntime-description"),
+			Labels:      graphql.Labels{testConfig.SubscriptionProviderLabelKey: subscriptionProviderID, tenantfetcher.RegionKey: tenantfetcher.RegionPathParamValue, selectorKey: subscriptionProviderSubaccountID},
+		}
 
-	// Register provider runtime with the necessary label
-	runtime, err := fixtures.RegisterRuntimeFromInputWithinTenant(t, ctx, dexGraphQLClient, defaultTenantId, &runtimeInput)
-	defer fixtures.CleanupRuntime(t, ctx, dexGraphQLClient, defaultTenantId, &runtime)
-	require.NoError(t, err)
-	require.NotEmpty(t, runtime.ID)
+		// Register provider runtime with the necessary label
+		runtime, err := fixtures.RegisterRuntimeFromInputWithinTenant(t, ctx, dexGraphQLClient, defaultTenantId, &runtimeInput)
+		defer fixtures.CleanupRuntime(t, ctx, dexGraphQLClient, defaultTenantId, &runtime)
+		require.NoError(t, err)
+		require.NotEmpty(t, runtime.ID)
 
-	app, err := fixtures.RegisterApplication(t, ctx, dexGraphQLClient, "testingApp", secondaryTenant)
-	defer fixtures.CleanupApplication(t, ctx, dexGraphQLClient, secondaryTenant, &app)
-	require.NoError(t, err)
-	require.NotEmpty(t, app.ID)
+		app, err := fixtures.RegisterApplication(t, ctx, dexGraphQLClient, "testingApp", secondaryTenant)
+		defer fixtures.CleanupApplication(t, ctx, dexGraphQLClient, secondaryTenant, &app)
+		require.NoError(t, err)
+		require.NotEmpty(t, app.ID)
 
-	consumerApp, err := fixtures.RegisterApplication(t, ctx, dexGraphQLClient, "consumerApp", secondaryTenant)
-	defer fixtures.CleanupApplication(t, ctx, dexGraphQLClient, secondaryTenant, &consumerApp)
-	require.NoError(t, err)
-	require.NotEmpty(t, consumerApp.ID)
-	require.NotEmpty(t, consumerApp.Name)
+		consumerApp, err := fixtures.RegisterApplication(t, ctx, dexGraphQLClient, "consumerApp", secondaryTenant)
+		defer fixtures.CleanupApplication(t, ctx, dexGraphQLClient, secondaryTenant, &consumerApp)
+		require.NoError(t, err)
+		require.NotEmpty(t, consumerApp.ID)
+		require.NotEmpty(t, consumerApp.Name)
 
-	// Create label definition
-	scenarios := []string{"DEFAULT", "consumer-test-scenario"}
-	fixtures.UpdateScenariosLabelDefinitionWithinTenant(t, ctx, dexGraphQLClient, secondaryTenant, scenarios)
-	defer fixtures.UpdateScenariosLabelDefinitionWithinTenant(t, ctx, dexGraphQLClient, secondaryTenant, scenarios[:1])
+		// Create label definition
+		scenarios := []string{"DEFAULT", "consumer-test-scenario"}
+		fixtures.UpdateScenariosLabelDefinitionWithinTenant(t, ctx, dexGraphQLClient, secondaryTenant, scenarios)
+		defer fixtures.UpdateScenariosLabelDefinitionWithinTenant(t, ctx, dexGraphQLClient, secondaryTenant, scenarios[:1])
 
-	// Create automatic scenario assigment for consumer subaccount
-	asaInput := fixtures.FixAutomaticScenarioAssigmentInput(scenarios[1], selectorKey, subscriptionConsumerSubaccountID)
-	fixtures.CreateAutomaticScenarioAssignmentInTenant(t, ctx, dexGraphQLClient, asaInput, secondaryTenant)
-	defer fixtures.DeleteAutomaticScenarioAssignmentForScenarioWithinTenant(t, ctx, dexGraphQLClient, secondaryTenant, scenarios[1])
+		// Create automatic scenario assigment for consumer subaccount
+		asaInput := fixtures.FixAutomaticScenarioAssigmentInput(scenarios[1], selectorKey, subscriptionConsumerSubaccountID)
+		fixtures.CreateAutomaticScenarioAssignmentInTenant(t, ctx, dexGraphQLClient, asaInput, secondaryTenant)
+		defer fixtures.DeleteAutomaticScenarioAssignmentForScenarioWithinTenant(t, ctx, dexGraphQLClient, secondaryTenant, scenarios[1])
 
-	// Assign application to scenario
-	appLabelRequest := fixtures.FixSetApplicationLabelRequest(consumerApp.ID, scenariosLabel, scenarios[1:])
-	require.NoError(t, testctx.Tc.RunOperationWithCustomTenant(ctx, dexGraphQLClient, secondaryTenant, appLabelRequest, nil))
-	defer fixtures.UnassignApplicationFromScenarios(t, ctx, dexGraphQLClient, secondaryTenant, consumerApp.ID, testConfig.DefaultScenarioEnabled)
+		// Assign application to scenario
+		appLabelRequest := fixtures.FixSetApplicationLabelRequest(consumerApp.ID, scenariosLabel, scenarios[1:])
+		require.NoError(t, testctx.Tc.RunOperationWithCustomTenant(ctx, dexGraphQLClient, secondaryTenant, appLabelRequest, nil))
+		defer fixtures.UnassignApplicationFromScenarios(t, ctx, dexGraphQLClient, secondaryTenant, consumerApp.ID, testConfig.DefaultScenarioEnabled)
 
-	providedTenantIDs := tenantfetcher.Tenant{
-		TenantID:               accountID,
-		SubaccountID:           subscriptionConsumerSubaccountID,
-		Subdomain:              tenantfetcher.DefaultSubdomain,
-		SubscriptionProviderID: subscriptionProviderID,
-	}
+		providedTenantIDs := tenantfetcher.Tenant{
+			TenantID:               accountID,
+			SubaccountID:           subscriptionConsumerSubaccountID,
+			Subdomain:              tenantfetcher.DefaultSubdomain,
+			SubscriptionProviderID: subscriptionProviderID,
+		}
 
-	tenantProperties := tenantfetcher.TenantIDProperties{
-		TenantIDProperty:               testConfig.TenantIDProperty,
-		SubaccountTenantIDProperty:     testConfig.SubaccountTenantIDProperty,
-		CustomerIDProperty:             testConfig.CustomerIDProperty,
-		SubdomainProperty:              testConfig.SubdomainProperty,
-		SubscriptionProviderIDProperty: testConfig.SubscriptionProviderIDProperty,
-	}
+		tenantProperties := tenantfetcher.TenantIDProperties{
+			TenantIDProperty:               testConfig.TenantIDProperty,
+			SubaccountTenantIDProperty:     testConfig.SubaccountTenantIDProperty,
+			CustomerIDProperty:             testConfig.CustomerIDProperty,
+			SubdomainProperty:              testConfig.SubdomainProperty,
+			SubscriptionProviderIDProperty: testConfig.SubscriptionProviderIDProperty,
+		}
 
-	// Build a request for consumer subscription
-	request := tenantfetcher.CreateTenantRequest(t, providedTenantIDs, tenantProperties, http.MethodPut, testConfig.TenantFetcherFullRegionalURL, testConfig.ExternalServicesMockURL)
+		// Build a request for consumer subscription
+		request := tenantfetcher.CreateTenantRequest(t, providedTenantIDs, tenantProperties, http.MethodPut, testConfig.TenantFetcherFullRegionalURL, testConfig.ExternalServicesMockURL)
 
-	httpClient := &http.Client{
-		Timeout: 10 * time.Second,
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-		},
-	}
+		httpClient := &http.Client{
+			Timeout: 10 * time.Second,
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+			},
+		}
 
-	t.Log(fmt.Sprintf("Creating a subscription between consumer with subaccount id: %s and provider with name: %s and subaccount id: %s", tenantfetcher.ActualTenantID(providedTenantIDs), runtime.Name, subscriptionProviderSubaccountID))
-	response, err := httpClient.Do(request)
+		t.Log(fmt.Sprintf("Creating a subscription between consumer with subaccount id: %s and provider with name: %s and subaccount id: %s", tenantfetcher.ActualTenantID(providedTenantIDs), runtime.Name, subscriptionProviderSubaccountID))
+		response, err := httpClient.Do(request)
 
-	require.NoError(t, err)
-	require.Equal(t, http.StatusOK, response.StatusCode)
-	tenantfetcher.AssertRuntimeSubscription(t, ctx, runtime.ID, providedTenantIDs, dexGraphQLClient, testConfig.ConsumerSubaccountIdsLabelKey)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, response.StatusCode)
+		tenantfetcher.AssertRuntimeSubscription(t, ctx, runtime.ID, providedTenantIDs, dexGraphQLClient, testConfig.ConsumerSubaccountIdsLabelKey)
 
-	// HTTP client configured with manually signed client certificate
-	extIssuerCertHttpClient := extIssuerCertClient(t, subscriptionProviderSubaccountID)
+		// HTTP client configured with manually signed client certificate
+		extIssuerCertHttpClient := extIssuerCertClient(t, subscriptionProviderSubaccountID)
 
-	// Create a token with the necessary consumer claims and add it in authorization header
-	claims := map[string]interface{}{
-		"subsc-key-test": "subscription-flow",
-		"scope":          []string{},
-		"tenant":         subscriptionConsumerSubaccountID,
-		"identity":       "subscription-flow-identity",
-		"iss":            testConfig.ExternalServicesMockURL,
-		"exp":            time.Now().Unix() + int64(time.Minute.Seconds()),
-	}
-	headers := map[string][]string{"Authorization": {fmt.Sprintf("Bearer %s", token.FromExternalServicesMock(t, testConfig.ExternalServicesMockURL, claims))}}
+		// Create a token with the necessary consumer claims and add it in authorization header
+		claims := map[string]interface{}{
+			"subsc-key-test": "subscription-flow",
+			"scope":          []string{},
+			"tenant":         subscriptionConsumerSubaccountID,
+			"identity":       "subscription-flow-identity",
+			"iss":            testConfig.ExternalServicesMockURL,
+			"exp":            time.Now().Unix() + int64(time.Minute.Seconds()),
+		}
+		headers := map[string][]string{"Authorization": {fmt.Sprintf("Bearer %s", token.FromExternalServicesMock(t, testConfig.ExternalServicesMockURL, claims))}}
 
-	// Make a request to the ORD service with http client containing certificate with provider information and token with the consumer data.
-	respBody := makeRequestWithHeaders(t, extIssuerCertHttpClient, testConfig.ORDExternalCertSecuredServiceURL+"/systemInstances?$format=json", headers)
+		// Make a request to the ORD service with http client containing certificate with provider information and token with the consumer data.
+		respBody := makeRequestWithHeaders(t, extIssuerCertHttpClient, testConfig.ORDExternalCertSecuredServiceURL+"/systemInstances?$format=json", headers)
 
-	require.Equal(t, 1, len(gjson.Get(respBody, "value").Array()))
-	require.Equal(t, consumerApp.Name, gjson.Get(respBody, "value.0.title").String())
+		require.Equal(t, 1, len(gjson.Get(respBody, "value").Array()))
+		require.Equal(t, consumerApp.Name, gjson.Get(respBody, "value.0.title").String())
+	})
 }


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
It's currently not possible to execute tests involving the Tenant Fetcher on our prod landscapes, hence this test should be skipped there. In order to skip a test, one can add it to the `SKIP_TESTS_REGEX` env variable. It is later used in [this utility](https://github.com/kyma-incubator/compass/blob/main/tests/pkg/testing/testing.go#L24).

_PS: >95 lines of code are just identation, so the PR is actually really small._

Changes proposed in this pull request:
- Use the skip mechanism in the ORD Service E2E tests for the subscruption flow test
