### PR TITLE
Adapt ext-svc-mock self-reg cleanup

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -144,13 +144,13 @@ global:
       version: "0a651695"
     external_services_mock:
       dir:
-      version: "PR-2479"
+      version: "PR-2503"
     console:
       dir:
       version: "PR-68"
     e2e_tests:
       dir:
-      version: "PR-2499"
+      version: "PR-2503"
   isLocalEnv: false
   isForTesting: false
   enableInternalCommunicationPolicies: true

--- a/components/external-services-mock/internal/selfreg/handler.go
+++ b/components/external-services-mock/internal/selfreg/handler.go
@@ -3,12 +3,11 @@ package selfreg
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/davecgh/go-spew/spew"
-	"github.com/kyma-incubator/compass/components/director/pkg/log"
-	"github.com/kyma-incubator/compass/components/external-services-mock/internal/subscription"
 	"io"
 	"net/http"
 	"reflect"
+
+	"github.com/kyma-incubator/compass/components/external-services-mock/internal/subscription"
 
 	"github.com/pkg/errors"
 
@@ -37,6 +36,8 @@ func NewSelfRegisterHandler(c Config) *Handler {
 	return &Handler{c: c}
 }
 
+var SelfRegistrations = make(map[string]string, 0)
+
 func (h *Handler) HandleSelfRegPrep(w http.ResponseWriter, r *http.Request) {
 	name := r.URL.Query().Get(h.c.NameQueryParam)
 	if name == "" {
@@ -44,7 +45,8 @@ func (h *Handler) HandleSelfRegPrep(w http.ResponseWriter, r *http.Request) {
 		httphelpers.WriteError(w, err, http.StatusBadRequest)
 		return
 	}
-	if tenant := r.URL.Query().Get(h.c.TenantQueryParam); tenant == "" {
+	tenant := r.URL.Query().Get(h.c.TenantQueryParam)
+	if tenant == "" {
 		err := errors.New(fmt.Sprintf("%s query param missing", h.c.TenantQueryParam))
 		httphelpers.WriteError(w, err, http.StatusBadRequest)
 		return
@@ -73,28 +75,30 @@ func (h *Handler) HandleSelfRegPrep(w http.ResponseWriter, r *http.Request) {
 		httphelpers.WriteError(w, err, http.StatusBadRequest)
 		return
 	}
+
+	SelfRegistrations[name] = tenant
 }
 
 func (h *Handler) HandleSelfRegCleanup(w http.ResponseWriter, r *http.Request) {
 	params := mux.Vars(r)
-	if name, ok := params[NamePath]; !ok || name == "" {
+	name, ok := params[NamePath]
+	if !ok || name == "" {
 		err := errors.New(fmt.Sprintf("%s is missing from path", NamePath))
 		httphelpers.WriteError(w, err, http.StatusBadRequest)
 		return
 	}
-	log.D().Infof("Dump request:")
-	spew.Dump(r)
-	tenants, exists := r.Header["Tenant"]
 
-	log.D().Infof("Dump Tenants:")
-	spew.Dump(tenants)
-	if !exists {
-		err := errors.New("Tenant is missing in request header")
-		httphelpers.WriteError(w, err, http.StatusBadRequest)
-		return
+	providerSubaccount, cloningExists := SelfRegistrations[name]
+
+	subscriberExists := false
+	for _, provider := range subscription.Subscriptions {
+		if provider == providerSubaccount {
+			subscriberExists = true
+			break
+		}
 	}
 
-	if subscription.Subscriptions[tenants[0]] {
+	if cloningExists && subscriberExists {
 		// We swallow their error msg and print only the status code
 		err := errors.New("")
 		httphelpers.WriteError(w, err, http.StatusConflict)

--- a/components/external-services-mock/internal/subscription/handler.go
+++ b/components/external-services-mock/internal/subscription/handler.go
@@ -26,6 +26,8 @@ type JobStatus struct {
 	State string `json:"state"`
 }
 
+var Subscriptions = make(map[string]bool)
+
 // NewHandler returns new subscription handler responsible to subscribe and unsubscribe tenants
 func NewHandler(httpClient *http.Client, tenantConfig Config, providerConfig ProviderConfig, jobID string) *handler {
 	return &handler{
@@ -135,7 +137,13 @@ func (h *handler) executeSubscriptionRequest(r *http.Request, httpMethod string)
 		return http.StatusInternalServerError, errors.Wrap(err, "while creating subscription request")
 	}
 
-	log.C(ctx).Infof("Creating/Removing subscription for consumer with tenant id: %s and subaccount id: %s", consumerTenantID, h.tenantConfig.TestConsumerSubaccountID)
+	log.D().Infof("Changed\n")
+
+	if httpMethod == http.MethodPut {
+		log.C(ctx).Infof("Creating subscription for consumer with tenant id: %s and subaccount id: %s", consumerTenantID, h.tenantConfig.TestConsumerSubaccountID)
+	} else {
+		log.C(ctx).Infof("Removing subscription for consumer with tenant id: %s and subaccount id: %s", consumerTenantID, h.tenantConfig.TestConsumerSubaccountID)
+	}
 	resp, err := h.httpClient.Do(request)
 	if err != nil {
 		log.C(ctx).Errorf("while executing subscription request: %s", err.Error())
@@ -150,6 +158,11 @@ func (h *handler) executeSubscriptionRequest(r *http.Request, httpMethod string)
 	if resp.StatusCode != http.StatusOK {
 		log.C(ctx).Errorf("wrong status code while executing subscription request, got [%d], expected [%d]", resp.StatusCode, http.StatusOK)
 		return http.StatusInternalServerError, errors.New(fmt.Sprintf("wrong status code while executing subscription request, got [%d], expected [%d]", resp.StatusCode, http.StatusOK))
+	}
+	if httpMethod == http.MethodPut {
+		Subscriptions[consumerTenantID] = true
+	} else if httpMethod == http.MethodDelete {
+		delete(Subscriptions, consumerTenantID)
 	}
 
 	return http.StatusOK, nil

--- a/components/external-services-mock/internal/subscription/handler.go
+++ b/components/external-services-mock/internal/subscription/handler.go
@@ -26,7 +26,7 @@ type JobStatus struct {
 	State string `json:"state"`
 }
 
-var Subscriptions = make(map[string]bool)
+var Subscriptions = make(map[string]string)
 
 // NewHandler returns new subscription handler responsible to subscribe and unsubscribe tenants
 func NewHandler(httpClient *http.Client, tenantConfig Config, providerConfig ProviderConfig, jobID string) *handler {
@@ -137,8 +137,6 @@ func (h *handler) executeSubscriptionRequest(r *http.Request, httpMethod string)
 		return http.StatusInternalServerError, errors.Wrap(err, "while creating subscription request")
 	}
 
-	log.D().Infof("Changed\n")
-
 	if httpMethod == http.MethodPut {
 		log.C(ctx).Infof("Creating subscription for consumer with tenant id: %s and subaccount id: %s", consumerTenantID, h.tenantConfig.TestConsumerSubaccountID)
 	} else {
@@ -160,7 +158,7 @@ func (h *handler) executeSubscriptionRequest(r *http.Request, httpMethod string)
 		return http.StatusInternalServerError, errors.New(fmt.Sprintf("wrong status code while executing subscription request, got [%d], expected [%d]", resp.StatusCode, http.StatusOK))
 	}
 	if httpMethod == http.MethodPut {
-		Subscriptions[consumerTenantID] = true
+		Subscriptions[consumerTenantID] = providerSubaccID
 	} else if httpMethod == http.MethodDelete {
 		delete(Subscriptions, consumerTenantID)
 	}

--- a/tests/director/tests/runtime_contexts_api_test.go
+++ b/tests/director/tests/runtime_contexts_api_test.go
@@ -275,8 +275,7 @@ func TestRuntimeContextSubscriptionFlows(stdT *testing.T) {
 		err = testctx.Tc.RunOperationWithCustomTenant(ctx, certSecuredGraphQLClient, subscriptionConsumerSubaccountID, deleteRuntimeReq, &rtmExt)
 		require.Empty(t, rtmExt)
 		require.Error(t, err)
-		// TODO:: Adjust external-services-mock to handle self-registration cleanup properly
-		// If we call with tenant that have owner=false, we shouldn't be able to cleanup the self-registered runtime
+		// We shouldn't be able cleanup the self-registered runtime if there is a subscription
 		require.Contains(t, err.Error(), "received unexpected status code 409")
 
 		subscription.BuildAndExecuteUnsubscribeRequest(t, providerRuntime.ID, providerRuntime.Name, httpClient, conf.SubscriptionConfig.URL, apiPath, subscriptionToken, conf.SubscriptionConfig.PropagatedProviderSubaccountHeader, subscriptionConsumerSubaccountID, subscriptionConsumerTenantID, subscriptionProviderSubaccountID)

--- a/tests/director/tests/runtime_contexts_api_test.go
+++ b/tests/director/tests/runtime_contexts_api_test.go
@@ -277,7 +277,7 @@ func TestRuntimeContextSubscriptionFlows(stdT *testing.T) {
 		require.Error(t, err)
 		// TODO:: Adjust external-services-mock to handle self-registration cleanup properly
 		// If we call with tenant that have owner=false, we shouldn't be able to cleanup the self-registered runtime
-		//require.Contains(t, err.Error(), "An error occurred during cleanup of self-registered runtime")
+		require.Contains(t, err.Error(), "received unexpected status code 409")
 
 		subscription.BuildAndExecuteUnsubscribeRequest(t, providerRuntime.ID, providerRuntime.Name, httpClient, conf.SubscriptionConfig.URL, apiPath, subscriptionToken, conf.SubscriptionConfig.PropagatedProviderSubaccountHeader, subscriptionConsumerSubaccountID, subscriptionConsumerTenantID, subscriptionProviderSubaccountID)
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Adjust external-services-mock to handle self-registration cleanup properly. We shouldn't be able cleanup self-registered runtime if there is a subscription.

Changes proposed in this pull request:
- Adjust external-services-mock to handle self-registration cleanup properly

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- https://github.com/kyma-incubator/compass/pull/2498

**Pull Request status**
<!-- Feel free to construct the checklist with whatever items seem most reasonable for your change. You could disassemble the Implementation part to even smaller separate checklist items if you're working on something big for example. But do make the effort to provide a checklist of some sort so that the core team as well as the community can have an idea about the progress of your Pull Request.
-->

- [x] Implementation
- [x] [N/A] Unit tests
- [x] [N/A] Integration tests
- [x] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [x] [N/A] Mocks are regenerated, using the automated script
