### PR TITLE
Install ns adapter as helm post hook

### DIFF
--- a/chart/compass/charts/ns-adapter/templates/deployment.yaml
+++ b/chart/compass/charts/ns-adapter/templates/deployment.yaml
@@ -7,9 +7,11 @@ metadata:
     app: {{ .Chart.Name }}
     reqlimit: big
     release: {{ .Release.Name }}
+  {{- if .Values.global.isLocalEnv }}
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "0"
+  {{- end }}
 spec:
   replicas: {{ .Values.deployment.minReplicas }}
   selector:

--- a/chart/compass/charts/ns-adapter/templates/deployment.yaml
+++ b/chart/compass/charts/ns-adapter/templates/deployment.yaml
@@ -7,6 +7,9 @@ metadata:
     app: {{ .Chart.Name }}
     reqlimit: big
     release: {{ .Release.Name }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "0"
 spec:
   replicas: {{ .Values.deployment.minReplicas }}
   selector:


### PR DESCRIPTION
**Description**
compass-migration job is failing(sporadically) because during its execution in parallel there is ns-adapter component which register application template, in later stage the migration job introduce unique indexes and data(app template with same name) which violates the unique index and the migration fails

Changes proposed in this pull request:
- run the notification adapter as post helm hook when the db is up and running


- [x] Implementation
