### PR TITLE
Rate limiting

### DIFF
--- a/chart/compass/charts/director/templates/rate-limit-filter.yaml
+++ b/chart/compass/charts/director/templates/rate-limit-filter.yaml
@@ -1,7 +1,7 @@
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
-  name: {{ template "fullname" . }}-rate-limit
+  name: {{ template "fullname" . }}-rate-limit-filter
   namespace: {{ .Release.Namespace }}
 spec:
   workloadSelector:

--- a/chart/compass/charts/director/templates/rate-limit-filter.yaml
+++ b/chart/compass/charts/director/templates/rate-limit-filter.yaml
@@ -1,0 +1,81 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: EnvoyFilter
+metadata:
+  name: {{ template "fullname" . }}-rate-limit
+  namespace: {{ .Release.Namespace }}
+spec:
+  workloadSelector:
+    labels:
+      app: {{ .Chart.Name }}
+  configPatches:
+    - applyTo: HTTP_FILTER
+      match:
+        listener:
+          filterChain:
+            filter:
+              name: "envoy.http_connection_manager"
+      patch:
+        operation: INSERT_BEFORE
+        value:
+          name: envoy.filters.http.local_ratelimit
+          typed_config:
+            "@type": type.googleapis.com/udpa.type.v1.TypedStruct
+            type_url: type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+            value:
+              stat_prefix: http_local_rate_limiter_{{ .Chart.Name }}
+
+    - applyTo: HTTP_ROUTE
+      match:
+        context: SIDECAR_INBOUND
+        routeConfiguration:
+          vhost:
+            name: "inbound|http|{{ .Values.global.director.graphql.external.port }}"
+      patch:
+        operation: MERGE
+        value:
+          route:
+            rate_limits:
+              - actions:
+                  - request_headers:
+                      header_name: "{{ .Values.global.gateway.headers.rateLimit }}"
+                      descriptor_key: "consumer"
+          typed_per_filter_config:
+            envoy.filters.http.local_ratelimit:
+              "@type": type.googleapis.com/udpa.type.v1.TypedStruct
+              type_url: type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+              value:
+                stat_prefix: http_local_rate_limiter_{{ .Chart.Name }}
+                descriptors:
+                  - entries:
+                      - key: "consumer"
+                        value: "{{ .Values.rateLimit.runtimes.headerValue }}"
+                    token_bucket:
+                      max_tokens: {{ .Values.rateLimit.runtimes.maxTokens }}
+                      tokens_per_fill: {{.Values.rateLimit.runtimes.tokensPerFill }}
+                      fill_interval: "{{ .Values.rateLimit.runtimes.fillInterval }}"
+                  - entries:
+                      - key: "consumer"
+                        value: "{{ .Values.rateLimit.apps.headerValue }}"
+                    token_bucket:
+                      max_tokens: {{ .Values.rateLimit.apps.maxTokens }}
+                      tokens_per_fill: {{.Values.rateLimit.apps.tokensPerFill }}
+                      fill_interval: "{{ .Values.rateLimit.apps.fillInterval }}"
+                filter_enabled:
+                  runtime_key: local_rate_limit_enabled
+                  default_value:
+                    numerator: 100
+                    denominator: HUNDRED
+                filter_enforced:
+                  runtime_key: local_rate_limit_enforced
+                  default_value:
+                    numerator: 100
+                    denominator: HUNDRED
+                token_bucket:
+                  max_tokens: {{ .Values.rateLimit.common.maxTokens }}
+                  tokens_per_fill: {{ .Values.rateLimit.common.tokensPerFill }}
+                  fill_interval: "{{ .Values.rateLimit.common.fillInterval }}"
+                response_headers_to_add:
+                  - append: false
+                    header:
+                      key: x-local-rate-limit
+                      value: "{{ .Chart.Name }}"

--- a/chart/compass/charts/director/values.yaml
+++ b/chart/compass/charts/director/values.yaml
@@ -53,3 +53,19 @@ readinessProbe:
   initialDelaySeconds: 5
   timeoutSeconds: 2
   periodSeconds: 5
+
+rateLimit:
+  runtimes:
+    headerValue: Runtime
+    maxTokens: 3000
+    tokensPerFill: 300
+    fillInterval: "60s"
+  apps:
+    headerValue: Application
+    maxTokens: 3000
+    tokensPerFill: 300
+    fillInterval: "60s"
+  common:
+    maxTokens: 5000
+    tokensPerFill: 500
+    fillInterval: "60s"

--- a/chart/compass/charts/gateway/templates/oathkeeper-rules.yaml
+++ b/chart/compass/charts/gateway/templates/oathkeeper-rules.yaml
@@ -157,6 +157,10 @@ spec:
 {{ toYaml .Values.global.oathkeeper.mutators.certificateResolverService | indent 4 }}
   - handler: hydrator
 {{ toYaml .Values.global.oathkeeper.mutators.tenantMappingService | indent 4 }}
+  - handler: header
+    config:
+      headers:
+        {{ .Values.global.gateway.headers.rateLimit }}: "{{ .Values.rateLimit.headerValue }}"
   - handler: id_token
     config:
       claims: {{ .Values.global.oathkeeper.idTokenConfig.claims | quote }}

