### PR TITLE
Fix app template subscriptions with second region

### DIFF
--- a/chart/compass/charts/external-services-mock/templates/deployment.yaml
+++ b/chart/compass/charts/external-services-mock/templates/deployment.yaml
@@ -71,7 +71,7 @@ spec:
               - name: APP_DEFAULT_TENANT
                 value: "{{ (index .Values.global.tenants 9).id }}"
               - name: APP_TRUSTED_TENANT
-                value: "{{ (index .Values.global.tenants 25).id }}"
+                value: "{{ (index .Values.global.tenants 26).id }}"
               - name: APP_CA_CERT
                 valueFrom:
                   secretKeyRef:

--- a/chart/compass/templates/tests/director/director-test.yaml
+++ b/chart/compass/templates/tests/director/director-test.yaml
@@ -109,6 +109,8 @@ spec:
               value: {{ .Values.global.tests.externalCertConfiguration.ouCertSubaccountID }}
             - name: TEST_EXTERNAL_CERT_SUBJECT
               value: {{ printf .Values.global.externalCertConfiguration.subjectPattern .Values.global.tests.subscription.tenants.providerSubaccountID .Values.global.externalCertConfiguration.locality .Values.global.externalCertConfiguration.commonName }}
+            - name: TEST_EXTERNAL_CERT_SUBJECT_REGION2
+              value: {{ printf .Values.global.externalCertConfiguration.subjectPattern .Values.global.tests.subscription.tenants.providerSubaccountIDRegion2 .Values.global.externalCertConfiguration.locality .Values.global.externalCertConfiguration.commonName }}
             - name: EXTERNAL_CERT_COMMON_NAME
               value: {{ .Values.global.externalCertConfiguration.commonName }}
             - name: EXTERNAL_CLIENT_CERT_TEST_SECRET_NAME
@@ -119,6 +121,8 @@ spec:
               value: {{ .Values.global.tests.subscription.externalCertTestJobName }}
             - name: CERT_SVC_INSTANCE_TEST_SECRET_NAME
               value: {{ .Values.global.tests.subscription.certSvcInstanceTestSecretName }}
+            - name: CERT_SVC_INSTANCE_TEST_REGION2_SECRET_NAME
+              value: {{ .Values.global.tests.subscription.certSvcInstanceTestRegion2SecretName }}
             - name: EXTERNAL_CERT_CRONJOB_CONTAINER_NAME
               value: {{ .Values.global.externalCertConfiguration.rotationCronjob.containerName }}
             - name: APP_RUNTIME_TYPE_LABEL_KEY
@@ -158,6 +162,8 @@ spec:
               value: {{ .Values.global.tests.subscription.propagatedProviderSubaccountHeader }}
             - name: APP_TEST_PROVIDER_SUBACCOUNT_ID
               value: {{ .Values.global.tests.subscription.tenants.providerSubaccountID }}
+            - name: APP_TEST_PROVIDER_SUBACCOUNT_ID_REGION_2
+              value:  {{ .Values.global.tests.subscription.tenants.providerSubaccountIDRegion2 }}
             - name: APP_TEST_CONSUMER_SUBACCOUNT_ID
               value: {{ .Values.global.tests.subscription.tenants.consumerSubaccountID }}
             - name: APP_TEST_CONSUMER_TENANT_ID

--- a/chart/compass/templates/tests/director/director-test.yaml
+++ b/chart/compass/templates/tests/director/director-test.yaml
@@ -162,7 +162,7 @@ spec:
               value: {{ .Values.global.tests.subscription.propagatedProviderSubaccountHeader }}
             - name: APP_TEST_PROVIDER_SUBACCOUNT_ID
               value: {{ .Values.global.tests.subscription.tenants.providerSubaccountID }}
-            - name: APP_TEST_PROVIDER_SUBACCOUNT_ID_REGION_2
+            - name: APP_TEST_PROVIDER_SUBACCOUNT_ID_REGION2
               value:  {{ .Values.global.tests.subscription.tenants.providerSubaccountIDRegion2 }}
             - name: APP_TEST_CONSUMER_SUBACCOUNT_ID
               value: {{ .Values.global.tests.subscription.tenants.consumerSubaccountID }}

