### PR TITLE
Fix tenant conversions

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -91,7 +91,7 @@ global:
       version: "PR-2166"
     director:
       dir:
-      version: "PR-2166"
+      version: "PR-2194"
     gateway:
       dir:
       version: "PR-2166"

--- a/components/director/internal/tenantmapping/system_auth_context_provider.go
+++ b/components/director/internal/tenantmapping/system_auth_context_provider.go
@@ -156,9 +156,8 @@ func (m *systemAuthContextProvider) getTenantAndScopesForIntegrationSystem(ctx c
 		if apperrors.IsNotFoundError(err) {
 			log.C(ctx).Warningf("Could not find external tenant with ID: %s, error: %s", externalTenantID, err.Error())
 
-			log.C(ctx).Info("Setting external tenant ID to both external and internal tenant...")
-			// TODO: Remove once the whole tenant hierarchy is stored in tenant_mappings table
-			return NewTenantContext(externalTenantID, externalTenantID), scopes, nil
+			log.C(ctx).Infof("Returning tenant context with empty internal tenant ID and external ID %s", externalTenantID)
+			return NewTenantContext(externalTenantID, ""), scopes, nil
 		}
 		return TenantContext{}, scopes, errors.Wrapf(err, "while getting external tenant mapping [ExternalTenantID=%s]", externalTenantID)
 	}


### PR DESCRIPTION
**Description**
In the system auth context provider we didn't adapt external <-> internal tenant conversions. In case external tenant is not UUID and we don't have that tenant in the DB, we use same ID for internal tenant and that results in error from DB side because it's not valid UUID syntax

Changes proposed in this pull request:
- When missing external tenant in the DB do not use the same value for internal ID but set it to empty("")


- [x] Implementation
- [x] Unit tests
- [x] Integration tests
- [x] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