--- a/chart/compass/charts/gateway/templates/rate-limit-filter.yaml
+++ b/chart/compass/charts/gateway/templates/rate-limit-filter.yaml
@@ -1,0 +1,45 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: EnvoyFilter
+metadata:
+  name: {{ template "fullname" . }}-rate-limit-filter
+  namespace: {{ .Release.Namespace }}
+spec:
+  workloadSelector:
+    labels:
+      app: {{ .Chart.Name }}
+  configPatches:
+    - applyTo: HTTP_FILTER
+      match:
+        context: SIDECAR_INBOUND
+        listener:
+          filterChain:
+            filter:
+              name: "envoy.filters.network.http_connection_manager"
+      patch:
+        operation: INSERT_BEFORE
+        value:
+          name: envoy.filters.http.local_ratelimit
+          typed_config:
+            "@type": type.googleapis.com/udpa.type.v1.TypedStruct
+            type_url: type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+            value:
+              stat_prefix: http_local_rate_limiter_{{ .Chart.Name }}
+              token_bucket:
+                max_tokens: {{ .Values.rateLimit.maxTokens }}
+                tokens_per_fill:  {{ .Values.rateLimit.tokensPerFill }}
+                fill_interval:  "{{ .Values.rateLimit.fillInterval }}"
+              filter_enabled:
+                runtime_key: local_rate_limit_enabled
+                default_value:
+                  numerator: 100
+                  denominator: HUNDRED
+              filter_enforced:
+                runtime_key: local_rate_limit_enforced
+                default_value:
+                  numerator: 100
+                  denominator: HUNDRED
+              response_headers_to_add:
+                - append: false
+                  header:
+                    key: x-local-rate-limit
+                    value: "{{ .Chart.Name }}"

--- a/chart/compass/charts/gateway/values.yaml
+++ b/chart/compass/charts/gateway/values.yaml
@@ -19,5 +19,11 @@ gateway:
     enabled: false
     authMode: "basic"
 
+rateLimit:
+  headerValue: "{{ print .Extra.consumerType }}"
+  maxTokens: 5000
+  tokensPerFill: 500
+  fillInterval: "60s"
+
 metrics:
   port: 3001

--- a/chart/compass/charts/ord-service/templates/rate-limit-filter.yaml
+++ b/chart/compass/charts/ord-service/templates/rate-limit-filter.yaml
@@ -1,0 +1,45 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: EnvoyFilter
+metadata:
+  name: {{ template "fullname" . }}-rate-limit-filter
+  namespace: {{ .Release.Namespace }}
+spec:
+  workloadSelector:
+    labels:
+      app: {{ .Chart.Name }}
+  configPatches:
+    - applyTo: HTTP_FILTER
+      match:
+        context: SIDECAR_INBOUND
+        listener:
+          filterChain:
+            filter:
+              name: "envoy.filters.network.http_connection_manager"
+      patch:
+        operation: INSERT_BEFORE
+        value:
+          name: envoy.filters.http.local_ratelimit
+          typed_config:
+            "@type": type.googleapis.com/udpa.type.v1.TypedStruct
+            type_url: type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+            value:
+              stat_prefix: http_local_rate_limiter_{{ .Chart.Name }}
+              token_bucket:
+                max_tokens: {{ .Values.rateLimit.maxTokens }}
+                tokens_per_fill:  {{ .Values.rateLimit.tokensPerFill }}
+                fill_interval:  "{{ .Values.rateLimit.fillInterval }}"
+              filter_enabled:
+                runtime_key: local_rate_limit_enabled
+                default_value:
+                  numerator: 100
+                  denominator: HUNDRED
+              filter_enforced:
+                runtime_key: local_rate_limit_enforced
+                default_value:
+                  numerator: 100
+                  denominator: HUNDRED
+              response_headers_to_add:
+                - append: false
+                  header:
+                    key: x-local-rate-limit
+                    value: "{{ .Chart.Name }}"

--- a/chart/compass/charts/ord-service/values.yaml
+++ b/chart/compass/charts/ord-service/values.yaml
@@ -27,3 +27,7 @@ deployment:
   strategy: {} # Read more: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
   nodeSelector: {}
 
+rateLimit:
+  maxTokens: 2000
+  tokensPerFill: 200
+  fillInterval: "60s"

--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -257,6 +257,7 @@ global:
         host: compass-gateway-sap-mtls
         certSecret: compass-gateway-mtls-certs # Use connector's root CA as root CA by default. This should be overridden for productive deployments.
     headers:
+      rateLimit: X-Flow-Identity
       request:
         remove:
           - "Client-Id-From-Token"


### PR DESCRIPTION
**Description**

This PR utilizes Istio's local rate-limit feature to implement rate-limiting in CMP. Additional hydrators were added so that we are able to make more specific rate-limiting. 


**Pull Request status**

- [X] Implementation
- [ ] Unit tests
- [ ] Integration tests
- [ ] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [ ] Mocks are regenerated, using the automated script
