### PR TITLE
Enhance error messages

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -91,7 +91,7 @@ global:
       version: "PR-2166"
     director:
       dir:
-      version: "PR-2166"
+      version: "PR-2196"
     gateway:
       dir:
       version: "PR-2166"

--- a/components/director/internal/domain/runtime/selfreg_manager.go
+++ b/components/director/internal/domain/runtime/selfreg_manager.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/kyma-incubator/compass/components/director/pkg/apperrors"
+
 	"github.com/kyma-incubator/compass/components/director/internal/consumer"
 
 	"github.com/kyma-incubator/compass/components/director/internal/model"
@@ -85,7 +87,7 @@ func (s *selfRegisterManager) PrepareRuntimeForSelfRegistration(ctx context.Cont
 		}
 
 		if response.StatusCode != http.StatusCreated {
-			return labels, errors.New(fmt.Sprintf("received unexpected status %d while preparing self-registered runtime: %s", response.StatusCode, string(respBytes)))
+			return labels, apperrors.NewCustomErrorWithCode(response.StatusCode, fmt.Sprintf("received unexpected status %d while preparing self-registered runtime: %s", response.StatusCode, string(respBytes)))
 		}
 
 		selfRegLabelVal := gjson.GetBytes(respBytes, s.cfg.SelfRegisterResponseKey)

--- a/components/director/internal/error_presenter/presenter.go
+++ b/components/director/internal/error_presenter/presenter.go
@@ -38,7 +38,7 @@ func (p *presenter) Do(ctx context.Context, err error) *gqlerror.Error {
 	}
 
 	if apperrors.ErrorCode(customErr) == apperrors.InternalError {
-		log.C(ctx).WithField("errorID", errID).WithError(err).Errorf("Internal Server Error: %v", err)
+		log.C(ctx).WithField("errorID", errID).Errorf("Internal Server Error: %v", err)
 		return newGraphqlErrorResponse(ctx, apperrors.InternalError, "Internal Server Error [errorID=%s]", errID)
 	}
 

--- a/components/director/internal/error_presenter/presenter.go
+++ b/components/director/internal/error_presenter/presenter.go
@@ -33,12 +33,12 @@ func (p *presenter) Do(ctx context.Context, err error) *gqlerror.Error {
 	errID := p.uuidService.Generate()
 
 	if found := errors.As(err, &customErr); !found {
-		log.C(ctx).WithField("errorID", errID).WithError(err).Errorf("Unknown error: %v", err)
-		return newGraphqlErrorResponse(ctx, apperrors.InternalError, "Internal Server Error [errorID=%s]", errID)
+		log.C(ctx).WithField("errorID", errID).Errorf("Unknown error: %v", err)
+		return newGraphqlErrorResponse(ctx, apperrors.InternalError, "Internal Server Error [errorID=%s, reason: %s]", errID, err.Error())
 	}
 
 	if apperrors.ErrorCode(customErr) == apperrors.InternalError {
-		log.C(ctx).WithField("errorID", errID).WithError(err).Errorf("Internal Server Error: %v", err)
+		log.C(ctx).WithField("errorID", errID).Errorf("Internal Server Error: %v", err)
 		return newGraphqlErrorResponse(ctx, apperrors.InternalError, "Internal Server Error [errorID=%s]", errID)
 	}
 

--- a/components/director/internal/error_presenter/presenter.go
+++ b/components/director/internal/error_presenter/presenter.go
@@ -38,7 +38,7 @@ func (p *presenter) Do(ctx context.Context, err error) *gqlerror.Error {
 	}
 
 	if apperrors.ErrorCode(customErr) == apperrors.InternalError {
-		log.C(ctx).WithField("errorID", errID).Errorf("Internal Server Error: %v", err)
+		log.C(ctx).WithField("errorID", errID).WithError(err).Errorf("Internal Server Error: %v", err)
 		return newGraphqlErrorResponse(ctx, apperrors.InternalError, "Internal Server Error [errorID=%s]", errID)
 	}
 

--- a/components/director/internal/error_presenter/presenter_test.go
+++ b/components/director/internal/error_presenter/presenter_test.go
@@ -35,14 +35,12 @@ func TestPresenter_ErrorPresenter(t *testing.T) {
 		err := presenter.Do(ctx, errors.New(errMsg))
 
 		entry := hook.LastEntry()
-		actualErrMsg, ok := entry.Data[logrus.ErrorKey].(error)
-		require.True(t, ok)
 
 		// THEN
 		require.NotNil(t, entry)
 		assert.Equal(t, fmt.Sprintf("Unknown error: %s", errMsg), entry.Message)
-		assert.Equal(t, errMsg, actualErrMsg.Error())
 		assert.Contains(t, err.Error(), "Internal Server Error")
+		assert.Contains(t, err.Error(), fmt.Sprintf("reason: %s", errMsg))
 		hook.Reset()
 	})
 
