### PR TITLE
Fix test secret reference

### DIFF
--- a/chart/compass/charts/director/templates/external-certificate-rotation-job.yaml
+++ b/chart/compass/charts/director/templates/external-certificate-rotation-job.yaml
@@ -125,7 +125,7 @@ spec:
                   echo -e "${YELLOW}Saving an unencrypted copy of the private key... ${NC}" # Later we use it to create a k8s secret, currently k8s does not support loading encrypted private keys
                   openssl rsa -in /tmp/encrypted-private-key.pem -out /tmp/unencrypted-private-key.pem -passin pass:"$PASS_PHRASE"
 
-                  echo -e "${YELLOW}Creating a CSR in json with the following subject: $CERT_SUBJECT_PATTERN ${NC}"
+                  echo -e "${YELLOW}Creating a CSR with the following subject: $CERT_SUBJECT_PATTERN ${NC}"
                   openssl req -new -sha256 -key /tmp/encrypted-private-key.pem -passin pass:"$PASS_PHRASE" -out /tmp/my-csr.pem -subj "$CERT_SUBJECT_PATTERN"
                   JSON_CSR=$(jq -sR '.' /tmp/my-csr.pem)
                   echo -e "${YELLOW}Created CSR: $JSON_CSR ${NC}"

--- a/chart/compass/templates/tests/director/director-test.yaml
+++ b/chart/compass/templates/tests/director/director-test.yaml
@@ -163,6 +163,8 @@ spec:
               value: {{ .Values.global.director.subscription.subscriptionLabelKey }}
             - name: SKIP_TESTS_REGEX
               value: {{ .Values.global.tests.director.skipPattern }}
+            - name: CERT_SVC_INSTANCE_TEST_INTEGRATION_SYSTEM_SECRET_NAME
+              value: {{ .Values.global.externalCertConfiguration.secrets.externalCertSvcSecret.name }}
             - name: APP_EXTERNAL_CERT_TEST_INTEGRATION_SYSTEM_OU_SUBACCOUNT
               value: {{ .Values.global.externalCertConfiguration.ouCertSubaccountID }}
             - name: APP_EXTERNAL_CERT_TEST_INTEGRATION_SYSTEM_CN

--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -142,7 +142,7 @@ global:
       version: "PR-68"
     e2e_tests:
       dir:
-      version: "PR-2476"
+      version: "PR-2481"
   isLocalEnv: false
   isForTesting: false
   oauth2:

