### PR TITLE
Fix auditlog and ns-adapter e2e-tests

### DIFF
--- a/chart/compass/templates/tests/external-services-mock/external-services-mock-test.yaml
+++ b/chart/compass/templates/tests/external-services-mock/external-services-mock-test.yaml
@@ -80,6 +80,11 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.global.externalServicesMock.auditlog.secret.name }}
                   key: {{ .Values.global.externalServicesMock.auditlog.secret.tokenUrlKey }}
+            - name: AUDITLOG_TOKEN_PATH
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.global.externalServicesMock.auditlog.secret.name }}
+                  key: {{ .Values.global.externalServicesMock.auditlog.mtlsTokenPath }}
             - name: AUDITLOG_CLIENT_ID
               valueFrom:
                 secretKeyRef:

--- a/chart/compass/templates/tests/external-services-mock/external-services-mock-test.yaml
+++ b/chart/compass/templates/tests/external-services-mock/external-services-mock-test.yaml
@@ -81,10 +81,7 @@ spec:
                   name: {{ .Values.global.externalServicesMock.auditlog.secret.name }}
                   key: {{ .Values.global.externalServicesMock.auditlog.secret.tokenUrlKey }}
             - name: AUDITLOG_TOKEN_PATH
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.global.externalServicesMock.auditlog.secret.name }}
-                  key: {{ .Values.global.externalServicesMock.auditlog.mtlsTokenPath }}
+              value: {{ .Values.global.externalServicesMock.auditlog.mtlsTokenPath }}
             - name: AUDITLOG_CLIENT_ID
               valueFrom:
                 secretKeyRef:

--- a/chart/compass/templates/tests/ns-adapter/ns-adapter-test.yaml
+++ b/chart/compass/templates/tests/ns-adapter/ns-adapter-test.yaml
@@ -162,6 +162,10 @@ kind: ServiceAccount
 metadata:
   name: {{ .Chart.Name }}-e2e-ns-adapter
   namespace: {{ .Values.global.tests.namespace }}
+  {{- if eq .Values.global.database.embedded.enabled false }}
+  annotations:
+    iam.gke.io/gcp-service-account: {{ $.Values.global.database.sqlProxyServiceAccount | quote }}
+  {{- end }}
   labels:
     app: {{ $.Chart.Name }}
     release: {{ $.Release.Name }}

--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -666,6 +666,7 @@ global:
     auditlog:
       applyMockConfiguration: false
       managementApiPath: /audit-log/v2/configuration-changes/search
+      mtlsTokenPath: "/cert/token"
       secret:
         name: "auditlog-instance-management"
         urlKey: url

--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -127,7 +127,7 @@ global:
       version: "PR-56"
     e2e_tests:
       dir:
-      version: "PR-2242"
+      version: "PR-2249"
   isLocalEnv: false
   isForTesting: false
   oauth2:

