### PR TITLE
[Hotfix] adapt ord views not to rely on global_subaccount_id label

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -120,7 +120,7 @@ global:
       version: "PR-52"
     e2e_tests:
       dir:
-      version: "PR-2182"
+      version: "PR-2187"
   isLocalEnv: false
   oauth2:
     host: oauth2

--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -103,7 +103,7 @@ global:
       version: "PR-58"
     schema_migrator:
       dir:
-      version: "PR-2166"
+      version: "PR-2188"
     system_broker:
       dir:
       version: "PR-2166"
@@ -120,7 +120,7 @@ global:
       version: "PR-52"
     e2e_tests:
       dir:
-      version: "PR-2187"
+      version: "PR-2188"
   isLocalEnv: false
   oauth2:
     host: oauth2

--- a/components/schema-migrator/migrations/director/20220119113231_ord_views_tenant_from_table_not_label.down.sql
+++ b/components/schema-migrator/migrations/director/20220119113231_ord_views_tenant_from_table_not_label.down.sql
@@ -1,0 +1,500 @@
+BEGIN;
+
+DROP VIEW IF EXISTS tenants_specifications;
+DROP VIEW IF EXISTS tenants_apis;
+DROP VIEW IF EXISTS tenants_apps;
+DROP VIEW IF EXISTS tenants_bundles;
+DROP VIEW IF EXISTS tenants_events;
+DROP VIEW IF EXISTS tenants_packages;
+DROP VIEW IF EXISTS tenants_products;
+DROP VIEW IF EXISTS tenants_vendors;
+DROP VIEW IF EXISTS tenants_tombstones;
+
+DROP FUNCTION IF EXISTS apps_subaccounts_func();
+
+-----
+
+CREATE OR REPLACE FUNCTION apps_subaccounts_func()
+    returns TABLE(id uuid, tenant_id text, provider_tenant_id text)
+    language plpgsql
+AS
+$$
+BEGIN
+    RETURN QUERY
+        SELECT l.app_id                 AS id,
+               asa.target_tenant_id::text AS tenant_id,
+               asa.target_tenant_id::text AS provider_tenant_id
+        FROM labels l
+                 -- 2) Get subaccounts in those scenarios (Putting a subaccount in a
+                 -- scenario will reflect on creating an ASA for the subaccount.
+                 JOIN automatic_scenario_assignments asa
+                      ON asa.tenant_id = l.tenant_id AND l.value ? asa.scenario::text
+             -- 1) Get all scenario labels for applications
+        WHERE l.app_id IS NOT NULL
+          AND l.key::text = 'scenarios'::text;
+END
+$$;
+
+-----
+
+CREATE OR REPLACE FUNCTION consumers_provider_for_runtimes_func()
+    returns TABLE(provider_tenant text, consumer_tenants jsonb)
+    language plpgsql
+AS
+$$
+BEGIN
+    RETURN QUERY
+        SELECT l1.value ->> 0 AS provider_tenant, l2.value AS consumer_tenants
+        FROM (SELECT *
+              FROM labels
+              WHERE key::text = 'global_subaccount_id'
+                AND (value ->> 0) IS NOT NULL) l1 -- Get the subaccount for each runtime
+                 JOIN (SELECT * FROM labels WHERE key::text = 'consumer_subaccount_ids') l2 -- Get all the consumer subaccounts for each runtime
+                      ON l1.runtime_id = l2.runtime_id AND l1.runtime_id IS NOT NULL;
+END
+$$;
+
+-----
+
+CREATE OR REPLACE VIEW tenants_apis
+            (tenant_id, provider_tenant_id, id, app_id, name, description, group_name, default_auth, version_value,
+             version_deprecated, version_deprecated_since, version_for_removal, ord_id, short_description,
+             system_instance_aware, api_protocol, tags, countries, links, api_resource_links, release_status,
+             sunset_date, changelog_entries, labels, package_id, visibility, disabled, part_of_products,
+             line_of_business, industry, ready, created_at, updated_at, deleted_at, error, implementation_standard,
+             custom_implementation_standard, custom_implementation_standard_description, target_urls, extensible,
+             successors, resource_hash, documentation_labels)
+AS
+SELECT DISTINCT t_apps.tenant_id,
+                t_apps.provider_tenant_id,
+                apis.id,
+                apis.app_id,
+                apis.name,
+                apis.description,
+                apis.group_name,
+                apis.default_auth,
+                apis.version_value,
+                apis.version_deprecated,
+                apis.version_deprecated_since,
+                apis.version_for_removal,
+                apis.ord_id,
+                apis.short_description,
+                apis.system_instance_aware,
+                CASE
+                    WHEN apis.api_protocol IS NULL AND specs.api_spec_type::text = 'ODATA'::text THEN 'odata-v2'::text
+                    WHEN apis.api_protocol IS NULL AND specs.api_spec_type::text = 'OPEN_API'::text THEN 'rest'::text
+                    ELSE apis.api_protocol::text
+                    END AS api_protocol,
+                apis.tags,
+                apis.countries,
+                apis.links,
+                apis.api_resource_links,
+                apis.release_status,
+                apis.sunset_date,
+                apis.changelog_entries,
+                apis.labels,
+                apis.package_id,
+                apis.visibility,
+                apis.disabled,
+                apis.part_of_products,
+                apis.line_of_business,
+                apis.industry,
+                apis.ready,
+                apis.created_at,
+                apis.updated_at,
+                apis.deleted_at,
+                apis.error,
+                apis.implementation_standard,
+                apis.custom_implementation_standard,
+                apis.custom_implementation_standard_description,
+                apis.target_urls,
+                apis.extensible,
+                apis.successors,
+                apis.resource_hash,
+                apis.documentation_labels
+FROM api_definitions apis
+         JOIN (SELECT a1.id,
+                      a1.tenant_id::text AS tenant_id,
+                      a1.tenant_id::text AS provider_tenant_id
+               FROM tenant_applications a1
+               UNION ALL
+               SELECT apps_subaccounts_func.id,
+                      apps_subaccounts_func.tenant_id,
+                      apps_subaccounts_func.provider_tenant_id
+               FROM apps_subaccounts_func() apps_subaccounts_func(id, tenant_id, provider_tenant_id)
+               UNION ALL
+               SELECT a_s.id,
+                      a_s.tenant_id,
+                      (SELECT business_tenant_mappings.id::text AS id
+                       FROM business_tenant_mappings
+                       WHERE business_tenant_mappings.external_tenant::text = cpr.provider_tenant) AS provider_tenant_id
+               FROM apps_subaccounts_func() a_s(id, tenant_id, provider_tenant_id)
+                        JOIN consumers_provider_for_runtimes_func() cpr(provider_tenant, consumer_tenants)
+                             ON cpr.consumer_tenants ? (((SELECT business_tenant_mappings.external_tenant
+                                                          FROM business_tenant_mappings
+                                                          WHERE business_tenant_mappings.id = a_s.tenant_id::uuid))::text)) t_apps
+              ON apis.app_id = t_apps.id
+         LEFT JOIN specifications specs ON apis.id = specs.api_def_id;
+
+-----
+
+CREATE OR REPLACE VIEW tenants_apps
+            (tenant_id, provider_tenant_id, id, name, description, status_condition, status_timestamp, healthcheck_url,
+             integration_system_id, provider_name, base_url, labels, ready, created_at, updated_at, deleted_at, error,
+             app_template_id, correlation_ids, system_number, product_type)
+AS
+SELECT DISTINCT t_apps.tenant_id,
+                t_apps.provider_tenant_id,
+                apps.id,
+                apps.name,
+                apps.description,
+                apps.status_condition,
+                apps.status_timestamp,
+                apps.healthcheck_url,
+                apps.integration_system_id,
+                apps.provider_name,
+                apps.base_url,
+                apps.labels,
+                apps.ready,
+                apps.created_at,
+                apps.updated_at,
+                apps.deleted_at,
+                apps.error,
+                apps.app_template_id,
+                apps.correlation_ids,
+                apps.system_number,
+                tmpl.name AS product_type
+FROM applications apps
+         LEFT JOIN app_templates tmpl ON apps.app_template_id = tmpl.id
+         JOIN (SELECT a1.id,
+                      a1.tenant_id::text AS tenant_id,
+                      a1.tenant_id::text AS provider_tenant_id
+               FROM tenant_applications a1
+               UNION ALL
+               SELECT apps_subaccounts_func.id,
+                      apps_subaccounts_func.tenant_id,
+                      apps_subaccounts_func.provider_tenant_id
+               FROM apps_subaccounts_func() apps_subaccounts_func(id, tenant_id, provider_tenant_id)
+               UNION ALL
+               SELECT a_s.id,
+                      a_s.tenant_id,
+                      (SELECT business_tenant_mappings.id::text AS id
+                       FROM business_tenant_mappings
+                       WHERE business_tenant_mappings.external_tenant::text = cpr.provider_tenant) AS provider_tenant_id
+               FROM apps_subaccounts_func() a_s(id, tenant_id, provider_tenant_id)
+                        JOIN consumers_provider_for_runtimes_func() cpr(provider_tenant, consumer_tenants)
+                             ON cpr.consumer_tenants ? (((SELECT business_tenant_mappings.external_tenant
+                                                          FROM business_tenant_mappings
+                                                          WHERE business_tenant_mappings.id = a_s.tenant_id::uuid))::text)) t_apps
+              ON apps.id = t_apps.id;
+
+-----
+
+CREATE OR REPLACE VIEW tenants_bundles
+            (tenant_id, provider_tenant_id, id, app_id, name, description, instance_auth_request_json_schema,
+             default_instance_auth, ord_id, short_description, links, labels, credential_exchange_strategies, ready,
+             created_at, updated_at, deleted_at, error, correlation_ids)
+as
+SELECT DISTINCT t_apps.tenant_id,
+                t_apps.provider_tenant_id,
+                b.id,
+                b.app_id,
+                b.name,
+                b.description,
+                b.instance_auth_request_json_schema,
+                b.default_instance_auth,
+                b.ord_id,
+                b.short_description,
+                b.links,
+                b.labels,
+                b.credential_exchange_strategies,
+                b.ready,
+                b.created_at,
+                b.updated_at,
+                b.deleted_at,
+                b.error,
+                b.correlation_ids
+FROM bundles b
+         JOIN (SELECT a1.id,
+                      a1.tenant_id::text AS tenant_id,
+                      a1.tenant_id::text AS provider_tenant_id
+               FROM tenant_applications a1
+               UNION ALL
+               SELECT apps_subaccounts_func.id,
+                      apps_subaccounts_func.tenant_id,
+                      apps_subaccounts_func.provider_tenant_id
+               FROM apps_subaccounts_func() apps_subaccounts_func(id, tenant_id, provider_tenant_id)
+               UNION ALL
+               SELECT a_s.id,
+                      a_s.tenant_id,
+                      (SELECT business_tenant_mappings.id::text AS id
+                       FROM business_tenant_mappings
+                       WHERE business_tenant_mappings.external_tenant::text = cpr.provider_tenant) AS provider_tenant_id
+               FROM apps_subaccounts_func() a_s(id, tenant_id, provider_tenant_id)
+                        JOIN consumers_provider_for_runtimes_func() cpr(provider_tenant, consumer_tenants)
+                             ON cpr.consumer_tenants ? (((SELECT business_tenant_mappings.external_tenant
+                                                          FROM business_tenant_mappings
+                                                          WHERE business_tenant_mappings.id = a_s.tenant_id::uuid))::text)) t_apps
+              ON b.app_id = t_apps.id;
+
+-----
+
+CREATE OR REPLACE VIEW tenants_events
+            (tenant_id, provider_tenant_id, id, app_id, name, description, group_name, version_value,
+             version_deprecated, version_deprecated_since, version_for_removal, ord_id, short_description,
+             system_instance_aware, changelog_entries, links, tags, countries, release_status, sunset_date, labels,
+             package_id, visibility, disabled, part_of_products, line_of_business, industry, ready, created_at,
+             updated_at, deleted_at, error, extensible, successors, resource_hash)
+as
+SELECT DISTINCT t_apps.tenant_id,
+                t_apps.provider_tenant_id,
+                events.id,
+                events.app_id,
+                events.name,
+                events.description,
+                events.group_name,
+                events.version_value,
+                events.version_deprecated,
+                events.version_deprecated_since,
+                events.version_for_removal,
+                events.ord_id,
+                events.short_description,
+                events.system_instance_aware,
+                events.changelog_entries,
+                events.links,
+                events.tags,
+                events.countries,
+                events.release_status,
+                events.sunset_date,
+                events.labels,
+                events.package_id,
+                events.visibility,
+                events.disabled,
+                events.part_of_products,
+                events.line_of_business,
+                events.industry,
+                events.ready,
+                events.created_at,
+                events.updated_at,
+                events.deleted_at,
+                events.error,
+                events.extensible,
+                events.successors,
+                events.resource_hash
+FROM event_api_definitions events
+         JOIN (SELECT a1.id,
+                      a1.tenant_id::text AS tenant_id,
+                      a1.tenant_id::text AS provider_tenant_id
+               FROM tenant_applications a1
+               UNION ALL
+               SELECT apps_subaccounts_func.id,
+                      apps_subaccounts_func.tenant_id,
+                      apps_subaccounts_func.provider_tenant_id
+               FROM apps_subaccounts_func() apps_subaccounts_func(id, tenant_id, provider_tenant_id)
+               UNION ALL
+               SELECT a_s.id,
+                      a_s.tenant_id,
+                      (SELECT business_tenant_mappings.id::text AS id
+                       FROM business_tenant_mappings
+                       WHERE business_tenant_mappings.external_tenant::text = cpr.provider_tenant) AS provider_tenant_id
+               FROM apps_subaccounts_func() a_s(id, tenant_id, provider_tenant_id)
+                        JOIN consumers_provider_for_runtimes_func() cpr(provider_tenant, consumer_tenants)
+                             ON cpr.consumer_tenants ? (((SELECT business_tenant_mappings.external_tenant
+                                                          FROM business_tenant_mappings
+                                                          WHERE business_tenant_mappings.id = a_s.tenant_id::uuid))::text)) t_apps
+              ON events.app_id = t_apps.id;
+
+-----
+
+CREATE OR REPLACE VIEW tenants_packages
+            (tenant_id, provider_tenant_id, id, ord_id, title, short_description, description, version, package_links,
+             links, licence_type, tags, countries, labels, policy_level, app_id, custom_policy_level, vendor,
+             part_of_products, line_of_business, industry, resource_hash)
+AS
+SELECT DISTINCT t_apps.tenant_id,
+                t_apps.provider_tenant_id,
+                p.id,
+                p.ord_id,
+                p.title,
+                p.short_description,
+                p.description,
+                p.version,
+                p.package_links,
+                p.links,
+                p.licence_type,
+                p.tags,
+                p.countries,
+                p.labels,
+                p.policy_level,
+                p.app_id,
+                p.custom_policy_level,
+                p.vendor,
+                p.part_of_products,
+                p.line_of_business,
+                p.industry,
+                p.resource_hash
+FROM packages p
+         JOIN (SELECT a1.id,
+                      a1.tenant_id::text AS tenant_id,
+                      a1.tenant_id::text AS provider_tenant_id
+               FROM tenant_applications a1
+               UNION ALL
+               SELECT apps_subaccounts_func.id,
+                      apps_subaccounts_func.tenant_id,
+                      apps_subaccounts_func.provider_tenant_id
+               FROM apps_subaccounts_func() apps_subaccounts_func(id, tenant_id, provider_tenant_id)
+               UNION ALL
+               SELECT a_s.id,
+                      a_s.tenant_id,
+                      (SELECT business_tenant_mappings.id::text AS id
+                       FROM business_tenant_mappings
+                       WHERE business_tenant_mappings.external_tenant::text = cpr.provider_tenant) AS provider_tenant_id
+               FROM apps_subaccounts_func() a_s(id, tenant_id, provider_tenant_id)
+                        JOIN consumers_provider_for_runtimes_func() cpr(provider_tenant, consumer_tenants)
+                             ON cpr.consumer_tenants ? (((SELECT business_tenant_mappings.external_tenant
+                                                          FROM business_tenant_mappings
+                                                          WHERE business_tenant_mappings.id = a_s.tenant_id::uuid))::text)) t_apps
+              ON p.app_id = t_apps.id;
+
+-----
+
+CREATE OR REPLACE VIEW tenants_products
+            (tenant_id, provider_tenant_id, ord_id, app_id, title, short_description, vendor, parent, labels,
+             correlation_ids, id, documentation_labels)
+AS
+SELECT DISTINCT t_apps.tenant_id,
+                t_apps.provider_tenant_id,
+                p.ord_id,
+                p.app_id,
+                p.title,
+                p.short_description,
+                p.vendor,
+                p.parent,
+                p.labels,
+                p.correlation_ids,
+                p.id,
+                p.documentation_labels
+FROM products p
+         JOIN (SELECT a1.id,
+                      a1.tenant_id::text AS tenant_id,
+                      a1.tenant_id::text AS provider_tenant_id
+               FROM tenant_applications a1
+               UNION ALL
+               SELECT apps_subaccounts_func.id,
+                      apps_subaccounts_func.tenant_id,
+                      apps_subaccounts_func.provider_tenant_id
+               FROM apps_subaccounts_func() apps_subaccounts_func(id, tenant_id, provider_tenant_id)
+               UNION ALL
+               SELECT a_s.id,
+                      a_s.tenant_id,
+                      (SELECT business_tenant_mappings.id::text AS id
+                       FROM business_tenant_mappings
+                       WHERE business_tenant_mappings.external_tenant::text = cpr.provider_tenant) AS provider_tenant_id
+               FROM apps_subaccounts_func() a_s(id, tenant_id, provider_tenant_id)
+                        JOIN consumers_provider_for_runtimes_func() cpr(provider_tenant, consumer_tenants)
+                             ON cpr.consumer_tenants ? (((SELECT business_tenant_mappings.external_tenant
+                                                          FROM business_tenant_mappings
+                                                          WHERE business_tenant_mappings.id = a_s.tenant_id::uuid))::text)) t_apps
+              ON p.app_id = t_apps.id OR p.app_id IS NULL;
+
+-----
+
+CREATE OR REPLACE VIEW tenants_vendors
+            (tenant_id, provider_tenant_id, ord_id, app_id, title, labels, partners, id, documentation_labels)
+AS
+SELECT DISTINCT t_apps.tenant_id,
+                t_apps.provider_tenant_id,
+                v.ord_id,
+                v.app_id,
+                v.title,
+                v.labels,
+                v.partners,
+                v.id,
+                v.documentation_labels
+FROM vendors v
+         JOIN (SELECT a1.id,
+                      a1.tenant_id::text AS tenant_id,
+                      a1.tenant_id::text AS provider_tenant_id
+               FROM tenant_applications a1
+               UNION ALL
+               SELECT apps_subaccounts_func.id,
+                      apps_subaccounts_func.tenant_id,
+                      apps_subaccounts_func.provider_tenant_id
+               FROM apps_subaccounts_func() apps_subaccounts_func(id, tenant_id, provider_tenant_id)
+               UNION ALL
+               SELECT a_s.id,
+                      a_s.tenant_id,
+                      (SELECT business_tenant_mappings.id::text AS id
+                       FROM business_tenant_mappings
+                       WHERE business_tenant_mappings.external_tenant::text = cpr.provider_tenant) AS provider_tenant_id
+               FROM apps_subaccounts_func() a_s(id, tenant_id, provider_tenant_id)
+                        JOIN consumers_provider_for_runtimes_func() cpr(provider_tenant, consumer_tenants)
+                             ON cpr.consumer_tenants ? (((SELECT business_tenant_mappings.external_tenant
+                                                          FROM business_tenant_mappings
+                                                          WHERE business_tenant_mappings.id = a_s.tenant_id::uuid))::text)) t_apps
+              ON v.app_id = t_apps.id OR v.app_id IS NULL;
+
+-----
+
+CREATE OR REPLACE VIEW tenants_tombstones(tenant_id, provider_tenant_id, ord_id, app_id, removal_date, id)
+AS
+SELECT DISTINCT t_apps.tenant_id,
+                t_apps.provider_tenant_id,
+                t.ord_id,
+                t.app_id,
+                t.removal_date,
+                t.id
+FROM tombstones t
+         JOIN (SELECT a1.id,
+                      a1.tenant_id::text AS tenant_id,
+                      a1.tenant_id::text AS provider_tenant_id
+               FROM tenant_applications a1
+               UNION ALL
+               SELECT apps_subaccounts_func.id,
+                      apps_subaccounts_func.tenant_id,
+                      apps_subaccounts_func.provider_tenant_id
+               FROM apps_subaccounts_func() apps_subaccounts_func(id, tenant_id, provider_tenant_id)
+               UNION ALL
+               SELECT a_s.id,
+                      a_s.tenant_id,
+                      (SELECT business_tenant_mappings.id::text AS id
+                       FROM business_tenant_mappings
+                       WHERE business_tenant_mappings.external_tenant::text = cpr.provider_tenant) AS provider_tenant_id
+               FROM apps_subaccounts_func() a_s(id, tenant_id, provider_tenant_id)
+                        JOIN consumers_provider_for_runtimes_func() cpr(provider_tenant, consumer_tenants)
+                             ON cpr.consumer_tenants ? (((SELECT business_tenant_mappings.external_tenant
+                                                          FROM business_tenant_mappings
+                                                          WHERE business_tenant_mappings.id = a_s.tenant_id::uuid))::text)) t_apps
+              ON t.app_id = t_apps.id;
+
+-----
+
+CREATE OR REPLACE VIEW tenants_specifications
+            (tenant_id, provider_tenant_id, id, api_def_id, event_def_id, spec_data, api_spec_format, api_spec_type,
+             event_spec_format, event_spec_type, custom_type, created_at)
+AS
+SELECT DISTINCT t_api_event_def.tenant_id,
+                t_api_event_def.provider_tenant_id,
+                spec.id,
+                spec.api_def_id,
+                spec.event_def_id,
+                spec.spec_data,
+                spec.api_spec_format,
+                spec.api_spec_type,
+                spec.event_spec_format,
+                spec.event_spec_type,
+                spec.custom_type,
+                spec.created_at
+FROM specifications spec
+         JOIN (SELECT a.id,
+                      a.tenant_id,
+                      a.provider_tenant_id
+               FROM tenants_apis a
+               UNION ALL
+               SELECT e.id,
+                      e.tenant_id,
+                      e.provider_tenant_id
+               FROM tenants_events e) t_api_event_def
+              ON spec.api_def_id = t_api_event_def.id OR spec.event_def_id = t_api_event_def.id;
+
+COMMIT;

