### PR TITLE
Fix tenant fetcher to read different field from the event

### DIFF
--- a/chart/compass/templates/tenant-fetcher-job.yaml
+++ b/chart/compass/templates/tenant-fetcher-job.yaml
@@ -150,8 +150,8 @@ spec:
                 value: {{ $config.fieldMapping.discriminatorValue }}
               - name: APP_MAPPING_FIELD_DETAILS
                 value: {{ $config.fieldMapping.detailsField }}
-              - name: APP_MAPPING_FIELD_PARENT_ID
-                value: {{ default "parentGuid" $config.fieldMapping.parentIDField }}
+              - name: APP_GLOBAL_ACCOUNT_KEY
+                value: {{ default "gaID" $config.fieldMapping.globalAccountID }}
               - name: APP_SYNC_SUBACCOUNTS
                 value: {{ $config.shouldSyncSubaccounts | quote }}
               - name: APP_TENANT_TOTAL_PAGES_FIELD

--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -567,7 +567,7 @@ global:
         discriminatorValue: ""
         detailsField: "details"
         entityTypeField: "entityType"
-        parentIDField: "parentGuid"
+        globalAccountID: "gaID"
         regionField: "region"
         movedSubaccountTargetField: "targetGlobalAccountGUID"
         movedSubaccountSourceField: "sourceGlobalAccountGUID"

--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -91,7 +91,7 @@ global:
       version: "PR-2163"
     director:
       dir:
-      version: "PR-2167"
+      version: "PR-2170"
     gateway:
       dir:
       version: "PR-2163"
@@ -120,7 +120,7 @@ global:
       version: "PR-51"
     e2e_tests:
       dir:
-      version: "PR-2156"
+      version: "PR-2170"
   isLocalEnv: false
   oauth2:
     host: oauth2

