### PR TITLE
Add verbose output on app delete

### DIFF
--- a/chart/compass/templates/tests/pairing-adapter/pairing-adapter-test.yaml
+++ b/chart/compass/templates/tests/pairing-adapter/pairing-adapter-test.yaml
@@ -81,6 +81,7 @@ spec:
               value: "{{ $.Values.global.pairingAdapter.configMap.integrationSystemID }}"
             - name: APP_LOCAL_ADAPTER_FQDN
               value: "{{ $.Values.global.pairingAdapter.configMap.localAdapterFQDN }}"
+            {{ end }}
             - name: APP_DB_USER
               valueFrom:
                 secretKeyRef:
@@ -111,7 +112,6 @@ spec:
                 secretKeyRef:
                   name: compass-postgresql
                   key: postgresql-sslMode
-            {{ end }}
 {{ $shouldAdd = false }}
 {{ end }}
 {{- end -}}

--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -142,7 +142,7 @@ global:
       version: "PR-68"
     e2e_tests:
       dir:
-      version: "PR-2385"
+      version: "PR-2409"
   isLocalEnv: false
   isForTesting: false
   oauth2:

--- a/tests/pkg/fixtures/application_queries.go
+++ b/tests/pkg/fixtures/application_queries.go
@@ -10,6 +10,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/kyma-incubator/compass/components/director/pkg/graphql"
+	"github.com/kyma-incubator/compass/components/director/pkg/log"
 	"github.com/kyma-incubator/compass/tests/pkg/testctx"
 	gcli "github.com/machinebox/graphql"
 	"github.com/stretchr/testify/require"
@@ -116,11 +117,13 @@ func UnpairAsyncApplicationInTenant(t require.TestingT, ctx context.Context, gql
 
 func CleanupApplication(t require.TestingT, ctx context.Context, gqlClient *gcli.Client, tenant string, app *graphql.ApplicationExt) {
 	if app == nil || app.Application.BaseEntity == nil || app.ID == "" {
+		log.D().Infof("Cleanup of applicaiton was bypassed as applicaiton was %+v", app)
 		return
 	}
 	deleteRequest := FixUnregisterApplicationRequest(app.ID)
 
 	deleteApplicationFunc := func() error {
+		log.D().Infof("Attempt to delete applicaiton %+v", app)
 		err := testctx.Tc.RunOperationWithCustomTenant(ctx, gqlClient, tenant, deleteRequest, &app)
 		if err != nil && !strings.Contains(strings.ToLower(err.Error()), "not found") {
 			return err


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:
- Verbose output on app delete

**Pull Request status**
- [x] Implementation
- [x] Unit tests
- [x] Integration tests
- [x] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [x] Mocks are regenerated, using the automated script
