### PR TITLE
Cleanup as preparation of test execution

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -142,7 +142,7 @@ global:
       version: "PR-68"
     e2e_tests:
       dir:
-      version: "PR-2399"
+      version: "PR-2402"
   isLocalEnv: false
   isForTesting: false
   oauth2:

--- a/tests/director/tests/application_templates_api_test.go
+++ b/tests/director/tests/application_templates_api_test.go
@@ -374,7 +374,7 @@ func cleanupAppTemplate(t *testing.T, name string) {
 
 	for _, appTemplate := range output.Data {
 		if appTemplate.Name == name {
-			t.Log("App template %s with ID %s found - deleting ...", appTemplate.Name, appTemplate.ID)
+			t.Logf("App template %q with ID %q found - deleting ...", appTemplate.Name, appTemplate.ID)
 			fixtures.CleanupApplicationTemplate(t, ctx, certSecuredGraphQLClient, tenantId, appTemplate)
 			return
 		}

--- a/tests/director/tests/application_templates_api_test.go
+++ b/tests/director/tests/application_templates_api_test.go
@@ -374,7 +374,7 @@ func cleanupAppTemplate(t *testing.T, name string) {
 
 	for _, appTemplate := range output.Data {
 		if appTemplate.Name == name {
-			t.Log("App template %q with ID %q found - deleting ...", appTemplate.Name, appTemplate.ID)
+			t.Log("App template %s with ID %s found - deleting ...", appTemplate.Name, appTemplate.ID)
 			fixtures.CleanupApplicationTemplate(t, ctx, certSecuredGraphQLClient, tenantId, appTemplate)
 			return
 		}


### PR DESCRIPTION
**Description**
Changes proposed in this pull request:
- Execute cleanup as preparation of app template test execution

**Pull Request status**
- [ ] Implementation
- [ ] Unit tests
- [ ] Integration tests
- [ ] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [ ] Mocks are regenerated, using the automated script
