### PR TITLE
[v1.37.0] Fix tenants resync: add tenant listing in chunks

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -118,7 +118,7 @@ global:
       version: "PR-2383"
     director:
       dir:
-      version: "PR-2483"
+      version: "PR-2509"
     hydrator:
       dir:
       version: "PR-2458"

--- a/components/director/internal/domain/tenant/repository.go
+++ b/components/director/internal/domain/tenant/repository.go
@@ -4,11 +4,11 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"math"
 	"strings"
 	"text/template"
 
 	"github.com/jmoiron/sqlx"
-
 	"github.com/kyma-incubator/compass/components/director/pkg/log"
 
 	"github.com/kyma-incubator/compass/components/director/pkg/tenant"
@@ -30,6 +30,8 @@ const (
 	tableName                      string = `public.business_tenant_mappings`
 	labelDefinitionsTableName      string = `public.label_definitions`
 	labelDefinitionsTenantIDColumn string = `tenant_id`
+
+	maxParameterChunkSize int = 50000 // max parameters size in PostgreSQL is 65535
 )
 
 var (
@@ -181,8 +183,25 @@ func (r *pgRepository) ListPageBySearchTerm(ctx context.Context, searchTerm stri
 	}, nil
 }
 
-// ListByExternalTenants retrieves all tenants with matching external ID from the Compass storage.
-func (r *pgRepository) ListByExternalTenants(ctx context.Context, externalTenant []string) ([]*model.BusinessTenantMapping, error) {
+// ListByExternalTenants retrieves all tenants with matching external ID from the Compass storage in chunks.
+func (r *pgRepository) ListByExternalTenants(ctx context.Context, externalTenantIDs []string) ([]*model.BusinessTenantMapping, error) {
+	tenants := make([]*model.BusinessTenantMapping, 0)
+
+	for len(externalTenantIDs) > 0 {
+		chunkSize := int(math.Min(float64(len(externalTenantIDs)), float64(maxParameterChunkSize)))
+		tenantsChunk := externalTenantIDs[:chunkSize]
+		tenantsFromDB, err := r.listByExternalTenantIDs(ctx, tenantsChunk)
+		if err != nil {
+			return nil, err
+		}
+		externalTenantIDs = externalTenantIDs[chunkSize:]
+		tenants = append(tenants, tenantsFromDB...)
+	}
+
+	return tenants, nil
+}
+
+func (r *pgRepository) listByExternalTenantIDs(ctx context.Context, externalTenant []string) ([]*model.BusinessTenantMapping, error) {
 	var entityCollection tenant.EntityCollection
 
 	conditions := repo.Conditions{
@@ -192,12 +211,7 @@ func (r *pgRepository) ListByExternalTenants(ctx context.Context, externalTenant
 		return nil, err
 	}
 
-	items := make([]*model.BusinessTenantMapping, 0, len(entityCollection))
-	for _, entity := range entityCollection {
-		tmModel := r.conv.FromEntity(&entity)
-		items = append(items, tmModel)
-	}
-	return items, nil
+	return r.multipleFromEntities(entityCollection), nil
 }
 
 // Update updates the values of tenant with matching internal, and external IDs.


### PR DESCRIPTION
**HOTFIX**
https://github.com/kyma-incubator/compass/pull/2508

**Description**
In the latest releases we've introduced a change in the synchronization logic of tenants with an external system - before we compared all exsting tenants with the ones associated with create/delete events (resulting in dumping the whole `business_tenants_mapping` table), now, we fetch only the tenants that match the external IDs from the newest events. 

This "optimised' logic brakes the full resync of tenants - in some cases we might have to process events for more than 100k tenants, but our DB has max parameters size of 65535, hence we cannot try to retrieve all ~100k tenants at once.

The chosen approach is to query tenants by chunks - 50k per chunk. The approach is open for discussion.

Changes proposed in this pull request:
- `ListByExternalTenants` now chunks the DB requests if the provided tenants are more than 50k.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- NGPBUG-194007

**Pull Request status**
<!-- Feel free to construct the checklist with whatever items seem most reasonable for your change. You could disassemble the Implementation part to even smaller separate checklist items if you're working on something big for example. But do make the effort to provide a checklist of some sort so that the core team as well as the community can have an idea about the progress of your Pull Request.
-->

- [x] Implementation
- [x] Unit tests
- [ ] Integration tests
- [ ] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [x] Mocks are regenerated, using the automated script