--- a/chart/compass/templates/tests/ord-service/ord-service-test.yaml
+++ b/chart/compass/templates/tests/ord-service/ord-service-test.yaml
@@ -137,6 +137,8 @@ spec:
               value: {{ .Values.global.tests.externalCertConfiguration.ouCertSubaccountID }}
             - name: TEST_EXTERNAL_CERT_SUBJECT
               value: {{ printf .Values.global.externalCertConfiguration.subjectPattern .Values.global.tests.subscription.tenants.providerSubaccountID .Values.global.externalCertConfiguration.locality .Values.global.externalCertConfiguration.commonName }}
+            - name: TEST_EXTERNAL_CERT_SUBJECT_REGION2
+              value: {{ printf .Values.global.externalCertConfiguration.subjectPattern .Values.global.tests.subscription.tenants.providerSubaccountIDRegion2 .Values.global.externalCertConfiguration.locality .Values.global.externalCertConfiguration.commonName }}
             - name: EXTERNAL_CLIENT_CERT_TEST_SECRET_NAME
               value: {{ .Values.global.tests.subscription.externalClientCertTestSecretName }}
             - name: EXTERNAL_CLIENT_CERT_TEST_SECRET_NAMESPACE
@@ -145,6 +147,8 @@ spec:
               value: {{ .Values.global.tests.subscription.externalCertTestJobName }}
             - name: CERT_SVC_INSTANCE_TEST_SECRET_NAME
               value: {{ .Values.global.tests.subscription.certSvcInstanceTestSecretName }}
+            - name: CERT_SVC_INSTANCE_TEST_REGION2_SECRET_NAME
+              value: {{ .Values.global.tests.subscription.certSvcInstanceTestRegion2SecretName }}
             - name: EXTERNAL_CERT_CRONJOB_CONTAINER_NAME
               value: {{ .Values.global.externalCertConfiguration.rotationCronjob.containerName }}
             - name: BASIC_USERNAME

--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -798,7 +798,7 @@ global:
       tenants:
         consumerAccountID: "5984a414-1eed-4972-af2c-b2b6a415c7d7" # ApplicationsForRuntimeTenantName from our testing tenants
         providerSubaccountID: "f8075207-1478-4a80-bd26-24a4785a2bfd" # TestProviderSubaccount from our testing tenants
-        providerSubaccountIDRegion2: "f3cfe09f-68ef-4cb6-9ca2-e389c926a53b" # TestProviderSubaccountRegion2 from our testing tenants
+        providerSubaccountIDRegion2: "731b7bc4-5472-41d2-a447-e4c0f45de739" # TestProviderSubaccountRegion2 from our testing tenants
         consumerSubaccountID: "1f538f34-30bf-4d3d-aeaa-02e69eef84ae" # randomly chosen
         consumerTenantID: "ba49f1aa-ddc1-43ff-943c-fe949857a34a" # randomly chosen
       oauthSecret:

--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -64,6 +64,10 @@ global:
       id: f8075207-1478-4a80-bd26-24a4785a2bfd
       type: subaccount
       parent: 5577cf46-4f78-45fa-b55f-a42a3bdba868
+    - name: TestProviderSubaccountRegion2
+      id: 731b7bc4-5472-41d2-a447-e4c0f45de739
+      type: subaccount
+      parent: 5577cf46-4f78-45fa-b55f-a42a3bdba868
     - name: TestCertificateSubaccount
       id: 123e4567-e89b-12d3-a456-426614174001
       type: subaccount
@@ -794,6 +798,7 @@ global:
       tenants:
         consumerAccountID: "5984a414-1eed-4972-af2c-b2b6a415c7d7" # ApplicationsForRuntimeTenantName from our testing tenants
         providerSubaccountID: "f8075207-1478-4a80-bd26-24a4785a2bfd" # TestProviderSubaccount from our testing tenants
+        providerSubaccountIDRegion2: "f3cfe09f-68ef-4cb6-9ca2-e389c926a53b" # TestProviderSubaccountRegion2 from our testing tenants
         consumerSubaccountID: "1f538f34-30bf-4d3d-aeaa-02e69eef84ae" # randomly chosen
         consumerTenantID: "ba49f1aa-ddc1-43ff-943c-fe949857a34a" # randomly chosen
       oauthSecret:
