### PR TITLE
[HOTFIX] Fix resources are not deleted when tenant is deleted

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -87,7 +87,7 @@ global:
       version: "PR-2118"
     director:
       dir:
-      version: "PR-2148"
+      version: "PR-2151"
     gateway:
       dir:
       version: "PR-2077"
@@ -99,7 +99,7 @@ global:
       version: "PR-52"
     schema_migrator:
       dir:
-      version: "PR-2131"
+      version: "PR-2151"
     system_broker:
       dir:
       version: "PR-2084"

--- a/components/director/internal/domain/tenant/fixtures_test.go
+++ b/components/director/internal/domain/tenant/fixtures_test.go
@@ -138,30 +138,16 @@ func newGraphQLTenant(id, internalID, name string) *graphql.Tenant {
 	}
 }
 
-func fixTenantAccessesForApplication() []repo.TenantAccess {
+func fixTenantAccesses() []repo.TenantAccess {
 	return []repo.TenantAccess{
 		{
 			TenantID:   testID,
-			ResourceID: "app1",
+			ResourceID: "resourceID",
 			Owner:      true,
 		},
 	}
 }
 
-func fixTenantAccessesForRuntime() []repo.TenantAccess {
-	return []repo.TenantAccess{
-		{
-			TenantID:   testID,
-			ResourceID: "runtime1",
-			Owner:      true,
-		},
-	}
-}
-
-func fixTenantAccessesForRuntimeRow() []driver.Value {
-	return []driver.Value{testID, "runtime1", true}
-}
-
-func fixTenantAccessesForApplicationRow() []driver.Value {
-	return []driver.Value{testID, "app1", true}
+func fixTenantAccessesRow() []driver.Value {
+	return []driver.Value{testID, "resourceID", true}
 }

--- a/components/director/internal/domain/tenant/repository_test.go
+++ b/components/director/internal/domain/tenant/repository_test.go
@@ -509,25 +509,18 @@ func TestPgRepository_Update(t *testing.T) {
 			WithArgs(testName, testExternal, testParentID2, "account", "Compass", tenantEntity.Active, testID).
 			WillReturnResult(sqlmock.NewResult(-1, 1))
 
-		appTenantAccesses := fixTenantAccessesForApplication()
-		dbMock.ExpectQuery(regexp.QuoteMeta(`SELECT tenant_id, id, owner FROM tenant_applications WHERE tenant_id = $1 AND owner = $2`)).
-			WithArgs(testID, true).WillReturnRows(sqlmock.NewRows(repo.M2MColumns).AddRow(fixTenantAccessesForApplicationRow()...))
+		for range resource.TopLevelEntities {
+			tenantAccesses := fixTenantAccesses()
 
-		dbMock.ExpectExec(regexp.QuoteMeta(`WITH RECURSIVE parents AS (SELECT t1.id, t1.parent FROM business_tenant_mappings t1 WHERE id = ? UNION ALL SELECT t2.id, t2.parent FROM business_tenant_mappings t2 INNER JOIN parents t on t2.id = t.parent) INSERT INTO tenant_applications ( tenant_id, id, owner ) (SELECT parents.id AS tenant_id, ? as id, ? AS owner FROM parents)`)).
-			WithArgs(testParentID2, appTenantAccesses[0].ResourceID, true).WillReturnResult(sqlmock.NewResult(-1, 1))
+			dbMock.ExpectQuery(`SELECT tenant_id, id, owner FROM (.+) WHERE tenant_id = \$1 AND owner = \$2`).
+				WithArgs(testID, true).WillReturnRows(sqlmock.NewRows(repo.M2MColumns).AddRow(fixTenantAccessesRow()...))
 
-		dbMock.ExpectExec(regexp.QuoteMeta(`WITH RECURSIVE parents AS (SELECT t1.id, t1.parent FROM business_tenant_mappings t1 WHERE id = $1 UNION ALL SELECT t2.id, t2.parent FROM business_tenant_mappings t2 INNER JOIN parents t on t2.id = t.parent) DELETE FROM tenant_applications WHERE id IN ($2) AND owner = true AND tenant_id IN (SELECT id FROM parents)`)).
-			WithArgs(testParentID, appTenantAccesses[0].ResourceID).WillReturnResult(sqlmock.NewResult(-1, 1))
+			dbMock.ExpectExec(`WITH RECURSIVE parents AS \(SELECT t1\.id, t1\.parent FROM business_tenant_mappings t1 WHERE id = \? UNION ALL SELECT t2\.id, t2\.parent FROM business_tenant_mappings t2 INNER JOIN parents t on t2\.id = t\.parent\) INSERT INTO (.+) \( tenant_id, id, owner \) \(SELECT parents\.id AS tenant_id, \? as id, \? AS owner FROM parents\)`).
+				WithArgs(testParentID2, tenantAccesses[0].ResourceID, true).WillReturnResult(sqlmock.NewResult(-1, 1))
 
-		runtimeTenantAccesses := fixTenantAccessesForRuntime()
-		dbMock.ExpectQuery(regexp.QuoteMeta(`SELECT tenant_id, id, owner FROM tenant_runtimes WHERE tenant_id = $1 AND owner = $2`)).
-			WithArgs(testID, true).WillReturnRows(sqlmock.NewRows(repo.M2MColumns).AddRow(fixTenantAccessesForRuntimeRow()...))
-
-		dbMock.ExpectExec(regexp.QuoteMeta(`WITH RECURSIVE parents AS (SELECT t1.id, t1.parent FROM business_tenant_mappings t1 WHERE id = ? UNION ALL SELECT t2.id, t2.parent FROM business_tenant_mappings t2 INNER JOIN parents t on t2.id = t.parent) INSERT INTO tenant_runtimes ( tenant_id, id, owner ) (SELECT parents.id AS tenant_id, ? as id, ? AS owner FROM parents)`)).
-			WithArgs(testParentID2, runtimeTenantAccesses[0].ResourceID, true).WillReturnResult(sqlmock.NewResult(-1, 1))
-
-		dbMock.ExpectExec(regexp.QuoteMeta(`WITH RECURSIVE parents AS (SELECT t1.id, t1.parent FROM business_tenant_mappings t1 WHERE id = $1 UNION ALL SELECT t2.id, t2.parent FROM business_tenant_mappings t2 INNER JOIN parents t on t2.id = t.parent) DELETE FROM tenant_runtimes WHERE id IN ($2) AND owner = true AND tenant_id IN (SELECT id FROM parents)`)).
-			WithArgs(testParentID, runtimeTenantAccesses[0].ResourceID).WillReturnResult(sqlmock.NewResult(-1, 1))
+			dbMock.ExpectExec(`WITH RECURSIVE parents AS \(SELECT t1\.id, t1\.parent FROM business_tenant_mappings t1 WHERE id = \$1 UNION ALL SELECT t2\.id, t2\.parent FROM business_tenant_mappings t2 INNER JOIN parents t on t2\.id = t\.parent\) DELETE FROM (.+) WHERE id IN \(\$2\) AND owner = true AND tenant_id IN \(SELECT id FROM parents\)`).
+				WithArgs(testParentID, tenantAccesses[0].ResourceID).WillReturnResult(sqlmock.NewResult(-1, 1))
+		}
 
 		ctx := persistence.SaveToContext(context.TODO(), db)
 		tenantMappingRepo := tenant.NewRepository(mockConverter)
@@ -565,7 +558,7 @@ func TestPgRepository_Update(t *testing.T) {
 			WithArgs(testName, testExternal, testParentID2, "account", "Compass", tenantEntity.Active, testID).
 			WillReturnResult(sqlmock.NewResult(-1, 1))
 
-		dbMock.ExpectQuery(regexp.QuoteMeta(`SELECT tenant_id, id, owner FROM tenant_applications WHERE tenant_id = $1 AND owner = $2`)).
+		dbMock.ExpectQuery(`SELECT tenant_id, id, owner FROM (.+) WHERE tenant_id = \$1 AND owner = \$2`).
 			WithArgs(testID, true).WillReturnError(testError)
 
 		ctx := persistence.SaveToContext(context.TODO(), db)
@@ -605,11 +598,11 @@ func TestPgRepository_Update(t *testing.T) {
 			WithArgs(testName, testExternal, testParentID2, "account", "Compass", tenantEntity.Active, testID).
 			WillReturnResult(sqlmock.NewResult(-1, 1))
 
-		appTenantAccesses := fixTenantAccessesForApplication()
-		dbMock.ExpectQuery(regexp.QuoteMeta(`SELECT tenant_id, id, owner FROM tenant_applications WHERE tenant_id = $1 AND owner = $2`)).
-			WithArgs(testID, true).WillReturnRows(sqlmock.NewRows(repo.M2MColumns).AddRow(fixTenantAccessesForApplicationRow()...))
+		appTenantAccesses := fixTenantAccesses()
+		dbMock.ExpectQuery(`SELECT tenant_id, id, owner FROM (.+) WHERE tenant_id = \$1 AND owner = \$2`).
+			WithArgs(testID, true).WillReturnRows(sqlmock.NewRows(repo.M2MColumns).AddRow(fixTenantAccessesRow()...))
 
-		dbMock.ExpectExec(regexp.QuoteMeta(`WITH RECURSIVE parents AS (SELECT t1.id, t1.parent FROM business_tenant_mappings t1 WHERE id = ? UNION ALL SELECT t2.id, t2.parent FROM business_tenant_mappings t2 INNER JOIN parents t on t2.id = t.parent) INSERT INTO tenant_applications ( tenant_id, id, owner ) (SELECT parents.id AS tenant_id, ? as id, ? AS owner FROM parents)`)).
+		dbMock.ExpectExec(`WITH RECURSIVE parents AS \(SELECT t1\.id, t1\.parent FROM business_tenant_mappings t1 WHERE id = \? UNION ALL SELECT t2\.id, t2\.parent FROM business_tenant_mappings t2 INNER JOIN parents t on t2\.id = t\.parent\) INSERT INTO (.+) \( tenant_id, id, owner \) \(SELECT parents\.id AS tenant_id, \? as id, \? AS owner FROM parents\)`).
 			WithArgs(testParentID2, appTenantAccesses[0].ResourceID, true).WillReturnError(testError)
 
 		ctx := persistence.SaveToContext(context.TODO(), db)
@@ -649,14 +642,14 @@ func TestPgRepository_Update(t *testing.T) {
 			WithArgs(testName, testExternal, testParentID2, "account", "Compass", tenantEntity.Active, testID).
 			WillReturnResult(sqlmock.NewResult(-1, 1))
 
-		appTenantAccesses := fixTenantAccessesForApplication()
-		dbMock.ExpectQuery(regexp.QuoteMeta(`SELECT tenant_id, id, owner FROM tenant_applications WHERE tenant_id = $1 AND owner = $2`)).
-			WithArgs(testID, true).WillReturnRows(sqlmock.NewRows(repo.M2MColumns).AddRow(fixTenantAccessesForApplicationRow()...))
+		appTenantAccesses := fixTenantAccesses()
+		dbMock.ExpectQuery(`SELECT tenant_id, id, owner FROM (.+) WHERE tenant_id = \$1 AND owner = \$2`).
+			WithArgs(testID, true).WillReturnRows(sqlmock.NewRows(repo.M2MColumns).AddRow(fixTenantAccessesRow()...))
 
-		dbMock.ExpectExec(regexp.QuoteMeta(`WITH RECURSIVE parents AS (SELECT t1.id, t1.parent FROM business_tenant_mappings t1 WHERE id = ? UNION ALL SELECT t2.id, t2.parent FROM business_tenant_mappings t2 INNER JOIN parents t on t2.id = t.parent) INSERT INTO tenant_applications ( tenant_id, id, owner ) (SELECT parents.id AS tenant_id, ? as id, ? AS owner FROM parents)`)).
+		dbMock.ExpectExec(`WITH RECURSIVE parents AS \(SELECT t1\.id, t1\.parent FROM business_tenant_mappings t1 WHERE id = \? UNION ALL SELECT t2\.id, t2\.parent FROM business_tenant_mappings t2 INNER JOIN parents t on t2\.id = t\.parent\) INSERT INTO (.+) \( tenant_id, id, owner \) \(SELECT parents\.id AS tenant_id, \? as id, \? AS owner FROM parents\)`).
 			WithArgs(testParentID2, appTenantAccesses[0].ResourceID, true).WillReturnResult(sqlmock.NewResult(-1, 1))
 
-		dbMock.ExpectExec(regexp.QuoteMeta(`WITH RECURSIVE parents AS (SELECT t1.id, t1.parent FROM business_tenant_mappings t1 WHERE id = $1 UNION ALL SELECT t2.id, t2.parent FROM business_tenant_mappings t2 INNER JOIN parents t on t2.id = t.parent) DELETE FROM tenant_applications WHERE id IN ($2) AND owner = true AND tenant_id IN (SELECT id FROM parents)`)).
+		dbMock.ExpectExec(`WITH RECURSIVE parents AS \(SELECT t1\.id, t1\.parent FROM business_tenant_mappings t1 WHERE id = \$1 UNION ALL SELECT t2\.id, t2\.parent FROM business_tenant_mappings t2 INNER JOIN parents t on t2\.id = t\.parent\) DELETE FROM (.+) WHERE id IN \(\$2\) AND owner = true AND tenant_id IN \(SELECT id FROM parents\)`).
 			WithArgs(testParentID, appTenantAccesses[0].ResourceID).WillReturnError(testError)
 
 		ctx := persistence.SaveToContext(context.TODO(), db)
@@ -692,19 +685,15 @@ func TestPgRepository_DeleteByExternalTenant(t *testing.T) {
 			WithArgs(testExternal, tenantEntity.Inactive).
 			WillReturnRows(rowsToReturn)
 
-		appTenantAccesses := fixTenantAccessesForApplication()
-		dbMock.ExpectQuery(regexp.QuoteMeta(`SELECT tenant_id, id, owner FROM tenant_applications WHERE tenant_id = $1 AND owner = $2`)).
-			WithArgs(testID, true).WillReturnRows(sqlmock.NewRows(repo.M2MColumns).AddRow(fixTenantAccessesForApplicationRow()...))
+		for range resource.TopLevelEntities {
+			tenantAccesses := fixTenantAccesses()
 
-		dbMock.ExpectExec(regexp.QuoteMeta(`WITH RECURSIVE parents AS (SELECT t1.id, t1.parent FROM business_tenant_mappings t1 WHERE id = $1 UNION ALL SELECT t2.id, t2.parent FROM business_tenant_mappings t2 INNER JOIN parents t on t2.id = t.parent) DELETE FROM tenant_applications WHERE id IN ($2) AND owner = true AND tenant_id IN (SELECT id FROM parents)`)).
-			WithArgs(testID, appTenantAccesses[0].ResourceID).WillReturnResult(sqlmock.NewResult(-1, 1))
+			dbMock.ExpectQuery(`SELECT tenant_id, id, owner FROM (.+) WHERE tenant_id = \$1 AND owner = \$2`).
+				WithArgs(testID, true).WillReturnRows(sqlmock.NewRows(repo.M2MColumns).AddRow(fixTenantAccessesRow()...))
 
-		runtimeTenantAccesses := fixTenantAccessesForRuntime()
-		dbMock.ExpectQuery(regexp.QuoteMeta(`SELECT tenant_id, id, owner FROM tenant_runtimes WHERE tenant_id = $1 AND owner = $2`)).
-			WithArgs(testID, true).WillReturnRows(sqlmock.NewRows(repo.M2MColumns).AddRow(fixTenantAccessesForRuntimeRow()...))
-
-		dbMock.ExpectExec(regexp.QuoteMeta(`WITH RECURSIVE parents AS (SELECT t1.id, t1.parent FROM business_tenant_mappings t1 WHERE id = $1 UNION ALL SELECT t2.id, t2.parent FROM business_tenant_mappings t2 INNER JOIN parents t on t2.id = t.parent) DELETE FROM tenant_runtimes WHERE id IN ($2) AND owner = true AND tenant_id IN (SELECT id FROM parents)`)).
-			WithArgs(testID, runtimeTenantAccesses[0].ResourceID).WillReturnResult(sqlmock.NewResult(-1, 1))
+			dbMock.ExpectExec(`DELETE FROM (.+) WHERE id IN \(\$1\)`).
+				WithArgs(tenantAccesses[0].ResourceID).WillReturnResult(sqlmock.NewResult(-1, 1))
+		}
 
 		dbMock.ExpectExec(deleteStatement).
 			WithArgs(testExternal).
@@ -775,7 +764,7 @@ func TestPgRepository_DeleteByExternalTenant(t *testing.T) {
 			WithArgs(testExternal, tenantEntity.Inactive).
 			WillReturnRows(rowsToReturn)
 
-		dbMock.ExpectQuery(regexp.QuoteMeta(`SELECT tenant_id, id, owner FROM tenant_applications WHERE tenant_id = $1 AND owner = $2`)).
+		dbMock.ExpectQuery(`SELECT tenant_id, id, owner FROM (.+) WHERE tenant_id = \$1 AND owner = \$2`).
 			WithArgs(testID, true).WillReturnError(testError)
 
 		ctx := persistence.SaveToContext(context.TODO(), db)
@@ -807,12 +796,12 @@ func TestPgRepository_DeleteByExternalTenant(t *testing.T) {
 			WithArgs(testExternal, tenantEntity.Inactive).
 			WillReturnRows(rowsToReturn)
 
-		appTenantAccesses := fixTenantAccessesForApplication()
-		dbMock.ExpectQuery(regexp.QuoteMeta(`SELECT tenant_id, id, owner FROM tenant_applications WHERE tenant_id = $1 AND owner = $2`)).
-			WithArgs(testID, true).WillReturnRows(sqlmock.NewRows(repo.M2MColumns).AddRow(fixTenantAccessesForApplicationRow()...))
+		appTenantAccesses := fixTenantAccesses()
+		dbMock.ExpectQuery(`SELECT tenant_id, id, owner FROM (.+) WHERE tenant_id = \$1 AND owner = \$2`).
+			WithArgs(testID, true).WillReturnRows(sqlmock.NewRows(repo.M2MColumns).AddRow(fixTenantAccessesRow()...))
 
-		dbMock.ExpectExec(regexp.QuoteMeta(`WITH RECURSIVE parents AS (SELECT t1.id, t1.parent FROM business_tenant_mappings t1 WHERE id = $1 UNION ALL SELECT t2.id, t2.parent FROM business_tenant_mappings t2 INNER JOIN parents t on t2.id = t.parent) DELETE FROM tenant_applications WHERE id IN ($2) AND owner = true AND tenant_id IN (SELECT id FROM parents)`)).
-			WithArgs(testID, appTenantAccesses[0].ResourceID).WillReturnError(testError)
+		dbMock.ExpectExec(`DELETE FROM (.+) WHERE id IN \(\$1\)`).
+			WithArgs(appTenantAccesses[0].ResourceID).WillReturnError(testError)
 
 		ctx := persistence.SaveToContext(context.TODO(), db)
 		repo := tenant.NewRepository(mockConverter)
@@ -843,19 +832,15 @@ func TestPgRepository_DeleteByExternalTenant(t *testing.T) {
 			WithArgs(testExternal, tenantEntity.Inactive).
 			WillReturnRows(rowsToReturn)
 
-		appTenantAccesses := fixTenantAccessesForApplication()
-		dbMock.ExpectQuery(regexp.QuoteMeta(`SELECT tenant_id, id, owner FROM tenant_applications WHERE tenant_id = $1 AND owner = $2`)).
-			WithArgs(testID, true).WillReturnRows(sqlmock.NewRows(repo.M2MColumns).AddRow(fixTenantAccessesForApplicationRow()...))
+		for range resource.TopLevelEntities {
+			tenantAccesses := fixTenantAccesses()
 
-		dbMock.ExpectExec(regexp.QuoteMeta(`WITH RECURSIVE parents AS (SELECT t1.id, t1.parent FROM business_tenant_mappings t1 WHERE id = $1 UNION ALL SELECT t2.id, t2.parent FROM business_tenant_mappings t2 INNER JOIN parents t on t2.id = t.parent) DELETE FROM tenant_applications WHERE id IN ($2) AND owner = true AND tenant_id IN (SELECT id FROM parents)`)).
-			WithArgs(testID, appTenantAccesses[0].ResourceID).WillReturnResult(sqlmock.NewResult(-1, 1))
+			dbMock.ExpectQuery(`SELECT tenant_id, id, owner FROM (.+) WHERE tenant_id = \$1 AND owner = \$2`).
+				WithArgs(testID, true).WillReturnRows(sqlmock.NewRows(repo.M2MColumns).AddRow(fixTenantAccessesRow()...))
 
-		runtimeTenantAccesses := fixTenantAccessesForRuntime()
-		dbMock.ExpectQuery(regexp.QuoteMeta(`SELECT tenant_id, id, owner FROM tenant_runtimes WHERE tenant_id = $1 AND owner = $2`)).
-			WithArgs(testID, true).WillReturnRows(sqlmock.NewRows(repo.M2MColumns).AddRow(fixTenantAccessesForRuntimeRow()...))
-
-		dbMock.ExpectExec(regexp.QuoteMeta(`WITH RECURSIVE parents AS (SELECT t1.id, t1.parent FROM business_tenant_mappings t1 WHERE id = $1 UNION ALL SELECT t2.id, t2.parent FROM business_tenant_mappings t2 INNER JOIN parents t on t2.id = t.parent) DELETE FROM tenant_runtimes WHERE id IN ($2) AND owner = true AND tenant_id IN (SELECT id FROM parents)`)).
-			WithArgs(testID, runtimeTenantAccesses[0].ResourceID).WillReturnResult(sqlmock.NewResult(-1, 1))
+			dbMock.ExpectExec(`DELETE FROM (.+) WHERE id IN \(\$1\)`).
+				WithArgs(tenantAccesses[0].ResourceID).WillReturnResult(sqlmock.NewResult(-1, 1))
+		}
 
 		dbMock.ExpectExec(deleteStatement).
 			WithArgs(testExternal).WillReturnError(testError)

--- a/components/director/pkg/resource/resource.go
+++ b/components/director/pkg/resource/resource.go
@@ -116,12 +116,15 @@ func (t Type) TenantAccessTable() (string, bool) {
 	return tbl, ok
 }
 
-// TopLevelEntities is a set of entities that has a many-to-many relationship with the tenants.
-var TopLevelEntities = []Type{Application, Runtime}
+// TopLevelEntities is a map of entities that has a many-to-many relationship with the tenants along with their table names.
+var TopLevelEntities = map[Type]string{
+	Application: "public.applications",
+	Runtime:     "public.runtimes",
+}
 
 // IsTopLevel returns true only if the entity has a many-to-many relationship with the tenants.
 func (t Type) IsTopLevel() bool {
-	for _, topLevelType := range TopLevelEntities {
+	for topLevelType := range TopLevelEntities {
 		if t == topLevelType {
 			return true
 		}

--- a/components/schema-migrator/migrations/director/20211201114401_delete-orphaned-data.down.sql
+++ b/components/schema-migrator/migrations/director/20211201114401_delete-orphaned-data.down.sql
@@ -1,0 +1,2 @@
+BEGIN;
+COMMIT;

--- a/components/schema-migrator/migrations/director/20211201114401_delete-orphaned-data.up.sql
+++ b/components/schema-migrator/migrations/director/20211201114401_delete-orphaned-data.up.sql
@@ -1,0 +1,9 @@
+BEGIN;
+
+-- delete all applications that have no tenant having access to them - orphaned data
+DELETE FROM applications WHERE id NOT IN (SELECT id FROM tenant_applications);
+
+-- delete all runtimes that have no tenant having access to them - orphaned data
+DELETE FROM runtimes WHERE id NOT IN (SELECT id FROM tenant_runtimes);
+
+COMMIT;


### PR DESCRIPTION
**Description**

When a tenant is deleted all resources owned by it should be deleted as well.
