### PR TITLE
Add annotation so that Pods can be evicted by autoscaler

### DIFF
--- a/chart/compass/charts/cockpit/templates/deployment.yaml
+++ b/chart/compass/charts/cockpit/templates/deployment.yaml
@@ -15,6 +15,8 @@ spec:
     {{- toYaml .Values.deployment.strategy | nindent 4 }}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
       labels:
         app: {{ .Chart.Name }}
         reqlimit: {{ .Values.global.istio.ingressgateway.requestPayloadSizeLimit2MBLabel }}

--- a/chart/compass/charts/connectivity-adapter/templates/deployment.yaml
+++ b/chart/compass/charts/connectivity-adapter/templates/deployment.yaml
@@ -20,6 +20,8 @@ spec:
     {{- toYaml .Values.deployment.strategy | nindent 4 }}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
       labels:
         app: {{ .Chart.Name }}
         reqlimit: {{ .Values.global.istio.ingressgateway.requestPayloadSizeLimit2MBLabel }}

--- a/chart/compass/charts/connector/templates/deployment.yaml
+++ b/chart/compass/charts/connector/templates/deployment.yaml
@@ -20,6 +20,8 @@ spec:
     {{- toYaml .Values.deployment.strategy | nindent 4 }}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
       labels:
         app: {{ .Chart.Name }}
         reqlimit: {{ .Values.global.istio.ingressgateway.requestPayloadSizeLimit2MBLabel }}

--- a/chart/compass/charts/director/templates/deployment.yaml
+++ b/chart/compass/charts/director/templates/deployment.yaml
@@ -17,6 +17,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
         restartOnNewInstallationMarker: {{ randAlphaNum 5 | quote }} # Restarts the deployment on a new Helm installation. (https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments)
         {{ if .Values.deployment.resourcesIstioProxy.requests.cpu }}
         sidecar.istio.io/proxyCPU: {{ .Values.deployment.resourcesIstioProxy.requests.cpu }}

--- a/chart/compass/charts/external-services-mock/templates/deployment.yaml
+++ b/chart/compass/charts/external-services-mock/templates/deployment.yaml
@@ -13,6 +13,8 @@ spec:
             release: {{ .Release.Name }}
     template:
         metadata:
+            annotations:
+                cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
             labels:
                 app: {{ .Chart.Name }}
                 release: {{ .Release.Name }}

--- a/chart/compass/charts/gateway/templates/deployment.yaml
+++ b/chart/compass/charts/gateway/templates/deployment.yaml
@@ -17,6 +17,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
         restartOnNewInstallationMarker: {{ randAlphaNum 5 | quote }} # Restarts the deployment on a new Helm installation. (https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments)
       labels:
         app: {{ .Chart.Name }}

--- a/chart/compass/charts/ns-adapter/templates/deployment.yaml
+++ b/chart/compass/charts/ns-adapter/templates/deployment.yaml
@@ -23,6 +23,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
         {{ if .Values.deployment.resourcesIstioProxy.requests.cpu }}
         sidecar.istio.io/proxyCPU: {{ .Values.deployment.resourcesIstioProxy.requests.cpu }}
         {{ end }}

--- a/chart/compass/charts/operations-controller/templates/deployment.yaml
+++ b/chart/compass/charts/operations-controller/templates/deployment.yaml
@@ -14,6 +14,8 @@ spec:
       control-plane: controller-manager
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
       labels:
         app: {{ .Chart.Name }}
         reqlimit: {{ .Values.global.istio.ingressgateway.requestPayloadSizeLimit2MBLabel }}

--- a/chart/compass/charts/ord-service/templates/deployment.yaml
+++ b/chart/compass/charts/ord-service/templates/deployment.yaml
@@ -17,6 +17,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
         {{ if .Values.deployment.resourcesIstioProxy.requests.cpu }}
         sidecar.istio.io/proxyCPU: {{ .Values.deployment.resourcesIstioProxy.requests.cpu }}
         {{ end }}

--- a/chart/compass/charts/pairing-adapter/templates/deployment.yaml
+++ b/chart/compass/charts/pairing-adapter/templates/deployment.yaml
@@ -23,6 +23,7 @@ spec:
     template:
         metadata:
             annotations:
