### PR TITLE
Switch liter config to Go 1.17

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -110,7 +110,7 @@ global:
       version: "PR-2383"
     director:
       dir:
-      version: "PR-2403"
+      version: "PR-2457"
     hydrator:
       dir:
       version: "PR-2408"

--- a/components/director/.golangci.yml
+++ b/components/director/.golangci.yml
@@ -1,4 +1,7 @@
 run:
+  # Use Go 1.17 because of https://github.com/golangci/golangci-lint/issues/2649
+  go: '1.17'
+
   # default concurrency is a available CPU number
   concurrency: 4
 

--- a/components/director/hack/plugins/descriptionsdecorator/plugin.go
+++ b/components/director/hack/plugins/descriptionsdecorator/plugin.go
@@ -93,6 +93,7 @@ func (p *descriptionsDecoratorPlugin) ensureDescription(f *ast.FieldDefinition, 
 	dirs, err := ioutil.ReadDir(p.examplesDirectory)
 	if err != nil {
 		log.D().Infof("no examples under %s directory, skipping adding description", p.examplesDirectory)
+		//lint:ignore nilerr can proceed
 		return nil
 	}
 	for _, dir := range dirs {

--- a/components/director/hack/plugins/formatter.go
+++ b/components/director/hack/plugins/formatter.go
@@ -60,7 +60,7 @@ func (f *formatter) writeString(s string) {
 	}
 }
 
-func (f *formatter) writeIndent() *formatter {
+func (f *formatter) WriteIndent() *formatter {
 	if f.lineHead {
 		f.writeString(strings.Repeat("\t", f.indent))
 	}
@@ -82,7 +82,7 @@ func (f *formatter) WriteNewline() *formatter {
 // WriteWord missing godoc
 func (f *formatter) WriteWord(word string) *formatter {
 	if f.lineHead {
-		f.writeIndent()
+		f.WriteIndent()
 	}
 	if f.padNext {
 		f.writeString(" ")
@@ -96,7 +96,7 @@ func (f *formatter) WriteWord(word string) *formatter {
 // WriteString missing godoc
 func (f *formatter) WriteString(s string) *formatter {
 	if f.lineHead {
-		f.writeIndent()
+		f.WriteIndent()
 	}
 	if f.padNext {
 		f.writeString(" ")

--- a/components/director/internal/appmetadatavalidation/handler.go
+++ b/components/director/internal/appmetadatavalidation/handler.go
@@ -25,7 +25,6 @@ func (h *handler) Handler() func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			ctx := context.WithValue(r.Context(), TenantHeader, r.Header.Get("Tenant"))
 			next.ServeHTTP(w, r.WithContext(ctx))
-			return
 		})
 	}
 }


### PR DESCRIPTION
**Description**
- Enforce linter to use syntax for Go 1.17
- Adjust several small linter findings

**Pull Request status**
- [x] Implementation
- [ ] Unit tests
- [ ] Integration tests
- [x] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [ ] Mocks are regenerated, using the automated script
