### PR TITLE
Reduce memory load in tenant-fetcher on demand API

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -106,7 +106,7 @@ global:
       version: "PR-2358"
     director:
       dir:
-      version: "PR-2363"
+      version: "PR-2365"
     hydrator:
       dir:
       version: "PR-2358"

--- a/components/director/internal/tenantfetchersvc/tenant_fetcher_test.go
+++ b/components/director/internal/tenantfetchersvc/tenant_fetcher_test.go
@@ -45,7 +45,7 @@ func TestFetcher_FetchTenantOnDemand(t *testing.T) {
 			TransactionerFn: txGen.ThatDoesntExpectCommit,
 			TenantStorageSvcFn: func() *tfautomock.TenantStorageService {
 				svc := &tfautomock.TenantStorageService{}
-				svc.On("List", txtest.CtxWithDBMatcher()).Return([]*model.BusinessTenantMapping{&businessSubaccount1BusinessMapping}, nil).Once()
+				svc.On("GetTenantByExternalID", txtest.CtxWithDBMatcher(), businessSubaccount1BusinessMapping.ExternalTenant).Return(&businessSubaccount1BusinessMapping, nil).Once()
 				return svc
 			},
 			APIClientFn:      UnusedEventAPIClient,

--- a/installation/scripts/prow/compass-smoke-test.sh
+++ b/installation/scripts/prow/compass-smoke-test.sh
@@ -60,6 +60,7 @@ MIGRATE_HOME="${BASE_DIR}/migrate"
 COMPASS_DIR="$( cd "$( dirname "${INSTALLATION_DIR}/../.." )" && pwd )"  
 ORD_SVC_DIR="${BASE_DIR}/ord-service"
 TEST_RESULT=true
+export PATH="/google-cloud-sdk/bin:${PATH}"
 
 mkdir -p "${JAVA_HOME}"
 export JAVA_HOME


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:
- Currently, in order to determine the parent of a given subaccount, tenant-fetcher on-demand API first reads all tenants from the database, which results in a high memory load. With this change, only one tenant (if the corresponding parent exists in the database) is loaded into the memory.


**Pull Request status**
<!-- Feel free to construct the checklist with whatever items seem most reasonable for your change. You could disassemble the Implementation part to even smaller separate checklist items if you're working on something big for example. But do make the effort to provide a checklist of some sort so that the core team as well as the community can have an idea about the progress of your Pull Request.
-->

- [x] Implementation
- [x] Unit tests
- [ ] Integration tests
- [x] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [ ] Mocks are regenerated, using the automated script
