### PR TITLE
Remove wrong check in jwks job

### DIFF
--- a/chart/compass/templates/jwks-job.yaml
+++ b/chart/compass/templates/jwks-job.yaml
@@ -84,11 +84,6 @@ spec:
               echo "$KCM" | yq '.data."config.yaml"' | \
               yq ".authenticators.jwt.config.jwks_urls = [\"$JWKS_URL\"]" > $CONFIG_FILE
 
-              if echo "$KCM" | grep -q "$JWKS_URL"; then
-              echo "The jwks url has already been added"
-              exit 0
-              fi
-
               export YQ_CMD=".data.\"config.yaml\" = \"$(cat $CONFIG_FILE)\""
 
               echo "$KCM" | yq "$YQ_CMD" > $CM_FILE


### PR DESCRIPTION
**Description**
As it currently is, the job sometimes does not make the jwks configuration adjustment that is needed for Compass to function properly. This PR fixes it.

**Pull Request status**

- [X] Implementation
- [ ] Unit tests
- [ ] Integration tests
- [ ] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [ ] Mocks are regenerated, using the automated script
