### PR TITLE
Bump ORD Service version

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -122,7 +122,7 @@ global:
       version: "PR-2383"
     ord_service:
       dir:
-      version: "PR-70"
+      version: "PR-71"
     schema_migrator:
       dir:
       version: "PR-2436"


### PR DESCRIPTION
Bump ORD Service Version: https://github.com/kyma-incubator/ord-service/pull/71