@@ -56,13 +54,10 @@ func TestPresenter_ErrorPresenter(t *testing.T) {
 		err := presenter.Do(ctx, customErr)
 
 		entry := hook.LastEntry()
-		actualErrMsg, ok := entry.Data[logrus.ErrorKey].(error)
-		require.True(t, ok)
 
 		// THEN
 		require.NotNil(t, entry)
-		assert.Equal(t, fmt.Sprintf("Internal Server Error: %s", actualErrMsg.Error()), entry.Message)
-		assert.Equal(t, fmt.Sprintf("Internal Server Error: %s", errMsg), actualErrMsg.Error())
+		assert.Equal(t, fmt.Sprintf("Internal Server Error: %s", customErr.Error()), entry.Message)
 		assert.Contains(t, err.Error(), "Internal Server Error")
 		hook.Reset()
 	})

--- a/components/director/pkg/apperrors/consts.go
+++ b/components/director/pkg/apperrors/consts.go
@@ -41,6 +41,10 @@ const (
 	CannotUpdateObjectInManyBundles ErrorType = 34
 	// ConcurrentUpdate is the error code for ConcurrentUpdate errors.
 	ConcurrentUpdate ErrorType = 35
+	// BadRequest is the error code for BadRequest errors.
+	BadRequest ErrorType = 400
+	// Conflict is the error code for Conflict errors.
+	Conflict ErrorType = 409
 )
 
 const (

--- a/components/director/pkg/apperrors/errors.go
+++ b/components/director/pkg/apperrors/errors.go
@@ -339,6 +339,15 @@ func NewConcurrentUpdate() error {
 	}
 }
 
+// NewCustomErrorWithCode returns Error with a given code and message
+func NewCustomErrorWithCode(code int, msg string) error {
+	return Error{
+		errorCode: ErrorType(code),
+		Message:   msg,
+		arguments: map[string]string{},
+	}
+}
+
 // IsValueNotFoundInConfiguration missing godoc
 func IsValueNotFoundInConfiguration(err error) bool {
 	if customErr, ok := err.(Error); ok {

--- a/components/director/pkg/apperrors/errortype_string.go
+++ b/components/director/pkg/apperrors/errortype_string.go
@@ -26,11 +26,15 @@ func _() {
 	_ = x[InvalidStatusCondition-33]
 	_ = x[CannotUpdateObjectInManyBundles-34]
 	_ = x[ConcurrentUpdate-35]
+	_ = x[BadRequest-400]
+	_ = x[Conflict-409]
 }
 
 const (
 	_ErrorType_name_0 = "InternalErrorUnknownError"
 	_ErrorType_name_1 = "NotFoundNotUniqueInvalidDataInsufficientScopesTenantRequiredTenantNotFoundUnauthorizedInvalidOperationOperationTimeoutEmptyDataInconsistentDataNotUniqueNameConcurrentOperationInvalidStatusConditionCannotUpdateObjectInManyBundlesConcurrentUpdate"
+	_ErrorType_name_2 = "BadRequest"
+	_ErrorType_name_3 = "Conflict"
 )
 
 var (
@@ -46,6 +50,10 @@ func (i ErrorType) String() string {
 	case 20 <= i && i <= 35:
 		i -= 20
 		return _ErrorType_name_1[_ErrorType_index_1[i]:_ErrorType_index_1[i+1]]
+	case i == 400:
+		return _ErrorType_name_2
+	case i == 409:
+		return _ErrorType_name_3
 	default:
 		return "ErrorType(" + strconv.FormatInt(int64(i), 10) + ")"
 	}


### PR DESCRIPTION
**Description**
Enhance error message with correct status code and meaningful message

Changes proposed in this pull request:
- Add new graphql error that accept error code and message and use it for self register flow


- [x] Implementation
- [x] Unit tests
- [x] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