+                cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
                 restartOnNewInstallationMarker: {{ randAlphaNum 5 | quote }} # Restarts the deployment on a new Helm installation. (https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments)
             labels:
                 app: {{ $.Chart.Name }}

--- a/chart/compass/charts/postgresql/templates/statefulset-slaves.yaml
+++ b/chart/compass/charts/postgresql/templates/statefulset-slaves.yaml
@@ -29,8 +29,9 @@ spec:
 {{- with .Values.slave.podLabels }}
 {{ toYaml . | indent 8 }}
 {{- end }}
-{{- with .Values.slave.podAnnotations }}
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+{{- with .Values.slave.podAnnotations }}
 {{ toYaml . | indent 8 }}
 {{- end }}
     spec:

--- a/chart/compass/charts/postgresql/templates/statefulset.yaml
+++ b/chart/compass/charts/postgresql/templates/statefulset.yaml
@@ -33,8 +33,9 @@ spec:
 {{- with .Values.master.podLabels }}
 {{ toYaml . | indent 8 }}
 {{- end }}
-{{- with .Values.master.podAnnotations }}
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+{{- with .Values.master.podAnnotations }}
 {{ toYaml . | indent 8 }}
 {{- end }}
     spec:

--- a/chart/compass/charts/prometheus-postgres-exporter/templates/deployment.yaml
+++ b/chart/compass/charts/prometheus-postgres-exporter/templates/deployment.yaml
@@ -25,6 +25,7 @@ spec:
 {{ toYaml .Values.podLabels | trim | indent 8 }}
 {{- end }}
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
 {{- if .Values.annotations }}
 {{ toYaml .Values.annotations | indent 8 }}

--- a/chart/compass/charts/system-broker/templates/deployment.yaml
+++ b/chart/compass/charts/system-broker/templates/deployment.yaml
@@ -16,6 +16,8 @@ spec:
     {{- toYaml .Values.deployment.strategy | nindent 4 }}
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
       labels:
         app: {{ .Chart.Name }}
         reqlimit: {{ .Values.global.istio.ingressgateway.requestPayloadSizeLimit2MBLabel }}

--- a/chart/compass/charts/tenant-fetcher/templates/deployment.yaml
+++ b/chart/compass/charts/tenant-fetcher/templates/deployment.yaml
@@ -17,6 +17,7 @@ spec:
   template:
     metadata:
       annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
         {{ if .Values.deployment.resourcesIstioProxy.requests.cpu }}
         sidecar.istio.io/proxyCPU: {{ .Values.deployment.resourcesIstioProxy.requests.cpu }}
         {{ end }}

--- a/installation/resources/installer-local.yaml
+++ b/installation/resources/installer-local.yaml
@@ -105,12 +105,14 @@ spec:
     matchLabels:
       name: compass-installer
   # Installer is designed to be run as a single instance only
-  # We enforce it by changing default rolling update to recreate startegy.
+  # We enforce it by changing default rolling update to recreate strategy.
   # With that k8s will first delete old pod and then provision new one during upgrade.
   strategy:
     type: Recreate
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
       labels:
         name: compass-installer
     spec:

--- a/installation/resources/installer.yaml
+++ b/installation/resources/installer.yaml
@@ -103,12 +103,14 @@ spec:
     matchLabels:
       name: compass-installer
   # Installer is designed to be run as a single instance only
-  # We enforce it by changing default rolling update to recreate startegy.
+  # We enforce it by changing default rolling update to recreate strategy.
   # With that k8s will first delete old pod and then provision new one during upgrade.
   strategy:
     type: Recreate
   template:
     metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
       labels:
         name: compass-installer
     spec:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Currently, Pods are blocking scale down of underutilized node/s because they have local storage (volume). This PR adds `cluster-autoscaler.kubernetes.io/safe-to-evict": "true"` annotation via their Deployments/StatefulSets/DaemonSets so that the autoscaler can perform the scaling.

**Pull Request status**
<!-- Feel free to construct the checklist with whatever items seem most reasonable for your change. You could disassemble the Implementation part to even smaller separate checklist items if you're working on something big for example. But do make the effort to provide a checklist of some sort so that the core team as well as the community can have an idea about the progress of your Pull Request.
-->

- [x] Implementation
- [] Unit tests
- [] Integration tests
- [] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [] Mocks are regenerated, using the automated script
