### PR TITLE
[HOTFIX] Fix runtime context's parent owner check

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -118,7 +118,7 @@ global:
       version: "PR-2501"
     director:
       dir:
-      version: "PR-2501"
+      version: "PR-2513"
     hydrator:
       dir:
       version: "PR-2501"

--- a/components/director/internal/domain/formation/service_test.go
+++ b/components/director/internal/domain/formation/service_test.go
@@ -4057,6 +4057,11 @@ func TestServiceUnassignFormation(t *testing.T) {
 				labelService.On("GetLabel", ctx, Tnt, runtimeLblInput).Return(nil, testErr)
 				return labelService
 			},
+			FormationRepositoryFn: func() *automock.FormationRepository {
+				formationRepo := &automock.FormationRepository{}
+				formationRepo.On("GetByName", ctx, testFormationName, Tnt).Return(expected, nil).Once()
+				return formationRepo
+			},
 			AsaRepoFN: func() *automock.AutomaticFormationAssignmentRepository {
 				asaRepo := &automock.AutomaticFormationAssignmentRepository{}
 				asaRepo.On("ListAll", ctx, Tnt).Return(nil, nil)
@@ -4087,6 +4092,11 @@ func TestServiceUnassignFormation(t *testing.T) {
 				}, nil)
 				return labelService
 			},
+			FormationRepositoryFn: func() *automock.FormationRepository {
+				formationRepo := &automock.FormationRepository{}
+				formationRepo.On("GetByName", ctx, testFormationName, Tnt).Return(expected, nil).Once()
+				return formationRepo
+			},
 			AsaRepoFN: func() *automock.AutomaticFormationAssignmentRepository {
 				asaRepo := &automock.AutomaticFormationAssignmentRepository{}
 				asaRepo.On("ListAll", ctx, Tnt).Return(nil, nil)
@@ -4111,6 +4121,11 @@ func TestServiceUnassignFormation(t *testing.T) {
 				}, nil)
 				return labelService
 			},
