### PR TITLE
[Hotfix] Fix ord tests

### DIFF
--- a/chart/compass/charts/director/templates/deployment.yaml
+++ b/chart/compass/charts/director/templates/deployment.yaml
@@ -144,7 +144,7 @@ spec:
             - name: APP_INFO_API_ENDPOINT
               value: {{ .Values.global.director.info.path }}
             - name: APP_INFO_CERT_SUBJECT
-              value: {{ printf .Values.global.externalCertConfiguration.subjectPattern .Values.global.externalCertConfiguration.locality .Values.global.externalCertConfiguration.commonName | trimPrefix "/" | replace "/" ", " | quote }}
+              value: {{ printf .Values.global.externalCertConfiguration.subjectPattern .Values.global.externalCertConfiguration.ouCertSubaccountID .Values.global.externalCertConfiguration.locality .Values.global.externalCertConfiguration.commonName | trimPrefix "/" | replace "/" ", " | quote }}
             - name: APP_INFO_CERT_ISSUER
               value: {{ .Values.global.externalCertConfiguration.issuer }}
             - name: APP_INFO_ROOT_CA

--- a/chart/compass/charts/director/templates/external-certificate-rotation-job.yaml
+++ b/chart/compass/charts/director/templates/external-certificate-rotation-job.yaml
@@ -137,7 +137,7 @@ spec:
                 - name: CERT_SVC_API_PATH
                   value: {{ .Values.global.externalCertConfiguration.certSvcApiPath }}
                 - name: CERT_SUBJECT_PATTERN
-                  value: {{ printf .Values.global.externalCertConfiguration.subjectPattern .Values.global.externalCertConfiguration.locality .Values.global.externalCertConfiguration.commonName }}
+                  value: {{ printf .Values.global.externalCertConfiguration.subjectPattern .Values.global.externalCertConfiguration.ouCertSubaccountID .Values.global.externalCertConfiguration.locality .Values.global.externalCertConfiguration.commonName }}
                 - name: EXPECTED_ISSUER_LOCALITY
                   value: {{ .Values.global.externalCertConfiguration.issuerLocality }}
                 - name: CERT_VALIDITY

--- a/chart/compass/templates/tests/director/director-test.yaml
+++ b/chart/compass/templates/tests/director/director-test.yaml
@@ -111,7 +111,7 @@ spec:
             - name: APP_INFO_API_ENDPOINT
               value: {{ .Values.global.director.info.path }}
             - name: APP_INFO_CERT_SUBJECT
-              value: {{ printf .Values.global.externalCertConfiguration.subjectPattern .Values.global.externalCertConfiguration.locality .Values.global.externalCertConfiguration.commonName | trimPrefix "/" | replace "/" ", " | quote }}
+              value: {{ printf .Values.global.externalCertConfiguration.subjectPattern .Values.global.externalCertConfiguration.ouCertSubaccountID .Values.global.externalCertConfiguration.locality .Values.global.externalCertConfiguration.commonName | trimPrefix "/" | replace "/" ", " | quote }}
             - name: APP_INFO_CERT_ISSUER
               value: {{ .Values.global.externalCertConfiguration.issuer }}
             - name: APP_SELF_REGISTER_DISTINGUISH_LABEL_KEY

--- a/chart/compass/templates/tests/ord-service/ord-service-test.yaml
+++ b/chart/compass/templates/tests/ord-service/ord-service-test.yaml
@@ -157,6 +157,10 @@ spec:
               value: {{ .Values.global.director.selfRegister.distinguishLabel }}
             - name: APP_SELF_REGISTER_LABEL_KEY
               value: {{ .Values.global.director.selfRegister.label }}
+            - name: ACCOUNT_TENANT_ID
+              value: {{ .Values.global.tests.ordService.accountTenantID }}
+            - name: SUBACCOUNT_TENANT_ID
+              value: {{ .Values.global.externalCertConfiguration.ouCertSubaccountID }}
         {{if eq .Values.global.database.embedded.enabled false}}
         - name: cloudsql-proxy
           image: gcr.io/cloudsql-docker/gce-proxy:1.23.0-alpine

