### PR TITLE
Fix e2e apptemplate tests which use different region

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -146,7 +146,7 @@ global:
       version: "PR-68"
     e2e_tests:
       dir:
-      version: "PR-2474"
+      version: "PR-2485"
   isLocalEnv: false
   isForTesting: false
   oauth2:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Some tests are using a different region for the subscription flow. But for that region, a different subaccount needs to be used in the tests. This PR changes the subaccount in the cert for those cases.
Changes proposed in this pull request:
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- ...

**Pull Request status**
<!-- Feel free to construct the checklist with whatever items seem most reasonable for your change. You could disassemble the Implementation part to even smaller separate checklist items if you're working on something big for example. But do make the effort to provide a checklist of some sort so that the core team as well as the community can have an idea about the progress of your Pull Request.
-->

- [ ] Implementation
- [ ] Unit tests
- [ ] Integration tests
- [ ] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [ ] Mocks are regenerated, using the automated script
