### PR TITLE
Fix subscription tests configuration

### DIFF
--- a/chart/compass/templates/tests/director/director-test.yaml
+++ b/chart/compass/templates/tests/director/director-test.yaml
@@ -99,15 +99,17 @@ spec:
             - name: APP_SKIP_SSL_VALIDATION
               value: "{{ .Values.global.tests.http.client.skipSSLValidation }}"
             - name: TEST_EXTERNAL_CERT_SUBJECT
-              value: {{ printf .Values.global.externalCertConfiguration.subjectPattern .Values.global.externalCertConfiguration.ouCertSubaccountID .Values.global.externalCertConfiguration.locality .Values.global.tests.director.externalCertIntSystemCN }}
+              value: {{ printf .Values.global.externalCertConfiguration.subjectPattern .Values.global.tests.subscription.tenants.providerSubaccountID .Values.global.externalCertConfiguration.locality .Values.global.externalCertConfiguration.commonName }}
+            - name: EXTERNAL_CERT_COMMON_NAME
+              value: {{ .Values.global.externalCertConfiguration.commonName }}
             - name: EXTERNAL_CLIENT_CERT_TEST_SECRET_NAME
-              value: {{ .Values.global.tests.director.externalClientCertTestSecretName }}
+              value: {{ .Values.global.tests.subscription.externalClientCertTestSecretName }}
             - name: EXTERNAL_CLIENT_CERT_TEST_SECRET_NAMESPACE
-              value: {{ .Values.global.tests.director.externalClientCertTestSecretNamespace }}
+              value: {{ .Values.global.tests.subscription.externalClientCertTestSecretNamespace }}
             - name: EXTERNAL_CERT_TEST_JOB_NAME
-              value: {{ .Values.global.tests.director.externalCertTestJobName }}
+              value: {{ .Values.global.tests.subscription.externalCertTestJobName }}
             - name: CERT_SVC_INSTANCE_TEST_SECRET_NAME
-              value: {{ .Values.global.externalCertConfiguration.secrets.externalCertSvcSecret.name }}
+              value: {{ .Values.global.tests.subscription.certSvcInstanceTestSecretName }}
             - name: EXTERNAL_CERT_CRONJOB_CONTAINER_NAME
               value: {{ .Values.global.externalCertConfiguration.rotationCronjob.containerName }}
             - name: APP_RUNTIME_TYPE_LABEL_KEY
@@ -161,7 +163,9 @@ spec:
               value: {{ .Values.global.director.subscription.subscriptionLabelKey }}
             - name: SKIP_TESTS_REGEX
               value: {{ .Values.global.tests.director.skipPattern }}
-            - name: APP_EXTERNAL_CERT_TEST_CN
+            - name: APP_EXTERNAL_CERT_TEST_INTEGRATION_SYSTEM_OU_SUBACCOUNT
+              value: {{ .Values.global.externalCertConfiguration.ouCertSubaccountID }}
+            - name: APP_EXTERNAL_CERT_TEST_INTEGRATION_SYSTEM_CN
               value: {{ .Values.global.tests.director.externalCertIntSystemCN }}
           {{ if .Values.global.isLocalEnv }}
           volumeMounts:
@@ -239,11 +243,11 @@ rules:
     verbs: ["get"]
   - apiGroups: ["*"]
     resources: ["secrets"]
-    resourceNames: ["{{ .Values.global.tests.director.externalClientCertTestSecretName }}"]
+    resourceNames: ["{{ .Values.global.tests.subscription.externalClientCertTestSecretName }}"]
     verbs: ["get", "delete"]
   - apiGroups: ["*"]
     resources: ["jobs"]
-    resourceNames: [{{ .Values.global.tests.director.externalCertTestJobName }}]
+    resourceNames: [{{ .Values.global.tests.subscription.externalCertTestJobName }}]
     verbs: ["get", "delete"]
   - apiGroups: ["*"]
     resources: ["jobs"]

--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -142,7 +142,7 @@ global:
       version: "PR-68"
     e2e_tests:
       dir:
-      version: "PR-2470"
+      version: "PR-2476"
   isLocalEnv: false
   isForTesting: false
   oauth2:
@@ -770,10 +770,7 @@ global:
         skipSSLValidation: false
     director:
       skipPattern: ""
-      externalClientCertTestSecretName: "external-client-certificate-integration-system-test-secret"
-      externalClientCertTestSecretNamespace: "compass-system"
       externalCertIntSystemCN: "integration-system-test"
-      externalCertTestJobName: "external-client-certificate-integration-system-test-job"
     tenantFetcher:
       tenantOnDemandID: "8d42d818-d4c4-4036-b82f-b199db7ffeb5"
     ordService:

