### PR TITLE
Add missing env in director tests

### DIFF
--- a/chart/compass/templates/tests/director/director-test.yaml
+++ b/chart/compass/templates/tests/director/director-test.yaml
@@ -159,6 +159,8 @@ spec:
               value: {{ .Values.global.director.subscription.consumerSubaccountLabelKey }}
             - name: APP_SUBSCRIPTION_LABEL_KEY
               value: {{ .Values.global.director.subscription.subscriptionLabelKey }}
+            - name: SKIP_TESTS_REGEX
+              value: {{ .Values.global.tests.director.skipPattern }}
           {{ if .Values.global.isLocalEnv }}
           volumeMounts:
             - mountPath: "/src/github.com/kyma-incubator/compass/components/director/examples"


### PR DESCRIPTION
**Description**
The PR name says it all


**Related issue(s)**
- https://github.com/kyma-incubator/compass/pull/2447

**Pull Request status**
- [x] Implementation
- [x] [N/A] Unit tests
- [x] [N/A] Integration tests
- [x] [N/A] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [x] [N/A] Mocks are regenerated, using the automated script
