### PR TITLE
Add additional Application Provider onboarding validation

### DIFF
--- a/components/director/internal/domain/apptemplate/apptmpltest/selfreg_manager.go
+++ b/components/director/internal/domain/apptemplate/apptmpltest/selfreg_manager.go
@@ -25,7 +25,7 @@ func NoopSelfRegManager() *automock.SelfRegisterManager {
 func SelfRegManagerThatDoesPrepWithNoErrors(res map[string]interface{}) func() *automock.SelfRegisterManager {
 	return func() *automock.SelfRegisterManager {
 		srm := &automock.SelfRegisterManager{}
-		srm.On("PrepareForSelfRegistration", mock.Anything, resource.ApplicationTemplate, mock.Anything, mock.AnythingOfType("string")).Return(res, nil).Once()
+		srm.On("PrepareForSelfRegistration", mock.Anything, resource.ApplicationTemplate, mock.Anything, mock.AnythingOfType("string"), mock.Anything).Return(res, nil).Once()
 		return srm
 	}
 }
@@ -34,7 +34,7 @@ func SelfRegManagerThatDoesPrepWithNoErrors(res map[string]interface{}) func() *
 func SelfRegManagerThatReturnsErrorOnPrep() *automock.SelfRegisterManager {
 	srm := &automock.SelfRegisterManager{}
 	labels := make(map[string]interface{})
-	srm.On("PrepareForSelfRegistration", mock.Anything, resource.ApplicationTemplate, mock.Anything, mock.AnythingOfType("string")).Return(labels, errors.New(SelfRegErrorMsg)).Once()
+	srm.On("PrepareForSelfRegistration", mock.Anything, resource.ApplicationTemplate, mock.Anything, mock.AnythingOfType("string"), mock.Anything).Return(labels, errors.New(SelfRegErrorMsg)).Once()
 	return srm
 }
 

--- a/components/director/internal/domain/apptemplate/automock/self_register_manager.go
+++ b/components/director/internal/domain/apptemplate/automock/self_register_manager.go
@@ -44,13 +44,13 @@ func (_m *SelfRegisterManager) GetSelfRegDistinguishingLabelKey() string {
 	return r0
 }
 
-// PrepareForSelfRegistration provides a mock function with given fields: ctx, resourceType, labels, id
-func (_m *SelfRegisterManager) PrepareForSelfRegistration(ctx context.Context, resourceType resource.Type, labels map[string]interface{}, id string) (map[string]interface{}, error) {
-	ret := _m.Called(ctx, resourceType, labels, id)
+// PrepareForSelfRegistration provides a mock function with given fields: ctx, resourceType, labels, id, validate
+func (_m *SelfRegisterManager) PrepareForSelfRegistration(ctx context.Context, resourceType resource.Type, labels map[string]interface{}, id string, validate func() error) (map[string]interface{}, error) {
+	ret := _m.Called(ctx, resourceType, labels, id, validate)
 
 	var r0 map[string]interface{}
-	if rf, ok := ret.Get(0).(func(context.Context, resource.Type, map[string]interface{}, string) map[string]interface{}); ok {
-		r0 = rf(ctx, resourceType, labels, id)
+	if rf, ok := ret.Get(0).(func(context.Context, resource.Type, map[string]interface{}, string, func() error) map[string]interface{}); ok {
+		r0 = rf(ctx, resourceType, labels, id, validate)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(map[string]interface{})
@@ -58,8 +58,8 @@ func (_m *SelfRegisterManager) PrepareForSelfRegistration(ctx context.Context, r
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, resource.Type, map[string]interface{}, string) error); ok {
-		r1 = rf(ctx, resourceType, labels, id)
+	if rf, ok := ret.Get(1).(func(context.Context, resource.Type, map[string]interface{}, string, func() error) error); ok {
+		r1 = rf(ctx, resourceType, labels, id, validate)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/components/director/internal/domain/runtime/automock/self_register_manager.go
+++ b/components/director/internal/domain/runtime/automock/self_register_manager.go
@@ -44,13 +44,13 @@ func (_m *SelfRegisterManager) GetSelfRegDistinguishingLabelKey() string {
 	return r0
 }
 
-// PrepareForSelfRegistration provides a mock function with given fields: ctx, resourceType, labels, id
-func (_m *SelfRegisterManager) PrepareForSelfRegistration(ctx context.Context, resourceType resource.Type, labels map[string]interface{}, id string) (map[string]interface{}, error) {
-	ret := _m.Called(ctx, resourceType, labels, id)
+// PrepareForSelfRegistration provides a mock function with given fields: ctx, resourceType, labels, id, validate
+func (_m *SelfRegisterManager) PrepareForSelfRegistration(ctx context.Context, resourceType resource.Type, labels map[string]interface{}, id string, validate func() error) (map[string]interface{}, error) {
+	ret := _m.Called(ctx, resourceType, labels, id, validate)
 
 	var r0 map[string]interface{}
-	if rf, ok := ret.Get(0).(func(context.Context, resource.Type, map[string]interface{}, string) map[string]interface{}); ok {
-		r0 = rf(ctx, resourceType, labels, id)
+	if rf, ok := ret.Get(0).(func(context.Context, resource.Type, map[string]interface{}, string, func() error) map[string]interface{}); ok {
+		r0 = rf(ctx, resourceType, labels, id, validate)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(map[string]interface{})
@@ -58,8 +58,8 @@ func (_m *SelfRegisterManager) PrepareForSelfRegistration(ctx context.Context, r
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, resource.Type, map[string]interface{}, string) error); ok {
-		r1 = rf(ctx, resourceType, labels, id)
+	if rf, ok := ret.Get(1).(func(context.Context, resource.Type, map[string]interface{}, string, func() error) error); ok {
+		r1 = rf(ctx, resourceType, labels, id, validate)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/components/director/internal/domain/runtime/resolver.go
+++ b/components/director/internal/domain/runtime/resolver.go
@@ -96,7 +96,7 @@ type BundleInstanceAuthService interface {
 // SelfRegisterManager missing godoc
 //go:generate mockery --name=SelfRegisterManager --output=automock --outpkg=automock --case=underscore --disable-version-string
 type SelfRegisterManager interface {
-	PrepareForSelfRegistration(ctx context.Context, resourceType resource.Type, labels map[string]interface{}, id string) (map[string]interface{}, error)
+	PrepareForSelfRegistration(ctx context.Context, resourceType resource.Type, labels map[string]interface{}, id string, validate func() error) (map[string]interface{}, error)
 	CleanupSelfRegistration(ctx context.Context, selfRegisterLabelValue, region string) error
 	GetSelfRegDistinguishingLabelKey() string
 }
@@ -293,7 +293,8 @@ func (r *Resolver) RegisterRuntime(ctx context.Context, in graphql.RuntimeRegist
 
 	id := r.uidService.Generate()
 
-	labels, err := r.selfRegManager.PrepareForSelfRegistration(ctx, resource.Runtime, convertedIn.Labels, id)
+	validate := func() error { return nil }
+	labels, err := r.selfRegManager.PrepareForSelfRegistration(ctx, resource.Runtime, convertedIn.Labels, id, validate)
 	if err != nil {
 		return nil, err
 	}

--- a/components/director/internal/domain/runtime/rtmtest/selfreg_manager.go
+++ b/components/director/internal/domain/runtime/rtmtest/selfreg_manager.go
@@ -28,7 +28,7 @@ func NoopSelfRegManager() *automock.SelfRegisterManager {
 func SelfRegManagerThatDoesPrepWithNoErrors(res map[string]interface{}) func() *automock.SelfRegisterManager {
 	return func() *automock.SelfRegisterManager {
 		srm := &automock.SelfRegisterManager{}
-		srm.On("PrepareForSelfRegistration", mock.Anything, resource.Runtime, mock.Anything, mock.AnythingOfType("string")).Return(res, nil).Once()
+		srm.On("PrepareForSelfRegistration", mock.Anything, resource.Runtime, mock.Anything, mock.AnythingOfType("string"), mock.Anything).Return(res, nil).Once()
 		return srm
 	}
 }
@@ -37,7 +37,7 @@ func SelfRegManagerThatDoesPrepWithNoErrors(res map[string]interface{}) func() *
 func SelfRegManagerThatReturnsErrorOnPrep() *automock.SelfRegisterManager {
 	srm := &automock.SelfRegisterManager{}
 	labels := make(map[string]interface{})
-	srm.On("PrepareForSelfRegistration", mock.Anything, resource.Runtime, mock.Anything, mock.AnythingOfType("string")).Return(labels, errors.New(SelfRegErrorMsg)).Once()
+	srm.On("PrepareForSelfRegistration", mock.Anything, resource.Runtime, mock.Anything, mock.AnythingOfType("string"), mock.Anything).Return(labels, errors.New(SelfRegErrorMsg)).Once()
 	return srm
 }
 

--- a/components/director/internal/selfregmanager/selfreg_manager.go
+++ b/components/director/internal/selfregmanager/selfreg_manager.go
@@ -54,10 +54,11 @@ func NewSelfRegisterManager(cfg config.SelfRegConfig, provider ExternalSvcCaller
 	}
 	return &selfRegisterManager{cfg: cfg, callerProvider: provider}, nil
 }
+//TODO add is self reg flow and use it for update app template
 
 // PrepareForSelfRegistration executes the prerequisite calls for self-registration in case the runtime
 // is being self-registered
-func (s *selfRegisterManager) PrepareForSelfRegistration(ctx context.Context, resourceType resource.Type, labels map[string]interface{}, id string) (map[string]interface{}, error) {
+func (s *selfRegisterManager) PrepareForSelfRegistration(ctx context.Context, resourceType resource.Type, labels map[string]interface{}, id string, validate func() error) (map[string]interface{}, error) {
 	consumerInfo, err := consumer.LoadFromContext(ctx)
 	if err != nil {
 		return labels, errors.Wrapf(err, "while loading consumer")
@@ -67,6 +68,10 @@ func (s *selfRegisterManager) PrepareForSelfRegistration(ctx context.Context, re
 		distinguishLabel, exists := labels[s.cfg.SelfRegisterDistinguishLabelKey]
 		if !exists {
 			return labels, errors.Errorf("missing %q label", s.cfg.SelfRegisterDistinguishLabelKey)
+		}
+
+		if err := validate(); err != nil {
+			return labels, err
 		}
 
 		regionValue, exists := labels[RegionLabel]

--- a/components/director/internal/selfregmanager/selfreg_manager_test.go
+++ b/components/director/internal/selfregmanager/selfreg_manager_test.go
@@ -227,7 +227,8 @@ func TestSelfRegisterManager_PrepareRuntimeForSelfRegistration(t *testing.T) {
 			manager, err := selfregmanager.NewSelfRegisterManager(testCase.Config, svcCallerProvider)
 			require.NoError(t, err)
 
-			output, err := manager.PrepareForSelfRegistration(testCase.Context, testCase.ResourceType, testCase.Input.Labels, testUUID)
+			validation := func() error { return nil }
+			output, err := manager.PrepareForSelfRegistration(testCase.Context, testCase.ResourceType, testCase.Input.Labels, testUUID, validation)
 			if testCase.ExpectedErr != nil {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), testCase.ExpectedErr.Error())

--- a/installation/resources/installer-config-gke-benchmark.yaml.tpl
+++ b/installation/resources/installer-config-gke-benchmark.yaml.tpl
@@ -16,7 +16,7 @@ data:
   global.systemFetcher.enabled: "true"
   global.systemFetcher.systemsAPIEndpoint: "http://compass-external-services-mock.compass-system.svc.cluster.local:8080/systemfetcher/systems"
   global.systemFetcher.systemsAPIFilterCriteria: "no"
-  global.systemFetcher.systemToTemplateMappings: '[{"Name": "temp1", "SourceKey": ["prop"], "SourceValue": ["val1"] },{"Name": "temp2", "SourceKey": ["prop"], "SourceValue": ["val2"] }]'
+  global.systemFetcher.systemToTemplateMappings: '[{"Name": "SAP temp1 (eu-1)", "SourceKey": ["prop"], "SourceValue": ["val1"] },{"Name": "SAP temp2 (eu-1)", "SourceKey": ["prop"], "SourceValue": ["val2"] }]'
   global.kubernetes.serviceAccountTokenIssuer: "https://container.googleapis.com/v1/projects/$CLOUDSDK_CORE_PROJECT/locations/$CLOUDSDK_COMPUTE_ZONE/clusters/$COMMON_NAME"
   global.kubernetes.serviceAccountTokenJWKS: "https://container.googleapis.com/v1/projects/$CLOUDSDK_CORE_PROJECT/locations/$CLOUDSDK_COMPUTE_ZONE/clusters/$COMMON_NAME/jwks"
   global.oathkeeper.mutators.authenticationMappingServices.tenant-fetcher.authenticator.enabled: "true"

--- a/installation/resources/installer-config-local.yaml.tpl
+++ b/installation/resources/installer-config-local.yaml.tpl
@@ -44,7 +44,7 @@ data:
   global.systemFetcher.enabled: "true"
   global.systemFetcher.systemsAPIEndpoint: "http://compass-external-services-mock.compass-system.svc.cluster.local:8080/systemfetcher/systems"
   global.systemFetcher.systemsAPIFilterCriteria: "no"
-  global.systemFetcher.systemToTemplateMappings: '[{"Name": "temp1", "SourceKey": ["prop"], "SourceValue": ["val1"] }, {"Name": "temp2", "SourceKey": ["prop"], "SourceValue": ["val2"] }]'
+  global.systemFetcher.systemToTemplateMappings: '[{"Name": "SAP temp1 (eu-1)", "SourceKey": ["prop"], "SourceValue": ["val1"] }, {"Name": "SAP temp2 (eu-1)", "SourceKey": ["prop"], "SourceValue": ["val2"] }]'
   global.oathkeeper.mutators.authenticationMappingServices.tenant-fetcher.authenticator.enabled: "true"
   global.oathkeeper.mutators.authenticationMappingServices.subscriber.authenticator.enabled: "true"
   global.oathkeeper.mutators.authenticationMappingServices.nsadapter.authenticator.enabled: "true"

--- a/tests/director/tests/application_api_test.go
+++ b/tests/director/tests/application_api_test.go
@@ -3,6 +3,7 @@ package tests
 import (
 	"context"
 	"fmt"
+	"github.com/kyma-incubator/compass/components/director/pkg/str"
 	"testing"
 
 	"github.com/kyma-incubator/compass/components/director/pkg/graphql"
@@ -1493,24 +1494,29 @@ func TestMergeApplications(t *testing.T) {
 	baseURL := ptr.String("http://base.com")
 	healthURL := ptr.String("http://health.com")
 	providerName := ptr.String("test-provider")
-	description := ptr.String("app description")
+	description := "app description"
 	tenantId := tenant.TestTenants.GetDefaultTenantID()
 	namePlaceholder := "name"
+	displayNamePlaceholder := "display-name"
 	managedLabelValue := "true"
 	sccLabelValue := "cloud connector"
-	expectedProductType := "MergeTemplate"
+	expectedProductType := createAppTemplateName("MergeTemplate")
 	newFormation := "formation-merge-applications-e2e"
 
 	appTmplInput := fixAppTemplateInput(expectedProductType)
 	appTmplInput.ApplicationInput.Name = "{{name}}"
 	appTmplInput.ApplicationInput.BaseURL = baseURL
 	appTmplInput.ApplicationInput.ProviderName = nil
-	appTmplInput.ApplicationInput.Description = nil
+	appTmplInput.ApplicationInput.Description = ptr.String("{{display-name}}")
 	appTmplInput.ApplicationInput.HealthCheckURL = nil
 	appTmplInput.Placeholders = []*graphql.PlaceholderDefinitionInput{
 		{
 			Name:        namePlaceholder,
 			Description: ptr.String("description"),
+		},
+		{
+			Name:        displayNamePlaceholder,
+			Description: ptr.String(description),
 		},
 	}
 
@@ -1525,6 +1531,10 @@ func TestMergeApplications(t *testing.T) {
 				Placeholder: namePlaceholder,
 				Value:       "app1-e2e-merge",
 			},
+			{
+				Placeholder: displayNamePlaceholder,
+				Value:       description,
+			},
 		},
 	}
 
@@ -1533,6 +1543,10 @@ func TestMergeApplications(t *testing.T) {
 			{
 				Placeholder: namePlaceholder,
 				Value:       "app2-e2e-merge",
+			},
+			{
+				Placeholder: displayNamePlaceholder,
+				Value:       description,
 			},
 		},
 	}
@@ -1559,7 +1573,7 @@ func TestMergeApplications(t *testing.T) {
 	updateInput := fixtures.FixSampleApplicationUpdateInput("after")
 	updateInput.ProviderName = providerName
 	updateInput.HealthCheckURL = healthURL
-	updateInput.Description = description
+	updateInput.Description = ptr.String(description)
 	updateInputGQL, err := testctx.Tc.Graphqlizer.ApplicationUpdateInputToGQL(updateInput)
 	require.NoError(t, err)
 
@@ -1629,7 +1643,7 @@ func TestMergeApplications(t *testing.T) {
 	// THEN
 	require.NoError(t, err)
 
-	assert.Equal(t, description, destApp.Description)
+	assert.Equal(t, description, str.PtrStrToStr(destApp.Description))
 	assert.Equal(t, healthURL, destApp.HealthCheckURL)
 	assert.Equal(t, providerName, destApp.ProviderName)
 	assert.Equal(t, managedLabelValue, destApp.Labels[managedLabel])

--- a/tests/director/tests/certificates_access_test.go
+++ b/tests/director/tests/certificates_access_test.go
@@ -80,7 +80,9 @@ func TestIntegrationSystemAccess(t *testing.T) {
 
 			t.Log(fmt.Sprintf("Trying to create application template in account tenant %s via client certificate", test.tenant))
 
-			appTmplInput := fixAppTemplateInput(fmt.Sprintf("app-template-%s", test.resourceSuffix))
+			name := fmt.Sprintf("app-template-%s", test.resourceSuffix)
+			appTemplateName := createAppTemplateName(name)
+			appTmplInput := fixAppTemplateInput(appTemplateName)
 			at, err := fixtures.CreateApplicationTemplateFromInput(t, ctx, directorCertSecuredClient, test.tenant, appTmplInput)
 			defer fixtures.CleanupApplicationTemplate(t, ctx, certSecuredGraphQLClient, test.tenant, &at)
 			if test.expectErr {

--- a/tests/director/tests/sensitive_data_strip_test.go
+++ b/tests/director/tests/sensitive_data_strip_test.go
@@ -28,7 +28,8 @@ func TestSensitiveDataStrip(t *testing.T) {
 	tenantId := tenant.TestTenants.GetDefaultTenantID()
 
 	t.Log("Creating application template")
-	appTmpInput := fixAppTemplateWithWebhookInput("app-template-test")
+	appTemplateName := createAppTemplateName("app-template-test")
+	appTmpInput := fixAppTemplateWithWebhookInput(appTemplateName)
 
 	appTemplate, err := fixtures.CreateApplicationTemplateFromInput(t, ctx, certSecuredGraphQLClient, tenantId, appTmpInput)
 	defer fixtures.CleanupApplicationTemplate(t, ctx, certSecuredGraphQLClient, tenantId, &appTemplate)

--- a/tests/director/tests/validation_test.go
+++ b/tests/director/tests/validation_test.go
@@ -471,7 +471,8 @@ func TestUpdateApplicationTemplate_Validation(t *testing.T) {
 
 	tenantId := tenant.TestTenants.GetDefaultTenantID()
 
-	input := fixAppTemplateInput("validation-test-app-tpl")
+	appTemplateName := createAppTemplateName("validation-test-app-tpl")
+	input := fixAppTemplateInput(appTemplateName)
 
 	appTpl, err := fixtures.CreateApplicationTemplateFromInput(t, ctx, certSecuredGraphQLClient, tenantId, input)
 	defer fixtures.CleanupApplicationTemplate(t, ctx, certSecuredGraphQLClient, tenantId, &appTpl)
@@ -504,7 +505,8 @@ func TestRegisterApplicationFromTemplate_Validation(t *testing.T) {
 
 	tenantId := tenant.TestTenants.GetDefaultTenantID()
 
-	input := fixAppTemplateInput("validation-app")
+	appTemplateName := createAppTemplateName("validation-app")
+	input := fixAppTemplateInput(appTemplateName)
 
 	tmpl, err := fixtures.CreateApplicationTemplateFromInput(t, ctx, certSecuredGraphQLClient, tenantId, input)
 	defer fixtures.CleanupApplicationTemplate(t, ctx, certSecuredGraphQLClient, tenantId, &tmpl)

--- a/tests/external-services-mock/tests/async_api_delete_test.go
+++ b/tests/external-services-mock/tests/async_api_delete_test.go
@@ -103,10 +103,22 @@ func TestAsyncAPIDeleteApplicationWithAppTemplateWebhook(stdT *testing.T) {
 		defer cancel()
 		appName := fmt.Sprintf("app-async-del-%s", time.Now().Format("060102150405"))
 		appTemplateName := fmt.Sprintf("test-app-tmpl-%s", time.Now().Format("060102150405"))
+		appTemplateName = fmt.Sprintf("SAP %s (%s)", appTemplateName, testConfig.AppSelfRegRegion)
 		appTemplateInput := graphql.ApplicationTemplateInput{
 			Name: appTemplateName,
 			ApplicationInput: &graphql.ApplicationRegisterInput{
-				Name: appName,
+				Name:         "{{name}}",
+				Description:  ptr.String("test {{display-name}}"),
+			},
+			Placeholders: []*graphql.PlaceholderDefinitionInput{
+				{
+					Name:        "name",
+					Description: &appName,
+				},
+				{
+					Name:        "display-name",
+					Description: ptr.String("display-name"),
+				},
 			},
 			Labels: graphql.Labels{
 				testConfig.AppSelfRegDistinguishLabelKey: []interface{}{testConfig.AppSelfRegDistinguishLabelValue},
@@ -131,6 +143,16 @@ func TestAsyncAPIDeleteApplicationWithAppTemplateWebhook(stdT *testing.T) {
 		t.Log(fmt.Sprintf("Registering application from template: %s", appTemplateName))
 		appFromAppTemplateInput := graphql.ApplicationFromTemplateInput{
 			TemplateName: appTemplateName,
+			Values:     []*graphql.TemplateValueInput{
+				{
+					Placeholder: "name",
+					Value:       appName,
+				},
+				{
+					Placeholder: "display-name",
+					Value:       "display-name",
+				},
+			},
 		}
 		appFromTemplateInputGQL, err := testctx.Tc.Graphqlizer.ApplicationFromTemplateInputToGQL(appFromAppTemplateInput)
 		require.NoError(t, err)
@@ -156,10 +178,22 @@ func TestAsyncAPIDeleteApplicationPrioritizationWithBothAppTemplateAndAppWebhook
 		defer cancel()
 		appName := fmt.Sprintf("app-async-del-%s", time.Now().Format("060102150405"))
 		appTemplateName := fmt.Sprintf("test-app-tmpl-%s", time.Now().Format("060102150405"))
+		appTemplateName = fmt.Sprintf("SAP %s (%s)", appTemplateName, testConfig.AppSelfRegRegion)
 		appTemplateInput := graphql.ApplicationTemplateInput{
 			Name: appTemplateName,
 			ApplicationInput: &graphql.ApplicationRegisterInput{
-				Name: appName,
+				Name:         "{{name}}",
+				Description:  ptr.String("test {{display-name}}"),
+			},
+			Placeholders: []*graphql.PlaceholderDefinitionInput{
+				{
+					Name:        "name",
+					Description: &appName,
+				},
+				{
+					Name:        "display-name",
+					Description: ptr.String("display-name"),
+				},
 			},
 			Labels: graphql.Labels{
 				testConfig.AppSelfRegDistinguishLabelKey: []interface{}{testConfig.AppSelfRegDistinguishLabelValue},
@@ -184,6 +218,16 @@ func TestAsyncAPIDeleteApplicationPrioritizationWithBothAppTemplateAndAppWebhook
 		t.Log(fmt.Sprintf("Registering application from template: %s", appName))
 		appFromAppTemplateInput := graphql.ApplicationFromTemplateInput{
 			TemplateName: appTemplateName,
+			Values:     []*graphql.TemplateValueInput{
+				{
+					Placeholder: "name",
+					Value:       appName,
+				},
+				{
+					Placeholder: "display-name",
+					Value:       "display-name",
+				},
+			},
 		}
 		appFromTemplateInputGQL, err := testctx.Tc.Graphqlizer.ApplicationFromTemplateInputToGQL(appFromAppTemplateInput)
 		require.NoError(t, err)

--- a/tests/ord-service/tests/api_test.go
+++ b/tests/ord-service/tests/api_test.go
@@ -32,7 +32,6 @@ import (
 	directorSchema "github.com/kyma-incubator/compass/components/director/pkg/graphql"
 	"github.com/kyma-incubator/compass/tests/pkg/clients"
 	"github.com/kyma-incubator/compass/tests/pkg/fixtures"
-	"github.com/kyma-incubator/compass/tests/pkg/ptr"
 	"github.com/kyma-incubator/compass/tests/pkg/request"
 	"github.com/kyma-incubator/compass/tests/pkg/tenant"
 	"github.com/kyma-incubator/compass/tests/pkg/testctx"
@@ -681,16 +680,8 @@ func TestORDService(t *testing.T) {
 	})
 
 	t.Run("Additional non-ORD details about system instances are exposed", func(t *testing.T) {
-		expectedProductType := "productType"
+		expectedProductType := fmt.Sprintf("SAP %s (%s)", "productType", testConfig.SelfRegRegion)
 		appTmplInput := fixtures.FixApplicationTemplate(expectedProductType)
-		placeholderKey := "new-placeholder"
-		appTmplInput.ApplicationInput.Description = ptr.String("test {{new-placeholder}}")
-		appTmplInput.Placeholders = []*directorSchema.PlaceholderDefinitionInput{
-			{
-				Name:        placeholderKey,
-				Description: ptr.String("description"),
-			},
-		}
 		appTmplInput.Labels[testConfig.SelfRegDistinguishLabelKey] = []interface{}{testConfig.SelfRegDistinguishLabelValue}
 		appTmplInput.Labels[tenantfetcher.RegionKey] = testConfig.SelfRegRegion
 
@@ -701,7 +692,11 @@ func TestORDService(t *testing.T) {
 		appFromTmpl := directorSchema.ApplicationFromTemplateInput{
 			TemplateName: expectedProductType, Values: []*directorSchema.TemplateValueInput{
 				{
-					Placeholder: placeholderKey,
+					Placeholder: "name",
+					Value:       "new-value",
+				},
+				{
+					Placeholder: "display-name",
 					Value:       "new-value",
 				},
 			},

--- a/tests/pairing-adapter/tests/mtls_flow_test.go
+++ b/tests/pairing-adapter/tests/mtls_flow_test.go
@@ -31,7 +31,7 @@ import (
 func TestGettingTokenWithMTLSWorks(t *testing.T) {
 	ctx := context.Background()
 	defaultTestTenant := tenant.TestTenants.GetDefaultTenantID()
-	templateName := conf.TemplateName
+	templateName := fmt.Sprintf("SAP %s (%s)", conf.TemplateName, conf.SelfRegRegion)
 	namePlaceholderKey := "name"
 	displayNamePlaceholderKey := "display-name"
 	appTemplate := &directorSchema.ApplicationTemplate{}

--- a/tests/pkg/fixtures/application_template_requests.go
+++ b/tests/pkg/fixtures/application_template_requests.go
@@ -11,15 +11,16 @@ import (
 
 func FixApplicationTemplate(name string) graphql.ApplicationTemplateInput {
 	appTemplateDesc := "app-template-desc"
-	placeholderDesc := "new-placeholder-desc"
+	placeholderDisplayName := "new-placeholder-display-name"
+	appInputName := "app"
 	providerName := "compass-tests"
 	appTemplateInput := graphql.ApplicationTemplateInput{
 		Name:        name,
 		Description: &appTemplateDesc,
 		ApplicationInput: &graphql.ApplicationRegisterInput{
-			Name:         "app",
+			Name:         "{{name}}",
 			ProviderName: &providerName,
-			Description:  ptr.String("test {{new-placeholder}}"),
+			Description:  ptr.String("test {{display-name}}"),
 			Labels: graphql.Labels{
 				"a": []string{"b", "c"},
 				"d": []string{"e", "f"},
@@ -32,8 +33,12 @@ func FixApplicationTemplate(name string) graphql.ApplicationTemplateInput {
 		},
 		Placeholders: []*graphql.PlaceholderDefinitionInput{
 			{
-				Name:        "new-placeholder",
-				Description: &placeholderDesc,
+				Name:        "name",
+				Description: &appInputName,
+			},
+			{
+				Name:        "display-name",
+				Description: &placeholderDisplayName,
 			},
 		},
 		Labels: graphql.Labels{

--- a/tests/system-fetcher/tests/handler_test.go
+++ b/tests/system-fetcher/tests/handler_test.go
@@ -58,8 +58,9 @@ const (
 		"additionalAttributes": {}
 	}`
 
-	nameLabelKey    = "displayName"
-	namePlaceholder = "name"
+	nameLabelKey           = "displayName"
+	namePlaceholder        = "name"
+	displayNamePlaceholder = "display-name"
 )
 
 var additionalSystemLabels = directorSchema.Labels{
@@ -97,12 +98,14 @@ func TestSystemFetcherSuccess(t *testing.T) {
 	setMockSystems(t, mockSystems, tenant.TestTenants.GetDefaultTenantID())
 	defer cleanupMockSystems(t)
 
-	template, err := fixtures.CreateApplicationTemplateFromInput(t, ctx, certSecuredGraphQLClient, tenant.TestTenants.GetDefaultTenantID(), fixApplicationTemplate("temp1"))
+	appTemplateName1 := fmt.Sprintf("SAP %s (%s)", "temp1", cfg.SelfRegRegion)
+	template, err := fixtures.CreateApplicationTemplateFromInput(t, ctx, certSecuredGraphQLClient, tenant.TestTenants.GetDefaultTenantID(), fixApplicationTemplate(appTemplateName1))
 	defer fixtures.CleanupApplicationTemplate(t, ctx, certSecuredGraphQLClient, tenant.TestTenants.GetDefaultTenantID(), &template)
 	require.NoError(t, err)
 	require.NotEmpty(t, template.ID)
 
-	appTemplateInput2 := fixApplicationTemplate("temp2")
+	appTemplateName2 := fmt.Sprintf("SAP %s (%s)", "temp2", cfg.SelfRegRegion)
+	appTemplateInput2 := fixApplicationTemplate(appTemplateName2)
 	appTemplateInput2.Webhooks = append(appTemplateInput2.Webhooks, testPkg.BuildMockedWebhook(cfg.ExternalSvcMockURL+"/", directorSchema.WebhookTypeUnregisterApplication))
 	template2, err := fixtures.CreateApplicationTemplateFromInput(t, ctx, certSecuredGraphQLClient, tenant.TestTenants.GetDefaultTenantID(), appTemplateInput2)
 	defer fixtures.CleanupApplicationTemplate(t, ctx, certSecuredGraphQLClient, tenant.TestTenants.GetDefaultTenantID(), &template2)
@@ -160,14 +163,16 @@ func TestSystemFetcherSuccessForMoreThanOnePage(t *testing.T) {
 	setMultipleMockSystemsResponses(t, tenant.TestTenants.GetDefaultTenantID())
 	defer cleanupMockSystems(t)
 
-	appTemplateInput2 := fixApplicationTemplate("temp2")
+	appTemplateName2 := fmt.Sprintf("SAP %s (%s)", "temp2", cfg.SelfRegRegion)
+	appTemplateInput2 := fixApplicationTemplate(appTemplateName2)
 	appTemplateInput2.Webhooks = append(appTemplateInput2.Webhooks, testPkg.BuildMockedWebhook(cfg.ExternalSvcMockURL+"/", directorSchema.WebhookTypeUnregisterApplication))
 	template2, err := fixtures.CreateApplicationTemplateFromInput(t, ctx, certSecuredGraphQLClient, tenant.TestTenants.GetDefaultTenantID(), appTemplateInput2)
 	defer fixtures.CleanupApplicationTemplate(t, ctx, certSecuredGraphQLClient, tenant.TestTenants.GetDefaultTenantID(), &template2)
 	require.NoError(t, err)
 	require.NotEmpty(t, template2.ID)
 
-	template, err := fixtures.CreateApplicationTemplateFromInput(t, ctx, certSecuredGraphQLClient, tenant.TestTenants.GetDefaultTenantID(), fixApplicationTemplate("temp1"))
+	appTemplateName1 := fmt.Sprintf("SAP %s (%s)", "temp1", cfg.SelfRegRegion)
+	template, err := fixtures.CreateApplicationTemplateFromInput(t, ctx, certSecuredGraphQLClient, tenant.TestTenants.GetDefaultTenantID(), fixApplicationTemplate(appTemplateName1))
 	defer fixtures.CleanupApplicationTemplate(t, ctx, certSecuredGraphQLClient, tenant.TestTenants.GetDefaultTenantID(), &template)
 	require.NoError(t, err)
 	require.NotEmpty(t, template.ID)
@@ -255,12 +260,14 @@ func TestSystemFetcherDuplicateSystemsForTwoTenants(t *testing.T) {
 	setMockSystems(t, mockSystems, tenant.TestTenants.GetSystemFetcherTenantID())
 	defer cleanupMockSystems(t)
 
-	template, err := fixtures.CreateApplicationTemplateFromInput(t, ctx, certSecuredGraphQLClient, tenant.TestTenants.GetDefaultTenantID(), fixApplicationTemplate("temp1"))
+	appTemplateName1 := fmt.Sprintf("SAP %s (%s)", "temp1", cfg.SelfRegRegion)
+	template, err := fixtures.CreateApplicationTemplateFromInput(t, ctx, certSecuredGraphQLClient, tenant.TestTenants.GetDefaultTenantID(), fixApplicationTemplate(appTemplateName1))
 	defer fixtures.CleanupApplicationTemplate(t, ctx, certSecuredGraphQLClient, tenant.TestTenants.GetDefaultTenantID(), &template)
 	require.NoError(t, err)
 	require.NotEmpty(t, template.ID)
 
-	appTemplateInput2 := fixApplicationTemplate("temp2")
+	appTemplateName2 := fmt.Sprintf("SAP %s (%s)", "temp2", cfg.SelfRegRegion)
+	appTemplateInput2 := fixApplicationTemplate(appTemplateName2)
 	appTemplateInput2.Webhooks = append(appTemplateInput2.Webhooks, testPkg.BuildMockedWebhook(cfg.ExternalSvcMockURL+"/", directorSchema.WebhookTypeUnregisterApplication))
 	template2, err := fixtures.CreateApplicationTemplateFromInput(t, ctx, certSecuredGraphQLClient, tenant.TestTenants.GetDefaultTenantID(), appTemplateInput2)
 	defer fixtures.CleanupApplicationTemplate(t, ctx, certSecuredGraphQLClient, tenant.TestTenants.GetDefaultTenantID(), &template2)
@@ -366,12 +373,14 @@ func TestSystemFetcherDuplicateSystems(t *testing.T) {
 	setMockSystems(t, mockSystems, tenant.TestTenants.GetDefaultTenantID())
 	defer cleanupMockSystems(t)
 
-	template, err := fixtures.CreateApplicationTemplateFromInput(t, ctx, certSecuredGraphQLClient, tenant.TestTenants.GetDefaultTenantID(), fixApplicationTemplate("temp1"))
+	appTemplateName1 := fmt.Sprintf("SAP %s (%s)", "temp1", cfg.SelfRegRegion)
+	template, err := fixtures.CreateApplicationTemplateFromInput(t, ctx, certSecuredGraphQLClient, tenant.TestTenants.GetDefaultTenantID(), fixApplicationTemplate(appTemplateName1))
 	defer fixtures.CleanupApplicationTemplate(t, ctx, certSecuredGraphQLClient, tenant.TestTenants.GetDefaultTenantID(), &template)
 	require.NoError(t, err)
 	require.NotEmpty(t, template.ID)
 
-	appTemplateInput2 := fixApplicationTemplate("temp2")
+	appTemplateName2 := fmt.Sprintf("SAP %s (%s)", "temp2", cfg.SelfRegRegion)
+	appTemplateInput2 := fixApplicationTemplate(appTemplateName2)
 	appTemplateInput2.Webhooks = append(appTemplateInput2.Webhooks, testPkg.BuildMockedWebhook(cfg.ExternalSvcMockURL+"/", directorSchema.WebhookTypeUnregisterApplication))
 	template2, err := fixtures.CreateApplicationTemplateFromInput(t, ctx, certSecuredGraphQLClient, tenant.TestTenants.GetDefaultTenantID(), appTemplateInput2)
 	defer fixtures.CleanupApplicationTemplate(t, ctx, certSecuredGraphQLClient, tenant.TestTenants.GetDefaultTenantID(), &template2)
@@ -486,12 +495,14 @@ func TestSystemFetcherCreateAndDelete(t *testing.T) {
 
 	setMockSystems(t, mockSystems, tenant.TestTenants.GetDefaultTenantID())
 
-	template, err := fixtures.CreateApplicationTemplateFromInput(t, ctx, certSecuredGraphQLClient, tenant.TestTenants.GetDefaultTenantID(), fixApplicationTemplate("temp1"))
+	appTemplateName1 := fmt.Sprintf("SAP %s (%s)", "temp1", cfg.SelfRegRegion)
+	template, err := fixtures.CreateApplicationTemplateFromInput(t, ctx, certSecuredGraphQLClient, tenant.TestTenants.GetDefaultTenantID(), fixApplicationTemplate(appTemplateName1))
 	defer fixtures.CleanupApplicationTemplate(t, ctx, certSecuredGraphQLClient, tenant.TestTenants.GetDefaultTenantID(), &template)
 	require.NoError(t, err)
 	require.NotEmpty(t, template.ID)
 
-	appTemplateInput2 := fixApplicationTemplate("temp2")
+	appTemplateName2 := fmt.Sprintf("SAP %s (%s)", "temp2", cfg.SelfRegRegion)
+	appTemplateInput2 := fixApplicationTemplate(appTemplateName2)
 	appTemplateInput2.Webhooks = append(appTemplateInput2.Webhooks, testPkg.BuildMockedWebhook(cfg.ExternalSvcMockURL+"/", directorSchema.WebhookTypeUnregisterApplication))
 	template2, err := fixtures.CreateApplicationTemplateFromInput(t, ctx, certSecuredGraphQLClient, tenant.TestTenants.GetDefaultTenantID(), appTemplateInput2)
 	defer fixtures.CleanupApplicationTemplate(t, ctx, certSecuredGraphQLClient, tenant.TestTenants.GetDefaultTenantID(), &template2)
@@ -804,8 +815,9 @@ func fixApplicationTemplate(name string) directorSchema.ApplicationTemplateInput
 		Name:        name,
 		Description: str.Ptr("template description"),
 		ApplicationInput: &directorSchema.ApplicationRegisterInput{
-			Name:   fmt.Sprintf("{{%s}}", namePlaceholder),
-			Labels: additionalSystemLabels,
+			Name:        fmt.Sprintf("{{%s}}", namePlaceholder),
+			Description: ptr.String(fmt.Sprintf("{{%s}}", displayNamePlaceholder)),
+			Labels:      additionalSystemLabels,
 			Webhooks: []*directorSchema.WebhookInput{{
 				Type: directorSchema.WebhookTypeConfigurationChanged,
 				URL:  ptr.String("http://url.com"),
@@ -815,6 +827,9 @@ func fixApplicationTemplate(name string) directorSchema.ApplicationTemplateInput
 		Placeholders: []*directorSchema.PlaceholderDefinitionInput{
 			{
 				Name: namePlaceholder,
+			},
+			{
+				Name: displayNamePlaceholder,
 			},
 		},
 		AccessLevel: directorSchema.ApplicationTemplateAccessLevelGlobal,


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:
- Add application template name validation. “SAP <product name> (<region>)”
- Add application template placeholder validation. Exactly two placeholders are expected: "name" and "display-name" 

**Pull Request status**
- [X] Implementation
- [X] Unit tests
- [X] Integration tests
- [X] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [X] Mocks are regenerated, using the automated script