--- a/tests/director/tests/application_api_test.go
+++ b/tests/director/tests/application_api_test.go
@@ -3,7 +3,6 @@ package tests
 import (
 	"context"
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/kyma-incubator/compass/tests/pkg/certs/certprovider"
@@ -71,19 +70,7 @@ func TestRegisterApplicationWithAllSimpleFieldsProvided(t *testing.T) {
 func TestRegisterApplicationWithExternalCertificate(t *testing.T) {
 	ctx := context.Background()
 
-	// We need an externally issued cert with a subject that is not part of the access level mappings
-	externalCertProviderConfig := certprovider.ExternalCertProviderConfig{
-		ExternalClientCertTestSecretName:      conf.ExternalCertProviderConfig.ExternalClientCertTestSecretName,
-		ExternalClientCertTestSecretNamespace: conf.ExternalCertProviderConfig.ExternalClientCertTestSecretNamespace,
-		CertSvcInstanceTestSecretName:         conf.ExternalCertProviderConfig.CertSvcInstanceTestSecretName,
-		ExternalCertCronjobContainerName:      conf.ExternalCertProviderConfig.ExternalCertCronjobContainerName,
-		ExternalCertTestJobName:               conf.ExternalCertProviderConfig.ExternalCertTestJobName,
-		TestExternalCertSubject:               strings.Replace(conf.ExternalCertProviderConfig.TestExternalCertSubject, "integration-system-test", "external-cert", -1),
-		ExternalClientCertCertKey:             conf.ExternalCertProviderConfig.ExternalClientCertCertKey,
-		ExternalClientCertKeyKey:              conf.ExternalCertProviderConfig.ExternalClientCertKeyKey,
-	}
-
-	pk, cert := certprovider.NewExternalCertFromConfig(t, ctx, externalCertProviderConfig)
+	pk, cert := certprovider.NewExternalCertFromConfig(t, ctx, conf.ExternalCertProviderConfig)
 	directorCertSecuredClient := gql.NewCertAuthorizedGraphQLClientWithCustomURL(conf.DirectorExternalCertSecuredURL, pk, cert, conf.SkipSSLValidation)
 
 	in := fixtures.FixSampleApplicationRegisterInputWithName("test", "register-app-with-external-cert")

--- a/tests/director/tests/certificates_access_test.go
+++ b/tests/director/tests/certificates_access_test.go
@@ -19,7 +19,22 @@ import (
 func TestIntegrationSystemAccess(t *testing.T) {
 	// Build graphql director client configured with certificate
 	ctx := context.Background()
-	pk, cert := certprovider.NewExternalCertFromConfig(t, ctx, conf.ExternalCertProviderConfig)
+
+	replacer := strings.NewReplacer(conf.TestProviderSubaccountID, conf.ExternalCertTestIntSystemOUSubaccount, conf.ExternalCertCommonName, conf.ExternalCertTestIntSystemCommonName)
+
+	// We need an externally issued cert with a subject that is not part of the access level mappings
+	externalCertProviderConfig := certprovider.ExternalCertProviderConfig{
+		ExternalClientCertTestSecretName:      conf.ExternalCertProviderConfig.ExternalClientCertTestSecretName,
+		ExternalClientCertTestSecretNamespace: conf.ExternalCertProviderConfig.ExternalClientCertTestSecretNamespace,
+		CertSvcInstanceTestSecretName:         conf.ExternalCertProviderConfig.CertSvcInstanceTestSecretName,
+		ExternalCertCronjobContainerName:      conf.ExternalCertProviderConfig.ExternalCertCronjobContainerName,
+		ExternalCertTestJobName:               conf.ExternalCertProviderConfig.ExternalCertTestJobName,
+		TestExternalCertSubject:               replacer.Replace(conf.ExternalCertProviderConfig.TestExternalCertSubject),
+		ExternalClientCertCertKey:             conf.ExternalCertProviderConfig.ExternalClientCertCertKey,
+		ExternalClientCertKeyKey:              conf.ExternalCertProviderConfig.ExternalClientCertKeyKey,
+	}
+
+	pk, cert := certprovider.NewExternalCertFromConfig(t, ctx, externalCertProviderConfig)
 	directorCertSecuredClient := gql.NewCertAuthorizedGraphQLClientWithCustomURL(conf.DirectorExternalCertSecuredURL, pk, cert, conf.SkipSSLValidation)
 
 	testCases := []struct {

--- a/tests/director/tests/main_test.go
+++ b/tests/director/tests/main_test.go
@@ -35,18 +35,20 @@ type DirectorConfig struct {
 	ConsumerID                     string `envconfig:"APP_INFO_CERT_CONSUMER_ID"`
 	CertLoaderConfig               certloader.Config
 	certprovider.ExternalCertProviderConfig
-	SubscriptionConfig               subscription.Config
-	TestProviderSubaccountID         string
-	TestConsumerSubaccountID         string
-	TestConsumerTenantID             string
-	ExternalServicesMockBaseURL      string
-	TokenPath                        string
-	SubscriptionProviderAppNameValue string
-	ConsumerSubaccountLabelKey       string
-	SubscriptionLabelKey             string
-	RuntimeTypeLabelKey              string
-	KymaRuntimeTypeLabelValue        string
-	ExternalCertTestCN               string
+	SubscriptionConfig                    subscription.Config
+	TestProviderSubaccountID              string
+	TestConsumerSubaccountID              string
+	TestConsumerTenantID                  string
+	ExternalServicesMockBaseURL           string
+	TokenPath                             string
+	SubscriptionProviderAppNameValue      string
+	ConsumerSubaccountLabelKey            string
+	SubscriptionLabelKey                  string
+	RuntimeTypeLabelKey                   string
+	KymaRuntimeTypeLabelValue             string
+	ExternalCertCommonName                string `envconfig:"EXTERNAL_CERT_COMMON_NAME"`
+	ExternalCertTestIntSystemOUSubaccount string `envconfig:"APP_EXTERNAL_CERT_TEST_INTEGRATION_SYSTEM_OU_SUBACCOUNT"`
+	ExternalCertTestIntSystemCommonName   string `envconfig:"APP_EXTERNAL_CERT_TEST_INTEGRATION_SYSTEM_CN"`
 }
 
 type BaseDirectorConfig struct {

--- a/tests/director/tests/runtime_contexts_api_test.go
+++ b/tests/director/tests/runtime_contexts_api_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"strings"
 	"testing"
 	"time"
 
@@ -169,20 +168,8 @@ func TestRuntimeContextSubscriptionFlows(stdT *testing.T) {
 		subscriptionConsumerSubaccountID := conf.TestConsumerSubaccountID // the parent is ApplicationsForRuntimeTenantName
 		subscriptionConsumerTenantID := conf.TestConsumerTenantID
 
-		// We need an externally issued cert with a subject that is not part of the access level mappings
-		externalCertProviderConfig := certprovider.ExternalCertProviderConfig{
-			ExternalClientCertTestSecretName:      conf.ExternalCertProviderConfig.ExternalClientCertTestSecretName,
-			ExternalClientCertTestSecretNamespace: conf.ExternalCertProviderConfig.ExternalClientCertTestSecretNamespace,
-			CertSvcInstanceTestSecretName:         conf.ExternalCertProviderConfig.CertSvcInstanceTestSecretName,
-			ExternalCertCronjobContainerName:      conf.ExternalCertProviderConfig.ExternalCertCronjobContainerName,
-			ExternalCertTestJobName:               conf.ExternalCertProviderConfig.ExternalCertTestJobName,
-			TestExternalCertSubject:               strings.Replace(conf.ExternalCertProviderConfig.TestExternalCertSubject, conf.ExternalCertTestCN, "rtm-ctx-test-cn", -1),
-			ExternalClientCertCertKey:             conf.ExternalCertProviderConfig.ExternalClientCertCertKey,
-			ExternalClientCertKeyKey:              conf.ExternalCertProviderConfig.ExternalClientCertKeyKey,
-		}
-
 		// Prepare provider external client certificate and secret and Build graphql director client configured with certificate
-		providerClientKey, providerRawCertChain := certprovider.NewExternalCertFromConfig(t, ctx, externalCertProviderConfig)
+		providerClientKey, providerRawCertChain := certprovider.NewExternalCertFromConfig(t, ctx, conf.ExternalCertProviderConfig)
 		directorCertSecuredClient := gql.NewCertAuthorizedGraphQLClientWithCustomURL(conf.DirectorExternalCertSecuredURL, providerClientKey, providerRawCertChain, conf.SkipSSLValidation)
 
 		providerRuntimeInput := graphql.RuntimeRegisterInput{


### PR DESCRIPTION
**Description**
Use the "consumer-provider" external certificate configuration as the default one in the director test, similar to the configuration in the ord-service tests because the main flows are related to it. And "override" it for the certificate_access tests.

Changes proposed in this pull request:
- Change the external cert configuration to use subject with the provider subaccount as the default one

**Pull Request status**
- [x] Implementation
- [x] [N/A] Unit tests
- [x] [N/A] Integration tests
- [x] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [x] [N/A] Mocks are regenerated, using the automated script