--- a/tests/external-services-mock/tests/auditlog_integration_test.go
+++ b/tests/external-services-mock/tests/auditlog_integration_test.go
@@ -63,7 +63,7 @@ func TestAuditlogIntegration(t *testing.T) {
 	timeTo := timeFrom.Add(1 * time.Minute)
 
 	t.Log("Get auditlog service Token")
-	auditlogToken := token.GetClientCredentialsTokenWithClient(t, context.Background(), httpClient, testConfig.Auditlog.TokenURL+"/cert/token", testConfig.Auditlog.ClientID, "", "")
+	auditlogToken := token.GetClientCredentialsTokenWithClient(t, context.Background(), httpClient, testConfig.Auditlog.TokenURL+testConfig.Auditlog.TokenPath, testConfig.Auditlog.ClientID, "", "")
 
 	t.Log("Get auditlog from auditlog API")
 	auditlogs := fixtures.SearchForAuditlogByTimestampAndString(t, httpClient, testConfig.Auditlog, auditlogToken, appName, timeFrom, timeTo)

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -3,66 +3,72 @@ module github.com/kyma-incubator/compass/tests
 go 1.17
 
 require (
-	github.com/99designs/gqlgen v0.11.3 // indirect
-	github.com/Masterminds/goutils v1.1.1 // indirect
-	github.com/Masterminds/semver/v3 v3.1.1 // indirect
-	github.com/Masterminds/sprig/v3 v3.2.2 // indirect
-	github.com/agnivade/levenshtein v1.1.0 // indirect
-	github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d // indirect
 	github.com/avast/retry-go v3.0.0+incompatible
-	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/evanphx/json-patch v4.12.0+incompatible // indirect
-	github.com/form3tech-oss/jwt-go v3.2.5+incompatible
-	github.com/go-logr/logr v0.4.0 // indirect
-	github.com/go-ozzo/ozzo-validation/v4 v4.3.0 // indirect
-	github.com/gogo/protobuf v1.3.2 // indirect
-	github.com/golang/protobuf v1.5.2 // indirect
-	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/uuid v1.3.0
-	github.com/googleapis/gnostic v0.5.5 // indirect
-	github.com/hashicorp/errwrap v1.1.0 // indirect
-	github.com/hashicorp/go-multierror v1.1.1 // indirect
-	github.com/huandu/xstrings v1.3.2 // indirect
-	github.com/imdario/mergo v0.3.11 // indirect
 	github.com/jmoiron/sqlx v1.3.4
-	github.com/json-iterator/go v1.1.12 // indirect
-	github.com/kr/pretty v0.2.1 // indirect
 	github.com/kyma-incubator/compass/components/connectivity-adapter v0.0.0-20220225101454-1e11cf2f8a9b
 	github.com/kyma-incubator/compass/components/connector v0.0.0-20220225101454-1e11cf2f8a9b
 	github.com/kyma-incubator/compass/components/director v0.0.0-20220225142835-04e0a9794c6d
 	github.com/kyma-incubator/compass/components/external-services-mock v0.0.0-20220225101454-1e11cf2f8a9b
 	github.com/kyma-incubator/compass/components/gateway v0.0.0-20220225101454-1e11cf2f8a9b
 	github.com/kyma-incubator/compass/components/operations-controller v0.0.0-20220225101454-1e11cf2f8a9b
+	github.com/machinebox/graphql v0.2.3-0.20181106130121-3a9253180225
+	github.com/pkg/errors v0.9.1
+	github.com/robfig/cron/v3 v3.0.1
+	github.com/sirupsen/logrus v1.8.1
+	github.com/stretchr/testify v1.7.0
+	github.com/tidwall/gjson v1.14.0
+	github.com/tidwall/sjson v1.2.4
+	github.com/vrischmann/envconfig v1.3.0
+	golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd
+	golang.org/x/oauth2 v0.0.0-20220223155221-ee480838109b
+	k8s.io/api v0.20.2
+	k8s.io/apimachinery v0.20.2
+	k8s.io/client-go v0.20.2
+)
+
+require (
+	github.com/99designs/gqlgen v0.11.3 // indirect
+	github.com/Masterminds/goutils v1.1.1 // indirect
+	github.com/Masterminds/semver/v3 v3.1.1 // indirect
+	github.com/Masterminds/sprig/v3 v3.2.2 // indirect
+	github.com/agnivade/levenshtein v1.1.0 // indirect
+	github.com/asaskevich/govalidator v0.0.0-20210307081110-f21760c49a8d // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/evanphx/json-patch v4.12.0+incompatible // indirect
+	github.com/form3tech-oss/jwt-go v3.2.5+incompatible // indirect
+	github.com/go-logr/logr v0.4.0 // indirect
+	github.com/go-ozzo/ozzo-validation/v4 v4.3.0 // indirect
+	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/google/gofuzz v1.2.0 // indirect
+	github.com/googleapis/gnostic v0.5.5 // indirect
+	github.com/hashicorp/errwrap v1.1.0 // indirect
+	github.com/hashicorp/go-multierror v1.1.1 // indirect
+	github.com/huandu/xstrings v1.3.2 // indirect
+	github.com/imdario/mergo v0.3.11 // indirect
+	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/kr/pretty v0.2.1 // indirect
 	github.com/kyma-incubator/compass/components/system-broker v0.0.0-20220208132958-a8193aa87b45 // indirect
 	github.com/lib/pq v1.10.4 // indirect
-	github.com/machinebox/graphql v0.2.3-0.20181106130121-3a9253180225
 	github.com/mitchellh/copystructure v1.1.2 // indirect
 	github.com/mitchellh/reflectwalk v1.0.1 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/onrik/logrus v0.9.0 // indirect
 	github.com/patrickmn/go-cache v2.1.0+incompatible // indirect
-	github.com/pkg/errors v0.9.1
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/prometheus/common v0.26.0
-	github.com/robfig/cron/v3 v3.0.1
+	github.com/prometheus/common v0.26.0 // indirect
 	github.com/shopspring/decimal v1.2.0 // indirect
-	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/cast v1.4.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	github.com/stretchr/testify v1.7.0
-	github.com/tidwall/gjson v1.14.0
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.0 // indirect
-	github.com/tidwall/sjson v1.2.4
 	github.com/vektah/gqlparser/v2 v2.1.0 // indirect
-	github.com/vrischmann/envconfig v1.3.0
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	github.com/xeipuuv/gojsonschema v1.2.0 // indirect
 	golang.org/x/crypto v0.0.0-20210817164053-32db794688a5 // indirect
-	golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd
-	golang.org/x/oauth2 v0.0.0-20220223155221-ee480838109b
 	golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e // indirect
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
 	golang.org/x/text v0.3.7 // indirect
@@ -72,9 +78,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
-	k8s.io/api v0.20.2
-	k8s.io/apimachinery v0.20.2
-	k8s.io/client-go v0.20.2
 	k8s.io/klog/v2 v2.4.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20201113171705-d219536bb9fd // indirect
 	k8s.io/utils v0.0.0-20210111153108-fddb29f9d009 // indirect

--- a/tests/pkg/config/auditlog.go
+++ b/tests/pkg/config/auditlog.go
@@ -2,6 +2,7 @@ package config
 
 type AuditlogConfig struct {
 	TokenURL          string `envconfig:"AUDITLOG_TOKEN_URL"`
+	TokenPath         string `envconfig:"AUDITLOG_TOKEN_PATH"`
 	ClientID          string `envconfig:"AUDITLOG_CLIENT_ID"`
 	X509Cert          string `envconfig:"AUDITLOG_X509_CERT"`
 	X509Key           string `envconfig:"AUDITLOG_X509_KEY"`


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Fixing TestAuditlogIntegration e2e test and NS-Adapter tests.

Changes proposed in this pull request:
- Extract the token path in TestAuditlogIntegration as an environment variable
- Add annotation in ns-adapter service account

**Pull Request status**
<!-- Feel free to construct the checklist with whatever items seem most reasonable for your change. You could disassemble the Implementation part to even smaller separate checklist items if you're working on something big for example. But do make the effort to provide a checklist of some sort so that the core team as well as the community can have an idea about the progress of your Pull Request.
-->

- [x] Implementation
- [ ] Unit tests
- [ ] Integration tests
- [x] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [ ] Mocks are regenerated, using the automated script
