### PR TITLE
Update merge app e2e test not to assert DEFAULT scenario

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -138,7 +138,7 @@ global:
       version: "PR-68"
     e2e_tests:
       dir:
-      version: "PR-2332"
+      version: "PR-2367"
   isLocalEnv: false
   isForTesting: false
   oauth2:

--- a/tests/director/tests/application_api_test.go
+++ b/tests/director/tests/application_api_test.go
@@ -1502,7 +1502,6 @@ func TestMergeApplications(t *testing.T) {
 	sccLabelValue := "cloud connector"
 	expectedProductType := "MergeTemplate"
 	newFormation := "formation-merge-applications-e2e"
-	destScenariosValue := []interface{}{"DEFAULT", newFormation}
 
 	appTmplInput := fixtures.FixApplicationTemplate(expectedProductType)
 	appTmplInput.ApplicationInput.Name = "{{name}}"
@@ -1526,7 +1525,7 @@ func TestMergeApplications(t *testing.T) {
 		TemplateName: expectedProductType, Values: []*graphql.TemplateValueInput{
 			{
 				Placeholder: namePlaceholder,
-				Value:       "app1",
+				Value:       "app1-e2e-merge",
 			},
 		},
 	}
@@ -1535,7 +1534,7 @@ func TestMergeApplications(t *testing.T) {
 		TemplateName: expectedProductType, Values: []*graphql.TemplateValueInput{
 			{
 				Placeholder: namePlaceholder,
-				Value:       "app2",
+				Value:       "app2-e2e-merge",
 			},
 		},
 	}
@@ -1603,7 +1602,7 @@ func TestMergeApplications(t *testing.T) {
 	assert.Equal(t, providerName, destApp.ProviderName)
 	assert.Equal(t, managedLabelValue, destApp.Labels[managedLabel])
 	assert.Equal(t, sccLabelValue, destApp.Labels[sccLabel])
-	assert.Equal(t, destScenariosValue, destApp.Labels[ScenariosLabel])
+	assert.Contains(t, destApp.Labels[ScenariosLabel], newFormation)
 
 	srcApp := graphql.ApplicationExt{}
 	getSrcAppReq := fixtures.FixGetApplicationRequest(outputSrcApp.ID)


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:
- On local environment, DEFAULT scenario is assigned to every application that is being registered, while on gcp envs DEFAULT has to be explicitly assigned. This PR removes the assertion that the DEFAULT scenario should always be present in a registered application

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- ...

**Pull Request status**
<!-- Feel free to construct the checklist with whatever items seem most reasonable for your change. You could disassemble the Implementation part to even smaller separate checklist items if you're working on something big for example. But do make the effort to provide a checklist of some sort so that the core team as well as the community can have an idea about the progress of your Pull Request.
-->

- [ ] Implementation
- [ ] Unit tests
- [ ] Integration tests
- [ ] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [ ] Mocks are regenerated, using the automated script
