### PR TITLE
register/unregister runtime without tenant header

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -120,7 +120,7 @@ global:
       version: "PR-52"
     e2e_tests:
       dir:
-      version: "PR-2166"
+      version: "PR-2179"
   isLocalEnv: false
   oauth2:
     host: oauth2

--- a/tests/director/tests/runtime_api_test.go
+++ b/tests/director/tests/runtime_api_test.go
@@ -456,7 +456,6 @@ func TestRuntimeRegisterUpdateAndUnregisterWithCertificate(t *testing.T) {
 	t.Run("Test runtime operations(CUD) with externally issued certificate", func(t *testing.T) {
 		// GIVEN
 		ctx := context.Background()
-		subscriptionProviderSubaccountID := tenant.TestTenants.GetIDByName(t, tenant.TestProviderSubaccount)
 
 		// Build graphql director client configured with certificate
 		clientKey, rawCertChain := certs.ClientCertPair(t, conf.ExternalCA.Certificate, conf.ExternalCA.Key)
@@ -464,25 +463,17 @@ func TestRuntimeRegisterUpdateAndUnregisterWithCertificate(t *testing.T) {
 
 		protectedConsumerSubaccountIdsLabel := "consumer_subaccount_ids"
 
-		runtimeInput := graphql.RuntimeInput{
+		runtimeInput := &graphql.RuntimeInput{
 			Name:        "register-runtime-with-protected-labels",
 			Description: ptr.String("register-runtime-with-protected-labels-description"),
 			Labels:      graphql.Labels{protectedConsumerSubaccountIdsLabel: []string{"subaccountID-1", "subaccountID-2"}},
 		}
-		actualRtm := graphql.RuntimeExt{}
 
 		t.Log("Successfully register runtime using certificate with protected labels and validate that they are excluded")
-		// GIVEN
-		runtimeInGQL, err := testctx.Tc.Graphqlizer.RuntimeInputToGQL(runtimeInput)
-		require.NoError(t, err)
-
-		// WHEN
-		registerReq := fixtures.FixRegisterRuntimeRequest(runtimeInGQL)
-		err = testctx.Tc.RunOperationWithoutTenant(ctx, directorCertSecuredClient, registerReq, &actualRtm)
-		defer fixtures.CleanupRuntime(t, ctx, directorCertSecuredClient, subscriptionProviderSubaccountID, &actualRtm)
+		actualRtm := fixtures.RegisterRuntimeFromInputWithoutTenant(t, ctx, directorCertSecuredClient, runtimeInput)
+		defer fixtures.CleanupRuntimeWithoutTenant(t, ctx, directorCertSecuredClient, &actualRtm)
 
 		//THEN
-		require.NoError(t, err)
 		require.NotEmpty(t, actualRtm.ID)
 		require.Equal(t, runtimeInput.Name, actualRtm.Name)
 		require.Equal(t, runtimeInput.Description, actualRtm.Description)
@@ -490,25 +481,18 @@ func TestRuntimeRegisterUpdateAndUnregisterWithCertificate(t *testing.T) {
 
 		t.Log("Successfully register runtime with certificate")
 		// GIVEN
-		runtimeInput = graphql.RuntimeInput{
+		runtimeInput = &graphql.RuntimeInput{
 			Name:        "runtime-create-update-delete",
 			Description: ptr.String("runtime-create-update-delete-description"),
-			Labels:      graphql.Labels{conf.SelfRegisterDistinguishLabelKey: []interface{}{"distinguish-label-value"}, tenantfetcher.RegionKey: tenantfetcher.RegionPathParamValue},
+			Labels:      graphql.Labels{conf.SelfRegisterDistinguishLabelKey: []interface{}{"id-value!t12345"}, tenantfetcher.RegionKey: tenantfetcher.RegionPathParamValue},
 		}
-		actualRuntime := graphql.RuntimeExt{}
 
-		runtimeInGQL, err = testctx.Tc.Graphqlizer.RuntimeInputToGQL(runtimeInput)
-		require.NoError(t, err)
-
-		// WHEN
-		registerReq = fixtures.FixRegisterRuntimeRequest(runtimeInGQL)
-		err = testctx.Tc.RunOperationWithoutTenant(ctx, directorCertSecuredClient, registerReq, &actualRuntime)
-		defer fixtures.CleanupRuntime(t, ctx, directorCertSecuredClient, subscriptionProviderSubaccountID, &actualRuntime)
+		actualRuntime := fixtures.RegisterRuntimeFromInputWithoutTenant(t, ctx, directorCertSecuredClient, runtimeInput)
+		defer fixtures.CleanupRuntimeWithoutTenant(t, ctx, directorCertSecuredClient, &actualRuntime)
 
 		//THEN
-		require.NoError(t, err)
 		require.NotEmpty(t, actualRuntime.ID)
-		assertions.AssertRuntime(t, runtimeInput, actualRuntime, conf.DefaultScenarioEnabled, true)
+		assertions.AssertRuntime(t, *runtimeInput, actualRuntime, conf.DefaultScenarioEnabled, true)
 
 		t.Log("Successfully set regular runtime label using certificate")
 		// GIVEN
@@ -516,7 +500,7 @@ func TestRuntimeRegisterUpdateAndUnregisterWithCertificate(t *testing.T) {
 
 		// WHEN
 		addLabelReq := fixtures.FixSetRuntimeLabelRequest(actualRuntime.ID, "regular_label", []string{"labelValue"})
-		err = testctx.Tc.RunOperationWithoutTenant(ctx, directorCertSecuredClient, addLabelReq, &actualLabel)
+		err := testctx.Tc.RunOperationWithoutTenant(ctx, directorCertSecuredClient, addLabelReq, &actualLabel)
 
 		//THEN
 		require.NoError(t, err)
@@ -549,12 +533,12 @@ func TestRuntimeRegisterUpdateAndUnregisterWithCertificate(t *testing.T) {
 		runtimeInput.Name = "updated-runtime"
 		runtimeInput.Description = ptr.String("updated-runtime-description")
 		runtimeInput.Labels = graphql.Labels{
-			conf.SelfRegisterDistinguishLabelKey: []interface{}{"distinguish-label-value"}, tenantfetcher.RegionKey: tenantfetcher.RegionPathParamValue, protectedConsumerSubaccountIdsLabel: []interface{}{"subaccountID-1", "subaccountID-2"},
+			conf.SelfRegisterDistinguishLabelKey: []interface{}{"id-value!t12345"}, tenantfetcher.RegionKey: tenantfetcher.RegionPathParamValue, protectedConsumerSubaccountIdsLabel: []interface{}{"subaccountID-1", "subaccountID-2"},
 		}
 		runtimeStatusCond := graphql.RuntimeStatusConditionConnected
 		runtimeInput.StatusCondition = &runtimeStatusCond
 
-		runtimeInGQL, err = testctx.Tc.Graphqlizer.RuntimeInputToGQL(runtimeInput)
+		runtimeInGQL, err := testctx.Tc.Graphqlizer.RuntimeInputToGQL(*runtimeInput)
 		require.NoError(t, err)
 		updateRuntimeReq := fixtures.FixUpdateRuntimeRequest(actualRuntime.ID, runtimeInGQL)
 
@@ -586,7 +570,6 @@ func TestQueryRuntimesWithCertificate(t *testing.T) {
 	t.Run("Query runtime with externally issued certificate", func(t *testing.T) {
 		// GIVEN
 		ctx := context.Background()
-		subscriptionProviderSubaccountID := tenant.TestTenants.GetIDByName(t, tenant.TestProviderSubaccount)
 
 		// Build graphql director client configured with certificate
 		clientKey, rawCertChain := certs.ClientCertPair(t, conf.ExternalCA.Certificate, conf.ExternalCA.Key)
@@ -596,7 +579,7 @@ func TestQueryRuntimesWithCertificate(t *testing.T) {
 		defer func() {
 			for _, id := range idsToRemove {
 				if id != "" {
-					fixtures.UnregisterRuntime(t, ctx, directorCertSecuredClient, subscriptionProviderSubaccountID, id)
+					fixtures.UnregisterRuntimeWithoutTenant(t, ctx, directorCertSecuredClient, id)
 				}
 			}
 		}()
@@ -652,7 +635,6 @@ func TestQuerySpecificRuntimeWithCertificate(t *testing.T) {
 	t.Run("Query specific runtime with externally issued certificate", func(t *testing.T) {
 		// GIVEN
 		ctx := context.Background()
-		subscriptionProviderSubaccountID := tenant.TestTenants.GetIDByName(t, tenant.TestProviderSubaccount)
 
 		// Build graphql director client configured with certificate
 		clientKey, rawCertChain := certs.ClientCertPair(t, conf.ExternalCA.Certificate, conf.ExternalCA.Key)
@@ -666,7 +648,7 @@ func TestQuerySpecificRuntimeWithCertificate(t *testing.T) {
 		registerReq := fixtures.FixRegisterRuntimeRequest(runtimeInGQL)
 		createdRuntime := graphql.RuntimeExt{}
 		err = testctx.Tc.RunOperationWithoutTenant(ctx, directorCertSecuredClient, registerReq, &createdRuntime)
-		defer fixtures.CleanupRuntime(t, ctx, directorCertSecuredClient, subscriptionProviderSubaccountID, &createdRuntime)
+		defer fixtures.CleanupRuntimeWithoutTenant(t, ctx, directorCertSecuredClient, &createdRuntime)
 
 		require.NoError(t, err)
 		require.NotEmpty(t, createdRuntime.ID)

--- a/tests/ord-service/tests/subscription_flow_test.go
+++ b/tests/ord-service/tests/subscription_flow_test.go
@@ -48,7 +48,6 @@ func TestSelfRegisterFlow(stdT *testing.T) {
 
 		// defaultTenantId is the parent of the subaccountID
 		defaultTenantId := tenant.TestTenants.GetDefaultTenantID()
-		subaccountID := tenant.TestTenants.GetIDByName(t, tenant.TestProviderSubaccount)
 
 		// Build graphql director client configured with certificate
 		clientKey, rawCertChain := certs.ClientCertPair(t, testConfig.ExternalCA.Certificate, testConfig.ExternalCA.Key)
@@ -76,9 +75,8 @@ func TestSelfRegisterFlow(stdT *testing.T) {
 			Description: ptr.String("selfRegisterRuntime-description"),
 			Labels:      graphql.Labels{testConfig.SelfRegisterDistinguishLabelKey: distinguishLblValue},
 		}
-		runtime, err := fixtures.RegisterRuntimeFromInputWithinTenant(t, ctx, directorCertSecuredClient, subaccountID, &runtimeInput)
-		defer fixtures.CleanupRuntime(t, ctx, directorCertSecuredClient, subaccountID, &runtime)
-		require.NoError(t, err)
+		runtime := fixtures.RegisterRuntimeFromInputWithoutTenant(t, ctx, directorCertSecuredClient, &runtimeInput)
+		defer fixtures.CleanupRuntimeWithoutTenant(t, ctx, directorCertSecuredClient, &runtime)
 		require.NotEmpty(t, runtime.ID)
 		strLbl, ok := runtime.Labels[testConfig.SelfRegisterLabelKey].(string)
 		require.True(t, ok)
@@ -87,7 +85,7 @@ func TestSelfRegisterFlow(stdT *testing.T) {
 		// Verify that the label returned cannot be modified
 		setLabelRequest := fixtures.FixSetRuntimeLabelRequest(runtime.ID, testConfig.SelfRegisterLabelKey, "value")
 		label := graphql.Label{}
-		err = testctx.Tc.RunOperationWithCustomTenant(ctx, directorCertSecuredClient, subaccountID, setLabelRequest, &label)
+		err = testctx.Tc.RunOperationWithoutTenant(ctx, directorCertSecuredClient, setLabelRequest, &label)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), fmt.Sprintf("could not set unmodifiable label with key %s", testConfig.SelfRegisterLabelKey))
 
@@ -124,9 +122,8 @@ func TestConsumerProviderFlow(stdT *testing.T) {
 		}
 
 		// Register provider runtime with the necessary label
-		runtime, err := fixtures.RegisterRuntimeFromInputWithinTenant(t, ctx, directorCertSecuredClient, subscriptionProviderSubaccountID, &runtimeInput)
-		defer fixtures.CleanupRuntime(t, ctx, directorCertSecuredClient, subscriptionProviderSubaccountID, &runtime)
-		require.NoError(t, err)
+		runtime := fixtures.RegisterRuntimeFromInputWithoutTenant(t, ctx, directorCertSecuredClient, &runtimeInput)
+		defer fixtures.CleanupRuntimeWithoutTenant(t, ctx, directorCertSecuredClient, &runtime)
 		require.NotEmpty(t, runtime.ID)
 
 		// Register application

--- a/tests/pkg/fixtures/runtime_queries.go
+++ b/tests/pkg/fixtures/runtime_queries.go
@@ -81,7 +81,6 @@ func CleanupRuntimeWithoutTenant(t require.TestingT, ctx context.Context, gqlCli
 
 	err := testctx.Tc.RunOperationWithoutTenant(ctx, gqlClient, delReq, nil)
 	assertions.AssertNoErrorForOtherThanNotFound(t, err)
-	require.NoError(t, err)
 }
 
 func GetRuntime(t require.TestingT, ctx context.Context, gqlClient *gcli.Client, tenant, id string) graphql.RuntimeExt {


### PR DESCRIPTION
**Description**
When we have CRUD operations on runtime executed with certificate we should not pass tenant header

Changes proposed in this pull request:
- Introduce new utils that execute requests without tenant header

- [x] Implementation
- [x] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
