### PR TITLE
Use upsert instead of create for tenant access

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -110,7 +110,7 @@ global:
       version: "PR-2383"
     director:
       dir:
-      version: "PR-2438"
+      version: "PR-2467"
     hydrator:
       dir:
       version: "PR-2458"

--- a/components/director/internal/domain/subscription/service.go
+++ b/components/director/internal/domain/subscription/service.go
@@ -184,7 +184,7 @@ func (s *service) SubscribeTenantToRuntime(ctx context.Context, providerID, suba
 			return false, errors.Errorf("entity %s does not have access table", resource.RuntimeContext)
 		}
 
-		if err := repo.CreateTenantAccessRecursively(ctx, m2mTable, &repo.TenantAccess{
+		if err := repo.UpsertTenantAccessRecursively(ctx, m2mTable, &repo.TenantAccess{
 			TenantID:   consumerInternalTenant,
 			ResourceID: runtime.ID,
 			Owner:      false,

--- a/components/director/internal/domain/subscription/service_test.go
+++ b/components/director/internal/domain/subscription/service_test.go
@@ -138,7 +138,7 @@ func TestSubscribeRegionalTenant(t *testing.T) {
 				return uidSvc
 			},
 			TenantAccessMock: func(dbMock testdb.DBMock) {
-				dbMock.ExpectExec(regexp.QuoteMeta(fmt.Sprintf("WITH RECURSIVE parents AS (SELECT t1.id, t1.parent FROM business_tenant_mappings t1 WHERE id = ? UNION ALL SELECT t2.id, t2.parent FROM business_tenant_mappings t2 INNER JOIN parents t on t2.id = t.parent) INSERT INTO %s ( %s, %s, %s ) (SELECT parents.id AS tenant_id, ? as id, ? AS owner FROM parents)", runtimeM2MTableName, repo.M2MTenantIDColumn, repo.M2MResourceIDColumn, repo.M2MOwnerColumn))).
+				dbMock.ExpectExec(regexp.QuoteMeta(fmt.Sprintf("WITH RECURSIVE parents AS (SELECT t1.id, t1.parent FROM business_tenant_mappings t1 WHERE id = ? UNION ALL SELECT t2.id, t2.parent FROM business_tenant_mappings t2 INNER JOIN parents t on t2.id = t.parent) INSERT INTO %s ( %s, %s, %s ) (SELECT parents.id AS tenant_id, ? as id, ? AS owner FROM parents) ON CONFLICT ( tenant_id, id ) DO NOTHING", runtimeM2MTableName, repo.M2MTenantIDColumn, repo.M2MResourceIDColumn, repo.M2MOwnerColumn))).
 					WithArgs(subaccountTenantInternalID, providerRuntimeID, false).WillReturnResult(sqlmock.NewResult(1, 1))
 			},
 			IsSuccessful: true,
@@ -322,7 +322,7 @@ func TestSubscribeRegionalTenant(t *testing.T) {
 			},
 			UIDServiceFn: unusedUUIDSvc,
 			TenantAccessMock: func(dbMock testdb.DBMock) {
-				dbMock.ExpectExec(regexp.QuoteMeta(fmt.Sprintf("WITH RECURSIVE parents AS (SELECT t1.id, t1.parent FROM business_tenant_mappings t1 WHERE id = ? UNION ALL SELECT t2.id, t2.parent FROM business_tenant_mappings t2 INNER JOIN parents t on t2.id = t.parent) INSERT INTO %s ( %s, %s, %s ) (SELECT parents.id AS tenant_id, ? as id, ? AS owner FROM parents)", runtimeM2MTableName, repo.M2MTenantIDColumn, repo.M2MResourceIDColumn, repo.M2MOwnerColumn))).
+				dbMock.ExpectExec(regexp.QuoteMeta(fmt.Sprintf("WITH RECURSIVE parents AS (SELECT t1.id, t1.parent FROM business_tenant_mappings t1 WHERE id = ? UNION ALL SELECT t2.id, t2.parent FROM business_tenant_mappings t2 INNER JOIN parents t on t2.id = t.parent) INSERT INTO %s ( %s, %s, %s ) (SELECT parents.id AS tenant_id, ? as id, ? AS owner FROM parents) ON CONFLICT ( tenant_id, id ) DO NOTHING", runtimeM2MTableName, repo.M2MTenantIDColumn, repo.M2MResourceIDColumn, repo.M2MOwnerColumn))).
 					WithArgs(subaccountTenantInternalID, providerRuntimeID, false).WillReturnError(testError)
 			},
 			ExpectedErrorOutput: "Unexpected error while executing SQL query",
@@ -360,7 +360,7 @@ func TestSubscribeRegionalTenant(t *testing.T) {
 				return uidSvc
 			},
 			TenantAccessMock: func(dbMock testdb.DBMock) {
-				dbMock.ExpectExec(regexp.QuoteMeta(fmt.Sprintf("WITH RECURSIVE parents AS (SELECT t1.id, t1.parent FROM business_tenant_mappings t1 WHERE id = ? UNION ALL SELECT t2.id, t2.parent FROM business_tenant_mappings t2 INNER JOIN parents t on t2.id = t.parent) INSERT INTO %s ( %s, %s, %s ) (SELECT parents.id AS tenant_id, ? as id, ? AS owner FROM parents)", runtimeM2MTableName, repo.M2MTenantIDColumn, repo.M2MResourceIDColumn, repo.M2MOwnerColumn))).
+				dbMock.ExpectExec(regexp.QuoteMeta(fmt.Sprintf("WITH RECURSIVE parents AS (SELECT t1.id, t1.parent FROM business_tenant_mappings t1 WHERE id = ? UNION ALL SELECT t2.id, t2.parent FROM business_tenant_mappings t2 INNER JOIN parents t on t2.id = t.parent) INSERT INTO %s ( %s, %s, %s ) (SELECT parents.id AS tenant_id, ? as id, ? AS owner FROM parents) ON CONFLICT ( tenant_id, id ) DO NOTHING", runtimeM2MTableName, repo.M2MTenantIDColumn, repo.M2MResourceIDColumn, repo.M2MOwnerColumn))).
 					WithArgs(subaccountTenantInternalID, providerRuntimeID, false).WillReturnResult(sqlmock.NewResult(1, 1))
 			},
 			ExpectedErrorOutput: testError.Error(),


### PR DESCRIPTION
**Description**
During provider runtime registration tenant access record is created and when we try to create a new one recursively for the consumer tenant it fails because of a unique constraint violation

Changes proposed in this pull request:
- Use upsert instead of create

**Related issue(s)**
- https://github.com/kyma-incubator/compass/pull/2391

**Pull Request status**
- [x] Implementation
- [x] Unit tests
- [x] [N/A] Integration tests
- [x] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [x] [N/A] Mocks are regenerated, using the automated script
