### PR TITLE
Runtime contexts improvements

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -125,7 +125,7 @@ global:
       version: "PR-70"
     schema_migrator:
       dir:
-      version: "PR-2463"
+      version: "PR-2464"
     system_broker:
       dir:
       version: "PR-2383"

--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -125,7 +125,7 @@ global:
       version: "PR-70"
     schema_migrator:
       dir:
-      version: "PR-2436"
+      version: "PR-2463"
     system_broker:
       dir:
       version: "PR-2383"

--- a/components/schema-migrator/migrations/director/20220701113309_runtime_contexts_improvements.down.sql
+++ b/components/schema-migrator/migrations/director/20220701113309_runtime_contexts_improvements.down.sql
@@ -1,0 +1,28 @@
+BEGIN;
+
+CREATE OR REPLACE VIEW runtime_contexts_labels_tenants AS
+SELECT l.id, tr.tenant_id, tr.owner FROM labels AS l
+    INNER JOIN runtime_contexts rc ON l.runtime_context_id = rc.id
+    INNER JOIN tenant_runtimes tr ON rc.runtime_id = tr.id AND (l.tenant_id IS NULL OR l.tenant_id = tr.tenant_id);
+
+
+-- Aggregated labels view
+CREATE OR REPLACE VIEW labels_tenants AS
+(SELECT l.id, ta.tenant_id, ta.owner FROM labels AS l
+    INNER JOIN tenant_applications ta
+        ON l.app_id = ta.id AND (l.tenant_id IS NULL OR l.tenant_id = ta.tenant_id))
+UNION ALL
+(SELECT l.id, tr.tenant_id, tr.owner FROM labels AS l
+    INNER JOIN tenant_runtimes tr
+        ON l.runtime_id = tr.id AND (l.tenant_id IS NULL OR l.tenant_id = tr.tenant_id))
+UNION ALL
+(SELECT l.id, tr.tenant_id, tr.owner FROM labels AS l
+    INNER JOIN runtime_contexts rc ON l.runtime_context_id = rc.id
+    INNER JOIN tenant_runtimes tr ON rc.runtime_id = tr.id AND (l.tenant_id IS NULL OR l.tenant_id = tr.tenant_id));
+
+
+DROP INDEX labels_runtime_context_id;
+DROP INDEX tenant_runtime_contexts_rtm_context_id;
+DROP INDEX tenant_runtime_contexts_tenant_id;
+
+COMMIT;

--- a/components/schema-migrator/migrations/director/20220701113309_runtime_contexts_improvements.up.sql
+++ b/components/schema-migrator/migrations/director/20220701113309_runtime_contexts_improvements.up.sql
@@ -1,0 +1,36 @@
+BEGIN;
+
+CREATE OR REPLACE VIEW runtime_contexts_labels_tenants AS
+SELECT l.id, trc.tenant_id, trc.owner FROM labels AS l
+    INNER JOIN tenant_runtime_contexts trc
+        ON l.runtime_context_id = trc.id AND (l.tenant_id IS NULL OR l.tenant_id = trc.tenant_id);
+
+
+-- Aggregated labels view
+CREATE OR REPLACE VIEW labels_tenants AS
+(SELECT l.id, ta.tenant_id, ta.owner FROM labels AS l
+    INNER JOIN tenant_applications ta
+        ON l.app_id = ta.id AND (l.tenant_id IS NULL OR l.tenant_id = ta.tenant_id))
+UNION ALL
+(SELECT l.id, tr.tenant_id, tr.owner FROM labels AS l
+    INNER JOIN tenant_runtimes tr
+        ON l.runtime_id = tr.id AND (l.tenant_id IS NULL OR l.tenant_id = tr.tenant_id))
+UNION ALL
+(SELECT l.id, trc.tenant_id, trc.owner FROM labels AS l
+    INNER JOIN tenant_runtime_contexts trc
+        ON l.runtime_context_id = trc.id AND (l.tenant_id IS NULL OR l.tenant_id = trc.tenant_id));
+
+
+CREATE INDEX labels_runtime_context_id
+    ON labels (runtime_context_id)
+    WHERE (labels.runtime_context_id IS NOT NULL);
+
+
+CREATE INDEX tenant_runtime_contexts_rtm_context_id
+    ON tenant_runtime_contexts (id);
+
+
+CREATE INDEX tenant_runtime_contexts_tenant_id
+    ON tenant_runtime_contexts (tenant_id);
+
+COMMIT;


### PR DESCRIPTION
**Description**
Currently, if we try to get more than a hundred runtime contexts as part of the runtime(s) the request times out.

Changes proposed in this pull request:
- Improvements in `runtime_contexts_labels_tenants` and `labels_tenants` views
- Add new indexes

**Pull Request status**
- [x] Implementation
- [x] [N/A] Unit tests
- [x] [N/A] Integration tests
- [x] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [x] [N/A] Mocks are regenerated, using the automated script
