### PR TITLE
Remove Secured App Type configuration

### DIFF
--- a/chart/compass/templates/ord-aggregator-job.yaml
+++ b/chart/compass/templates/ord-aggregator-job.yaml
@@ -73,8 +73,6 @@ spec:
                   value: "{{ .Values.global.ordAggregator.http.client.skipSSLValidation }}"
                 - name: APP_LOG_FORMAT
                   value: {{ .Values.global.log.format | quote }}
-                - name: APP_SECURED_APPLICATION_TYPES
-                  value: "{{ .Values.global.ordAggregator.securedApplicationTypes }}"
                 {{ if and ($.Values.global.metrics.enabled) ($.Values.global.metrics.pushEndpoint) }}
                 - name: APP_METRICS_PUSH_ENDPOINT
                   value: {{ $.Values.global.metrics.pushEndpoint}}

--- a/chart/compass/templates/tests/ord-aggregator/ord-aggregator-test.yaml
+++ b/chart/compass/templates/tests/ord-aggregator/ord-aggregator-test.yaml
@@ -48,8 +48,6 @@ spec:
               value: "https://{{ .Values.global.externalServicesMock.certSecuredHost }}.{{ .Values.global.ingress.domainName }}"
             - name: ORD_SERVICE_DEFAULT_RESPONSE_TYPE
               value: {{ .Values.global.ordService.defaultResponseType }}
-            - name: SECURED_APPLICATION_TYPES
-              value: "{{ .Values.global.ordAggregator.securedApplicationTypes }}"
             - name: AGGREGATOR_SCHEDULE
               value: "{{ .Values.global.ordAggregator.schedule }}"
             - name: USER_EMAIL

--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -415,7 +415,6 @@ global:
     dbPool:
       maxOpenConnections: 2
       maxIdleConnections: 2
-    securedApplicationTypes: "sample-app-type" # comma-separated values are used for specifying multiple application types
     accessStrategies:
       cmpMtls:
         policy: "compass-local-clients"

--- a/components/director/cmd/ordaggregator/main.go
+++ b/components/director/cmd/ordaggregator/main.go
@@ -146,7 +146,7 @@ func createORDAggregatorSvc(cfgProvider *configprovider.Provider, featuresConfig
 
 	accessStrategyExecutorProvider := accessstrategy.NewDefaultExecutorProvider()
 
-	ordClient := ord.NewClient(httpClient, featuresConfig.SecuredApplicationTypes, accessStrategyExecutorProvider)
+	ordClient := ord.NewClient(httpClient, accessStrategyExecutorProvider)
 
 	return ord.NewAggregatorService(transact, labelRepo, appSvc, webhookSvc, bundleSvc, bundleReferenceSvc, apiSvc, eventAPISvc, specSvc, packageSvc, productSvc, vendorSvc, tombstoneSvc, ordClient)
 }

--- a/components/director/internal/features/features.go
+++ b/components/director/internal/features/features.go
@@ -2,7 +2,6 @@ package features
 
 // Config missing godoc
 type Config struct {
-	DefaultScenarioEnabled  bool     `envconfig:"default=true,APP_DEFAULT_SCENARIO_ENABLED"`
-	ProtectedLabelPattern   string   `envconfig:"default=.*_defaultEventing,APP_PROTECTED_LABEL_PATTERN"`
-	SecuredApplicationTypes []string `envconfig:"default=empty,APP_SECURED_APPLICATION_TYPES"`
+	DefaultScenarioEnabled bool   `envconfig:"default=true,APP_DEFAULT_SCENARIO_ENABLED"`
+	ProtectedLabelPattern  string `envconfig:"default=.*_defaultEventing,APP_PROTECTED_LABEL_PATTERN"`
 }

