### PR TITLE
Enable MTLS communication with Google Cloud SQL

### DIFF
--- a/chart/compass/charts/director/templates/rbac.yaml
+++ b/chart/compass/charts/director/templates/rbac.yaml
@@ -3,6 +3,8 @@ kind: ServiceAccount
 metadata:
   name: {{ template "fullname" . }}
   namespace: {{ .Release.Namespace }}
+  annotations:
+    iam.gke.io/gcp-service-account: "{{ $.Values.global.sqlproxy.proxyUser }}@sap-{{ $.Values.global.sqlproxy.cloudsql.instance.project }}.iam.gserviceaccount.com"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/chart/compass/templates/ord-aggregator-job.yaml
+++ b/chart/compass/templates/ord-aggregator-job.yaml
@@ -120,6 +120,8 @@ kind: ServiceAccount
 metadata:
   name: {{ $.Chart.Name }}-ord-aggregator
   namespace: {{ $.Release.Namespace }}
+  annotations:
+    iam.gke.io/gcp-service-account: "{{ $.Values.global.sqlproxy.proxyUser }}@sap-{{ $.Values.global.sqlproxy.cloudsql.instance.project }}.iam.gserviceaccount.com"
   labels:
     app: {{ $.Chart.Name }}
     release: {{ $.Release.Name }}

--- a/chart/compass/templates/system-fetcher-job.yaml
+++ b/chart/compass/templates/system-fetcher-job.yaml
@@ -188,6 +188,8 @@ kind: ServiceAccount
 metadata:
   name: {{ $.Chart.Name }}-system-fetcher
   namespace: {{ $.Release.Namespace }}
+  annotations:
+    iam.gke.io/gcp-service-account: "{{ $.Values.global.sqlproxy.proxyUser }}@sap-{{ $.Values.global.sqlproxy.cloudsql.instance.project }}.iam.gserviceaccount.com"
   labels:
     app: {{ $.Chart.Name }}
     release: {{ $.Release.Name }}

--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -642,3 +642,9 @@ global:
       appID: "123-test-456"
       clientUser: "test-user"
       tenant: "test-tenant"
+
+  sqlproxy:
+    proxyUser: "proxy-user"
+    cloudsql:
+      instance:
+        project: "cmp"


### PR DESCRIPTION
**Description**
Enable mtls communication with gcloud using workload identity

**Pull Request status**
- [ ] Implementation
- [ ] Unit tests
- [ ] Integration tests
- [ ] `chart/compass/values.yaml` is updated
- [ ] Mocks are regenerated, using the automated script
