### PR TITLE
Fix long lock in application list

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -110,7 +110,7 @@ global:
       version: "PR-2383"
     director:
       dir:
-      version: "PR-2385"
+      version: "PR-2414"
     hydrator:
       dir:
       version: "PR-2385"

--- a/components/director/internal/domain/application/repository.go
+++ b/components/director/internal/domain/application/repository.go
@@ -274,7 +274,7 @@ func (r *pgRepository) List(ctx context.Context, tenant string, filter []*labelf
 func (r *pgRepository) ListGlobal(ctx context.Context, pageSize int, cursor string) (*model.ApplicationPage, error) {
 	var appsCollection EntityCollection
 
-	page, totalCount, err := r.globalPageableQuerier.ListGlobalWithSelectForUpdate(ctx, pageSize, cursor, "id", &appsCollection)
+	page, totalCount, err := r.globalPageableQuerier.ListGlobal(ctx, pageSize, cursor, "id", &appsCollection)
 
 	if err != nil {
 		return nil, err

--- a/components/director/internal/domain/application/repository_test.go
+++ b/components/director/internal/domain/application/repository_test.go
@@ -613,7 +613,7 @@ func TestPgRepository_ListGlobal(t *testing.T) {
 	inputCursor := ""
 	totalCount := 2
 
-	pageableQuery := `SELECT (.+) FROM public\.applications ORDER BY id LIMIT %d OFFSET %d FOR UPDATE$`
+	pageableQuery := `SELECT (.+) FROM public\.applications ORDER BY id LIMIT %d OFFSET %d$`
 	countQuery := `SELECT COUNT\(\*\) FROM public\.applications`
 
 	t.Run("Success", func(t *testing.T) {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Some time ago we introduced an approach for locking app resources in the ORD Aggregator, so that if an outside request tries to delete the currently processed app, it won't lead to a deadlock because of onordered child lock retrieval.
 

Changes proposed in this pull request:
- Use lits global for app listing instead of list for update - no production usage of app list (not app get by ID) requires lock acquisition

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- ...

**Pull Request status**
<!-- Feel free to construct the checklist with whatever items seem most reasonable for your change. You could disassemble the Implementation part to even smaller separate checklist items if you're working on something big for example. But do make the effort to provide a checklist of some sort so that the core team as well as the community can have an idea about the progress of your Pull Request.
-->

- [x] Implementation
- [x] Unit tests
- [x] [n/a] Integration tests
- [x] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [x] [n/a] Mocks are regenerated, using the automated script
