### PR TITLE
[HOTFIX] Fix runtime contexts tests' external cert configuration

### DIFF
--- a/chart/compass/templates/tests/director/director-test.yaml
+++ b/chart/compass/templates/tests/director/director-test.yaml
@@ -161,6 +161,8 @@ spec:
               value: {{ .Values.global.director.subscription.subscriptionLabelKey }}
             - name: SKIP_TESTS_REGEX
               value: {{ .Values.global.tests.director.skipPattern }}
+            - name: APP_EXTERNAL_CERT_TEST_CN
+              value: {{ .Values.global.tests.director.externalCertIntSystemCN }}
           {{ if .Values.global.isLocalEnv }}
           volumeMounts:
             - mountPath: "/src/github.com/kyma-incubator/compass/components/director/examples"

--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -142,7 +142,7 @@ global:
       version: "PR-68"
     e2e_tests:
       dir:
-      version: "PR-2438"
+      version: "PR-2471"
   isLocalEnv: false
   isForTesting: false
   oauth2:

--- a/tests/director/tests/main_test.go
+++ b/tests/director/tests/main_test.go
@@ -46,6 +46,7 @@ type DirectorConfig struct {
 	SubscriptionLabelKey             string
 	RuntimeTypeLabelKey              string
 	KymaRuntimeTypeLabelValue        string
+	ExternalCertTestCN               string
 }
 
 type BaseDirectorConfig struct {

--- a/tests/director/tests/runtime_contexts_api_test.go
+++ b/tests/director/tests/runtime_contexts_api_test.go
@@ -171,11 +171,11 @@ func TestRuntimeContextSubscriptionFlows(stdT *testing.T) {
 
 		// We need an externally issued cert with a subject that is not part of the access level mappings
 		externalCertProviderConfig := certprovider.ExternalCertProviderConfig{
-			ExternalClientCertTestSecretName:      "external-client-certificate-rtm-ctx-test-secret",
+			ExternalClientCertTestSecretName:      conf.ExternalCertProviderConfig.ExternalClientCertTestSecretName,
 			ExternalClientCertTestSecretNamespace: conf.ExternalCertProviderConfig.ExternalClientCertTestSecretNamespace,
 			CertSvcInstanceTestSecretName:         conf.ExternalCertProviderConfig.CertSvcInstanceTestSecretName,
 			ExternalCertCronjobContainerName:      conf.ExternalCertProviderConfig.ExternalCertCronjobContainerName,
-			ExternalCertTestJobName:               "external-client-certificate-rtm-ctx-test-job",
+			ExternalCertTestJobName:               conf.ExternalCertProviderConfig.ExternalCertTestJobName,
 			TestExternalCertSubject:               strings.Replace(conf.ExternalCertProviderConfig.TestExternalCertSubject, conf.ExternalCertTestCN, "rtm-ctx-test-cn", -1),
 			ExternalClientCertCertKey:             conf.ExternalCertProviderConfig.ExternalClientCertCertKey,
 			ExternalClientCertKeyKey:              conf.ExternalCertProviderConfig.ExternalClientCertKeyKey,

--- a/tests/director/tests/runtime_contexts_api_test.go
+++ b/tests/director/tests/runtime_contexts_api_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -168,8 +169,20 @@ func TestRuntimeContextSubscriptionFlows(stdT *testing.T) {
 		subscriptionConsumerSubaccountID := conf.TestConsumerSubaccountID // the parent is ApplicationsForRuntimeTenantName
 		subscriptionConsumerTenantID := conf.TestConsumerTenantID
 
+		// We need an externally issued cert with a subject that is not part of the access level mappings
+		externalCertProviderConfig := certprovider.ExternalCertProviderConfig{
+			ExternalClientCertTestSecretName:      "external-client-certificate-rtm-ctx-test-secret",
+			ExternalClientCertTestSecretNamespace: conf.ExternalCertProviderConfig.ExternalClientCertTestSecretNamespace,
+			CertSvcInstanceTestSecretName:         conf.ExternalCertProviderConfig.CertSvcInstanceTestSecretName,
+			ExternalCertCronjobContainerName:      conf.ExternalCertProviderConfig.ExternalCertCronjobContainerName,
+			ExternalCertTestJobName:               "external-client-certificate-rtm-ctx-test-job",
+			TestExternalCertSubject:               strings.Replace(conf.ExternalCertProviderConfig.TestExternalCertSubject, conf.ExternalCertTestCN, "rtm-ctx-test-cn", -1),
+			ExternalClientCertCertKey:             conf.ExternalCertProviderConfig.ExternalClientCertCertKey,
+			ExternalClientCertKeyKey:              conf.ExternalCertProviderConfig.ExternalClientCertKeyKey,
+		}
+
 		// Prepare provider external client certificate and secret and Build graphql director client configured with certificate
-		providerClientKey, providerRawCertChain := certprovider.NewExternalCertFromConfig(t, ctx, conf.ExternalCertProviderConfig)
+		providerClientKey, providerRawCertChain := certprovider.NewExternalCertFromConfig(t, ctx, externalCertProviderConfig)
 		directorCertSecuredClient := gql.NewCertAuthorizedGraphQLClientWithCustomURL(conf.DirectorExternalCertSecuredURL, providerClientKey, providerRawCertChain, conf.SkipSSLValidation)
 
 		providerRuntimeInput := graphql.RuntimeRegisterInput{


### PR DESCRIPTION
**Description**
The external cert configuration in the runtime contexts tests is the default one and when the tests are executed on real environment the call is match by three object context providers(`certServiceContextProvider`, `authenticatorContextProvider` and `accessLevelContextProvider`) instead of two(`certServiceContextProvider ` and `authenticatorContextProvider `)

Changes proposed in this pull request:
- Change the external cert configuration in the runtime contexts tests

**Related issue(s)**
- https://github.com/kyma-incubator/compass/pull/2391

**Pull Request status**
- [x] Implementation
- [x] [N/A] Unit tests
- [x] Integration tests
- [x] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [x] [N/A] Mocks are regenerated, using the automated script
