### PR TITLE
Reuse system number as local tenant ID in System Fetcher

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -110,7 +110,7 @@ global:
       version: "PR-2383"
     director:
       dir:
-      version: "PR-2381"
+      version: "PR-2439"
     hydrator:
       dir:
       version: "PR-2385"

--- a/components/director/internal/systemfetcher/service.go
+++ b/components/director/internal/systemfetcher/service.go
@@ -275,6 +275,10 @@ func (s *SystemFetcher) convertSystemToAppRegisterInput(ctx context.Context, sc 
 		return nil, err
 	}
 
+	if sc.ProductID == "S4_PC" { // temporary, will be removed in favor of a better abstraction with evolved application template input configurations
+		input.LocalTenantID = input.SystemNumber
+	}
+
 	return &model.ApplicationRegisterInputWithTemplate{
 		ApplicationRegisterInput: *input,
 		TemplateID:               sc.TemplateID,


### PR DESCRIPTION
# Reuse system number as local tenant ID in System Fetcher

**Description**

The local tenant id for some systems is discoverable when the system fetcher fetches systems from the upstream source. This change makes sure to assign this local tenant id for specific products (one in this case).

> This is a workaround solution, which will be removed in favor of a better application template abstraction later on.
