### PR TITLE
Rename the application template registered by NS Adapter

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -110,7 +110,7 @@ global:
       version: "PR-2383"
     director:
       dir:
-      version: "PR-2465"
+      version: "PR-2480"
     hydrator:
       dir:
       version: "PR-2458"

--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -163,7 +163,7 @@ global:
       gatewayHost: "compass-gateway-xsuaa"
     prefix: /nsadapter
     path: /nsadapter/api/v1/notifications
-    systemToTemplateMappings: '[{  "Name": "S4HANA",  "SourceKey": ["type"],  "SourceValue": ["abapSys"]},{  "Name": "S4HANA",  "SourceKey": ["type"],  "SourceValue": ["nonSAPsys"]},{  "Name": "S4HANA",  "SourceKey": ["type"],  "SourceValue": ["hana"]}]'
+    systemToTemplateMappings: '[{  "Name": "SAP S/4HANA On-Premise",  "SourceKey": ["type"],  "SourceValue": ["abapSys"]},{  "Name": "SAP S/4HANA On-Premise",  "SourceKey": ["type"],  "SourceValue": ["nonSAPsys"]},{  "Name": "SAP S/4HANA On-Premise",  "SourceKey": ["type"],  "SourceValue": ["hana"]}]'
     secret:
       name: nsadapter-secret
       subaccountKey: subaccount

--- a/components/director/cmd/ns-adapter/main.go
+++ b/components/director/cmd/ns-adapter/main.go
@@ -60,7 +60,7 @@ import (
 	"github.com/vrischmann/envconfig"
 )
 
-const appTemplateName = "S4HANA"
+const appTemplateName = "SAP S/4HANA On-Premise"
 
 func main() {
 	ctx, cancel := context.WithCancel(context.Background())
@@ -199,7 +199,7 @@ func registerAppTemplate(ctx context.Context, transact persistence.Transactioner
 
 	appTemplate := model.ApplicationTemplateInput{
 		Name:        appTemplateName,
-		Description: str.Ptr("Template for systems pushed from Notifications Service"),
+		Description: str.Ptr(appTemplateName),
 		ApplicationInputJSON: `{
 									"name": "{{name}}",
 									"description": "{{description}}",

--- a/components/director/run.sh
+++ b/components/director/run.sh
@@ -58,7 +58,7 @@ do
         ;;
         --ns-adapter)
           COMPONENT='ns-adapter'
-          export APP_SYSTEM_TO_TEMPLATE_MAPPINGS='[{  "Name": "S4HANA",  "SourceKey": ["type"],  "SourceValue": ["on-premise"]}]'
+          export APP_SYSTEM_TO_TEMPLATE_MAPPINGS='[{  "Name": "SAP S/4HANA On-Premise",  "SourceKey": ["type"],  "SourceValue": ["on-premise"]}]'
           shift
         ;;
         --jwks-endpoint)

--- a/tests/ns-adapter/tests/delta_report_test.go
+++ b/tests/ns-adapter/tests/delta_report_test.go
@@ -18,6 +18,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const appTemplateName = "SAP S/4HANA On-Premise"
+
 type System struct {
 	Protocol     string `json:"protocol"`
 	Host         string `json:"host"`
@@ -287,7 +289,7 @@ func TestDeltaReport(stdT *testing.T) {
 
 		// Register application
 		appFromTmpl := createApplicationFromTemplateInput(
-			"on-promise-system-1", "S4HANA", "description of the system", "08b6da37-e911-48fb-a0cb-fa635a6c4321", "",
+			"on-promise-system-1", appTemplateName, "description of the system", "08b6da37-e911-48fb-a0cb-fa635a6c4321", "",
 			"nonSAPsys", "127.0.0.1:3000", "mail", "", "reachable")
 		appFromTmplGQL, err := testctx.Tc.Graphqlizer.ApplicationFromTemplateInputToGQL(appFromTmpl)
 		require.NoError(t, err)
@@ -336,7 +338,7 @@ func TestDeltaReport(stdT *testing.T) {
 
 		// Register application
 		appFromTmpl := createApplicationFromTemplateInput(
-			"on-promise-system-1", "S4HANA", "description of the system", "08b6da37-e911-48fb-a0cb-fa635a6c4321", "",
+			"on-promise-system-1", appTemplateName, "description of the system", "08b6da37-e911-48fb-a0cb-fa635a6c4321", "",
 			"nonSAPsys", "127.0.0.1:3000", "mail", "", "reachable")
 		appFromTmplGQL, err := testctx.Tc.Graphqlizer.ApplicationFromTemplateInputToGQL(appFromTmpl)
 		require.NoError(t, err)

--- a/tests/ns-adapter/tests/full_report_test.go
+++ b/tests/ns-adapter/tests/full_report_test.go
@@ -337,7 +337,7 @@ func TestFullReport(stdT *testing.T) {
 
 		// Register application
 		appFromTmpl := createApplicationFromTemplateInput(
-			"on-promise-system-1", "S4HANA", "description of the system", testTenant, "",
+			"on-promise-system-1", appTemplateName, "description of the system", testTenant, "",
 			"nonSAPsys", "127.0.0.1:3000", "mail", "", "reachable")
 
 		appFromTmplGQL, err := testctx.Tc.Graphqlizer.ApplicationFromTemplateInputToGQL(appFromTmpl)
@@ -385,7 +385,7 @@ func TestFullReport(stdT *testing.T) {
 
 		// Register application
 		appFromTmpl := createApplicationFromTemplateInput(
-			"on-promise-system-1", "S4HANA", "description of the system", testTenant, "",
+			"on-promise-system-1", appTemplateName, "description of the system", testTenant, "",
 			"nonSAPsys", "127.0.0.1:3000", "mail", "", "reachable")
 
 		appFromTmplGQL, err := testctx.Tc.Graphqlizer.ApplicationFromTemplateInputToGQL(appFromTmpl)


### PR DESCRIPTION
# Rename the application template registered by NS Adapter

**Description**

Changes proposed in this pull request:
- Rename the application template registered by NS Adapter - S4HANA -> SAP S/4HANA On-Premise