### PR TITLE
[HOTFIX] Update cert-rotation-job environment in consumer-provider test

### DIFF
--- a/chart/compass/templates/internal-communication-policies.yaml
+++ b/chart/compass/templates/internal-communication-policies.yaml
@@ -11,6 +11,12 @@ spec:
       fromHeaders:
         - name: X-Authorization
           prefix: "Bearer "
+    - issuer: {{ .Values.global.kubernetes.serviceAccountTokenIssuer }}
+      jwksUri: {{ .Values.global.kubernetes.serviceAccountTokenJWKS }}
+      forwardOriginalToken: true
+      fromHeaders:
+        - name: X-Authorization
+          prefix: "Bearer "
 ---
 apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
@@ -83,6 +89,12 @@ spec:
       app.kubernetes.io/name: hydra
   jwtRules:
     - issuer: kubernetes/serviceaccount
+      jwksUri: {{ .Values.global.kubernetes.serviceAccountTokenJWKS }}
+      forwardOriginalToken: true
+      fromHeaders:
+        - name: X-Authorization
+          prefix: "Bearer "
+    - issuer: {{ .Values.global.kubernetes.serviceAccountTokenIssuer }}
       jwksUri: {{ .Values.global.kubernetes.serviceAccountTokenJWKS }}
       forwardOriginalToken: true
       fromHeaders:

--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -307,6 +307,7 @@ global:
         - "x-broker-api-request-identity"
 
   kubernetes:
+    serviceAccountTokenIssuer: kubernetes/serviceaccount
     serviceAccountTokenJWKS: https://kubernetes.default.svc.cluster.local/openid/v1/jwks
 
   ingress:

--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -120,7 +120,7 @@ global:
       version: "PR-59"
     e2e_tests:
       dir:
-      version: "PR-2221"
+      version: "PR-2229"
   isLocalEnv: false
   oauth2:
     host: oauth2

--- a/installation/resources/installer-config-gke-benchmark.yaml.tpl
+++ b/installation/resources/installer-config-gke-benchmark.yaml.tpl
@@ -16,7 +16,8 @@ data:
   global.systemFetcher.systemsAPIFilterCriteria: "no"
   global.systemFetcher.systemsAPIFilterTenantCriteriaPattern: "tenant=%s"
   global.systemFetcher.systemToTemplateMappings: '[{"Name": "temp1", "SourceKey": ["prop"], "SourceValue": ["val1"] },{"Name": "temp2", "SourceKey": ["prop"], "SourceValue": ["val2"] }]'
-  global.kubernetes.serviceAccountTokenJWKS: "https://container.googleapis.com/v1beta1/projects/$CLOUDSDK_CORE_PROJECT/locations/$CLOUDSDK_COMPUTE_ZONE/clusters/$COMMON_NAME/jwks"
+  global.kubernetes.serviceAccountTokenJWKS: "https://container.googleapis.com/v1/projects/$CLOUDSDK_CORE_PROJECT/locations/$CLOUDSDK_COMPUTE_ZONE/clusters/$COMMON_NAME/jwks"
+  global.kubernetes.serviceAccountTokenIssuer: "https://container.googleapis.com/v1/projects/$CLOUDSDK_CORE_PROJECT/locations/$CLOUDSDK_COMPUTE_ZONE/clusters/$COMMON_NAME"
   global.oathkeeper.mutators.authenticationMappingServices.tenant-fetcher.authenticator.enabled: "true"
   global.oathkeeper.mutators.authenticationMappingServices.subscriber.authenticator.enabled: "true"
   system-broker.http.client.skipSSLValidation: "true"

--- a/installation/resources/installer-config-gke-integration.yaml.tpl
+++ b/installation/resources/installer-config-gke-integration.yaml.tpl
@@ -18,7 +18,8 @@ data:
   global.systemFetcher.systemsAPIFilterTenantCriteriaPattern: "tenant=%s"
   global.systemFetcher.systemToTemplateMappings: '[{"Name": "temp1", "SourceKey": ["prop"], "SourceValue": ["val1"] },{"Name": "temp2", "SourceKey": ["prop"], "SourceValue": ["val2"] }]'
   global.migratorJob.nodeSelectorEnabled: "true"
