### PR TITLE
[HOTFIX] Make some of the pairing adapter fields as optional

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -138,7 +138,7 @@ global:
       version: "PR-66"
     e2e_tests:
       dir:
-      version: "PR-2342"
+      version: "PR-2347"
   isLocalEnv: false
   isForTesting: false
   oauth2:
@@ -809,7 +809,7 @@ global:
     configMap:
       manage: false
       key: "config.json"
-      name: "pairing-adapter-config"
+      name: "pairing-adapter-config-local"
       namespace: "compass-system"
       localAdapterFQDN: "http://compass-pairing-adapter.compass-system.svc.cluster.local/adapter-local-mtls"
     e2e:

--- a/tests/pkg/config/pairing-adapter.go
+++ b/tests/pkg/config/pairing-adapter.go
@@ -8,10 +8,10 @@ type PairingAdapterConfig struct {
 	SkipSSLValidation              bool `envconfig:"default=true"`
 	IsLocalEnv                     bool
 	TemplateName                   string
-	LocalAdapterFQDN               string
-	ConfigMapKey                   string
-	ConfigMapName                  string
-	ConfigMapNamespace             string
+	LocalAdapterFQDN               string `envconfig:"optional"`
+	ConfigMapKey                   string `envconfig:"optional"`
+	ConfigMapName                  string `envconfig:"optional"`
+	ConfigMapNamespace             string `envconfig:"optional"`
 	FQDNPairingAdapterURL          string
 	TestTenant                     string
 	TestClientUser                 string


### PR DESCRIPTION
**Description**
Some of the pairing adapter fields are used only in local setup. Add `optional` tag for them


**Related issue(s)**
- https://github.com/kyma-incubator/compass/pull/2342
- https://github.com/kyma-incubator/compass/pull/2346


- [x] Implementation
- [x] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
