### PR TITLE
Allow null for isDefaultBundle value

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -91,7 +91,7 @@ global:
       version: "PR-2166"
     director:
       dir:
-      version: "PR-2196"
+      version: "PR-2203"
     gateway:
       dir:
       version: "PR-2166"

--- a/components/director/internal/domain/api/service.go
+++ b/components/director/internal/domain/api/service.go
@@ -176,7 +176,8 @@ func (s *service) Create(ctx context.Context, appID string, bundleID, packageID 
 				APIDefaultTargetURL: &defaultTargetURL,
 			}
 			if defaultBundleID != "" && crrBndlID == defaultBundleID {
-				bundleRefInput.IsDefaultBundle = true
+				isDefaultBundle := true
+				bundleRefInput.IsDefaultBundle = &isDefaultBundle
 			}
 			err = s.bundleReferenceService.CreateByReferenceObjectID(ctx, *bundleRefInput, model.BundleAPIReference, &api.ID, &crrBndlID)
 			if err != nil {
@@ -308,7 +309,8 @@ func (s *service) updateBundleReferences(ctx context.Context, apiID *string, def
 			APIDefaultTargetURL: &defaultTargetURL,
 		}
 		if defaultBundleID != "" && defaultBundleID == crrBndlID {
-			bundleRefInput.IsDefaultBundle = true
+			isDefaultBundle := true
+			bundleRefInput.IsDefaultBundle = &isDefaultBundle
 		}
 
 		err := s.bundleReferenceService.UpdateByReferenceObjectID(ctx, *bundleRefInput, model.BundleAPIReference, apiID, &crrBndlID)
@@ -325,7 +327,8 @@ func (s *service) createBundleReferences(ctx context.Context, apiID *string, def
 			APIDefaultTargetURL: &defaultTargetURL,
 		}
 		if defaultBundleID != "" && crrBndlID == defaultBundleID {
-			bundleRefInput.IsDefaultBundle = true
+			isDefaultBundle := true
+			bundleRefInput.IsDefaultBundle = &isDefaultBundle
 		}
 
 		err := s.bundleReferenceService.CreateByReferenceObjectID(ctx, *bundleRefInput, model.BundleAPIReference, apiID, &crrBndlID)

--- a/components/director/internal/domain/api/service_test.go
+++ b/components/director/internal/domain/api/service_test.go
@@ -434,6 +434,7 @@ func TestService_Create(t *testing.T) {
 	frURL := "foo.bar"
 	spec := "test"
 	spec2 := "test2"
+	isDefaultBundle := true
 
 	modelInput := model.APIDefinitionInput{
 		Name:         name,
@@ -477,7 +478,7 @@ func TestService_Create(t *testing.T) {
 
 	bundleReferenceInputWithDefaultBundle := &model.BundleReferenceInput{
 		APIDefaultTargetURL: str.Ptr(api.ExtractTargetURLFromJSONArray(modelAPIDefinition.TargetURLs)),
-		IsDefaultBundle:     true,
+		IsDefaultBundle:     &isDefaultBundle,
 	}
 
 	singleDefaultTargetURLPerBundle := map[string]string{bundleID: targetURL}
@@ -961,6 +962,7 @@ func TestService_UpdateInManyBundles(t *testing.T) {
 	timestamp := time.Now()
 	frURL := "foo.bar"
 	spec := "spec"
+	isDefaultBundle := true
 
 	modelInput := model.APIDefinitionInput{
 		Name:         "Foo",
@@ -1001,12 +1003,12 @@ func TestService_UpdateInManyBundles(t *testing.T) {
 
 	bundleReferenceInputWithDefaultBundle := &model.BundleReferenceInput{
 		APIDefaultTargetURL: str.Ptr(api.ExtractTargetURLFromJSONArray(modelInput.TargetURLs)),
-		IsDefaultBundle:     true,
+		IsDefaultBundle:     &isDefaultBundle,
 	}
 
 	secondBundleReferenceInputWithDefaultBundle := &model.BundleReferenceInput{
 		APIDefaultTargetURL: str.Ptr(secondTargetURL),
-		IsDefaultBundle:     true,
+		IsDefaultBundle:     &isDefaultBundle,
 	}
 
 	defaultTargetURLPerBundleForUpdate := map[string]string{firstBndlID: firstTargetURL}

--- a/components/director/internal/domain/bundlereferences/converter.go
+++ b/components/director/internal/domain/bundlereferences/converter.go
@@ -36,7 +36,7 @@ func (c *converter) ToEntity(in model.BundleReference) Entity {
 		APIDefID:            apiDefID,
 		EventDefID:          eventDefID,
 		APIDefaultTargetURL: apiDefaultTargetURL,
-		IsDefaultBundle:     in.IsDefaultBundle,
+		IsDefaultBundle:     repo.NewNullableBool(in.IsDefaultBundle),
 	}
 }
 
@@ -53,7 +53,7 @@ func (c *converter) FromEntity(in Entity) (model.BundleReference, error) {
 		ObjectType:          objectType,
 		ObjectID:            repo.StringPtrFromNullableString(objectID),
 		APIDefaultTargetURL: repo.StringPtrFromNullableString(in.APIDefaultTargetURL),
-		IsDefaultBundle:     in.IsDefaultBundle,
+		IsDefaultBundle:     repo.BoolPtrFromNullableBool(in.IsDefaultBundle),
 	}, nil
 }
 

--- a/components/director/internal/domain/bundlereferences/entity.go
+++ b/components/director/internal/domain/bundlereferences/entity.go
@@ -9,5 +9,5 @@ type Entity struct {
 	APIDefID            sql.NullString `db:"api_def_id"`
 	EventDefID          sql.NullString `db:"event_def_id"`
 	APIDefaultTargetURL sql.NullString `db:"api_def_url"`
-	IsDefaultBundle     bool           `db:"is_default_bundle"`
+	IsDefaultBundle     sql.NullBool   `db:"is_default_bundle"`
 }

--- a/components/director/internal/domain/bundlereferences/fixtures_test.go
+++ b/components/director/internal/domain/bundlereferences/fixtures_test.go
@@ -20,6 +20,8 @@ const (
 	apiDefTargetURL = "http://test.com"
 )
 
+var isDefaultBundle = false
+
 func fixAPIBundleReferenceModel() model.BundleReference {
 	return model.BundleReference{
 		ID:                  bundleRefID,
@@ -27,7 +29,7 @@ func fixAPIBundleReferenceModel() model.BundleReference {
 		ObjectType:          model.BundleAPIReference,
 		ObjectID:            str.Ptr(apiDefID),
 		APIDefaultTargetURL: str.Ptr(apiDefTargetURL),
-		IsDefaultBundle:     false,
+		IsDefaultBundle:     &isDefaultBundle,
 	}
 }
 
@@ -38,7 +40,7 @@ func fixAPIBundleReferenceEntity() bundlereferences.Entity {
 		APIDefID:            repo.NewValidNullableString(apiDefID),
 		EventDefID:          sql.NullString{},
 		APIDefaultTargetURL: repo.NewValidNullableString(apiDefTargetURL),
-		IsDefaultBundle:     false,
+		IsDefaultBundle:     repo.NewNullableBool(&isDefaultBundle),
 	}
 }
 
@@ -49,7 +51,7 @@ func fixAPIBundleReferenceEntityWithArgs(bndlID, apiID, targetURL string) bundle
 		APIDefID:            repo.NewValidNullableString(apiID),
 		EventDefID:          sql.NullString{},
 		APIDefaultTargetURL: repo.NewValidNullableString(targetURL),
-		IsDefaultBundle:     false,
+		IsDefaultBundle:     repo.NewNullableBool(&isDefaultBundle),
 	}
 }
 
@@ -60,7 +62,7 @@ func fixInvalidAPIBundleReferenceEntity() bundlereferences.Entity {
 		APIDefID:            sql.NullString{},
 		EventDefID:          sql.NullString{},
 		APIDefaultTargetURL: repo.NewValidNullableString(apiDefTargetURL),
-		IsDefaultBundle:     false,
+		IsDefaultBundle:     repo.NewNullableBool(&isDefaultBundle),
 	}
 }
 
@@ -70,7 +72,7 @@ func fixEventBundleReferenceModel() model.BundleReference {
 		BundleID:        str.Ptr(bundleID),
 		ObjectType:      model.BundleEventReference,
 		ObjectID:        str.Ptr(eventDefID),
-		IsDefaultBundle: false,
+		IsDefaultBundle: &isDefaultBundle,
 	}
 }
 
@@ -81,7 +83,7 @@ func fixEventBundleReferenceEntity() bundlereferences.Entity {
 		APIDefID:            sql.NullString{},
 		EventDefID:          repo.NewValidNullableString(eventDefID),
 		APIDefaultTargetURL: sql.NullString{},
-		IsDefaultBundle:     false,
+		IsDefaultBundle:     repo.NewNullableBool(&isDefaultBundle),
 	}
 }
 
