### PR TITLE
Token issuer config

### DIFF
--- a/chart/compass/templates/internal-communication-policies.yaml
+++ b/chart/compass/templates/internal-communication-policies.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
 spec:
   jwtRules:
-    - issuer: kubernetes/serviceaccount
+    - issuer: {{ .Values.global.kubernetes.serviceAccountTokenIssuer }}
       jwksUri: {{ .Values.global.kubernetes.serviceAccountTokenJWKS }}
       forwardOriginalToken: true
       fromHeaders:
@@ -82,7 +82,7 @@ spec:
     matchLabels:
       app.kubernetes.io/name: hydra
   jwtRules:
-    - issuer: kubernetes/serviceaccount
+    - issuer: {{ .Values.global.kubernetes.serviceAccountTokenIssuer }}
       jwksUri: {{ .Values.global.kubernetes.serviceAccountTokenJWKS }}
       forwardOriginalToken: true
       fromHeaders:

--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -307,6 +307,7 @@ global:
         - "x-broker-api-request-identity"
 
   kubernetes:
+    serviceAccountTokenIssuer: kubernetes/serviceaccount
     serviceAccountTokenJWKS: https://kubernetes.default.svc.cluster.local/openid/v1/jwks
 
   ingress:

--- a/installation/resources/installer-config-gke-benchmark.yaml.tpl
+++ b/installation/resources/installer-config-gke-benchmark.yaml.tpl
@@ -16,6 +16,7 @@ data:
   global.systemFetcher.systemsAPIFilterCriteria: "no"
   global.systemFetcher.systemsAPIFilterTenantCriteriaPattern: "tenant=%s"
   global.systemFetcher.systemToTemplateMappings: '[{"Name": "temp1", "SourceKey": ["prop"], "SourceValue": ["val1"] },{"Name": "temp2", "SourceKey": ["prop"], "SourceValue": ["val2"] }]'
+  global.kubernetes.serviceAccountTokenIssuer: "https://container.googleapis.com/v1beta1/projects/$CLOUDSDK_CORE_PROJECT/locations/$CLOUDSDK_COMPUTE_ZONE/clusters/$COMMON_NAME"
   global.kubernetes.serviceAccountTokenJWKS: "https://container.googleapis.com/v1beta1/projects/$CLOUDSDK_CORE_PROJECT/locations/$CLOUDSDK_COMPUTE_ZONE/clusters/$COMMON_NAME/jwks"
   global.oathkeeper.mutators.authenticationMappingServices.tenant-fetcher.authenticator.enabled: "true"
   global.oathkeeper.mutators.authenticationMappingServices.subscriber.authenticator.enabled: "true"

--- a/installation/resources/installer-config-gke-integration.yaml.tpl
+++ b/installation/resources/installer-config-gke-integration.yaml.tpl
@@ -18,6 +18,7 @@ data:
   global.systemFetcher.systemsAPIFilterTenantCriteriaPattern: "tenant=%s"
   global.systemFetcher.systemToTemplateMappings: '[{"Name": "temp1", "SourceKey": ["prop"], "SourceValue": ["val1"] },{"Name": "temp2", "SourceKey": ["prop"], "SourceValue": ["val2"] }]'
   global.migratorJob.nodeSelectorEnabled: "true"
+  global.kubernetes.serviceAccountTokenIssuer: "https://container.googleapis.com/v1beta1/projects/$CLOUDSDK_CORE_PROJECT/locations/$CLOUDSDK_COMPUTE_ZONE/clusters/$COMMON_NAME"
   global.kubernetes.serviceAccountTokenJWKS: "https://container.googleapis.com/v1beta1/projects/$CLOUDSDK_CORE_PROJECT/locations/$CLOUDSDK_COMPUTE_ZONE/clusters/$COMMON_NAME/jwks"
   global.oathkeeper.mutators.authenticationMappingServices.tenant-fetcher.authenticator.enabled: "true"
   global.oathkeeper.mutators.authenticationMappingServices.subscriber.authenticator.enabled: "true"


### PR DESCRIPTION
**Description**
In Kubernetes v1.21 the default tokens mounted inside the pods which are issued for their respective service account are changed. Before the issuer would always be `kubernetes/serviceaccount` and after v1.21 it is a more cluster specific value. Since we use these tokens with our internal flows we need to configure our `RequestAuthentication` resources accordingly.

Changes proposed in this pull request:
- Make the issuer field inside `RequestAuthentiaction` resources configurable
- Adapt issuers for tests executed on PR 

**Pull Request status**


- [X] Implementation
- [ ] Unit tests
- [ ] Integration tests
- [X] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [ ] Mocks are regenerated, using the automated script