--- a/components/director/internal/open_resource_discovery/client.go
+++ b/components/director/internal/open_resource_discovery/client.go
@@ -11,7 +11,6 @@ import (
 	"github.com/kyma-incubator/compass/components/director/internal/open_resource_discovery/accessstrategy"
 
 	"github.com/kyma-incubator/compass/components/director/internal/model"
-	"github.com/kyma-incubator/compass/components/director/pkg/str"
 
 	httputil "github.com/kyma-incubator/compass/components/director/pkg/http"
 	"github.com/kyma-incubator/compass/components/director/pkg/log"
@@ -27,15 +26,13 @@ type Client interface {
 
 type client struct {
 	*http.Client
-	securedApplicationTypes        map[string]struct{}
 	accessStrategyExecutorProvider accessstrategy.ExecutorProvider
 }
 
 // NewClient creates new ORD Client via a provided http.Client
-func NewClient(httpClient *http.Client, securedApplicationTypes []string, accessStrategyExecutorProvider accessstrategy.ExecutorProvider) *client {
+func NewClient(httpClient *http.Client, accessStrategyExecutorProvider accessstrategy.ExecutorProvider) *client {
 	return &client{
 		Client:                         httpClient,
-		securedApplicationTypes:        str.SliceToMap(securedApplicationTypes),
 		accessStrategyExecutorProvider: accessStrategyExecutorProvider,
 	}
 }
@@ -117,7 +114,7 @@ func (c *client) fetchConfig(ctx context.Context, app *model.Application, webhoo
 	}
 
 	var resp *http.Response
-	if _, secured := c.securedApplicationTypes[app.Type]; secured {
+	if webhook.Auth != nil {
 		log.C(ctx).Infof("Application %q (id = %q, type = %q) configuration endpoint is secured and webhook credentials will be used", app.Name, app.ID, app.Type)
 		resp, err = httputil.GetRequestWithCredentials(ctx, c.Client, configURL, webhook.Auth)
 		if err != nil {

--- a/tests/ord-aggregator/tests/handler_test.go
+++ b/tests/ord-aggregator/tests/handler_test.go
@@ -165,13 +165,9 @@ func TestORDAggregator(t *testing.T) {
 		defer fixtures.CleanupApplication(t, ctx, dexGraphQLClient, testConfig.DefaultTestTenant, &thirdApp)
 		require.NoError(t, err)
 
-		fixtures.SetApplicationLabelWithTenant(t, ctx, dexGraphQLClient, testConfig.DefaultTestTenant, thirdApp.ID, applicationTypeLabelKey, testConfig.SecuredApplicationTypes[0])
-
 		fourthApp, err := fixtures.RegisterApplicationFromInput(t, ctx, dexGraphQLClient, testConfig.DefaultTestTenant, fourthAppInput)
 		defer fixtures.CleanupApplication(t, ctx, dexGraphQLClient, testConfig.DefaultTestTenant, &fourthApp)
 		require.NoError(t, err)
-
-		fixtures.SetApplicationLabelWithTenant(t, ctx, dexGraphQLClient, testConfig.DefaultTestTenant, fourthApp.ID, applicationTypeLabelKey, testConfig.SecuredApplicationTypes[0])
 
 		fifthApp, err := fixtures.RegisterApplicationFromInput(t, ctx, dexGraphQLClient, testConfig.DefaultTestTenant, fifthAppInput)
 		defer fixtures.CleanupApplication(t, ctx, dexGraphQLClient, testConfig.DefaultTestTenant, &fifthApp)


### PR DESCRIPTION
# Remove Secured App Type configuration

**Description**

Changes proposed in this pull request:
- Remove the env configuration for secured app type introduced here: https://github.com/kyma-incubator/compass/pull/2051

No need to have such a config, we can only look if the webhook has creds or not.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- ...

**Pull Request status**
<!-- Feel free to construct the checklist with whatever items seem most reasonable for your change. You could disassemble the Implementation part to even smaller separate checklist items if you're working on something big for example. But do make the effort to provide a checklist of some sort so that the core team as well as the community can have an idea about the progress of your Pull Request.
-->

- [x] Implementation
- [x] Unit tests
- [x] Integration tests
- [x] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [ ] Mocks are regenerated, using the automated script
