### PR TITLE
Fix director's run.sh.

### DIFF
--- a/components/director/run.sh
+++ b/components/director/run.sh
@@ -213,6 +213,7 @@ export APP_EXTERNAL_CLIENT_CERT_KEY="tls.crt"
 export APP_EXTERNAL_CLIENT_KEY_KEY="tls.key"
 export APP_EXTERNAL_CLIENT_CERT_VALUE="certValue"
 export APP_EXTERNAL_CLIENT_KEY_VALUE="keyValue"
+export APP_INFO_ROOT_CA="--- Feature Disabled Locally ---"
 
 # Tenant Fetcher properties
 export APP_SUBSCRIPTION_CALLBACK_SCOPE=Callback


### PR DESCRIPTION
**Description**
After one of the recent changes we've introduced another mandatory variable for the director and forgotten to add it to the run.sh script. This PR fixes that. 

Changes proposed in this pull request:
- Add environment variable to director's run.sh.

**Pull request status:**
- [X] Implementation
- [ ] Unit tests
- [ ] Integration tests
- [ ] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [ ] Mocks are regenerated, using the automated script