--- a/components/schema-migrator/migrations/director/20220119113231_ord_views_tenant_from_table_not_label.up.sql
+++ b/components/schema-migrator/migrations/director/20220119113231_ord_views_tenant_from_table_not_label.up.sql
@@ -1,0 +1,466 @@
+BEGIN;
+
+DROP VIEW IF EXISTS tenants_specifications; -- drop tenant_specifications because tenant_apis and tenant_events depends on it. There is no specific changes on this view.
+DROP VIEW IF EXISTS tenants_apis;
+DROP VIEW IF EXISTS tenants_apps;
+DROP VIEW IF EXISTS tenants_bundles;
+DROP VIEW IF EXISTS tenants_events;
+DROP VIEW IF EXISTS tenants_packages;
+DROP VIEW IF EXISTS tenants_products;
+DROP VIEW IF EXISTS tenants_vendors;
+DROP VIEW IF EXISTS tenants_tombstones;
+
+DROP FUNCTION IF EXISTS apps_subaccounts_func();
+DROP FUNCTION IF EXISTS consumers_provider_for_runtimes_func();
+
+-----
+
+CREATE OR REPLACE FUNCTION apps_subaccounts_func()
+    RETURNS TABLE(id uuid, tenant_id uuid, provider_tenant_id uuid)
+    language plpgsql
+AS
+$$
+BEGIN
+    RETURN QUERY
+        SELECT l.app_id             AS id,
+               asa.target_tenant_id AS tenant_id,
+               asa.target_tenant_id AS provider_tenant_id
+        FROM labels l
+                 -- 2) Get subaccounts in those scenarios (Putting a subaccount in a
+                 -- scenario will reflect on creating an ASA for the subaccount.
+                 JOIN automatic_scenario_assignments asa
+                      ON asa.tenant_id = l.tenant_id AND l.value ? asa.scenario::text
+             -- 1) Get all scenario labels for applications
+        WHERE l.app_id IS NOT NULL
+          AND l.key::text = 'scenarios'::text;
+END
+$$;
+
+-----
+
+CREATE OR REPLACE VIEW tenants_apis
+        (tenant_id, provider_tenant_id, id, app_id, name, description, group_name, default_auth, version_value,
+        version_deprecated, version_deprecated_since, version_for_removal, ord_id, short_description,
+        system_instance_aware, api_protocol, tags, countries, links, api_resource_links, release_status,
+        sunset_date, changelog_entries, labels, package_id, visibility, disabled, part_of_products,
+        line_of_business, industry, ready, created_at, updated_at, deleted_at, error, implementation_standard,
+        custom_implementation_standard, custom_implementation_standard_description, target_urls, extensible,
+        successors, resource_hash, documentation_labels)
+AS
+SELECT DISTINCT t_apps.tenant_id,
+                t_apps.provider_tenant_id,
+                apis.id,
+                apis.app_id,
+                apis.name,
+                apis.description,
+                apis.group_name,
+                apis.default_auth,
+                apis.version_value,
+                apis.version_deprecated,
+                apis.version_deprecated_since,
+                apis.version_for_removal,
+                apis.ord_id,
+                apis.short_description,
+                apis.system_instance_aware,
+                CASE
+                    WHEN apis.api_protocol IS NULL AND specs.api_spec_type::text = 'ODATA'::text THEN 'odata-v2'::text
+                    WHEN apis.api_protocol IS NULL AND specs.api_spec_type::text = 'OPEN_API'::text THEN 'rest'::text
+                    ELSE apis.api_protocol::text
+                    END AS api_protocol,
+                apis.tags,
+                apis.countries,
+                apis.links,
+                apis.api_resource_links,
+                apis.release_status,
+                apis.sunset_date,
+                apis.changelog_entries,
+                apis.labels,
+                apis.package_id,
+                apis.visibility,
+                apis.disabled,
+                apis.part_of_products,
+                apis.line_of_business,
+                apis.industry,
+                apis.ready,
+                apis.created_at,
+                apis.updated_at,
+                apis.deleted_at,
+                apis.error,
+                apis.implementation_standard,
+                apis.custom_implementation_standard,
+                apis.custom_implementation_standard_description,
+                apis.target_urls,
+                apis.extensible,
+                apis.successors,
+                apis.resource_hash,
+                apis.documentation_labels
+FROM api_definitions apis
+         JOIN (SELECT a1.id,
+                      a1.tenant_id::text AS tenant_id,
+                      a1.tenant_id::text AS provider_tenant_id
+               FROM tenant_applications a1
+               UNION ALL
+               SELECT apps_subaccounts_func.id,
+                      apps_subaccounts_func.tenant_id::text,
+                      apps_subaccounts_func.provider_tenant_id::text
+               FROM apps_subaccounts_func() apps_subaccounts_func(id, tenant_id, provider_tenant_id)
+               UNION ALL
+               SELECT ta.id AS app_id, ta.tenant_id::text AS consumer_tenant, tenant_runtimes.tenant_id::text AS provider_tenant
+               FROM (SELECT labels.runtime_id, v ->> 0 AS consumer_tenant
+                     FROM labels
+                              JOIN jsonb_array_elements(labels.value) AS v ON TRUE
+                     WHERE key = 'consumer_subaccount_ids') AS t_rts -- Get runtime and external consumer IDs pairs
+                        JOIN business_tenant_mappings t ON t_rts.consumer_tenant = t.external_tenant -- Get runtime and internal consumer IDs pairs
+                        JOIN apps_subaccounts_func() ta ON t.id = ta.tenant_id -- Get applications for consumer tenants
+                        JOIN tenant_runtimes ON t_rts.runtime_id = tenant_runtimes.id) t_apps
+              ON apis.app_id = t_apps.id
+         LEFT JOIN specifications specs ON apis.id = specs.api_def_id;
+
+-----
+
+CREATE OR REPLACE VIEW tenants_apps
+            (tenant_id, provider_tenant_id, id, name, description, status_condition, status_timestamp, healthcheck_url,
+             integration_system_id, provider_name, base_url, labels, ready, created_at, updated_at, deleted_at, error,
+             app_template_id, correlation_ids, system_number, product_type)
+AS
+SELECT DISTINCT t_apps.tenant_id,
+                t_apps.provider_tenant_id,
+                apps.id,
+                apps.name,
+                apps.description,
+                apps.status_condition,
+                apps.status_timestamp,
+                apps.healthcheck_url,
+                apps.integration_system_id,
+                apps.provider_name,
+                apps.base_url,
+                apps.labels,
+                apps.ready,
+                apps.created_at,
+                apps.updated_at,
+                apps.deleted_at,
+                apps.error,
+                apps.app_template_id,
+                apps.correlation_ids,
+                apps.system_number,
+                tmpl.name AS product_type
+FROM applications apps
+         LEFT JOIN app_templates tmpl ON apps.app_template_id = tmpl.id
+         JOIN (SELECT a1.id,
+                      a1.tenant_id::text AS tenant_id,
+                      a1.tenant_id::text AS provider_tenant_id
+               FROM tenant_applications a1
+               UNION ALL
+               SELECT apps_subaccounts_func.id,
+                      apps_subaccounts_func.tenant_id::text,
+                      apps_subaccounts_func.provider_tenant_id::text
+               FROM apps_subaccounts_func() apps_subaccounts_func(id, tenant_id, provider_tenant_id)
+               UNION ALL
+               SELECT ta.id AS app_id, ta.tenant_id::text AS consumer_tenant, tenant_runtimes.tenant_id::text AS provider_tenant
+               FROM (SELECT labels.runtime_id, v ->> 0 AS consumer_tenant
+                     FROM labels
+                              JOIN jsonb_array_elements(labels.value) AS v ON TRUE
+                     WHERE key = 'consumer_subaccount_ids') AS t_rts -- Get runtime and external consumer IDs pairs
+                        JOIN business_tenant_mappings t ON t_rts.consumer_tenant = t.external_tenant -- Get runtime and internal consumer IDs pairs
+                        JOIN apps_subaccounts_func() ta ON t.id = ta.tenant_id -- Get applications for consumer tenants
+                        JOIN tenant_runtimes ON t_rts.runtime_id = tenant_runtimes.id) t_apps
+              ON apps.id = t_apps.id;
+
+-----
+
+CREATE OR REPLACE VIEW tenants_bundles
+            (tenant_id, provider_tenant_id, id, app_id, name, description, instance_auth_request_json_schema,
+             default_instance_auth, ord_id, short_description, links, labels, credential_exchange_strategies, ready,
+             created_at, updated_at, deleted_at, error, correlation_ids)
+AS
+SELECT DISTINCT t_apps.tenant_id,
+                t_apps.provider_tenant_id,
+                b.id,
+                b.app_id,
+                b.name,
+                b.description,
+                b.instance_auth_request_json_schema,
+                b.default_instance_auth,
+                b.ord_id,
+                b.short_description,
+                b.links,
+                b.labels,
+                b.credential_exchange_strategies,
+                b.ready,
+                b.created_at,
+                b.updated_at,
+                b.deleted_at,
+                b.error,
+                b.correlation_ids
+FROM bundles b
+         JOIN (SELECT a1.id,
+                      a1.tenant_id::text AS tenant_id,
+                      a1.tenant_id::text AS provider_tenant_id
+               FROM tenant_applications a1
+               UNION ALL
+               SELECT apps_subaccounts_func.id,
+                      apps_subaccounts_func.tenant_id::text,
+                      apps_subaccounts_func.provider_tenant_id::text
+               FROM apps_subaccounts_func() apps_subaccounts_func(id, tenant_id, provider_tenant_id)
+               UNION ALL
+               SELECT ta.id AS app_id, ta.tenant_id::text AS consumer_tenant, tenant_runtimes.tenant_id::text AS provider_tenant
+               FROM (SELECT labels.runtime_id, v ->> 0 AS consumer_tenant
+                     FROM labels
+                              JOIN jsonb_array_elements(labels.value) AS v ON TRUE
+                     WHERE key = 'consumer_subaccount_ids') AS t_rts -- Get runtime and external consumer IDs pairs
+                        JOIN business_tenant_mappings t ON t_rts.consumer_tenant = t.external_tenant -- Get runtime and internal consumer IDs pairs
+                        JOIN apps_subaccounts_func() ta ON t.id = ta.tenant_id -- Get applications for consumer tenants
+                        JOIN tenant_runtimes ON t_rts.runtime_id = tenant_runtimes.id) t_apps
+              ON b.app_id = t_apps.id;
+
+-----
+
+CREATE OR REPLACE VIEW tenants_events
+            (tenant_id, provider_tenant_id, id, app_id, name, description, group_name, version_value,
+             version_deprecated, version_deprecated_since, version_for_removal, ord_id, short_description,
+             system_instance_aware, changelog_entries, links, tags, countries, release_status, sunset_date, labels,
+             package_id, visibility, disabled, part_of_products, line_of_business, industry, ready, created_at,
+             updated_at, deleted_at, error, extensible, successors, resource_hash)
+AS
+SELECT DISTINCT t_apps.tenant_id,
+                t_apps.provider_tenant_id,
+                events.id,
+                events.app_id,
+                events.name,
+                events.description,
+                events.group_name,
+                events.version_value,
+                events.version_deprecated,
+                events.version_deprecated_since,
+                events.version_for_removal,
+                events.ord_id,
+                events.short_description,
+                events.system_instance_aware,
+                events.changelog_entries,
+                events.links,
+                events.tags,
+                events.countries,
+                events.release_status,
+                events.sunset_date,
+                events.labels,
+                events.package_id,
+                events.visibility,
+                events.disabled,
+                events.part_of_products,
+                events.line_of_business,
+                events.industry,
+                events.ready,
+                events.created_at,
+                events.updated_at,
+                events.deleted_at,
+                events.error,
+                events.extensible,
+                events.successors,
+                events.resource_hash
+FROM event_api_definitions events
+         JOIN (SELECT a1.id,
+                      a1.tenant_id::text AS tenant_id,
+                      a1.tenant_id::text AS provider_tenant_id
+               FROM tenant_applications a1
+               UNION ALL
+               SELECT apps_subaccounts_func.id,
+                      apps_subaccounts_func.tenant_id::text,
+                      apps_subaccounts_func.provider_tenant_id::text
+               FROM apps_subaccounts_func() apps_subaccounts_func(id, tenant_id, provider_tenant_id)
+               UNION ALL
+               SELECT ta.id AS app_id, ta.tenant_id::text AS consumer_tenant, tenant_runtimes.tenant_id::text AS provider_tenant
+               FROM (SELECT labels.runtime_id, v ->> 0 AS consumer_tenant
+                     FROM labels
+                              JOIN jsonb_array_elements(labels.value) AS v ON TRUE
+                     WHERE key = 'consumer_subaccount_ids') AS t_rts -- Get runtime and external consumer IDs pairs
+                        JOIN business_tenant_mappings t ON t_rts.consumer_tenant = t.external_tenant -- Get runtime and internal consumer IDs pairs
+                        JOIN apps_subaccounts_func() ta ON t.id = ta.tenant_id -- Get applications for consumer tenants
+                        JOIN tenant_runtimes ON t_rts.runtime_id = tenant_runtimes.id) t_apps
+              ON events.app_id = t_apps.id;
+
+-----
+
+CREATE OR REPLACE VIEW tenants_packages
+            (tenant_id, provider_tenant_id, id, ord_id, title, short_description, description, version, package_links,
+             links, licence_type, tags, countries, labels, policy_level, app_id, custom_policy_level, vendor,
+             part_of_products, line_of_business, industry, resource_hash)
+AS
+SELECT DISTINCT t_apps.tenant_id,
+                t_apps.provider_tenant_id,
+                p.id,
+                p.ord_id,
+                p.title,
+                p.short_description,
+                p.description,
+                p.version,
+                p.package_links,
+                p.links,
+                p.licence_type,
+                p.tags,
+                p.countries,
+                p.labels,
+                p.policy_level,
+                p.app_id,
+                p.custom_policy_level,
+                p.vendor,
+                p.part_of_products,
+                p.line_of_business,
+                p.industry,
+                p.resource_hash
+FROM packages p
+         JOIN (SELECT a1.id,
+                      a1.tenant_id::text AS tenant_id,
+                      a1.tenant_id::text AS provider_tenant_id
+               FROM tenant_applications a1
+               UNION ALL
+               SELECT apps_subaccounts_func.id,
+                      apps_subaccounts_func.tenant_id::text,
+                      apps_subaccounts_func.provider_tenant_id::text
+               FROM apps_subaccounts_func() apps_subaccounts_func(id, tenant_id, provider_tenant_id)
+               UNION ALL
+               SELECT ta.id AS app_id, ta.tenant_id::text AS consumer_tenant, tenant_runtimes.tenant_id::text AS provider_tenant
+               FROM (SELECT labels.runtime_id, v ->> 0 AS consumer_tenant
+                     FROM labels
+                              JOIN jsonb_array_elements(labels.value) AS v ON TRUE
+                     WHERE key = 'consumer_subaccount_ids') AS t_rts -- Get runtime and external consumer IDs pairs
+                        JOIN business_tenant_mappings t ON t_rts.consumer_tenant = t.external_tenant -- Get runtime and internal consumer IDs pairs
+                        JOIN apps_subaccounts_func() ta ON t.id = ta.tenant_id -- Get applications for consumer tenants
+                        JOIN tenant_runtimes ON t_rts.runtime_id = tenant_runtimes.id) t_apps
+              ON p.app_id = t_apps.id;
+
+-----
+
+CREATE OR REPLACE VIEW tenants_products
+            (tenant_id, provider_tenant_id, ord_id, app_id, title, short_description, vendor, parent, labels,
+             correlation_ids, id, documentation_labels)
+AS
+SELECT DISTINCT t_apps.tenant_id,
+                t_apps.provider_tenant_id,
+                p.ord_id,
+                p.app_id,
+                p.title,
+                p.short_description,
+                p.vendor,
+                p.parent,
+                p.labels,
+                p.correlation_ids,
+                p.id,
+                p.documentation_labels
+FROM products p
+         JOIN (SELECT a1.id,
+                      a1.tenant_id::text AS tenant_id,
+                      a1.tenant_id::text AS provider_tenant_id
+               FROM tenant_applications a1
+               UNION ALL
+               SELECT apps_subaccounts_func.id,
+                      apps_subaccounts_func.tenant_id::text,
+                      apps_subaccounts_func.provider_tenant_id::text
+               FROM apps_subaccounts_func() apps_subaccounts_func(id, tenant_id, provider_tenant_id)
+               UNION ALL
+               SELECT ta.id AS app_id, ta.tenant_id::text AS consumer_tenant, tenant_runtimes.tenant_id::text AS provider_tenant
+               FROM (SELECT labels.runtime_id, v ->> 0 AS consumer_tenant
+                     FROM labels
+                              JOIN jsonb_array_elements(labels.value) AS v ON TRUE
+                     WHERE key = 'consumer_subaccount_ids') AS t_rts -- Get runtime and external consumer IDs pairs
+                        JOIN business_tenant_mappings t ON t_rts.consumer_tenant = t.external_tenant -- Get runtime and internal consumer IDs pairs
+                        JOIN apps_subaccounts_func() ta ON t.id = ta.tenant_id -- Get applications for consumer tenants
+                        JOIN tenant_runtimes ON t_rts.runtime_id = tenant_runtimes.id) t_apps
+              ON p.app_id = t_apps.id OR p.app_id IS NULL;
+
+-----
+
+CREATE OR REPLACE VIEW tenants_vendors
+            (tenant_id, provider_tenant_id, ord_id, app_id, title, labels, partners, id, documentation_labels)
+AS
+SELECT DISTINCT t_apps.tenant_id,
+                t_apps.provider_tenant_id,
+                v.ord_id,
+                v.app_id,
+                v.title,
+                v.labels,
+                v.partners,
+                v.id,
+                v.documentation_labels
+FROM vendors v
+         JOIN (SELECT a1.id,
+                      a1.tenant_id::text AS tenant_id,
+                      a1.tenant_id::text AS provider_tenant_id
+               FROM tenant_applications a1
+               UNION ALL
+               SELECT apps_subaccounts_func.id,
+                      apps_subaccounts_func.tenant_id::text,
+                      apps_subaccounts_func.provider_tenant_id::text
+               FROM apps_subaccounts_func() apps_subaccounts_func(id, tenant_id, provider_tenant_id)
+               UNION ALL
+               SELECT ta.id AS app_id, ta.tenant_id::text AS consumer_tenant, tenant_runtimes.tenant_id::text AS provider_tenant
+               FROM (SELECT labels.runtime_id, v ->> 0 AS consumer_tenant
+                     FROM labels
+                              JOIN jsonb_array_elements(labels.value) AS v ON TRUE
+                     WHERE key = 'consumer_subaccount_ids') AS t_rts -- Get runtime and external consumer IDs pairs
+                        JOIN business_tenant_mappings t ON t_rts.consumer_tenant = t.external_tenant -- Get runtime and internal consumer IDs pairs
+                        JOIN apps_subaccounts_func() ta ON t.id = ta.tenant_id -- Get applications for consumer tenants
+                        JOIN tenant_runtimes ON t_rts.runtime_id = tenant_runtimes.id) t_apps
+              ON v.app_id = t_apps.id OR v.app_id IS NULL;
+
+-----
+
+CREATE OR REPLACE VIEW tenants_tombstones(tenant_id, provider_tenant_id, ord_id, app_id, removal_date, id)
+AS
+SELECT DISTINCT t_apps.tenant_id,
+                t_apps.provider_tenant_id,
+                t.ord_id,
+                t.app_id,
+                t.removal_date,
+                t.id
+FROM tombstones t
+         JOIN (SELECT a1.id,
+                      a1.tenant_id::text AS tenant_id,
+                      a1.tenant_id::text AS provider_tenant_id
+               FROM tenant_applications a1
+               UNION ALL
+               SELECT apps_subaccounts_func.id,
+                      apps_subaccounts_func.tenant_id::text,
+                      apps_subaccounts_func.provider_tenant_id::text
+               FROM apps_subaccounts_func() apps_subaccounts_func(id, tenant_id, provider_tenant_id)
+               UNION ALL
+               SELECT ta.id AS app_id, ta.tenant_id::text AS consumer_tenant, tenant_runtimes.tenant_id::text AS provider_tenant
+               FROM (SELECT labels.runtime_id, v ->> 0 AS consumer_tenant
+                     FROM labels
+                              JOIN jsonb_array_elements(labels.value) AS v ON TRUE
+                     WHERE key = 'consumer_subaccount_ids') AS t_rts -- Get runtime and external consumer IDs pairs
+                        JOIN business_tenant_mappings t ON t_rts.consumer_tenant = t.external_tenant -- Get runtime and internal consumer IDs pairs
+                        JOIN apps_subaccounts_func() ta ON t.id = ta.tenant_id -- Get applications for consumer tenants
+                        JOIN tenant_runtimes ON t_rts.runtime_id = tenant_runtimes.id) t_apps
+              ON t.app_id = t_apps.id;
+
+-----
+
+CREATE OR REPLACE VIEW tenants_specifications
+            (tenant_id, provider_tenant_id, id, api_def_id, event_def_id, spec_data, api_spec_format, api_spec_type,
+             event_spec_format, event_spec_type, custom_type, created_at)
+AS
+SELECT DISTINCT t_api_event_def.tenant_id,
+                t_api_event_def.provider_tenant_id,
+                spec.id,
+                spec.api_def_id,
+                spec.event_def_id,
+                spec.spec_data,
+                spec.api_spec_format,
+                spec.api_spec_type,
+                spec.event_spec_format,
+                spec.event_spec_type,
+                spec.custom_type,
+                spec.created_at
+FROM specifications spec
+         JOIN (SELECT a.id,
+                      a.tenant_id,
+                      a.provider_tenant_id
+               FROM tenants_apis a
+               UNION ALL
+               SELECT e.id,
+                      e.tenant_id,
+                      e.provider_tenant_id
+               FROM tenants_events e) t_api_event_def
+              ON spec.api_def_id = t_api_event_def.id OR spec.event_def_id = t_api_event_def.id;
+
+COMMIT;

--- a/tests/ord-service/tests/subscription_flow_test.go
+++ b/tests/ord-service/tests/subscription_flow_test.go
@@ -118,7 +118,7 @@ func TestConsumerProviderFlow(stdT *testing.T) {
 		runtimeInput := graphql.RuntimeInput{
 			Name:        "providerRuntime",
 			Description: ptr.String("providerRuntime-description"),
-			Labels:      graphql.Labels{testConfig.SubscriptionProviderLabelKey: subscriptionProviderID, tenantfetcher.RegionKey: tenantfetcher.RegionPathParamValue, selectorKey: subscriptionProviderSubaccountID},
+			Labels:      graphql.Labels{testConfig.SubscriptionProviderLabelKey: subscriptionProviderID, tenantfetcher.RegionKey: tenantfetcher.RegionPathParamValue},
 		}
 
 		// Register provider runtime with the necessary label


### PR DESCRIPTION
**Description**
Currently ord views rely on `global_subaccount_id` label in the labels table so we can get the consumer tenant ID. But after storage redesign we may have resources which are created without that label. In that case the views cannot process and return correct data.

Changes proposed in this pull request:
- Adapt ord views not to relying on `global_subaccount_id` label


- [x] Implementation
- [x] Integration tests
- [x] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
