### PR TITLE
Fix deploy-on-k3d make target

### DIFF
--- a/components/director/Makefile
+++ b/components/director/Makefile
@@ -34,12 +34,17 @@ install-tools:
 
 deploy-on-k3d: build-for-k3d
 	kubectl config use-context k3d-kyma
+	kubectl patch -n $(NAMESPACE) deployment/compass-director -p '{"spec":{"template":{"spec":{"containers":[{"name":"director","imagePullPolicy":"Always"}]}}}}'
 	kubectl set image -n $(NAMESPACE) deployment/compass-director director=k3d-kyma-registry:5001/compass-director:latest
 	kubectl rollout restart -n $(NAMESPACE) deployment/compass-director
+	kubectl patch -n $(NAMESPACE) deployment/compass-ns-adapter -p '{"spec":{"template":{"spec":{"containers":[{"name":"ns-adapter","imagePullPolicy":"Always"}]}}}}'
 	kubectl set image -n $(NAMESPACE) deployment/compass-ns-adapter ns-adapter=k3d-kyma-registry:5001/compass-director:latest
 	kubectl rollout restart -n $(NAMESPACE) deployment/compass-ns-adapter
+	kubectl patch -n $(NAMESPACE) cronjob/compass-ord-aggregator -p '{"spec":{"jobTemplate":{"spec":{"template":{"spec":{"containers":[{"name":"aggregator","imagePullPolicy":"Always"}]}}}}}}'
 	kubectl set image -n $(NAMESPACE) cronjob/compass-ord-aggregator aggregator=k3d-kyma-registry:5001/compass-director:latest
+	kubectl patch -n $(NAMESPACE) cronjob/compass-system-fetcher -p '{"spec":{"jobTemplate":{"spec":{"template":{"spec":{"containers":[{"name":"system-fetcher","imagePullPolicy":"Always"}]}}}}}}'
 	kubectl set image -n $(NAMESPACE) cronjob/compass-system-fetcher system-fetcher=k3d-kyma-registry:5001/compass-director:latest
+	kubectl patch -n $(NAMESPACE) cronjob/compass-director-tenant-loader-external -p '{"spec":{"jobTemplate":{"spec":{"template":{"spec":{"containers":[{"name":"loader","imagePullPolicy":"Always"}]}}}}}}'
 	kubectl set image -n $(NAMESPACE) cronjob/compass-director-tenant-loader-external loader=k3d-kyma-registry:5001/compass-director:latest
 	kubectl get job -n $(NAMESPACE) compass-director-tenant-loader-default -o json  | jq "del(.spec.selector)" | jq "del(.spec.template.metadata.labels)" | jq "del(.status)" | kubectl patch -f - --patch '{"spec":  {"template":  {"spec":  {"containers": [{"name": "loader", "image": "k3d-kyma-registry:5001/compass-director:latest"}]}}}}' --dry-run=client -o yaml | kubectl replace --force -f -
 	kubectl get job -n $(NAMESPACE) compass-director-clients-scopes-synchronization -o json  | jq "del(.spec.selector)" | jq "del(.spec.template.metadata.labels)" | jq "del(.status)" | kubectl patch -f - --patch '{"spec":  {"template":  {"spec":  {"containers": [{"name": "sync", "image": "k3d-kyma-registry:5001/compass-director:latest"}]}}}}' --dry-run=client -o yaml | kubectl replace --force -f -

--- a/components/external-services-mock/Makefile
+++ b/components/external-services-mock/Makefile
@@ -31,6 +31,7 @@ build-local:
 
 deploy-on-k3d: build-for-k3d
 	kubectl config use-context k3d-kyma
+	kubectl patch -n $(NAMESPACE) deployment/compass-external-services-mock -p '{"spec":{"template":{"spec":{"containers":[{"name":"external-services-mock","imagePullPolicy":"Always"}]}}}}'
 	kubectl set image -n $(NAMESPACE) deployment/compass-external-services-mock external-services-mock=k3d-kyma-registry:5001/compass-external-services-mock:latest
 	kubectl rollout restart -n $(NAMESPACE) deployment/compass-external-services-mock
 	kubectl rollout restart -n $(NAMESPACE) deployment/compass-gateway

--- a/scripts/generic_make_go.mk
+++ b/scripts/generic_make_go.mk
@@ -199,5 +199,6 @@ exec:
 # Sets locally built image for a given component in k3d cluster
 deploy-on-k3d: build-for-k3d
 	kubectl config use-context k3d-kyma
+	kubectl patch -n $(NAMESPACE) deployment/$(DEPLOYMENT_NAME) -p '{"spec":{"template":{"spec":{"containers":[{"name":"'$(COMPONENT_NAME)'","imagePullPolicy":"Always"}]}}}}'
 	kubectl set image -n $(NAMESPACE) deployment/$(DEPLOYMENT_NAME) $(COMPONENT_NAME)=k3d-kyma-registry:5001/$(DEPLOYMENT_NAME):$(TAG)
 	kubectl rollout restart -n $(NAMESPACE) deployment/$(DEPLOYMENT_NAME)


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Currently, our deployments/jobs have `imagePullPolicy: IfNotPresent`, and when we do `make deploy-on-k3d` the newly built images are not fetched in the deployment/jobs.

Changes proposed in this pull request:
- make deploy-on-k3d not only to build the image and change it in the deployment but also to change the imagePullPolicy to Always in order to make sure that the image will be updated.

**Pull Request status**
<!-- Feel free to construct the checklist with whatever items seem most reasonable for your change. You could disassemble the Implementation part to even smaller separate checklist items if you're working on something big for example. But do make the effort to provide a checklist of some sort so that the core team as well as the community can have an idea about the progress of your Pull Request.
-->

- [x] Implementation
- [x] [N/A] Unit tests
- [x] [N/A] Integration tests
- [x] [N/A] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [x] [N/A] Mocks are regenerated, using the automated script