@@ -90,7 +92,7 @@ func fixEventBundleReferenceEntityWithArgs(bndlID, eventID string) bundlereferen
 		ID:              bundleRefID,
 		BundleID:        repo.NewValidNullableString(bndlID),
 		EventDefID:      repo.NewValidNullableString(eventID),
-		IsDefaultBundle: false,
+		IsDefaultBundle: repo.NewNullableBool(&isDefaultBundle),
 	}
 }
 
@@ -101,7 +103,7 @@ func fixInvalidEventBundleReferenceEntity() bundlereferences.Entity {
 		APIDefID:            sql.NullString{},
 		EventDefID:          sql.NullString{},
 		APIDefaultTargetURL: sql.NullString{},
-		IsDefaultBundle:     false,
+		IsDefaultBundle:     repo.NewNullableBool(&isDefaultBundle),
 	}
 }
 

--- a/components/director/internal/domain/eventdef/service.go
+++ b/components/director/internal/domain/eventdef/service.go
@@ -166,8 +166,9 @@ func (s *service) Create(ctx context.Context, appID string, bundleID, packageID 
 		for _, bndlID := range bundleIDs {
 			bundleRefInput := &model.BundleReferenceInput{}
 			if defaultBundleID != "" && bndlID == defaultBundleID {
+				isDefaultBundle := true
 				bundleRefInput = &model.BundleReferenceInput{
-					IsDefaultBundle: true,
+					IsDefaultBundle: &isDefaultBundle,
 				}
 			}
 			if err = s.bundleReferenceService.CreateByReferenceObjectID(ctx, *bundleRefInput, model.BundleEventReference, &eventAPI.ID, &bndlID); err != nil {
@@ -205,7 +206,8 @@ func (s *service) UpdateInManyBundles(ctx context.Context, id string, in model.E
 	for _, bundleID := range bundleIDsForCreation {
 		createBundleRefInput := &model.BundleReferenceInput{}
 		if defaultBundleID != "" && bundleID == defaultBundleID {
-			createBundleRefInput = &model.BundleReferenceInput{IsDefaultBundle: true}
+			isDefaultBundle := true
+			createBundleRefInput = &model.BundleReferenceInput{IsDefaultBundle: &isDefaultBundle}
 		}
 		if err = s.bundleReferenceService.CreateByReferenceObjectID(ctx, *createBundleRefInput, model.BundleEventReference, &event.ID, &bundleID); err != nil {
 			return err
@@ -221,7 +223,8 @@ func (s *service) UpdateInManyBundles(ctx context.Context, id string, in model.E
 	for _, bundleID := range bundleIDsFromBundleReference {
 		bundleRefInput := &model.BundleReferenceInput{}
 		if defaultBundleID != "" && bundleID == defaultBundleID {
-			bundleRefInput = &model.BundleReferenceInput{IsDefaultBundle: true}
+			isDefaultBundle := true
+			bundleRefInput = &model.BundleReferenceInput{IsDefaultBundle: &isDefaultBundle}
 		}
 		if err := s.bundleReferenceService.UpdateByReferenceObjectID(ctx, *bundleRefInput, model.BundleEventReference, &event.ID, &bundleID); err != nil {
 			return err

--- a/components/director/internal/domain/eventdef/service_test.go
+++ b/components/director/internal/domain/eventdef/service_test.go
@@ -461,7 +461,8 @@ func TestService_Create(t *testing.T) {
 	}
 
 	bundleReferenceInput := &model.BundleReferenceInput{}
-	bundleReferenceInputWithDefaultBundle := &model.BundleReferenceInput{IsDefaultBundle: true}
+	isDefault := true
+	bundleReferenceInputWithDefaultBundle := &model.BundleReferenceInput{IsDefaultBundle: &isDefault}
 	bundleIDs := []string{bundleID, bundleID2}
 
 	ctx := context.TODO()
@@ -913,8 +914,9 @@ func TestService_UpdateManyBundles(t *testing.T) {
 		Version: &model.Version{},
 	}
 
+	isDefault := true
 	bundleReferenceInputWithDefaultBundle := &model.BundleReferenceInput{
-		IsDefaultBundle: true,
+		IsDefaultBundle: &isDefault,
 	}
 
 	bundleIDsForCreation := []string{bndlID1, bndlID2}

--- a/components/director/internal/model/bundle_references.go
+++ b/components/director/internal/model/bundle_references.go
@@ -9,7 +9,7 @@ type BundleReference struct {
 	ObjectType          BundleReferenceObjectType
 	ObjectID            *string
 	APIDefaultTargetURL *string
-	IsDefaultBundle     bool
+	IsDefaultBundle     *bool
 }
 
 // BundleReferenceObjectType missing godoc
@@ -25,7 +25,7 @@ const (
 // BundleReferenceInput missing godoc
 type BundleReferenceInput struct {
 	APIDefaultTargetURL *string
-	IsDefaultBundle     bool
+	IsDefaultBundle     *bool
 }
 
 // ToBundleReference missing godoc


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:
- Currently isDefaultBundle property in BundleRefernce cannot be null and this can cause problem in deserialization of a API/Event definitions   

**Pull Request status**
<!-- Feel free to construct the checklist with whatever items seem most reasonable for your change. You could disassemble the Implementation part to even smaller separate checklist items if you're working on something big for example. But do make the effort to provide a checklist of some sort so that the core team as well as the community can have an idea about the progress of your Pull Request.
-->

- [x] Implementation
- [x] Unit tests
- [ ] Integration tests
- [x] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [ ] Mocks are regenerated, using the automated script
