### PR TITLE
[CMP-1303] Improve logging for GraphQL requests

### DIFF
--- a/components/director/cmd/director/main.go
+++ b/components/director/cmd/director/main.go
@@ -275,6 +275,7 @@ func main() {
 	operationMiddleware := operation.NewMiddleware(cfg.AppURL + cfg.LastOperationPath)
 
 	gqlServ := handler.NewDefaultServer(executableSchema)
+	gqlServ.Use(log.NewGqlLoggingInterceptor())
 	gqlServ.Use(operationMiddleware)
 	gqlServ.SetErrorPresenter(presenter.Do)
 	gqlServ.SetRecoverFunc(panichandler.RecoverFn)

--- a/components/director/internal/authenticator/middleware.go
+++ b/components/director/internal/authenticator/middleware.go
@@ -26,6 +26,13 @@ const (
 	JwksKeyIDKey = "kid"
 )
 
+const (
+	logKeyConsumerType  string = "consumer-type"
+	logKeyConsumerId           = "consumer-id"
+	logKeyTokenClientId        = "token-client-id"
+	logKeyFlow                 = "flow"
+)
+
 // ClaimsValidator missing godoc
 //go:generate mockery --name=ClaimsValidator --output=automock --outpkg=automock --case=underscore
 type ClaimsValidator interface {
@@ -91,6 +98,13 @@ func (a *Authenticator) Handler() func(next http.Handler) http.Handler {
 				log.C(ctx).WithError(err).Errorf("An error has occurred while parsing claims: %v", err)
 				apperrors.WriteAppError(ctx, w, err, http.StatusUnauthorized)
 				return
+			}
+
+			if mdc := log.MdcFromContext(ctx); nil != mdc {
+				mdc.Set(logKeyConsumerType, tokenClaims.ConsumerType)
+				mdc.Set(logKeyConsumerId, tokenClaims.ConsumerID)
+				mdc.Set(logKeyTokenClientId, tokenClaims.TokenClientID)
+				mdc.Set(logKeyFlow, tokenClaims.Flow)
 			}
 
 			if err := a.claimsValidator.Validate(ctx, *tokenClaims); err != nil {

--- a/components/director/internal/authenticator/middleware.go
+++ b/components/director/internal/authenticator/middleware.go
@@ -101,10 +101,18 @@ func (a *Authenticator) Handler() func(next http.Handler) http.Handler {
 			}
 
 			if mdc := log.MdcFromContext(ctx); nil != mdc {
-				mdc.Set(logKeyConsumerType, tokenClaims.ConsumerType)
-				mdc.Set(logKeyConsumerId, tokenClaims.ConsumerID)
-				mdc.Set(logKeyTokenClientId, tokenClaims.TokenClientID)
-				mdc.Set(logKeyFlow, tokenClaims.Flow)
+				if tokenClaims.ConsumerType != "" {
+					mdc.Set(logKeyConsumerType, tokenClaims.ConsumerType)
+				}
+				if tokenClaims.ConsumerID != "" {
+					mdc.Set(logKeyConsumerId, tokenClaims.ConsumerID)
+				}
+				if tokenClaims.TokenClientID != "" {
+					mdc.Set(logKeyTokenClientId, tokenClaims.TokenClientID)
+				}
+				if tokenClaims.Flow != "" {
+					mdc.Set(logKeyFlow, tokenClaims.Flow)
+				}
 			}
 
 			if err := a.claimsValidator.Validate(ctx, *tokenClaims); err != nil {

--- a/components/director/internal/authenticator/middleware.go
+++ b/components/director/internal/authenticator/middleware.go
@@ -101,18 +101,10 @@ func (a *Authenticator) Handler() func(next http.Handler) http.Handler {
 			}
 
 			if mdc := log.MdcFromContext(ctx); nil != mdc {
-				if tokenClaims.ConsumerType != "" {
-					mdc.Set(logKeyConsumerType, tokenClaims.ConsumerType)
-				}
-				if tokenClaims.ConsumerID != "" {
-					mdc.Set(logKeyConsumerId, tokenClaims.ConsumerID)
-				}
-				if tokenClaims.TokenClientID != "" {
-					mdc.Set(logKeyTokenClientId, tokenClaims.TokenClientID)
-				}
-				if tokenClaims.Flow != "" {
-					mdc.Set(logKeyFlow, tokenClaims.Flow)
-				}
+				mdc.Set(logKeyConsumerType, tokenClaims.ConsumerType)
+				mdc.Set(logKeyFlow, tokenClaims.Flow)
+				mdc.SetIfNotEmpty(logKeyConsumerId, tokenClaims.ConsumerID)
+				mdc.SetIfNotEmpty(logKeyTokenClientId, tokenClaims.TokenClientID)
 			}
 
 			if err := a.claimsValidator.Validate(ctx, *tokenClaims); err != nil {

--- a/components/director/internal/authenticator/middleware.go
+++ b/components/director/internal/authenticator/middleware.go
@@ -27,10 +27,10 @@ const (
 )
 
 const (
-	logKeyConsumerType  string = "consumer-type"
-	logKeyConsumerId           = "consumer-id"
-	logKeyTokenClientId        = "token-client-id"
-	logKeyFlow                 = "flow"
+	logKeyConsumerType  = "consumer-type"
+	logKeyConsumerId    = "consumer-id"
+	logKeyTokenClientId = "token-client-id"
+	logKeyFlow          = "flow"
 )
 
 // ClaimsValidator missing godoc

--- a/components/director/pkg/log/gql_ops_logger.go
+++ b/components/director/pkg/log/gql_ops_logger.go
@@ -29,7 +29,7 @@ func (m *opsInterceptor) Validate(_ graphql.ExecutableSchema) error {
 func (m *opsInterceptor) InterceptOperation(ctx context.Context, next graphql.OperationHandler) graphql.ResponseHandler {
 	if mdc := MdcFromContext(ctx); nil != mdc {
 		opsCtx := graphql.GetOperationContext(ctx)
-		mdc.Set(logKeyOperationType, opsCtx.Operation.Operation)
+		mdc.Set(logKeyOperationType, string(opsCtx.Operation.Operation))
 
 		selectionSet := ""
 		for _, selection := range opsCtx.Operation.SelectionSet {

--- a/components/director/pkg/log/gql_ops_logger.go
+++ b/components/director/pkg/log/gql_ops_logger.go
@@ -1,0 +1,48 @@
+package log
+
+import (
+	"context"
+	"github.com/99designs/gqlgen/graphql"
+	"github.com/vektah/gqlparser/v2/ast"
+)
+
+const (
+	logKeyOperationType string = "gql-op-type"
+	logKeySelectionSet  string = "gql-operation"
+)
+
+func NewGqlLoggingInterceptor() *opsInterceptor {
+	return &opsInterceptor{}
+}
+
+type opsInterceptor struct {
+}
+
+func (m *opsInterceptor) ExtensionName() string {
+	return "Logging Interceptor"
+}
+
+func (m *opsInterceptor) Validate(_ graphql.ExecutableSchema) error {
+	return nil
+}
+
+func (m *opsInterceptor) InterceptOperation(ctx context.Context, next graphql.OperationHandler) graphql.ResponseHandler {
+	if mdc := MdcFromContext(ctx); nil != mdc {
+		opsCtx := graphql.GetOperationContext(ctx)
+		mdc.Set(logKeyOperationType, opsCtx.Operation.Operation)
+
+		selectionSet := ""
+		for _, selection := range opsCtx.Operation.SelectionSet {
+			if field, ok := selection.(*ast.Field); ok {
+				if len(selectionSet) != 0 {
+					selectionSet += ","
+				}
+
+				selectionSet += field.Name
+			}
+		}
+		mdc.Set(logKeySelectionSet, selectionSet)
+	}
+
+	return next(ctx)
+}

--- a/components/director/pkg/log/gql_ops_logger_test.go
+++ b/components/director/pkg/log/gql_ops_logger_test.go
@@ -1,0 +1,41 @@
+package log
+
+import (
+	"context"
+	"github.com/99designs/gqlgen/graphql"
+	"github.com/vektah/gqlparser/v2/ast"
+	"testing"
+)
+
+const testOperationName = "myOperation"
+
+func TestGraphQlRequestDetailsLogging(t *testing.T) {
+	t.Run("log GQL query details", func(t *testing.T) {
+		ctx := ContextWithMdc(context.Background())
+		ctx = graphql.WithOperationContext(ctx, &graphql.OperationContext{
+			Operation: &ast.OperationDefinition{
+				Operation: ast.Query,
+				SelectionSet: []ast.Selection{&ast.Field{
+					Name: testOperationName,
+				}},
+			},
+		})
+
+		middleware := NewGqlLoggingInterceptor()
+		middleware.InterceptOperation(ctx, func(ctx context.Context) graphql.ResponseHandler {
+			return nil
+		})
+
+		mdc := MdcFromContext(ctx)
+		opType, ok := mdc.mdc[logKeyOperationType]
+		if !ok || opType.(string) != string(ast.Query) {
+			t.Errorf("The GraphQL operation type is missing or incorrect. Expected=%v; Actual=%v", ast.Query, opType)
+		}
+
+		opName, ok := mdc.mdc[logKeySelectionSet]
+		if !ok || opName.(string) != testOperationName {
+			t.Errorf("The GraphQL operation name is missing or incorrect: %v", opName)
+		}
+	})
+
+}

--- a/components/director/pkg/log/mdc.go
+++ b/components/director/pkg/log/mdc.go
@@ -1,0 +1,54 @@
+package log
+
+import (
+	"context"
+	"github.com/sirupsen/logrus"
+	"sync"
+)
+
+const contextKeyMdc string = "mapped-diagnostic-context"
+
+// ContextWithMdc returns a new context with attached MDC
+func ContextWithMdc(ctx context.Context) context.Context {
+	if nil == MdcFromContext(ctx) {
+		return context.WithValue(ctx, contextKeyMdc, NewMappedDiagnosticContext())
+	}
+
+	return ctx
+}
+
+// MdcFromContext returns the attached *MDC or nil if there is none
+func MdcFromContext(ctx context.Context) *MDC {
+	ptr, ok := ctx.Value(contextKeyMdc).(*MDC)
+	if !ok {
+		return nil
+	}
+	return ptr
+}
+
+type MDC struct {
+	mdc  map[string]interface{}
+	lock sync.Mutex
+}
+
+func NewMappedDiagnosticContext() *MDC {
+	return &MDC{
+		mdc:  make(map[string]interface{}),
+		lock: sync.Mutex{},
+	}
+}
+
+func (mdc *MDC) Set(key string, value interface{}) {
+	mdc.lock.Lock()
+	defer mdc.lock.Unlock()
+
+	mdc.mdc[key] = value
+}
+
+func (mdc *MDC) appendFields(entry *logrus.Entry) *logrus.Entry {
+	if len(mdc.mdc) == 0 {
+		return entry
+	}
+
+	return entry.WithFields(mdc.mdc)
+}

--- a/components/director/pkg/log/mdc.go
+++ b/components/director/pkg/log/mdc.go
@@ -45,6 +45,12 @@ func (mdc *MDC) Set(key string, value interface{}) {
 	mdc.mdc[key] = value
 }
 
+func (mdc *MDC) SetIfNotEmpty(key string, value string) {
+	if value != "" {
+		mdc.Set(key, value)
+	}
+}
+
 func (mdc *MDC) appendFields(entry *logrus.Entry) *logrus.Entry {
 	if len(mdc.mdc) == 0 {
 		return entry

--- a/components/director/pkg/log/mdc_test.go
+++ b/components/director/pkg/log/mdc_test.go
@@ -1,0 +1,78 @@
+package log
+
+import (
+	"context"
+	"github.com/sirupsen/logrus"
+	"testing"
+)
+
+func TestContextWithMdc(t *testing.T) {
+	t.Run("add MDC to context without MDC", func(t2 *testing.T) {
+		ctx := context.Background()
+		if mdc := MdcFromContext(ctx); nil != mdc {
+			t.Fatalf("[pre-condition] There should not have been any MDC in the provided context!")
+		}
+
+		ctx = ContextWithMdc(ctx)
+		if mdc := MdcFromContext(ctx); nil == mdc {
+			t.Fatalf("An MDC instance should have been attached to the context")
+		}
+	})
+
+	t.Run("do not replace the MDC instance in a context", func(t2 *testing.T) {
+		ctx := ContextWithMdc(context.Background())
+
+		var inner *map[string]interface{}
+		if mdc := MdcFromContext(ctx); nil == mdc {
+			t.Fatalf("[pre-condition] There should have been MDC in the provided context!")
+		} else {
+			inner = &mdc.mdc
+		}
+
+		ctx = ContextWithMdc(ctx)
+		if mdc := MdcFromContext(ctx); nil == mdc {
+			t.Fatalf("An MDC instance should have been attached to the context")
+		} else {
+			if inner != &mdc.mdc {
+				t.Fatalf("The MDC instance has been replaced")
+			}
+		}
+
+	})
+}
+
+func TestAppendMdcToLogEntry(t *testing.T) {
+	t.Run("do not modify log entry on empty MDC", func(t *testing.T) {
+		mdc := NewMappedDiagnosticContext()
+		entry := logrus.WithFields(make(map[string]interface{}))
+		newEntry := mdc.appendFields(entry)
+
+		if entry != newEntry {
+			t.Fatalf("The log entry should not have been modified")
+		}
+	})
+
+	t.Run("append MDC content to a log entry", func(t *testing.T) {
+		const testValue = "test-value"
+		const testKey = "test"
+
+		mdc := NewMappedDiagnosticContext()
+		mdc.Set(testKey, testValue)
+
+		entry := logrus.WithFields(make(map[string]interface{}))
+		newEntry := mdc.appendFields(entry)
+
+		if entry == newEntry {
+			t.Fatalf("The log entry should have been modified")
+		}
+
+		value, ok := newEntry.Data[testKey]
+		if !ok {
+			t.Fatalf("The expected key was not found in the log entry's data")
+		}
+		if value != testValue {
+			t.Fatalf("The filed value does not match. Expected '%v', but got '%v'", testValue, value)
+		}
+
+	})
+}

--- a/components/director/pkg/log/request.go
+++ b/components/director/pkg/log/request.go
@@ -33,6 +33,7 @@ func RequestLogger() func(next http.Handler) http.Handler {
 			entry := LoggerWithCorrelationID(r)
 
 			ctx = ContextWithLogger(ctx, entry)
+			ctx = ContextWithMdc(ctx)
 			r = r.WithContext(ctx)
 
 			start := time.Now()
@@ -59,6 +60,10 @@ func RequestLogger() func(next http.Handler) http.Handler {
 				"status_code": lrw.statusCode,
 				"took":        duration,
 			})
+
+			if mdc := MdcFromContext(ctx); nil != mdc {
+				afterLogger = mdc.appendFields(afterLogger)
+			}
 
 			afterLogger.Info("Finished handling request...")
 		})


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:
- Implementation of a "mapped diagnostic context" which can be used by the application to provide additional context in the log messages
- A `graphql.OperationInterceptor` that uses the MDC to enrich the logs with the graphql operation type and its selection set
- Enrich the logs with information from the auth layer (either token or a certificate)

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- CMP-1303

**Pull Request status**
<!-- Feel free to construct the checklist with whatever items seem most reasonable for your change. You could disassemble the Implementation part to even smaller separate checklist items if you're working on something big for example. But do make the effort to provide a checklist of some sort so that the core team as well as the community can have an idea about the progress of your Pull Request.
-->

- [x] Implementation
- [x] Unit tests
- [ ] Integration tests
- [ ] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [ ] Mocks are regenerated, using the automated script