@@ -807,6 +812,7 @@ global:
       externalClientCertTestSecretNamespace: "compass-system"
       externalCertTestJobName: "external-certificate-rotation-test-job"
       certSvcInstanceTestSecretName: "cert-svc-secret"
+      certSvcInstanceTestRegion2SecretName: "cert-svc-secret-eu2"
       consumerTokenURL: "http://compass-external-services-mock.compass-system.svc.cluster.local:8080"
       subscriptionURL: "http://compass-external-services-mock.compass-system.svc.cluster.local:8080"
       subscriptionProviderIdValue: "id-value!t12345"

--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -150,7 +150,7 @@ global:
       version: "PR-68"
     e2e_tests:
       dir:
-      version: "PR-2479"
+      version: "PR-2488"
   isLocalEnv: false
   isForTesting: false
   enableInternalCommunicationPolicies: true

--- a/tests/director/tests/application_templates_api_test.go
+++ b/tests/director/tests/application_templates_api_test.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"testing"
 
+	str "github.com/kyma-incubator/compass/components/director/pkg/str"
+
 	gcli "github.com/machinebox/graphql"
 
 	"github.com/kyma-incubator/compass/tests/pkg/certs/certprovider"
@@ -221,7 +223,7 @@ func TestCreateApplicationTemplate_SameNames(t *testing.T) {
 				appTemplateTwoOutput := fixtures.GetApplicationTemplate(t, ctx, certSecuredGraphQLClient, tenant.TestTenants.GetDefaultTenantID(), appTemplateTwo.ID)
 
 				appTemplateTwoInput.Labels[conf.SubscriptionConfig.SelfRegisterLabelKey] = appTemplateTwoOutput.Labels[conf.SubscriptionConfig.SelfRegisterLabelKey]
-				appTemplateTwoInput.Labels["global_subaccount_id"] = conf.ConsumerID
+				appTemplateTwoInput.Labels["global_subaccount_id"] = conf.TestProviderSubaccountIDRegion2
 				appTemplateTwoInput.ApplicationInput.Labels["applicationType"] = fmt.Sprintf("%s (%s)", testCase.AppTemplateTwoName, testCase.AppTemplateTwoRegion)
 
 				require.NotEmpty(t, appTemplateTwoOutput)
@@ -579,7 +581,14 @@ func TestQueryApplicationTemplates(t *testing.T) {
 
 	//THEN
 	t.Log("Check if application templates were received")
-	assert.Subset(t, output.Data, []*graphql.ApplicationTemplate{&appTemplate1, &appTemplate2})
+	appTemplateIDs := []string{appTemplate1.ID, appTemplate2.ID}
+	found := 0
+	for _, tmpl := range output.Data {
+		if str.ContainsInSlice(appTemplateIDs, tmpl.ID) {
+			found++
+		}
+	}
+	assert.Equal(t, 2, found)
 	saveExample(t, getApplicationTemplatesRequest.Query(), "query application templates")
 }
 

--- a/tests/director/tests/main_test.go
+++ b/tests/director/tests/main_test.go
@@ -37,6 +37,7 @@ type DirectorConfig struct {
 	certprovider.ExternalCertProviderConfig
 	SubscriptionConfig                     subscription.Config
 	TestProviderSubaccountID               string
+	TestProviderSubaccountIDRegion2        string
 	TestConsumerSubaccountID               string
 	TestConsumerTenantID                   string
 	ExternalServicesMockBaseURL            string

--- a/tests/pkg/certs/certprovider/ext_cert_provider.go
+++ b/tests/pkg/certs/certprovider/ext_cert_provider.go
@@ -19,9 +19,11 @@ type ExternalCertProviderConfig struct {
 	ExternalClientCertTestSecretName      string `envconfig:"EXTERNAL_CLIENT_CERT_TEST_SECRET_NAME"`
 	ExternalClientCertTestSecretNamespace string `envconfig:"EXTERNAL_CLIENT_CERT_TEST_SECRET_NAMESPACE"`
 	CertSvcInstanceTestSecretName         string `envconfig:"CERT_SVC_INSTANCE_TEST_SECRET_NAME"`
+	CertSvcInstanceTestRegion2SecretName  string `envconfig:"CERT_SVC_INSTANCE_TEST_REGION2_SECRET_NAME"`
 	ExternalCertCronjobContainerName      string `envconfig:"EXTERNAL_CERT_CRONJOB_CONTAINER_NAME"`
 	ExternalCertTestJobName               string `envconfig:"EXTERNAL_CERT_TEST_JOB_NAME"`
 	TestExternalCertSubject               string `envconfig:"TEST_EXTERNAL_CERT_SUBJECT"`
+	TestExternalCertSubjectRegion2        string `envconfig:"TEST_EXTERNAL_CERT_SUBJECT_REGION2"`
 	TestExternalCertCN                    string `envconfig:"TEST_EXTERNAL_CERT_CN"`
 	TestExternalCertOU                    string `envconfig:"TEST_EXTERNAL_CERT_OU"`
 	TestExternalCertOU2                   string `envconfig:"TEST_EXTERNAL_CERT_OU2"`
@@ -72,7 +74,11 @@ func createExtCertJob(t *testing.T, ctx context.Context, k8sClient *kubernetes.C
 					env.Value = testConfig.TestExternalCertSubject
 				}
 				if env.Name == "CERT_SVC_CSR_ENDPOINT" || env.Name == "CERT_SVC_CLIENT_ID" || env.Name == "CERT_SVC_OAUTH_URL" || env.Name == "CERT_SVC_OAUTH_CLIENT_CERT" || env.Name == "CERT_SVC_OAUTH_CLIENT_KEY" {
-					env.ValueFrom.SecretKeyRef.Name = testConfig.CertSvcInstanceTestSecretName // external certificate credentials used to execute consumer-provider test
+					if testConfig.CertSvcInstanceTestSecretName != "" {
+						env.ValueFrom.SecretKeyRef.Name = testConfig.CertSvcInstanceTestSecretName // external certificate credentials used to execute consumer-provider test
+					} else if testConfig.CertSvcInstanceTestRegion2SecretName != "" {
+						env.ValueFrom.SecretKeyRef.Name = testConfig.CertSvcInstanceTestRegion2SecretName // external certificate credentials used to execute consumer-provider test
+					}
 				}
 			}
 			break

--- a/tests/pkg/tenant/tenant_setup.go
+++ b/tests/pkg/tenant/tenant_setup.go
@@ -44,6 +44,7 @@ const (
 	ApplicationsForRuntimeWithHiddenAppsTenantName             = "TestApplicationsForRuntimeWithHiddenApps"
 	TestDeleteApplicationIfInScenario                          = "TestDeleteApplicationIfInScenario"
 	TestProviderSubaccount                                     = "TestProviderSubaccount"
+	TestProviderSubaccountRegion2                              = "TestProviderSubaccountRegion2"
 	TestConsumerSubaccount                                     = "TestConsumerSubaccount"
 	TestIntegrationSystemManagedSubaccount                     = "TestIntegrationSystemManagedSubaccount"
 	TestIntegrationSystemManagedAccount                        = "TestIntegrationSystemManagedAccount"
@@ -191,6 +192,14 @@ func (mgr *TestTenantsManager) Init() {
 		TestProviderSubaccount: {
 			Name:           TestProviderSubaccount,
 			ExternalTenant: "f8075207-1478-4a80-bd26-24a4785a2bfd",
+			ProviderName:   testProvider,
+			Type:           Subaccount,
+			Status:         Active,
+			Parent:         testDefaultTenant,
+		},
+		TestProviderSubaccountRegion2: {
+			Name:           TestProviderSubaccountRegion2,
+			ExternalTenant: "731b7bc4-5472-41d2-a447-e4c0f45de739",
 			ProviderName:   testProvider,
 			Type:           Subaccount,
 			Status:         Active,


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
When using a different region (region2) we need an additional setup so we can call the 3rd party systems with the correct subaccountID

Changes proposed in this pull request:
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- ...

**Pull Request status**
<!-- Feel free to construct the checklist with whatever items seem most reasonable for your change. You could disassemble the Implementation part to even smaller separate checklist items if you're working on something big for example. But do make the effort to provide a checklist of some sort so that the core team as well as the community can have an idea about the progress of your Pull Request.
-->

- [ ] Implementation
- [ ] Unit tests
- [ ] Integration tests
- [ ] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [ ] Mocks are regenerated, using the automated script