--- a/tests/director/tests/certificates_access_test.go
+++ b/tests/director/tests/certificates_access_test.go
@@ -26,9 +26,9 @@ func TestIntegrationSystemAccess(t *testing.T) {
 	externalCertProviderConfig := certprovider.ExternalCertProviderConfig{
 		ExternalClientCertTestSecretName:      conf.ExternalCertProviderConfig.ExternalClientCertTestSecretName,
 		ExternalClientCertTestSecretNamespace: conf.ExternalCertProviderConfig.ExternalClientCertTestSecretNamespace,
-		CertSvcInstanceTestSecretName:         conf.ExternalCertProviderConfig.CertSvcInstanceTestSecretName,
+		CertSvcInstanceTestSecretName:         conf.CertSvcInstanceTestIntSystemSecretName,
 		ExternalCertCronjobContainerName:      conf.ExternalCertProviderConfig.ExternalCertCronjobContainerName,
-		ExternalCertTestJobName:               conf.ExternalCertProviderConfig.ExternalCertTestJobName,
+		ExternalCertTestJobName:               "external-client-certificate-integration-system-test-job",
 		TestExternalCertSubject:               replacer.Replace(conf.ExternalCertProviderConfig.TestExternalCertSubject),
 		ExternalClientCertCertKey:             conf.ExternalCertProviderConfig.ExternalClientCertCertKey,
 		ExternalClientCertKeyKey:              conf.ExternalCertProviderConfig.ExternalClientCertKeyKey,

--- a/tests/director/tests/certificates_access_test.go
+++ b/tests/director/tests/certificates_access_test.go
@@ -28,7 +28,7 @@ func TestIntegrationSystemAccess(t *testing.T) {
 		ExternalClientCertTestSecretNamespace: conf.ExternalCertProviderConfig.ExternalClientCertTestSecretNamespace,
 		CertSvcInstanceTestSecretName:         conf.CertSvcInstanceTestIntSystemSecretName,
 		ExternalCertCronjobContainerName:      conf.ExternalCertProviderConfig.ExternalCertCronjobContainerName,
-		ExternalCertTestJobName:               "external-client-certificate-integration-system-test-job",
+		ExternalCertTestJobName:               conf.ExternalCertProviderConfig.ExternalCertTestJobName,
 		TestExternalCertSubject:               replacer.Replace(conf.ExternalCertProviderConfig.TestExternalCertSubject),
 		ExternalClientCertCertKey:             conf.ExternalCertProviderConfig.ExternalClientCertCertKey,
 		ExternalClientCertKeyKey:              conf.ExternalCertProviderConfig.ExternalClientCertKeyKey,

--- a/tests/director/tests/main_test.go
+++ b/tests/director/tests/main_test.go
@@ -35,20 +35,21 @@ type DirectorConfig struct {
 	ConsumerID                     string `envconfig:"APP_INFO_CERT_CONSUMER_ID"`
 	CertLoaderConfig               certloader.Config
 	certprovider.ExternalCertProviderConfig
-	SubscriptionConfig                    subscription.Config
-	TestProviderSubaccountID              string
-	TestConsumerSubaccountID              string
-	TestConsumerTenantID                  string
-	ExternalServicesMockBaseURL           string
-	TokenPath                             string
-	SubscriptionProviderAppNameValue      string
-	ConsumerSubaccountLabelKey            string
-	SubscriptionLabelKey                  string
-	RuntimeTypeLabelKey                   string
-	KymaRuntimeTypeLabelValue             string
-	ExternalCertCommonName                string `envconfig:"EXTERNAL_CERT_COMMON_NAME"`
-	ExternalCertTestIntSystemOUSubaccount string `envconfig:"APP_EXTERNAL_CERT_TEST_INTEGRATION_SYSTEM_OU_SUBACCOUNT"`
-	ExternalCertTestIntSystemCommonName   string `envconfig:"APP_EXTERNAL_CERT_TEST_INTEGRATION_SYSTEM_CN"`
+	SubscriptionConfig                     subscription.Config
+	TestProviderSubaccountID               string
+	TestConsumerSubaccountID               string
+	TestConsumerTenantID                   string
+	ExternalServicesMockBaseURL            string
+	TokenPath                              string
+	SubscriptionProviderAppNameValue       string
+	ConsumerSubaccountLabelKey             string
+	SubscriptionLabelKey                   string
+	RuntimeTypeLabelKey                    string
+	KymaRuntimeTypeLabelValue              string
+	ExternalCertCommonName                 string `envconfig:"EXTERNAL_CERT_COMMON_NAME"`
+	CertSvcInstanceTestIntSystemSecretName string `envconfig:"CERT_SVC_INSTANCE_TEST_INTEGRATION_SYSTEM_SECRET_NAME"`
+	ExternalCertTestIntSystemOUSubaccount  string `envconfig:"APP_EXTERNAL_CERT_TEST_INTEGRATION_SYSTEM_OU_SUBACCOUNT"`
+	ExternalCertTestIntSystemCommonName    string `envconfig:"APP_EXTERNAL_CERT_TEST_INTEGRATION_SYSTEM_CN"`
 }
 
 type BaseDirectorConfig struct {


### PR DESCRIPTION
Changes proposed in this pull request:
- Change the job name and secret reference for the certificate_access_test


**Pull Request status**
- [x] Implementation
- [x] [N/A] Unit tests
- [x] Integration tests
- [x] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [x] [N/A] Mocks are regenerated, using the automated script