+			FormationRepositoryFn: func() *automock.FormationRepository {
+				formationRepo := &automock.FormationRepository{}
+				formationRepo.On("GetByName", ctx, testFormationName, Tnt).Return(expected, nil).Once()
+				return formationRepo
+			},
 			AsaRepoFN: func() *automock.AutomaticFormationAssignmentRepository {
 				asaRepo := &automock.AutomaticFormationAssignmentRepository{}
 				asaRepo.On("ListAll", ctx, Tnt).Return(nil, nil)
@@ -4131,6 +4146,11 @@ func TestServiceUnassignFormation(t *testing.T) {
 				labelRepo := &automock.LabelRepository{}
 				labelRepo.On("Delete", ctx, Tnt, model.RuntimeLabelableObject, objectID, model.ScenariosKey).Return(testErr)
 				return labelRepo
+			},
+			FormationRepositoryFn: func() *automock.FormationRepository {
+				formationRepo := &automock.FormationRepository{}
+				formationRepo.On("GetByName", ctx, testFormationName, Tnt).Return(expected, nil).Once()
+				return formationRepo
 			},
 			AsaRepoFN: func() *automock.AutomaticFormationAssignmentRepository {
 				asaRepo := &automock.AutomaticFormationAssignmentRepository{}
@@ -4154,6 +4174,11 @@ func TestServiceUnassignFormation(t *testing.T) {
 					Version:    0,
 				}).Return(testErr)
 				return labelService
+			},
+			FormationRepositoryFn: func() *automock.FormationRepository {
+				formationRepo := &automock.FormationRepository{}
+				formationRepo.On("GetByName", ctx, testFormationName, Tnt).Return(expected, nil).Once()
+				return formationRepo
 			},
 			AsaRepoFN: func() *automock.AutomaticFormationAssignmentRepository {
 				asaRepo := &automock.AutomaticFormationAssignmentRepository{}
@@ -4195,18 +4220,6 @@ func TestServiceUnassignFormation(t *testing.T) {
 		},
 		{
 			Name: "error when fetching formation fails",
-			LabelServiceFn: func() *automock.LabelService {
-				labelService := &automock.LabelService{}
-				labelService.On("GetLabel", ctx, Tnt, runtimeLblInput).Return(runtimeLbl, nil)
-				labelService.On("UpdateLabel", ctx, Tnt, runtimeLbl.ID, &model.LabelInput{
-					Key:        model.ScenariosKey,
-					Value:      []string{secondTestFormationName},
-					ObjectID:   objectID,
-					ObjectType: model.RuntimeLabelableObject,
-					Version:    0,
-				}).Return(nil)
-				return labelService
-			},
 			AsaRepoFN: func() *automock.AutomaticFormationAssignmentRepository {
 				asaRepo := &automock.AutomaticFormationAssignmentRepository{}
 				asaRepo.On("ListAll", ctx, Tnt).Return(nil, nil)
@@ -7411,7 +7424,7 @@ func TestService_DeleteAutomaticScenarioAssignment(t *testing.T) {
 			},
 			FormationRepositoryFn: func() *automock.FormationRepository {
 				repo := &automock.FormationRepository{}
-				repo.On("GetByName", ctx, testFormationName, tnt).Return(&modelFormation, nil).Times(3)
+				repo.On("GetByName", ctx, testFormationName, tnt).Return(&modelFormation, nil).Times(4)
 				return repo
 			},
 			FormationTemplateRepositoryFn: func() *automock.FormationTemplateRepository {
@@ -7574,7 +7587,7 @@ func TestService_DeleteAutomaticScenarioAssignment(t *testing.T) {
 			},
 			FormationRepositoryFn: func() *automock.FormationRepository {
 				repo := &automock.FormationRepository{}
-				repo.On("GetByName", ctx, testFormationName, tnt).Return(&modelFormation, nil).Once()
+				repo.On("GetByName", ctx, testFormationName, tnt).Return(&modelFormation, nil).Twice()
 				return repo
 			},
 			FormationTemplateRepositoryFn: func() *automock.FormationTemplateRepository {
@@ -8483,7 +8496,7 @@ func TestService_RemoveAssignedScenario(t *testing.T) {
 			},
 			FormationRepositoryFn: func() *automock.FormationRepository {
 				repo := &automock.FormationRepository{}
-				repo.On("GetByName", ctx, testFormationName, tnt).Return(&modelFormation, nil).Times(3)
+				repo.On("GetByName", ctx, testFormationName, tnt).Return(&modelFormation, nil).Times(4)
 				return repo
 			},
 			FormationTemplateRepositoryFn: func() *automock.FormationTemplateRepository {
@@ -8640,7 +8653,7 @@ func TestService_RemoveAssignedScenario(t *testing.T) {
 			},
 			FormationRepositoryFn: func() *automock.FormationRepository {
 				repo := &automock.FormationRepository{}
-				repo.On("GetByName", ctx, testFormationName, tnt).Return(&modelFormation, nil).Once()
+				repo.On("GetByName", ctx, testFormationName, tnt).Return(&modelFormation, nil).Twice()
 				return repo
 			},
 			FormationTemplateRepositoryFn: func() *automock.FormationTemplateRepository {

--- a/components/director/internal/domain/runtime_context/service.go
+++ b/components/director/internal/domain/runtime_context/service.go
@@ -149,7 +149,7 @@ func (s *service) Create(ctx context.Context, in model.RuntimeContextInput) (str
 		// If we have a runtime with runtime context(s) we need to assign only the runtime context(s) to the formation.
 		// But if we create ASA in the provider account before registering runtime, the runtime will be assigned to the formation.
 		// And then if we register runtime context for this runtime, the runtime context will be assigned to the formation as well.
-		ownedRuntimeExists, err := s.runtimeRepo.OwnerExists(ctxWithParentTenant, tnt.Parent, in.RuntimeID)
+		ownedRuntimeExists, err := s.runtimeRepo.OwnerExists(ctx, rtmCtxTenant, in.RuntimeID)
 		if err != nil {
 			return "", errors.Wrapf(err, "while checking if runtime with id %q exists", in.RuntimeID)
 		}

--- a/components/director/internal/domain/runtime_context/service_test.go
+++ b/components/director/internal/domain/runtime_context/service_test.go
@@ -161,7 +161,7 @@ func TestService_Create(t *testing.T) {
 			},
 			RuntimeRepositoryFn: func() *automock.RuntimeRepository {
 				repo := &automock.RuntimeRepository{}
-				repo.On("OwnerExists", ctxWithParentTenant, parentTnt, runtimeID).Return(false, nil).Once()
+				repo.On("OwnerExists", ctxWithTenant, tnt, runtimeID).Return(false, nil).Once()
 				return repo
 			},
 			TenantServiceFN: func() *automock.TenantService {
@@ -194,7 +194,7 @@ func TestService_Create(t *testing.T) {
 			},
 			RuntimeRepositoryFn: func() *automock.RuntimeRepository {
 				repo := &automock.RuntimeRepository{}
-				repo.On("OwnerExists", ctxWithParentTenant, parentTnt, runtimeID).Return(true, nil).Once()
+				repo.On("OwnerExists", ctxWithTenant, tnt, runtimeID).Return(true, nil).Once()
 				return repo
 			},
 			TenantServiceFN: func() *automock.TenantService {
@@ -252,7 +252,7 @@ func TestService_Create(t *testing.T) {
 			},
 			RuntimeRepositoryFn: func() *automock.RuntimeRepository {
 				repo := &automock.RuntimeRepository{}
-				repo.On("OwnerExists", ctxWithParentTenant, parentTnt, runtimeID).Return(false, testErr).Once()
+				repo.On("OwnerExists", ctxWithTenant, tnt, runtimeID).Return(false, testErr).Once()
 				return repo
 			},
 			TenantServiceFN: func() *automock.TenantService {
@@ -285,7 +285,7 @@ func TestService_Create(t *testing.T) {
 			},
 			RuntimeRepositoryFn: func() *automock.RuntimeRepository {
 				repo := &automock.RuntimeRepository{}
-				repo.On("OwnerExists", ctxWithParentTenant, parentTnt, runtimeID).Return(true, nil).Once()
+				repo.On("OwnerExists", ctxWithTenant, tnt, runtimeID).Return(true, nil).Once()
 				return repo
 			},
 			TenantServiceFN: func() *automock.TenantService {
@@ -397,7 +397,7 @@ func TestService_Create(t *testing.T) {
 			},
 			RuntimeRepositoryFn: func() *automock.RuntimeRepository {
 				repo := &automock.RuntimeRepository{}
-				repo.On("OwnerExists", ctxWithParentTenant, parentTnt, runtimeID).Return(false, nil).Once()
+				repo.On("OwnerExists", ctxWithTenant, tnt, runtimeID).Return(false, nil).Once()
 				return repo
 			},
 			TenantServiceFN: func() *automock.TenantService {


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:
- Fix tenant used for runtime context's parent owner check
- Do not fail if unassign of a non-existing formation happens



**Pull Request status**
<!-- Feel free to construct the checklist with whatever items seem most reasonable for your change. You could disassemble the Implementation part to even smaller separate checklist items if you're working on something big for example. But do make the effort to provide a checklist of some sort so that the core team as well as the community can have an idea about the progress of your Pull Request.
-->

- [x] Implementation
- [x] Unit tests
- N/A Integration tests
- [x] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- N/A Mocks are regenerated, using the automated script