--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -120,7 +120,7 @@ global:
       version: "PR-52"
     e2e_tests:
       dir:
-      version: "PR-2179"
+      version: "PR-2182"
   isLocalEnv: false
   oauth2:
     host: oauth2

--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -430,7 +430,8 @@ global:
   externalCertConfiguration:
     issuer: "C=DE, L=local, O=SAP SE, OU=SAP Cloud Platform Clients, CN=compass-ca"
     issuerLocality: "" # It's empty because in local setup we use connector CA which didn't have Locality property
-    subjectPattern: "/C=DE/O=SAP SE/OU=SAP Cloud Platform Clients/OU=Region/OU=f8075207-1478-4a80-bd26-24a4785a2bfd/L=%s/CN=%s"
+    subjectPattern: "/C=DE/O=SAP SE/OU=SAP Cloud Platform Clients/OU=Region/OU=%s/L=%s/CN=%s"
+    ouCertSubaccountID: "f8075207-1478-4a80-bd26-24a4785a2bfd"
     commonName: "compass"
     locality: "local"
     certSvcApiPath: "/cert"
@@ -611,6 +612,7 @@ global:
           connectivityAdapter: true
     ordService:
       skipPattern: ""
+      accountTenantID: "5577cf46-4f78-45fa-b55f-a42a3bdba868" # testDefaultTenant from our testing tenants
     namespace: kyma-system
     connectivityAdapterFQDN: http://compass-connectivity-adapter.compass-system.svc.cluster.local
     directorFQDN: http://compass-director.compass-system.svc.cluster.local

--- a/tests/ord-service/tests/api_test.go
+++ b/tests/ord-service/tests/api_test.go
@@ -55,8 +55,8 @@ func TestORDService(t *testing.T) {
 	defaultTestTenant := tenant.TestTenants.GetIDByName(t, tenant.TenantSeparationTenantName)
 	secondaryTenant := tenant.TestTenants.GetIDByName(t, tenant.ApplicationsForRuntimeTenantName)
 
-	tenantFilteringTenant := tenant.TestTenants.GetDefaultTenantID()
-	subTenantID := tenant.TestTenants.GetIDByName(t, tenant.TestProviderSubaccount)
+	tenantFilteringTenant := testConfig.AccountTenantID
+	subTenantID := testConfig.SubaccountTenantID
 
 	tenantAPIProtocolFiltering := tenant.TestTenants.GetIDByName(t, tenant.ListLabelDefinitionsTenantName)
 

--- a/tests/ord-service/tests/main_test.go
+++ b/tests/ord-service/tests/main_test.go
@@ -74,6 +74,8 @@ type config struct {
 	ConsumerSubaccountIdsLabelKey    string
 	SelfRegisterDistinguishLabelKey  string `envconfig:"APP_SELF_REGISTER_DISTINGUISH_LABEL_KEY"`
 	SelfRegisterLabelKey             string `envconfig:"APP_SELF_REGISTER_LABEL_KEY"`
+	AccountTenantID                  string
+	SubaccountTenantID               string
 	SkipSSLValidation                bool   `envconfig:"default=false"`
 }
 

--- a/tests/ord-service/tests/main_test.go
+++ b/tests/ord-service/tests/main_test.go
@@ -76,7 +76,7 @@ type config struct {
 	SelfRegisterLabelKey             string `envconfig:"APP_SELF_REGISTER_LABEL_KEY"`
 	AccountTenantID                  string
 	SubaccountTenantID               string
-	SkipSSLValidation                bool   `envconfig:"default=false"`
+	SkipSSLValidation                bool `envconfig:"default=false"`
 }
 
 var testConfig config


### PR DESCRIPTION
**Description**
Due to incorrect tenants configuration ord tests are failing on real environment.

Changes proposed in this pull request:
- Make tenants used by ord tests configurable


**Pull Request status**
- [x] Implementation
- [x] Integration tests
- [x] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