--- a/components/director/internal/tenantfetcher/event_page.go
+++ b/components/director/internal/tenantfetcher/event_page.go
@@ -25,8 +25,10 @@ func (ep eventsPage) getEventsDetails() [][]byte {
 	tenantDetails := make([][]byte, 0)
 	gjson.GetBytes(ep.payload, ep.fieldMapping.EventsField).ForEach(func(key gjson.Result, event gjson.Result) bool {
 		entityType := event.Get(ep.fieldMapping.EntityTypeField)
+		globalAccountGUID := event.Get(ep.fieldMapping.GlobalAccountGUIDField)
 		details := event.Get(ep.fieldMapping.DetailsField).Map()
 		details[ep.fieldMapping.EntityTypeField] = entityType
+		details[ep.fieldMapping.GlobalAccountKey] = globalAccountGUID
 		allDetails := make(map[string]interface{})
 		for key, result := range details {
 			switch result.Type {
@@ -198,9 +200,9 @@ func constructSubaccountTenant(jsonPayload, name, subdomain, externalTenant stri
 		return nil, invalidFieldFormatError(ep.fieldMapping.RegionField)
 	}
 	region := regionField.String()
-	parentIDField := gjson.Get(jsonPayload, ep.fieldMapping.ParentIDField)
+	parentIDField := gjson.Get(jsonPayload, ep.fieldMapping.GlobalAccountKey)
 	if !parentIDField.Exists() {
-		return nil, invalidFieldFormatError(ep.fieldMapping.ParentIDField)
+		return nil, invalidFieldFormatError(ep.fieldMapping.GlobalAccountKey)
 	}
 	parentID := parentIDField.String()
 	return &model.BusinessTenantMappingInput{

--- a/components/director/internal/tenantfetcher/event_page_test.go
+++ b/components/director/internal/tenantfetcher/event_page_test.go
@@ -173,6 +173,7 @@ func Test_getMovedSubaccounts(t *testing.T) {
 func Test_getTenantMappings(t *testing.T) {
 	idField := "id"
 	globalAccountGUIDField := "globalAccountGUID"
+	globalAccountKey := "gaID"
 	id := "1"
 	nameField := "name"
 	name := "test-name"
@@ -201,12 +202,14 @@ func Test_getTenantMappings(t *testing.T) {
 		{
 			name: "successfully gets businessTenantMappingInputs for correct eventPage format",
 			fieldMapping: TenantFieldMapping{
-				NameField:       nameField,
-				IDField:         idField,
-				SubdomainField:  subdomainField,
-				EventsField:     "events",
-				DetailsField:    "details",
-				EntityTypeField: entityTypeField,
+				NameField:              nameField,
+				IDField:                idField,
+				SubdomainField:         subdomainField,
+				EventsField:            "events",
+				DetailsField:           "details",
+				EntityTypeField:        entityTypeField,
+				GlobalAccountGUIDField: globalAccountGUIDField,
+				GlobalAccountKey:       globalAccountKey,
 			},
 			errorFunc: func(t *testing.T, err error) {
 				assert.NoError(t, err)
@@ -235,6 +238,7 @@ func Test_getTenantMappings(t *testing.T) {
 				DiscriminatorValue:     "discriminator-value",
 				EntityTypeField:        entityTypeField,
 				GlobalAccountGUIDField: globalAccountGUIDField,
+				GlobalAccountKey:       globalAccountKey,
 			},
 			errorFunc: func(t *testing.T, err error) {
 				assert.NoError(t, err)
@@ -263,7 +267,7 @@ func Test_getTenantMappings(t *testing.T) {
 				DiscriminatorField: discriminatorField,
 				DiscriminatorValue: "discriminator-value",
 				EntityTypeField:    entityTypeField,
-				GlobalAccountKey:   "gaID",
+				GlobalAccountKey:   globalAccountKey,
 			},
 			errorFunc: func(t *testing.T, err error) {
 				assert.NoError(t, err)
@@ -333,7 +337,7 @@ func Test_getTenantMappings(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			events := make([][]byte, 0, len(test.detailsPairs))
 			for i, detailPair := range test.detailsPairs {
-				events = append(events, fixEventWithDetailsWithoutGA(fmt.Sprintf("id%d", i), fmt.Sprintf("foo%d", i), "GlobalAccount", constructJSONObject(detailPair...), test.fieldMapping))
+				events = append(events, fixEventWithDetails(fmt.Sprintf("id%d", i), fmt.Sprintf("foo%d", i), "GlobalAccount", fmt.Sprintf("gaID%d", i), constructJSONObject(detailPair...), test.fieldMapping))
 			}
 			page := eventsPage{
 				fieldMapping: test.fieldMapping,
@@ -375,10 +379,6 @@ func constructJSONObject(pairs ...Pair) string {
 
 func fixEventWithDetails(id, name, entityType, globalAccountGUID, details string, fieldMapping TenantFieldMapping) []byte {
 	return []byte(fmt.Sprintf(`{"%s":"%s", "%s":"%s", "%s":"%s","%s":"%s","%s":%s}`, fieldMapping.IDField, id, fieldMapping.NameField, name, fieldMapping.EntityTypeField, entityType, fieldMapping.GlobalAccountGUIDField, globalAccountGUID, fieldMapping.DetailsField, details))
-}
-
-func fixEventWithDetailsWithoutGA(id, name, entityType, details string, fieldMapping TenantFieldMapping) []byte {
-	return []byte(fmt.Sprintf(`{"%s":"%s", "%s":"%s", "%s":"%s","%s":%s}`, fieldMapping.IDField, id, fieldMapping.NameField, name, fieldMapping.EntityTypeField, entityType, fieldMapping.DetailsField, details))
 }
 
 func fixTenantEventsResponse(events []byte, total, pages int) TenantEventsResponse {

--- a/components/director/internal/tenantfetcher/event_page_test.go
+++ b/components/director/internal/tenantfetcher/event_page_test.go
@@ -18,7 +18,8 @@ func Test_getMovedSubaccounts(t *testing.T) {
 	nameField := "name"
 	subdomainField := "subdomain"
 	regionField := "region"
-	parentIDField := "parent"
+	parentID := "parent"
+	globalAccountKey := "gaID"
 	labelFieldMappingValue := "moved-label"
 	sourceTenantField := "source-tenant"
 	targetTenantField := "target-tenant"
@@ -37,14 +38,14 @@ func Test_getMovedSubaccounts(t *testing.T) {
 		},
 	}
 	fieldMapping := TenantFieldMapping{
-		IDField:         idField,
-		NameField:       nameField,
-		SubdomainField:  subdomainField,
-		EntityTypeField: entityTypeField,
-		RegionField:     regionField,
-		ParentIDField:   parentIDField,
-		EventsField:     "events",
-		DetailsField:    "details",
+		IDField:          idField,
+		NameField:        nameField,
+		SubdomainField:   subdomainField,
+		EntityTypeField:  entityTypeField,
+		RegionField:      regionField,
+		GlobalAccountKey: globalAccountKey,
+		EventsField:      "events",
+		DetailsField:     "details",
 	}
 	tests := []struct {
 		name               string
@@ -62,7 +63,6 @@ func Test_getMovedSubaccounts(t *testing.T) {
 					{nameField, "subaccount-name"},
 					{subdomainField, "subdomain"},
 					{regionField, "region"},
-					{parentIDField, "parent"},
 				},
 			},
 			assertRuntimesFunc: func(t *testing.T, runtimes []model.MovedSubaccountMappingInput) {
@@ -106,7 +106,7 @@ func Test_getMovedSubaccounts(t *testing.T) {
 			},
 		},
 		{
-			name: "empty mappings for get MovedSubaccountMappingInput when sourceTenant field is invalid",
+			name: "empty mappings for get MovedSubaccountMappingInput when targetTenant field is invalid",
 			detailsPairs: [][]Pair{
 				{
 					{labelFieldMappingValue, "label-value"},
@@ -129,7 +129,6 @@ func Test_getMovedSubaccounts(t *testing.T) {
 					{sourceTenantField, "123"},
 					{nameField, "name"},
 					{regionField, "region"},
-					{parentIDField, "parent"},
 					{"wrong", "456"},
 				},
 				{
@@ -138,7 +137,6 @@ func Test_getMovedSubaccounts(t *testing.T) {
 					{targetTenantField, "456"},
 					{nameField, "name"},
 					{regionField, "region"},
-					{parentIDField, "parent"},
 				},
 			},
 			errorFunc: func(t *testing.T, err error) {
@@ -154,7 +152,7 @@ func Test_getMovedSubaccounts(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			events := make([][]byte, 0, len(test.detailsPairs))
 			for i, detailPair := range test.detailsPairs {
-				events = append(events, fixEventWithDetails(fmt.Sprintf("id%d", i), fmt.Sprintf("foo%d", i), "GlobalAccount", constructJSONObject(detailPair...), fieldMapping))
+				events = append(events, fixEventWithDetails(fmt.Sprintf("id%d", i), fmt.Sprintf("foo%d", i), "GlobalAccount", parentID, constructJSONObject(detailPair...), fieldMapping))
 			}
 			page := eventsPage{
 				fieldMapping: fieldMapping,
@@ -174,6 +172,7 @@ func Test_getMovedSubaccounts(t *testing.T) {
 
 func Test_getTenantMappings(t *testing.T) {
 	idField := "id"
+	globalAccountGUIDField := "globalAccountGUID"
 	id := "1"
 	nameField := "name"
 	name := "test-name"
@@ -227,14 +226,15 @@ func Test_getTenantMappings(t *testing.T) {
 		{
 			name: "successfully gets businessTenantMappingInputs for correct eventPage format with discriminator field",
 			fieldMapping: TenantFieldMapping{
-				NameField:          nameField,
-				IDField:            idField,
-				EventsField:        "events",
-				DetailsField:       "details",
-				SubdomainField:     "subdomain",
-				DiscriminatorField: discriminatorField,
-				DiscriminatorValue: "discriminator-value",
-				EntityTypeField:    entityTypeField,
+				NameField:              nameField,
+				IDField:                idField,
+				EventsField:            "events",
+				DetailsField:           "details",
+				SubdomainField:         "subdomain",
+				DiscriminatorField:     discriminatorField,
+				DiscriminatorValue:     "discriminator-value",
+				EntityTypeField:        entityTypeField,
+				GlobalAccountGUIDField: globalAccountGUIDField,
 			},
 			errorFunc: func(t *testing.T, err error) {
 				assert.NoError(t, err)
@@ -263,6 +263,7 @@ func Test_getTenantMappings(t *testing.T) {
 				DiscriminatorField: discriminatorField,
 				DiscriminatorValue: "discriminator-value",
 				EntityTypeField:    entityTypeField,
+				GlobalAccountKey:   "gaID",
 			},
 			errorFunc: func(t *testing.T, err error) {
 				assert.NoError(t, err)
@@ -332,7 +333,7 @@ func Test_getTenantMappings(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			events := make([][]byte, 0, len(test.detailsPairs))
 			for i, detailPair := range test.detailsPairs {
-				events = append(events, fixEventWithDetails(fmt.Sprintf("id%d", i), fmt.Sprintf("foo%d", i), "GlobalAccount", constructJSONObject(detailPair...), test.fieldMapping))
+				events = append(events, fixEventWithDetailsWithoutGA(fmt.Sprintf("id%d", i), fmt.Sprintf("foo%d", i), "GlobalAccount", constructJSONObject(detailPair...), test.fieldMapping))
 			}
 			page := eventsPage{
 				fieldMapping: test.fieldMapping,
@@ -372,7 +373,11 @@ func constructJSONObject(pairs ...Pair) string {
 	return buffer.String()
 }
 
-func fixEventWithDetails(id, name, entityType, details string, fieldMapping TenantFieldMapping) []byte {
+func fixEventWithDetails(id, name, entityType, globalAccountGUID, details string, fieldMapping TenantFieldMapping) []byte {
+	return []byte(fmt.Sprintf(`{"%s":"%s", "%s":"%s", "%s":"%s","%s":"%s","%s":%s}`, fieldMapping.IDField, id, fieldMapping.NameField, name, fieldMapping.EntityTypeField, entityType, fieldMapping.GlobalAccountGUIDField, globalAccountGUID, fieldMapping.DetailsField, details))
+}
+
+func fixEventWithDetailsWithoutGA(id, name, entityType, details string, fieldMapping TenantFieldMapping) []byte {
 	return []byte(fmt.Sprintf(`{"%s":"%s", "%s":"%s", "%s":"%s","%s":%s}`, fieldMapping.IDField, id, fieldMapping.NameField, name, fieldMapping.EntityTypeField, entityType, fieldMapping.DetailsField, details))
 }
 

--- a/components/director/internal/tenantfetcher/fixtures_test.go
+++ b/components/director/internal/tenantfetcher/fixtures_test.go
@@ -22,15 +22,32 @@ func fixTenantEventsResponse(events []byte, total, pages int) tenantfetcher.Tena
 	}`, string(events), total, pages))
 }
 
-func fixEvent(t require.TestingT, eventType string, fields map[string]string) []byte {
+func fixEvent(t require.TestingT, eventType, ga string, fields map[string]string) []byte {
 	eventData, err := json.Marshal(fields)
 	if err != nil {
 		require.NoError(t, err)
 	}
-	return wrapIntoEventPageJSON(string(eventData), eventType)
+	return wrapIntoEventPageJSON(string(eventData), eventType, ga)
 }
 
-func wrapIntoEventPageJSON(eventData, eventType string) []byte {
+func fixEventWithoutGA(t require.TestingT, eventType string, fields map[string]string) []byte {
+	eventData, err := json.Marshal(fields)
+	if err != nil {
+		require.NoError(t, err)
+	}
+	return wrapIntoEventPageJSONWithoutGA(string(eventData), eventType)
+}
+
+func wrapIntoEventPageJSON(eventData, eventType, ga string) []byte {
+	return []byte(fmt.Sprintf(`{
+		"id":        "%s",
+		"type" "%s",
+        "globalAccountGUID": "%s",
+		"eventData": %s,
+	}`, fixID(), eventType, ga, eventData))
+}
+
+func wrapIntoEventPageJSONWithoutGA(eventData, eventType string) []byte {
 	return []byte(fmt.Sprintf(`{
 		"id":        "%s",
 		"type" "%s",

--- a/components/director/internal/tenantfetcher/fixtures_test.go
+++ b/components/director/internal/tenantfetcher/fixtures_test.go
@@ -30,14 +30,6 @@ func fixEvent(t require.TestingT, eventType, ga string, fields map[string]string
 	return wrapIntoEventPageJSON(string(eventData), eventType, ga)
 }
 
-func fixEventWithoutGA(t require.TestingT, eventType string, fields map[string]string) []byte {
-	eventData, err := json.Marshal(fields)
-	if err != nil {
-		require.NoError(t, err)
-	}
-	return wrapIntoEventPageJSONWithoutGA(string(eventData), eventType)
-}
-
 func wrapIntoEventPageJSON(eventData, eventType, ga string) []byte {
 	return []byte(fmt.Sprintf(`{
 		"id":        "%s",
@@ -45,14 +37,6 @@ func wrapIntoEventPageJSON(eventData, eventType, ga string) []byte {
         "globalAccountGUID": "%s",
 		"eventData": %s,
 	}`, fixID(), eventType, ga, eventData))
-}
-
-func wrapIntoEventPageJSONWithoutGA(eventData, eventType string) []byte {
-	return []byte(fmt.Sprintf(`{
-		"id":        "%s",
-		"type" "%s",
-		"eventData": %s,
-	}`, fixID(), eventType, eventData))
 }
 
 func fixBusinessTenantMappingInput(name, externalTenant, provider, subdomain, region, parent string, tenantType tenant.Type) model.BusinessTenantMappingInput {

--- a/components/director/internal/tenantfetcher/service.go
+++ b/components/director/internal/tenantfetcher/service.go
@@ -45,7 +45,9 @@ type TenantFieldMapping struct {
 
 	RegionField     string `envconfig:"APP_MAPPING_FIELD_REGION"`
 	EntityTypeField string `envconfig:"default=entityType,APP_MAPPING_FIELD_ENTITY_TYPE"`
-	ParentIDField   string `envconfig:"APP_MAPPING_FIELD_PARENT_ID"`
+
+	// This is not a value from the actual event but the key under which the GlobalAccountGUIDField will be stored to avoid collisions
+	GlobalAccountKey string `envconfig:"default=gaID,APP_GLOBAL_ACCOUNT_KEY"`
 }
 
 // MovedSubaccountsFieldMapping missing godoc

--- a/components/director/internal/tenantfetcher/service_test.go
+++ b/components/director/internal/tenantfetcher/service_test.go
@@ -110,9 +110,9 @@ func TestService_SyncAccountTenants(t *testing.T) {
 		tenantFieldMapping.EntityTypeField: "GlobalAccount",
 	}
 
-	event1 := fixEvent(t, "GlobalAccount", event1Fields)
-	event2 := fixEvent(t, "GlobalAccount", event2Fields)
-	event3 := fixEvent(t, "GlobalAccount", event3Fields)
+	event1 := fixEventWithoutGA(t, "GlobalAccount", event1Fields)
+	event2 := fixEventWithoutGA(t, "GlobalAccount", event2Fields)
+	event3 := fixEventWithoutGA(t, "GlobalAccount", event3Fields)
 
 	eventsToJSONArray := func(events ...[]byte) []byte {
 		return []byte(fmt.Sprintf(`[%s]`, bytes.Join(events, []byte(","))))
@@ -313,7 +313,7 @@ func TestService_SyncAccountTenants(t *testing.T) {
 					tenantFieldMapping.EntityTypeField: busTenant1.Type,
 				}
 
-				updatedTenant := fixEvent(t, busTenant1.Type, updatedEventFields)
+				updatedTenant := fixEventWithoutGA(t, busTenant1.Type, updatedEventFields)
 				client.On("FetchTenantEventsPage", tenantfetcher.CreatedAccountType, pageOneQueryParams).Return(fixTenantEventsResponse(eventsToJSONArray(event1), 1, 1), nil).Once()
 				client.On("FetchTenantEventsPage", tenantfetcher.UpdatedAccountType, pageOneQueryParams).Return(fixTenantEventsResponse(eventsToJSONArray(updatedTenant), 1, 1), nil).Once()
 
@@ -736,7 +736,7 @@ func TestService_SyncAccountTenants(t *testing.T) {
 					wrongFieldMapping.NameField: "qux",
 				}
 
-				wrongTenantEvents := eventsToJSONArray(fixEvent(t, "GlobalAccount", wrongTenantEventFields))
+				wrongTenantEvents := eventsToJSONArray(fixEventWithoutGA(t, "GlobalAccount", wrongTenantEventFields))
 				client.On("FetchTenantEventsPage", tenantfetcher.CreatedAccountType, pageOneQueryParams).Return(fixTenantEventsResponse(wrongTenantEvents, 1, 1), nil).Once()
 				attachNoResponseOnFirstPage(client, pageOneQueryParams, tenantfetcher.UpdatedAccountType, tenantfetcher.DeletedAccountType)
 				return client
@@ -772,6 +772,7 @@ func TestService_SyncAccountTenants(t *testing.T) {
 				DiscriminatorValue: "",
 				EventsField:        "events",
 				IDField:            "id",
+				GlobalAccountKey:   "gaID",
 				NameField:          "name",
 				CustomerIDField:    "customerId",
 				SubdomainField:     "subdomain",
@@ -941,7 +942,6 @@ func TestService_SyncSubaccountTenants(t *testing.T) {
 			SubdomainField:  "subdomain",
 			EntityTypeField: "type",
 			RegionField:     "region",
-			ParentIDField:   "parentId",
 		}
 
 		busTenant1GUID = "d1f08f02-2fda-4511-962a-17fd1f1aa477"
@@ -976,7 +976,6 @@ func TestService_SyncSubaccountTenants(t *testing.T) {
 		subaccountEvent1Fields = map[string]string{
 			tenantFieldMapping.IDField:         "S1",
 			tenantFieldMapping.NameField:       "foo",
-			tenantFieldMapping.ParentIDField:   busTenant1GUID,
 			tenantFieldMapping.RegionField:     "test-region",
 			tenantFieldMapping.SubdomainField:  "subdomain-1",
 			tenantFieldMapping.EntityTypeField: "Subaccount",
@@ -984,7 +983,6 @@ func TestService_SyncSubaccountTenants(t *testing.T) {
 		subaccountEvent2Fields = map[string]string{
 			tenantFieldMapping.IDField:         "S2",
 			tenantFieldMapping.NameField:       "bar",
-			tenantFieldMapping.ParentIDField:   busTenant2GUID,
 			tenantFieldMapping.RegionField:     "test-region",
 			tenantFieldMapping.SubdomainField:  "subdomain-2",
 			tenantFieldMapping.EntityTypeField: "Subaccount",
@@ -992,7 +990,6 @@ func TestService_SyncSubaccountTenants(t *testing.T) {
 		subaccountEvent3Fields = map[string]string{
 			tenantFieldMapping.IDField:         "S3",
 			tenantFieldMapping.NameField:       "baz",
-			tenantFieldMapping.ParentIDField:   busTenant3GUID,
 			tenantFieldMapping.RegionField:     "test-region",
 			tenantFieldMapping.SubdomainField:  "subdomain-3",
 			tenantFieldMapping.EntityTypeField: "Subaccount",
@@ -1000,7 +997,6 @@ func TestService_SyncSubaccountTenants(t *testing.T) {
 		subaccountEvent4Fields = map[string]string{
 			tenantFieldMapping.IDField:         "S4",
 			tenantFieldMapping.NameField:       "bsk",
-			tenantFieldMapping.ParentIDField:   busTenant4GUID,
 			tenantFieldMapping.RegionField:     "test-region",
 			tenantFieldMapping.SubdomainField:  "subdomain-4",
 			tenantFieldMapping.EntityTypeField: "Subaccount",
@@ -1008,10 +1004,10 @@ func TestService_SyncSubaccountTenants(t *testing.T) {
 			"target_tenant":                    "target",
 		}
 
-		subaccountEvent1 = fixEvent(t, "Subaccount", subaccountEvent1Fields)
-		subaccountEvent2 = fixEvent(t, "Subaccount", subaccountEvent2Fields)
-		subaccountEvent3 = fixEvent(t, "Subaccount", subaccountEvent3Fields)
-		subaccountEvent4 = fixEvent(t, "Subaccount", subaccountEvent4Fields)
+		subaccountEvent1 = fixEvent(t, "Subaccount", busTenant1GUID, subaccountEvent1Fields)
+		subaccountEvent2 = fixEvent(t, "Subaccount", busTenant2GUID, subaccountEvent2Fields)
+		subaccountEvent3 = fixEvent(t, "Subaccount", busTenant3GUID, subaccountEvent3Fields)
+		subaccountEvent4 = fixEvent(t, "Subaccount", busTenant4GUID, subaccountEvent4Fields)
 
 		subaccountEvents = eventsToJSONArray(subaccountEvent1, subaccountEvent2, subaccountEvent3, subaccountEvent4)
 	}
@@ -1194,13 +1190,12 @@ func TestService_SyncSubaccountTenants(t *testing.T) {
 				updatedEventFields := map[string]string{
 					tenantFieldMapping.IDField:         "S1",
 					tenantFieldMapping.NameField:       "updated-name",
-					tenantFieldMapping.ParentIDField:   busTenant1GUID,
 					tenantFieldMapping.RegionField:     "test-region",
 					tenantFieldMapping.SubdomainField:  "subdomain-1",
 					tenantFieldMapping.EntityTypeField: "Subaccount",
 				}
 
-				updatedTenant := fixEvent(t, parentTenant1.Type, updatedEventFields)
+				updatedTenant := fixEvent(t, parentTenant1.Type, busTenant1GUID, updatedEventFields)
 				client.On("FetchTenantEventsPage", tenantfetcher.CreatedSubaccountType, pageOneQueryParams).Return(fixTenantEventsResponse(eventsToJSONArray(subaccountEvent1), 1, 1), nil).Once()
 				client.On("FetchTenantEventsPage", tenantfetcher.UpdatedSubaccountType, pageOneQueryParams).Return(fixTenantEventsResponse(eventsToJSONArray(updatedTenant), 1, 1), nil).Once()
 
@@ -2094,7 +2089,7 @@ func TestService_SyncSubaccountTenants(t *testing.T) {
 					wrongFieldMapping.NameField: "qux",
 				}
 
-				wrongTenantEvents := eventsToJSONArray(fixEvent(t, "Subaccount", wrongTenantEventFields))
+				wrongTenantEvents := eventsToJSONArray(fixEvent(t, "Subaccount", "id992", wrongTenantEventFields))
 				client.On("FetchTenantEventsPage", tenantfetcher.CreatedSubaccountType, pageOneQueryParams).Return(fixTenantEventsResponse(wrongTenantEvents, 1, 1), nil).Once()
 				attachNoResponseOnFirstPage(client, pageOneQueryParams, tenantfetcher.UpdatedSubaccountType, tenantfetcher.DeletedSubaccountType, tenantfetcher.MovedSubaccountType)
 				return client
@@ -2200,19 +2195,19 @@ func TestService_SyncSubaccountTenants(t *testing.T) {
 				PageSizeValue:  "1",
 				PageStartValue: "1",
 			}, transact, kubeClient, tenantfetcher.TenantFieldMapping{
-				DetailsField:       "eventData",
-				DiscriminatorField: "",
-				DiscriminatorValue: "",
-				EventsField:        "events",
-				IDField:            "id",
-				NameField:          "name",
-				CustomerIDField:    "customerId",
-				SubdomainField:     "subdomain",
-				TotalPagesField:    "pages",
-				TotalResultsField:  "total",
-				EntityTypeField:    "type",
-				ParentIDField:      "parentId",
-				RegionField:        "region",
+				DetailsField:           "eventData",
+				DiscriminatorField:     "",
+				DiscriminatorValue:     "",
+				EventsField:            "events",
+				IDField:                "id",
+				NameField:              "name",
+				CustomerIDField:        "customerId",
+				SubdomainField:         "subdomain",
+				TotalPagesField:        "pages",
+				TotalResultsField:      "total",
+				EntityTypeField:        "type",
+				GlobalAccountGUIDField: "globalAccountGUID",
+				RegionField:            "region",
 			}, tenantfetcher.MovedSubaccountsFieldMapping{
 				LabelValue:   "id",
 				SourceTenant: "source_tenant",
@@ -2266,19 +2261,19 @@ func TestService_SyncSubaccountTenants(t *testing.T) {
 			PageSizeValue:  "1",
 			PageStartValue: "1",
 		}, transact, kubeClient, tenantfetcher.TenantFieldMapping{
-			DetailsField:       "eventData",
-			DiscriminatorField: "",
-			DiscriminatorValue: "",
-			EventsField:        "events",
-			IDField:            "id",
-			NameField:          "name",
-			CustomerIDField:    "customerId",
-			SubdomainField:     "subdomain",
-			TotalPagesField:    "pages",
-			TotalResultsField:  "total",
-			EntityTypeField:    "type",
-			ParentIDField:      "parentId",
-			RegionField:        "region",
+			DetailsField:           "eventData",
+			DiscriminatorField:     "",
+			DiscriminatorValue:     "",
+			EventsField:            "events",
+			IDField:                "id",
+			NameField:              "name",
+			CustomerIDField:        "customerId",
+			SubdomainField:         "subdomain",
+			TotalPagesField:        "pages",
+			TotalResultsField:      "total",
+			EntityTypeField:        "type",
+			GlobalAccountGUIDField: "globalAccountGUID",
+			RegionField:            "region",
 		}, tenantfetcher.MovedSubaccountsFieldMapping{
 			LabelValue:   "id",
 			SourceTenant: "source_tenant",

--- a/components/director/internal/tenantfetcher/service_test.go
+++ b/components/director/internal/tenantfetcher/service_test.go
@@ -110,9 +110,9 @@ func TestService_SyncAccountTenants(t *testing.T) {
 		tenantFieldMapping.EntityTypeField: "GlobalAccount",
 	}
 
-	event1 := fixEventWithoutGA(t, "GlobalAccount", event1Fields)
-	event2 := fixEventWithoutGA(t, "GlobalAccount", event2Fields)
-	event3 := fixEventWithoutGA(t, "GlobalAccount", event3Fields)
+	event1 := fixEvent(t, "GlobalAccount", busTenant1.ExternalTenant, event1Fields)
+	event2 := fixEvent(t, "GlobalAccount", busTenant2.ExternalTenant, event2Fields)
+	event3 := fixEvent(t, "GlobalAccount", busTenant3.ExternalTenant, event3Fields)
 
 	eventsToJSONArray := func(events ...[]byte) []byte {
 		return []byte(fmt.Sprintf(`[%s]`, bytes.Join(events, []byte(","))))
@@ -313,7 +313,7 @@ func TestService_SyncAccountTenants(t *testing.T) {
 					tenantFieldMapping.EntityTypeField: busTenant1.Type,
 				}
 
-				updatedTenant := fixEventWithoutGA(t, busTenant1.Type, updatedEventFields)
+				updatedTenant := fixEvent(t, busTenant1.Type, busTenant1.ExternalTenant, updatedEventFields)
 				client.On("FetchTenantEventsPage", tenantfetcher.CreatedAccountType, pageOneQueryParams).Return(fixTenantEventsResponse(eventsToJSONArray(event1), 1, 1), nil).Once()
 				client.On("FetchTenantEventsPage", tenantfetcher.UpdatedAccountType, pageOneQueryParams).Return(fixTenantEventsResponse(eventsToJSONArray(updatedTenant), 1, 1), nil).Once()
 
@@ -736,7 +736,7 @@ func TestService_SyncAccountTenants(t *testing.T) {
 					wrongFieldMapping.NameField: "qux",
 				}
 
-				wrongTenantEvents := eventsToJSONArray(fixEventWithoutGA(t, "GlobalAccount", wrongTenantEventFields))
+				wrongTenantEvents := eventsToJSONArray(fixEvent(t, "GlobalAccount", "", wrongTenantEventFields))
 				client.On("FetchTenantEventsPage", tenantfetcher.CreatedAccountType, pageOneQueryParams).Return(fixTenantEventsResponse(wrongTenantEvents, 1, 1), nil).Once()
 				attachNoResponseOnFirstPage(client, pageOneQueryParams, tenantfetcher.UpdatedAccountType, tenantfetcher.DeletedAccountType)
 				return client

--- a/tests/tenant-fetcher-job/tests/handler_test.go
+++ b/tests/tenant-fetcher-job/tests/handler_test.go
@@ -372,7 +372,7 @@ func TestCreateDeleteSubaccounts(t *testing.T) {
 	assert.Equal(t, subaccountNames[1], *subaccount2.Name)
 	parent, err := fixtures.GetTenantByExternalID(dexGraphQLClient, subaccountParent)
 	assert.NoError(t, err)
-	assert.Equal(t, parent.ID, subaccount2.ParentID)
+	assert.Equal(t, parent.InternalID, subaccount2.ParentID)
 }
 
 func TestMoveMissingSubaccounts(t *testing.T) {

--- a/tests/tenant-fetcher-job/tests/handler_test.go
+++ b/tests/tenant-fetcher-job/tests/handler_test.go
@@ -75,11 +75,11 @@ const (
 		"guid": "%s",
 		"displayName": "%s",
 		"subdomain": "%s",
-		"parentGuid": "%s",
 		"sourceGlobalAccountGUID": "%s",
 		"targetGlobalAccountGUID": "%s",
 		"region": "%s"
 	},
+	"globalAccountGUID": "%s",
 	"type": "Subaccount"
 }`
 )
@@ -413,7 +413,7 @@ func genMockGlobalAccountEvent(guid, displayName, customerID, subdomain string) 
 }
 
 func genMockSubaccountMoveEvent(guid, displayName, subdomain, parentGuid, sourceGlobalAccountGuid, targetGlobalAccountGuid, region string) string {
-	return fmt.Sprintf(mockSubaccountEventPattern, guid, displayName, subdomain, parentGuid, sourceGlobalAccountGuid, targetGlobalAccountGuid, region)
+	return fmt.Sprintf(mockSubaccountEventPattern, guid, displayName, subdomain, sourceGlobalAccountGuid, targetGlobalAccountGuid, region, parentGuid)
 }
 
 func genMockPage(events string, numEvents int) string {

--- a/tests/tenant-fetcher-job/tests/handler_test.go
+++ b/tests/tenant-fetcher-job/tests/handler_test.go
@@ -370,6 +370,7 @@ func TestCreateDeleteSubaccounts(t *testing.T) {
 	subaccount2, err := fixtures.GetTenantByExternalID(dexGraphQLClient, subaccountExternalTenants[1])
 	assert.NoError(t, err)
 	assert.Equal(t, subaccountNames[1], *subaccount2.Name)
+	assert.Equal(t, subaccountParent, subaccount2.ParentID)
 }
 
 func TestMoveMissingSubaccounts(t *testing.T) {

--- a/tests/tenant-fetcher-job/tests/handler_test.go
+++ b/tests/tenant-fetcher-job/tests/handler_test.go
@@ -75,6 +75,7 @@ const (
 		"guid": "%s",
 		"displayName": "%s",
 		"subdomain": "%s",
+		"parentGuid": "%s",
 		"sourceGlobalAccountGUID": "%s",
 		"targetGlobalAccountGUID": "%s",
 		"region": "%s"
@@ -134,6 +135,7 @@ func TestMoveSubaccounts(t *testing.T) {
 	subaccountRegion := "test"
 	subaccountSubdomain := "sub1"
 	subaccountParent := "ga1"
+	directoryParentGUID := "test-id" // this is not the global account parent ID but has different semantics
 
 	region := "local"
 	provider := "test"
@@ -190,8 +192,8 @@ func TestMoveSubaccounts(t *testing.T) {
 	runtime1 := registerRuntime(t, ctx, runtimeNames[0], subaccount1.InternalID)
 	runtime2 := registerRuntime(t, ctx, runtimeNames[1], subaccount2.InternalID)
 
-	event1 := genMockSubaccountMoveEvent(subaccountExternalTenants[0], subaccountNames[0], subaccountSubdomain, subaccountParent, gaExternalTenantIDs[0], gaExternalTenantIDs[1], subaccountRegion)
-	event2 := genMockSubaccountMoveEvent(subaccountExternalTenants[1], subaccountNames[1], subaccountSubdomain, subaccountParent, gaExternalTenantIDs[0], gaExternalTenantIDs[1], subaccountRegion)
+	event1 := genMockSubaccountMoveEvent(subaccountExternalTenants[0], subaccountNames[0], subaccountSubdomain, directoryParentGUID, subaccountParent, gaExternalTenantIDs[0], gaExternalTenantIDs[1], subaccountRegion)
+	event2 := genMockSubaccountMoveEvent(subaccountExternalTenants[1], subaccountNames[1], subaccountSubdomain, directoryParentGUID, subaccountParent, gaExternalTenantIDs[0], gaExternalTenantIDs[1], subaccountRegion)
 	setMockTenantEvents(t, []byte(genMockPage(strings.Join([]string{event1, event2}, ","), 2)), subaccountMoveSubPath)
 	defer cleanupMockEvents(t, subaccountMoveSubPath)
 
@@ -232,6 +234,7 @@ func TestMoveSubaccountsFailIfSubaccountHasFormationInTheSourceGA(t *testing.T) 
 	subaccountExternalTenants := []string{"sub1"}
 	subaccountRegion := "test"
 	subaccountSubdomain := "sub1"
+	directoryParentGUID := "test-id"
 
 	region := "local"
 	provider := "test"
@@ -283,7 +286,7 @@ func TestMoveSubaccountsFailIfSubaccountHasFormationInTheSourceGA(t *testing.T) 
 	fixtures.CreateAutomaticScenarioAssignmentInTenant(t, ctx, dexGraphQLClient, asaInput, defaultTenantID)
 	defer fixtures.DeleteAutomaticScenarioAssignmentForScenarioWithinTenant(t, ctx, dexGraphQLClient, defaultTenantID, scenarioName)
 
-	event1 := genMockSubaccountMoveEvent(subaccountExternalTenants[0], subaccountNames[0], subaccountSubdomain, defaultTenantID, defaultTenantID, gaExternalTenantIDs[0], subaccountRegion)
+	event1 := genMockSubaccountMoveEvent(subaccountExternalTenants[0], subaccountNames[0], subaccountSubdomain, directoryParentGUID, defaultTenantID, defaultTenantID, gaExternalTenantIDs[0], subaccountRegion)
 	setMockTenantEvents(t, []byte(genMockPage(strings.Join([]string{event1}, ","), 1)), subaccountMoveSubPath)
 	defer cleanupMockEvents(t, subaccountMoveSubPath)
 
@@ -319,6 +322,7 @@ func TestCreateDeleteSubaccounts(t *testing.T) {
 	subaccountRegion := "test"
 	subaccountParent := "ga1"
 	subaccountSubdomain := "sub1"
+	directoryParentGUID := "test-id"
 
 	provider := "test"
 	tenants := []graphql.BusinessTenantMappingInput{
@@ -347,11 +351,11 @@ func TestCreateDeleteSubaccounts(t *testing.T) {
 	// cleanup global account and subaccounts
 	defer cleanupTenants(t, ctx, directorInternalGQLClient, append(subaccountExternalTenants, gaExternalTenant))
 
-	deleteEvent := genMockSubaccountMoveEvent(subaccountExternalTenants[0], subaccountNames[0], subaccountSubdomain, subaccountParent, "", "", subaccountDeleteSubPath)
+	deleteEvent := genMockSubaccountMoveEvent(subaccountExternalTenants[0], subaccountNames[0], subaccountSubdomain, directoryParentGUID, subaccountParent, "", "", subaccountDeleteSubPath)
 	setMockTenantEvents(t, []byte(genMockPage(deleteEvent, 1)), subaccountDeleteSubPath)
 	defer cleanupMockEvents(t, subaccountDeleteSubPath)
 
-	createEvent := genMockSubaccountMoveEvent(subaccountExternalTenants[1], subaccountNames[1], subaccountSubdomain, subaccountParent, "", "", subaccountCreateSubPath)
+	createEvent := genMockSubaccountMoveEvent(subaccountExternalTenants[1], subaccountNames[1], subaccountSubdomain, directoryParentGUID, subaccountParent, "", "", subaccountCreateSubPath)
 	setMockTenantEvents(t, []byte(genMockPage(createEvent, 1)), subaccountCreateSubPath)
 	defer cleanupMockEvents(t, subaccountCreateSubPath)
 
@@ -385,10 +389,11 @@ func TestMoveMissingSubaccounts(t *testing.T) {
 	subaccountRegion := "test"
 	subaccountSubdomain := "sub1"
 	subaccountParent := "ga1"
+	directoryParentGUID := "test-id"
 
 	defer cleanupTenants(t, ctx, directorInternalGQLClient, []string{subaccountExternalTenant, gaExternalTenantIDs[1]})
 
-	event := genMockSubaccountMoveEvent(subaccountExternalTenant, subaccountName, subaccountSubdomain, subaccountParent, gaExternalTenantIDs[0], gaExternalTenantIDs[1], subaccountRegion)
+	event := genMockSubaccountMoveEvent(subaccountExternalTenant, subaccountName, subaccountSubdomain, directoryParentGUID, subaccountParent, gaExternalTenantIDs[0], gaExternalTenantIDs[1], subaccountRegion)
 	setMockTenantEvents(t, []byte(genMockPage(event, 1)), subaccountMoveSubPath)
 	defer cleanupMockEvents(t, subaccountMoveSubPath)
 
@@ -415,8 +420,8 @@ func genMockGlobalAccountEvent(guid, displayName, customerID, subdomain string) 
 	return fmt.Sprintf(mockGlobalAccountEventPattern, guid, displayName, customerID, subdomain)
 }
 
-func genMockSubaccountMoveEvent(guid, displayName, subdomain, parentGuid, sourceGlobalAccountGuid, targetGlobalAccountGuid, region string) string {
-	return fmt.Sprintf(mockSubaccountEventPattern, guid, displayName, subdomain, sourceGlobalAccountGuid, targetGlobalAccountGuid, region, parentGuid)
+func genMockSubaccountMoveEvent(guid, displayName, subdomain, directoryParentGUID, parentGuid, sourceGlobalAccountGuid, targetGlobalAccountGuid, region string) string {
+	return fmt.Sprintf(mockSubaccountEventPattern, guid, displayName, subdomain, directoryParentGUID, sourceGlobalAccountGuid, targetGlobalAccountGuid, region, parentGuid)
 }
 
 func genMockPage(events string, numEvents int) string {

--- a/tests/tenant-fetcher-job/tests/handler_test.go
+++ b/tests/tenant-fetcher-job/tests/handler_test.go
@@ -370,7 +370,9 @@ func TestCreateDeleteSubaccounts(t *testing.T) {
 	subaccount2, err := fixtures.GetTenantByExternalID(dexGraphQLClient, subaccountExternalTenants[1])
 	assert.NoError(t, err)
 	assert.Equal(t, subaccountNames[1], *subaccount2.Name)
-	assert.Equal(t, subaccountParent, subaccount2.ParentID)
+	parent, err := fixtures.GetTenantByExternalID(dexGraphQLClient, subaccountParent)
+	assert.NoError(t, err)
+	assert.Equal(t, parent.ID, subaccount2.ParentID)
 }
 
 func TestMoveMissingSubaccounts(t *testing.T) {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

This PR changes the field from the event response from which the Tenant Fetcher gets the parent of a subaccount.

Changes proposed in this pull request:
- changed field
- adapted unit and e2e tests

**Pull Request status**
<!-- Feel free to construct the checklist with whatever items seem most reasonable for your change. You could disassemble the Implementation part to even smaller separate checklist items if you're working on something big for example. But do make the effort to provide a checklist of some sort so that the core team as well as the community can have an idea about the progress of your Pull Request.
-->

- [x] Implementation
- [x] Unit tests
- [x] Integration tests
- [x] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [ ] Mocks are regenerated, using the automated script
