### PR TITLE
Hotfix - 1.19.2

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -79,7 +79,7 @@ global:
       version: "PR-2082"
     director:
       dir:
-      version: "PR-2095"
+      version: "PR-2098"
     gateway:
       dir:
       version: "PR-2077"

--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -108,7 +108,7 @@ global:
       version: "PR-46"
     e2e_tests:
       dir:
-      version: "PR-2095"
+      version: "PR-2098"
   isLocalEnv: false
   oauth2:
     host: oauth2

--- a/components/director/internal/tenantfetcher/service.go
+++ b/components/director/internal/tenantfetcher/service.go
@@ -265,7 +265,7 @@ func (s SubaccountService) SyncTenants() error {
 		totalNewEvents := len(tenantsToCreate) + len(tenantsToDelete) + len(runtimesToMove)
 		log.C(ctx).Printf("Amount of new events: %d", totalNewEvents)
 		if totalNewEvents == 0 {
-			return nil
+			continue
 		}
 
 		tx, err := s.transact.Begin()

--- a/components/director/internal/tenantfetcher/service_test.go
+++ b/components/director/internal/tenantfetcher/service_test.go
@@ -1602,7 +1602,7 @@ func TestService_SyncSubaccountTenants(t *testing.T) {
 			KubeClientFn: func() *automock.KubeClient {
 				client := &automock.KubeClient{}
 				client.On("GetTenantFetcherConfigMapData", mock.Anything).Return("1", "1", nil).Once()
-				client.AssertNotCalled(t, "UpdateTenantFetcherConfigMapData")
+				client.On("UpdateTenantFetcherConfigMapData", mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
 				return client
 			},
 		},

--- a/tests/connector/tests/apps_for_runtime_test.go
+++ b/tests/connector/tests/apps_for_runtime_test.go
@@ -18,9 +18,6 @@ const (
 
 func TestAppsForRuntimeWithCertificates(t *testing.T) {
 	scenarios := []string{DefaultScenario, TestScenario}
-	// Listing scenarios for LabelDefinition creates a default record if there are no scenarios. This invocation is needed so that we can later update the scenarios instead of creating a new LabelDefinition
-	_, err := fixtures.ListLabelDefinitionByKeyWithinTenant(ctx, directorAppsForRuntimeClient.DexGraphqlClient, ScenariosLabel, appsForRuntimeTenantID)
-	require.NoError(t, err)
 	fixtures.UpdateScenariosLabelDefinitionWithinTenant(t, ctx, directorAppsForRuntimeClient.DexGraphqlClient, appsForRuntimeTenantID, scenarios)
 
 	appIdToCommonName := make(map[string]string)

--- a/tests/director/tests/runtime_api_test.go
+++ b/tests/director/tests/runtime_api_test.go
@@ -663,11 +663,7 @@ func TestRuntimeRegisterUpdateAndUnregisterWithCertificate(stdT *testing.T) {
 		err = testctx.Tc.RunOperationWithoutTenant(ctx, directorCertSecuredClient, getRuntimeReq, &actualRuntime)
 		require.NoError(t, err)
 		require.NotEmpty(t, actualRuntime.ID)
-		if conf.DefaultScenarioEnabled {
-			assert.Len(t, actualRuntime.Labels, 4)
-		} else {
-			assert.Len(t, actualRuntime.Labels, 3)
-		}
+		assert.Len(t, actualRuntime.Labels, 4)
 
 		t.Log("Successfully update runtime and validate the protected labels are excluded")
 		//GIVEN

--- a/tests/director/tests/tenants_api_test.go
+++ b/tests/director/tests/tenants_api_test.go
@@ -29,12 +29,14 @@ func TestQueryTenants(t *testing.T) {
 
 	t.Log("Initializing one of the tenants")
 	initializedTenantID := tenant.TestTenants.GetIDByName(t, tenant.TenantsQueryInitializedTenantName)
-	unregisterApp := fixtures.RegisterSimpleApp(t, ctx, dexGraphQLClient, initializedTenantID)
-	defer unregisterApp()
+
+	// Listing scenarios for LabelDefinition creates a default record if there are no scenarios. This invocation is needed so that we can initialize the tenant.
+	_, err := fixtures.ListLabelDefinitionByKeyWithinTenant(ctx, dexGraphQLClient, "scenarios", initializedTenantID)
+	require.NoError(t, err)
 
 	// WHEN
 	t.Log("List tenants")
-	err := testctx.Tc.RunOperation(ctx, dexGraphQLClient, getTenantsRequest, &output)
+	err = testctx.Tc.RunOperation(ctx, dexGraphQLClient, getTenantsRequest, &output)
 	require.NoError(t, err)
 
 	//THEN

--- a/tests/pkg/fixtures/label_definitions_queries.go
+++ b/tests/pkg/fixtures/label_definitions_queries.go
@@ -65,6 +65,10 @@ func UpdateLabelDefinitionWithinTenant(t require.TestingT, ctx context.Context, 
 }
 
 func UpdateScenariosLabelDefinitionWithinTenant(t require.TestingT, ctx context.Context, gqlClient *gcli.Client, tenantID string, scenarios []string) *graphql.LabelDefinition {
+	// Listing scenarios for LabelDefinition creates a default record if there are no scenarios. This invocation is needed so that we can later update the scenarios instead of creating a new LabelDefinition
+	_, err := ListLabelDefinitionByKeyWithinTenant(ctx, gqlClient, "scenarios", tenantID)
+	require.NoError(t, err)
+
 	jsonSchema := map[string]interface{}{
 		"items": map[string]interface{}{
 			"enum": scenarios,


### PR DESCRIPTION
## Fixes
- Some e2e test rely on the fact that when registering application/runtime this will create scenario label definition and just use updateLabelDefinition mutation. Since #2095 this is no longer true. In order to create scenario label definition the user should call labelDefinition(key: "scenario") query first.
- Subaccount tenant fetcher full resync each time