### PR TITLE
Call global registry in ORD aggregator tests

### DIFF
--- a/chart/compass/templates/tests/ord-aggregator/ord-aggregator-test.yaml
+++ b/chart/compass/templates/tests/ord-aggregator/ord-aggregator-test.yaml
@@ -27,6 +27,7 @@ spec:
               - "oauth2.{{ .Values.global.ingress.domainName }}"
               - "compass-external-services-mock.compass-system.svc.cluster.local"
       {{ end }}
+      serviceAccountName: {{ $.Chart.Name }}-ord-aggregator-test
       containers:
         - name: ord-aggregator-tests
           image: {{ .Values.global.images.containerRegistry.path }}/{{ .Values.global.images.e2e_tests.dir }}compass-tests:{{ .Values.global.images.e2e_tests.version }}
@@ -52,6 +53,14 @@ spec:
               value: "http://compass-external-services-mock.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.global.externalServicesMock.basicSecuredPort }}/.well-known/open-resource-discovery"
             - name: EXTERNAL_SERVICES_MOCK_OAUTH_URL
               value: "http://compass-external-services-mock.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.global.externalServicesMock.oauthSecuredPort }}/.well-known/open-resource-discovery"
+            - name: GLOBAL_REGISTRY_URL
+              value: "{{ .Values.global.ordAggregator.globalRegistryUrl }}"
+            - name: APP_EXTERNAL_CLIENT_CERT_SECRET
+              value: "{{ .Values.global.externalCertConfiguration.secrets.externalClientCertSecret.namespace }}/{{ .Values.global.externalCertConfiguration.secrets.externalClientCertSecret.name }}"
+            - name: APP_EXTERNAL_CLIENT_CERT_KEY
+              value: "{{ .Values.global.externalCertConfiguration.secrets.externalClientCertSecret.certKey }}"
+            - name: APP_EXTERNAL_CLIENT_KEY_KEY
+              value: "{{ .Values.global.externalCertConfiguration.secrets.externalClientCertSecret.keyKey }}"
             - name: BASIC_USERNAME
               valueFrom:
                 secretKeyRef:
@@ -95,3 +104,37 @@ spec:
             - name: APP_ADDRESS
               value: "0.0.0.0:{{.Values.global.tests.token.server.port}}"
       restartPolicy: Never
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ $.Chart.Name }}-ord-aggregator-test
+  namespace: {{ .Values.global.tests.namespace }}
+  labels:
+    app: {{ $.Chart.Name }}
+    release: {{ $.Release.Name }}
+    helm.sh/chart: {{ $.Chart.Name }}-{{ $.Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/name: {{ template "name" . }}
+    app.kubernetes.io/managed-by: {{ $.Release.Service }}
+    app.kubernetes.io/instance: {{ $.Release.Name }}
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ $.Chart.Name }}-ord-aggregator-test
+  namespace: {{ .Values.global.tests.namespace }}
+  labels:
+    app: {{ $.Chart.Name }}
+    release: {{ $.Release.Name }}
+    helm.sh/chart: {{ $.Chart.Name }}-{{ $.Chart.Version | replace "+" "_" }}
+    app.kubernetes.io/name: {{ template "name" . }}
+    app.kubernetes.io/managed-by: {{ $.Release.Service }}
+    app.kubernetes.io/instance: {{ $.Release.Name }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ $.Chart.Name }}-ord-aggregator-test
+    namespace: {{ .Values.global.tests.namespace }}
+roleRef:
+  kind: Role
+  name: director-{{ .Values.global.externalCertConfiguration.secrets.externalClientCertSecret.name }}
+  apiGroup: rbac.authorization.k8s.io

--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -120,7 +120,7 @@ global:
       version: "PR-54"
     e2e_tests:
       dir:
-      version: "PR-2174"
+      version: "PR-2204"
   isLocalEnv: false
   oauth2:
     host: oauth2

--- a/tests/ord-aggregator/tests/handler_test.go
+++ b/tests/ord-aggregator/tests/handler_test.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/kyma-incubator/compass/components/director/pkg/accessstrategy"
- 	"github.com/kyma-incubator/compass/components/director/pkg/certloader"
+	"github.com/kyma-incubator/compass/components/director/pkg/certloader"
 	directorSchema "github.com/kyma-incubator/compass/components/director/pkg/graphql"
 	"github.com/kyma-incubator/compass/tests/pkg/assertions"
 	"github.com/kyma-incubator/compass/tests/pkg/fixtures"