-  global.kubernetes.serviceAccountTokenJWKS: "https://container.googleapis.com/v1beta1/projects/$CLOUDSDK_CORE_PROJECT/locations/$CLOUDSDK_COMPUTE_ZONE/clusters/$COMMON_NAME/jwks"
+  global.kubernetes.serviceAccountTokenJWKS: "https://container.googleapis.com/v1/projects/$CLOUDSDK_CORE_PROJECT/locations/$CLOUDSDK_COMPUTE_ZONE/clusters/$COMMON_NAME/jwks"
+  global.kubernetes.serviceAccountTokenIssuer: "https://container.googleapis.com/v1/projects/$CLOUDSDK_CORE_PROJECT/locations/$CLOUDSDK_COMPUTE_ZONE/clusters/$COMMON_NAME"
   global.oathkeeper.mutators.authenticationMappingServices.tenant-fetcher.authenticator.enabled: "true"
   global.oathkeeper.mutators.authenticationMappingServices.subscriber.authenticator.enabled: "true"
   system-broker.http.client.skipSSLValidation: "true"

--- a/tests/ord-service/tests/subscription_flow_test.go
+++ b/tests/ord-service/tests/subscription_flow_test.go
@@ -312,7 +312,7 @@ func createExtCertJob(t *testing.T, ctx context.Context, k8sClient *kubernetes.C
 				if env.Name == "CERT_SUBJECT_PATTERN" {
 					env.Value = testConfig.TestExternalCertSubject
 				}
-				if env.Name == "CERT_SVC_CSR_ENDPOINT" || env.Name == "CERT_SVC_CLIENT_ID" || env.Name == "CERT_SVC_CLIENT_SECRET" || env.Name == "CERT_SVC_OAUTH_URL" {
+				if env.Name == "CERT_SVC_CSR_ENDPOINT" || env.Name == "CERT_SVC_CLIENT_ID" || env.Name == "CERT_SVC_OAUTH_URL" || env.Name == "CERT_SVC_OAUTH_CLIENT_CERT" || env.Name == "CERT_SVC_OAUTH_CLIENT_KEY" {
 					env.ValueFrom.SecretKeyRef.Name = testConfig.CertSvcInstanceTestSecretName // external certificate credentials used to execute consumer-provider test
 				}
 			}

--- a/tests/pkg/k8s/jobs.go
+++ b/tests/pkg/k8s/jobs.go
@@ -56,13 +56,14 @@ func CreateJobByGivenJobDefinition(t *testing.T, ctx context.Context, k8sClient 
 func DeleteSecret(t *testing.T, ctx context.Context, k8sClient *kubernetes.Clientset, secretName, namespace string) {
 	t.Logf("Deleting test secret %q in %q namespace...", secretName, namespace)
 	err := k8sClient.CoreV1().Secrets(namespace).Delete(ctx, secretName, metav1.DeleteOptions{GracePeriodSeconds: &gracePeriod, PropagationPolicy: nil})
-	if strings.Contains(err.Error(), "not found") {
+	if err != nil && strings.Contains(err.Error(), "not found") {
 		require.Error(t, err)
 		t.Logf("Test secret %q in %q namespace does not exists", secretName, namespace)
-	} else {
-		require.NoError(t, err)
-		t.Logf("Test secret %q in %q namespace was successfully deleted", secretName, namespace)
+		return
 	}
+
+	require.NoError(t, err)
+	t.Logf("Test secret %q in %q namespace was successfully deleted", secretName, namespace)
 }
 
 func DeleteJob(t *testing.T, ctx context.Context, k8sClient *kubernetes.Clientset, jobName, namespace string) {

--- a/tests/pkg/k8s/jobs.go
+++ b/tests/pkg/k8s/jobs.go
@@ -2,6 +2,7 @@ package k8s
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -41,26 +42,31 @@ func CreateJobByCronJob(t *testing.T, ctx context.Context, k8sClient *kubernetes
 func GetCronJob(t *testing.T, ctx context.Context, k8sClient *kubernetes.Clientset, cronJobName, namespace string) *v1beta1.CronJob {
 	cronjob, err := k8sClient.BatchV1beta1().CronJobs(namespace).Get(ctx, cronJobName, metav1.GetOptions{})
 	require.NoError(t, err)
-	t.Logf("Got the cronjob \"%s\" from \"%s\" namespace", cronJobName, namespace)
+	t.Logf("Got the cronjob %q from %q namespace", cronJobName, namespace)
 	return cronjob
 }
 
 func CreateJobByGivenJobDefinition(t *testing.T, ctx context.Context, k8sClient *kubernetes.Clientset, jobName, namespace string, job *v1.Job) {
-	t.Logf("Creating test job with name: %s", jobName)
+	t.Logf("Creating test job with name: %q...", jobName)
 	_, err := k8sClient.BatchV1().Jobs(namespace).Create(ctx, job, metav1.CreateOptions{})
 	require.NoError(t, err)
-	t.Logf("Test job with name %s was successfully created", jobName)
+	t.Logf("Test job with name %q was successfully created", jobName)
 }
 
 func DeleteSecret(t *testing.T, ctx context.Context, k8sClient *kubernetes.Clientset, secretName, namespace string) {
-	t.Logf("Deleting test secret %q in %q namespace", secretName, namespace)
+	t.Logf("Deleting test secret %q in %q namespace...", secretName, namespace)
 	err := k8sClient.CoreV1().Secrets(namespace).Delete(ctx, secretName, metav1.DeleteOptions{GracePeriodSeconds: &gracePeriod, PropagationPolicy: nil})
-	require.NoError(t, err)
-	t.Logf("Test secret %q in %q namespace was successfully deleted", secretName, namespace)
+	if strings.Contains(err.Error(), "not found") {
+		require.Error(t, err)
+		t.Logf("Test secret %q in %q namespace does not exists", secretName, namespace)
+	} else {
+		require.NoError(t, err)
+		t.Logf("Test secret %q in %q namespace was successfully deleted", secretName, namespace)
+	}
 }
 
 func DeleteJob(t *testing.T, ctx context.Context, k8sClient *kubernetes.Clientset, jobName, namespace string) {
-	t.Logf("Deleting test job %s", jobName)
+	t.Logf("Deleting test job with name: %q...", jobName)
 
 	propagationPolicy := metav1.DeletePropagationForeground
 	err := k8sClient.BatchV1().Jobs(namespace).Delete(ctx, jobName, metav1.DeleteOptions{GracePeriodSeconds: &gracePeriod, PropagationPolicy: &propagationPolicy})
@@ -71,17 +77,17 @@ func DeleteJob(t *testing.T, ctx context.Context, k8sClient *kubernetes.Clientse
 	for {
 		select {
 		case <-elapsed:
-			t.Fatalf("Timeout reached waiting for job %s to be deleted. Exiting...", jobName)
+			t.Fatalf("Timeout reached waiting for job %q to be deleted. Exiting...", jobName)
 		default:
 		}
-		t.Logf("Waiting for job %s to be deleted", jobName)
+		t.Logf("Waiting for job %q to be deleted...", jobName)
 		_, err = k8sClient.BatchV1().Jobs(namespace).Get(ctx, jobName, metav1.GetOptions{})
 		if errors.IsNotFound(err) {
 			break
 		}
-		time.Sleep(time.Second * 2)
+		time.Sleep(time.Second * 5)
 	}
-	t.Logf("Test job %s deleted", jobName)
+	t.Logf("Test job with name %q was successfully deleted", jobName)
 }
 
 func WaitForJobToSucceed(t *testing.T, ctx context.Context, k8sClient *kubernetes.Clientset, jobName, namespace string) {
@@ -97,26 +103,26 @@ func WaitForJob(t *testing.T, ctx context.Context, k8sClient *kubernetes.Clients
 	for {
 		select {
 		case <-elapsed:
-			t.Fatalf("Timeout reached waiting for job %s to complete. Exiting...", jobName)
+			t.Fatalf("Timeout reached waiting for job %q to complete. Exiting...", jobName)
 		default:
 		}
-		t.Logf("Waiting for job %s to finish...", jobName)
+		t.Logf("Waiting for job %q to finish...", jobName)
 		job, err := k8sClient.BatchV1().Jobs(namespace).Get(ctx, jobName, metav1.GetOptions{})
 		require.NoError(t, err)
 		if job.Status.Failed > 0 {
 			if !shouldFail {
-				t.Fatalf("Job %s has failed while expecting to succeed. Exiting...", jobName)
+				t.Fatalf("Job %q has failed while expecting to succeed. Exiting...", jobName)
 			} else {
 				break
 			}
 		}
 		if job.Status.Succeeded > 0 {
 			if shouldFail {
-				t.Fatalf("Job %s has succeeded while expecting to fail. Exiting...", jobName)
+				t.Fatalf("Job %q has succeeded while expecting to fail. Exiting...", jobName)
 			} else {
 				break
 			}
 		}
-		time.Sleep(time.Second * 2)
+		time.Sleep(time.Second * 5)
 	}
 }


### PR DESCRIPTION
**Description**
We've missed in one of the previous PRs to adapt the cert-ratation-job configuration in consumer-provider test and that result in failing test
As part of this PR, second jwtRule is added to RequestAuthentication policies to avoid downtime/problems when we migrate our GCP cluster to newer Kubernetes version

Changes proposed in this pull request:
- Adjust cert-rotation test job configuration
- minor improvements - logs messages, time intervals, swallow error when secret does not exists, etc..
- add second jwtRule to RequestAuthentication policies with values for issuers/jwks_uri adjusted to new Kubernetes version


- [x] Implementation
- [ ] Unit tests
- [x] Integration tests
- [x] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [ ] Mocks are regenerated, using the automated script
