### PR TITLE
Fix misleading alert

### DIFF
--- a/chart/compass/charts/director/templates/tenant-loader-job-default.yaml
+++ b/chart/compass/charts/director/templates/tenant-loader-job-default.yaml
@@ -14,7 +14,7 @@ spec:
     template:
         metadata:
             labels:
-                app: {{ .Chart.Name }}
+                app: {{ .Chart.Name }}-tenant-loader
                 release: {{ .Release.Name }}
         spec:
             serviceAccountName: {{ template "fullname" . }}


### PR DESCRIPTION
**Description**
Prometheus matches pods that should be scraped for metrics using label selectors. The tenant-loader job has the same label as the director one and that results in a misleading alert

Changes proposed in this pull request:
- change the label of the tenant-loader job


**Pull Request status**
- [x] Implementation