--- a/tests/ord-aggregator/tests/handler_test.go
+++ b/tests/ord-aggregator/tests/handler_test.go
@@ -9,9 +9,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/kyma-incubator/compass/tests/pkg/assertions"
-
+	"github.com/kyma-incubator/compass/components/director/pkg/accessstrategy"
+ 	"github.com/kyma-incubator/compass/components/director/pkg/certloader"
 	directorSchema "github.com/kyma-incubator/compass/components/director/pkg/graphql"
+	"github.com/kyma-incubator/compass/tests/pkg/assertions"
 	"github.com/kyma-incubator/compass/tests/pkg/fixtures"
 	"github.com/kyma-incubator/compass/tests/pkg/request"
 	"github.com/pkg/errors"
@@ -67,12 +68,10 @@ const (
 	expectedNumberOfSystemInstances           = 6
 	expectedNumberOfPackages                  = 6
 	expectedNumberOfBundles                   = 12
-	expectedNumberOfProducts                  = 7
 	expectedNumberOfAPIs                      = 6
 	expectedNumberOfResourceDefinitionsPerAPI = 3
 	expectedNumberOfEvents                    = 12
 	expectedNumberOfTombstones                = 6
-	expectedNumberOfVendors                   = 7
 
 	expectedNumberOfAPIsInFirstBundle    = 1
 	expectedNumberOfAPIsInSecondBundle   = 1
@@ -87,6 +86,12 @@ const (
 	documentationLabelKey         = "Documentation label key"
 	documentationLabelFirstValue  = "Markdown Documentation with links"
 	documentationLabelSecondValue = "With multiple values"
+)
+
+var (
+	// The expected number is increased with initial number of global vendors/products before test execution
+	expectedNumberOfProducts = 6
+	expectedNumberOfVendors  = 6
 )
 
 func TestORDAggregator(t *testing.T) {
@@ -170,30 +175,6 @@ func TestORDAggregator(t *testing.T) {
 
 		ctx := context.Background()
 
-		app, err := fixtures.RegisterApplicationFromInput(t, ctx, dexGraphQLClient, testConfig.DefaultTestTenant, appInput)
-		defer fixtures.CleanupApplication(t, ctx, dexGraphQLClient, testConfig.DefaultTestTenant, &app)
-		require.NoError(t, err)
-
-		secondApp, err := fixtures.RegisterApplicationFromInput(t, ctx, dexGraphQLClient, testConfig.DefaultTestTenant, secondAppInput)
-		defer fixtures.CleanupApplication(t, ctx, dexGraphQLClient, testConfig.DefaultTestTenant, &secondApp)
-		require.NoError(t, err)
-
-		thirdApp, err := fixtures.RegisterApplicationFromInput(t, ctx, dexGraphQLClient, testConfig.DefaultTestTenant, thirdAppInput)
-		defer fixtures.CleanupApplication(t, ctx, dexGraphQLClient, testConfig.DefaultTestTenant, &thirdApp)
-		require.NoError(t, err)
-
-		fourthApp, err := fixtures.RegisterApplicationFromInput(t, ctx, dexGraphQLClient, testConfig.DefaultTestTenant, fourthAppInput)
-		defer fixtures.CleanupApplication(t, ctx, dexGraphQLClient, testConfig.DefaultTestTenant, &fourthApp)
-		require.NoError(t, err)
-
-		fifthApp, err := fixtures.RegisterApplicationFromInput(t, ctx, dexGraphQLClient, testConfig.DefaultTestTenant, fifthAppInput)
-		defer fixtures.CleanupApplication(t, ctx, dexGraphQLClient, testConfig.DefaultTestTenant, &fifthApp)
-		require.NoError(t, err)
-
-		sixthApp, err := fixtures.RegisterApplicationFromInput(t, ctx, dexGraphQLClient, testConfig.DefaultTestTenant, sixthAppInput)
-		defer fixtures.CleanupApplication(t, ctx, dexGraphQLClient, testConfig.DefaultTestTenant, &sixthApp)
-		require.NoError(t, err)
-
 		t.Log("Create integration system")
 		intSys, err := fixtures.RegisterIntegrationSystem(t, ctx, dexGraphQLClient, "", "test-int-system")
 		defer fixtures.CleanupIntegrationSystem(t, ctx, dexGraphQLClient, "", intSys)
@@ -222,6 +203,37 @@ func TestORDAggregator(t *testing.T) {
 		ctx = context.WithValue(ctx, oauth2.HTTPClient, unsecuredHttpClient)
 		httpClient := conf.Client(ctx)
 		httpClient.Timeout = 20 * time.Second
+
+		globalProductsNumber, globalVendorsNumber := getGlobalResourcesNumber(ctx, t, unsecuredHttpClient)
+		t.Logf("Global products number: %d, Global vendors number: %d", globalProductsNumber, globalVendorsNumber)
+
+		expectedNumberOfProducts += globalProductsNumber
+		expectedNumberOfVendors += globalVendorsNumber
+
+		// Register systems
+		app, err := fixtures.RegisterApplicationFromInput(t, ctx, dexGraphQLClient, testConfig.DefaultTestTenant, appInput)
+		defer fixtures.CleanupApplication(t, ctx, dexGraphQLClient, testConfig.DefaultTestTenant, &app)
+		require.NoError(t, err)
+
+		secondApp, err := fixtures.RegisterApplicationFromInput(t, ctx, dexGraphQLClient, testConfig.DefaultTestTenant, secondAppInput)
+		defer fixtures.CleanupApplication(t, ctx, dexGraphQLClient, testConfig.DefaultTestTenant, &secondApp)
+		require.NoError(t, err)
+
+		thirdApp, err := fixtures.RegisterApplicationFromInput(t, ctx, dexGraphQLClient, testConfig.DefaultTestTenant, thirdAppInput)
+		defer fixtures.CleanupApplication(t, ctx, dexGraphQLClient, testConfig.DefaultTestTenant, &thirdApp)
+		require.NoError(t, err)
+
+		fourthApp, err := fixtures.RegisterApplicationFromInput(t, ctx, dexGraphQLClient, testConfig.DefaultTestTenant, fourthAppInput)
+		defer fixtures.CleanupApplication(t, ctx, dexGraphQLClient, testConfig.DefaultTestTenant, &fourthApp)
+		require.NoError(t, err)
+
+		fifthApp, err := fixtures.RegisterApplicationFromInput(t, ctx, dexGraphQLClient, testConfig.DefaultTestTenant, fifthAppInput)
+		defer fixtures.CleanupApplication(t, ctx, dexGraphQLClient, testConfig.DefaultTestTenant, &fifthApp)
+		require.NoError(t, err)
+
+		sixthApp, err := fixtures.RegisterApplicationFromInput(t, ctx, dexGraphQLClient, testConfig.DefaultTestTenant, sixthAppInput)
+		defer fixtures.CleanupApplication(t, ctx, dexGraphQLClient, testConfig.DefaultTestTenant, &sixthApp)
+		require.NoError(t, err)
 
 		scheduleTime, err := parseCronTime(testConfig.AggregatorSchedule)
 		require.NoError(t, err)
@@ -397,4 +409,19 @@ func storeMappingBetweenORDAndInternalBundleID(t *testing.T, respBody string, nu
 	}
 
 	return ordAndInternalIDsMapping
+}
+
+func getGlobalResourcesNumber(ctx context.Context, t *testing.T, httpClient *http.Client) (int, int) {
+	certCache, err := certloader.StartCertLoader(ctx, testConfig.CertLoaderConfig)
+	require.NoError(t, err, "Failed to initialize certificate loader")
+
+	accessStrategyExecutorProvider := accessstrategy.NewDefaultExecutorProvider(certCache)
+	ordClient := NewGlobalRegistryClient(httpClient, accessStrategyExecutorProvider)
+
+	products, vendors, err := ordClient.GetGlobalProductsAndVendorsNumber(ctx, testConfig.GlobalRegistryURL)
+	if err != nil {
+		t.Logf("while fetching global registry resources from %s %v", testConfig.GlobalRegistryURL, err)
+		t.Fail()
+	}
+	return products, vendors
 }

--- a/tests/ord-aggregator/tests/main_test.go
+++ b/tests/ord-aggregator/tests/main_test.go
@@ -21,14 +21,13 @@ import (
 	"testing"
 	"time"
 
-	log "github.com/sirupsen/logrus"
-
+	"github.com/kyma-incubator/compass/components/director/pkg/certloader"
 	"github.com/kyma-incubator/compass/tests/pkg/gql"
 	"github.com/kyma-incubator/compass/tests/pkg/server"
-
 	"github.com/machinebox/graphql"
 	"github.com/pkg/errors"
 	c "github.com/robfig/cron/v3"
+	log "github.com/sirupsen/logrus"
 	"github.com/vrischmann/envconfig"
 )
 
@@ -48,6 +47,10 @@ type config struct {
 	BasicUsername                      string
 	BasicPassword                      string
 	ORDServiceDefaultResponseType      string
+	GlobalRegistryURL                  string
+	CertLoaderConfig                   certloader.Config
+	ClientTimeout                      time.Duration `envconfig:"default=60s"`
+	SkipSSLValidation                  bool          `envconfig:"default=false"`
 }
 
 var (

--- a/tests/ord-aggregator/tests/ord_document.go
+++ b/tests/ord-aggregator/tests/ord_document.go
@@ -1,0 +1,25 @@
+package tests
+
+import (
+	"github.com/kyma-incubator/compass/components/director/pkg/accessstrategy"
+)
+
+// WellKnownEndpoint is the single entry point for the discovery.
+const WellKnownEndpoint = "/.well-known/open-resource-discovery"
+
+// WellKnownConfig represents the whole config object
+type WellKnownConfig struct {
+	BaseURL                 string                  `json:"baseUrl"`
+	OpenResourceDiscoveryV1 OpenResourceDiscoveryV1 `json:"openResourceDiscoveryV1"`
+}
+
+// OpenResourceDiscoveryV1 contains all Documents' details
+type OpenResourceDiscoveryV1 struct {
+	Documents []DocumentDetails `json:"documents"`
+}
+
+// DocumentDetails contains fields related to the fetching of each Document
+type DocumentDetails struct {
+ 	URL              string                          `json:"url"`
+	AccessStrategies accessstrategy.AccessStrategies `json:"accessStrategies"`
+}

--- a/tests/ord-aggregator/tests/ord_document.go
+++ b/tests/ord-aggregator/tests/ord_document.go
@@ -20,6 +20,6 @@ type OpenResourceDiscoveryV1 struct {
 
 // DocumentDetails contains fields related to the fetching of each Document
 type DocumentDetails struct {
- 	URL              string                          `json:"url"`
+	URL              string                          `json:"url"`
 	AccessStrategies accessstrategy.AccessStrategies `json:"accessStrategies"`
 }

--- a/tests/ord-aggregator/tests/registry_client.go
+++ b/tests/ord-aggregator/tests/registry_client.go
@@ -1,0 +1,155 @@
+package tests
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/kyma-incubator/compass/components/director/pkg/accessstrategy"
+	httputil "github.com/kyma-incubator/compass/components/director/pkg/http"
+	"github.com/kyma-incubator/compass/components/director/pkg/log"
+	"github.com/pkg/errors"
+	"github.com/tidwall/gjson"
+)
+
+type client struct {
+	*http.Client
+	accessStrategyExecutorProvider accessstrategy.ExecutorProvider
+}
+
+func NewGlobalRegistryClient(httpClient *http.Client, accessStrategyExecutorProvider accessstrategy.ExecutorProvider) *client {
+	return &client{
+		Client:                         httpClient,
+		accessStrategyExecutorProvider: accessStrategyExecutorProvider,
+	}
+}
+
+func (c *client) GetGlobalProductsAndVendorsNumber(ctx context.Context, globalRegistryURL string) (int, int, error) {
+	config, err := c.fetchConfig(ctx, globalRegistryURL)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	baseURL, err := calculateBaseURL(globalRegistryURL, *config)
+	if err != nil {
+		return 0, 0, errors.Wrap(err, "while calculating baseURL")
+	}
+
+	globalProducts := 0
+	globalVendors := 0
+	for _, docDetails := range config.OpenResourceDiscoveryV1.Documents {
+		documentURL, err := buildDocumentURL(docDetails.URL, baseURL)
+		if err != nil {
+			return globalProducts, globalVendors, errors.Wrap(err, "error building document URL")
+		}
+		strategy, ok := docDetails.AccessStrategies.GetSupported()
+		if !ok {
+			return globalProducts, globalVendors, fmt.Errorf("unsupported access strategies for ORD Document %q", documentURL)
+		}
+		doc, err := c.fetchOpenDiscoveryDocumentWithAccessStrategy(ctx, documentURL, strategy)
+		if err != nil {
+			return globalProducts, globalVendors, errors.Wrapf(err, "error fetching ORD document from: %s", documentURL)
+		}
+
+		numberOfProducts := len(gjson.Get(doc, "products").Array())
+		globalProducts += numberOfProducts
+
+		numberOfVendors := len(gjson.Get(doc, "vendors").Array())
+		globalVendors += numberOfVendors
+	}
+
+	return globalProducts, globalVendors, nil
+}
+
+func (c *client) fetchOpenDiscoveryDocumentWithAccessStrategy(ctx context.Context, documentURL string, accessStrategy accessstrategy.Type) (string, error) {
+	log.C(ctx).Infof("Fetching ORD Document %q with Access Strategy %q", documentURL, accessStrategy)
+	executor, err := c.accessStrategyExecutorProvider.Provide(accessStrategy)
+	if err != nil {
+		return "", err
+	}
+
+	resp, err := executor.Execute(c.Client, documentURL)
+	if err != nil {
+		return "", err
+	}
+
+	defer closeBody(ctx, resp.Body)
+
+	if resp.StatusCode != http.StatusOK {
+		return "", errors.Errorf("error while fetching open resource discovery document %q: status code %d", documentURL, resp.StatusCode)
+	}
+
+	resp.Body = http.MaxBytesReader(nil, resp.Body, 2097152)
+	bodyBytes, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return "", errors.Wrap(err, "error reading document body")
+	}
+	return string(bodyBytes), nil
+}
+
+func closeBody(ctx context.Context, body io.ReadCloser) {
+	if err := body.Close(); err != nil {
+		log.C(ctx).WithError(err).Warnf("Got error on closing response body")
+	}
+}
+
+func (c *client) fetchConfig(ctx context.Context, globalRegistryURL string) (*WellKnownConfig, error) {
+	var resp *http.Response
+	var err error
+	resp, err = httputil.GetRequestWithoutCredentials(c.Client, globalRegistryURL)
+	if err != nil {
+		return nil, errors.Wrap(err, "error while fetching open resource discovery well-known configuration")
+	}
+
+	defer closeBody(ctx, resp.Body)
+
+	bodyBytes, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, errors.Wrap(err, "error reading response body")
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, errors.Errorf("error while fetching open resource discovery well-known configuration: status code %d Body: %s", resp.StatusCode, string(bodyBytes))
+	}
+
+	config := WellKnownConfig{}
+	if err := json.Unmarshal(bodyBytes, &config); err != nil {
+		return nil, errors.Wrap(err, "error unmarshaling json body")
+	}
+
+	return &config, nil
+}
+
+func buildDocumentURL(docURL, baseURL string) (string, error) {
+	docURLParsed, err := url.Parse(docURL)
+	if err != nil {
+		return "", err
+	}
+	if docURLParsed.IsAbs() {
+		return docURL, nil
+	}
+	return baseURL + docURL, nil
+}
+
+func calculateBaseURL(webhookURL string, config WellKnownConfig) (string, error) {
+	if config.BaseURL != "" {
+		return config.BaseURL, nil
+	}
+
+	parsedWebhookURL, err := url.ParseRequestURI(webhookURL)
+	if err != nil {
+		return "", errors.New("error while parsing input webhook url")
+	}
+
+	if strings.HasSuffix(parsedWebhookURL.Path, WellKnownEndpoint) {
+		strippedPath := strings.ReplaceAll(parsedWebhookURL.Path, WellKnownEndpoint, "")
+		parsedWebhookURL.Path = strippedPath
+		return parsedWebhookURL.String(), nil
+	}
+	return "", nil
+}


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:
- Transport #2200

**Pull Request status**
- [x] Implementation
- [x] Unit tests
- [x] Integration tests
- [x] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [x] Mocks are regenerated, using the automated script
