### PR TITLE
Specify GOARCH when building sandbox test Go binaries

### DIFF
--- a/tests/connectivity-adapter/Makefile
+++ b/tests/connectivity-adapter/Makefile
@@ -26,7 +26,7 @@ run:
 	@kubectl exec -n kyma-system oct-tp-compass-e2e-tests-compass-e2e-connectivity-adapter-local-0 -c connectivity-adapter-tests -- ./connectivity-adapter.test -test.run $(testName) -test.v
 
 sandbox-deploy-test:
-	env GOOS=linux go test -c ./tests -o connectivity-adapter.test
+	env GOOS=linux GOARCH=amd64 go test -c ./tests -o connectivity-adapter.test
 	kubectl cp ./connectivity-adapter.test kyma-system/oct-tp-compass-e2e-tests-compass-e2e-connectivity-adapter-local-0:/ -c connectivity-adapter-tests
 	rm ./connectivity-adapter.test
 

--- a/tests/connector/Makefile
+++ b/tests/connector/Makefile
@@ -28,7 +28,7 @@ run:
 	@kubectl exec -n kyma-system oct-tp-compass-e2e-tests-compass-e2e-connector-local-0 -c connector-tests -- ./connector.test -test.run $(testName) -test.v
 
 sandbox-deploy-test:
-	env GOOS=linux go test -c ./tests -o connector.test
+	env GOOS=linux GOARCH=amd64 go test -c ./tests -o connector.test
 	kubectl cp ./connector.test kyma-system/oct-tp-compass-e2e-tests-compass-e2e-connector-local-0:/ -c connector-tests
 	rm ./connector.test
 

--- a/tests/director/Makefile
+++ b/tests/director/Makefile
@@ -36,12 +36,12 @@ bench-run:
 	@kubectl exec -n kyma-system oct-tp-compass-e2e-tests-compass-e2e-director-local-0 -c director-tests -- ./director.bench -test.bench $(testName) -test.v
 
 sandbox-deploy-test:
-	env GOOS=linux go test -c ./tests -o director.test
+	env GOOS=linux GOARCH=amd64 go test -c ./tests -o director.test
 	kubectl cp ./director.test kyma-system/oct-tp-compass-e2e-tests-compass-e2e-director-local-0:/ -c director-tests
 	rm ./director.test
 
 sandbox-deploy-bench-test:
-	env GOOS=linux go test -c ./bench -o director.bench
+	env GOOS=linux GOARCH=amd64 go test -c ./bench -o director.bench
 	kubectl cp ./director.bench kyma-system/oct-tp-compass-e2e-tests-compass-e2e-director-local-0:/ -c director-tests
 	rm ./director.bench
 

--- a/tests/external-services-mock/Makefile
+++ b/tests/external-services-mock/Makefile
@@ -28,7 +28,7 @@ run:
 	@kubectl exec -n kyma-system oct-tp-compass-e2e-tests-compass-e2e-external-services-mock-local-0 -c external-services-mock-tests -- ./external-services-mock.test -test.run $(testName) -test.v
 
 sandbox-deploy-test:
-	env GOOS=linux go test -c ./tests -o external-services-mock.test
+	env GOOS=linux GOARCH=amd64 go test -c ./tests -o external-services-mock.test
 	kubectl cp ./external-services-mock.test kyma-system/oct-tp-compass-e2e-tests-compass-e2e-external-services-mock-local-0:/ -c external-services-mock-tests
 	rm ./external-services-mock.test
 

--- a/tests/gateway/Makefile
+++ b/tests/gateway/Makefile
@@ -28,7 +28,7 @@ run:
 	@kubectl exec -n kyma-system oct-tp-compass-e2e-tests-compass-e2e-gateway-local-0 -c gateway-tests -- ./gateway.test -test.run $(testName) -test.v
 
 sandbox-deploy-test:
-	env GOOS=linux go test -c ./tests -o gateway.test
+	env GOOS=linux GOARCH=amd64 go test -c ./tests -o gateway.test
 	kubectl cp ./gateway.test kyma-system/oct-tp-compass-e2e-tests-compass-e2e-gateway-local-0:/ -c gateway-tests
 	rm ./gateway.test
 

--- a/tests/istio/Makefile
+++ b/tests/istio/Makefile
@@ -22,7 +22,7 @@ run:
 	@kubectl exec -n kyma-system oct-tp-compass-e2e-tests-compass-e2e-istio-local-0 -c istio-tests -- ./istio.test test -run=$(testName) -test.v
 
 sandbox-deploy-test:
-	env GOOS=linux go test -c ./tests -o istio.test
+	env GOOS=linux GOARCH=amd64 go test -c ./tests -o istio.test
 	kubectl cp ./istio.test kyma-system/oct-tp-compass-e2e-tests-compass-e2e-istio-local-0:/ -c istio-tests
 	rm ./istio.test
 

--- a/tests/ns-adapter/Makefile
+++ b/tests/ns-adapter/Makefile
@@ -30,7 +30,7 @@ run:
 	@kubectl exec -n kyma-system oct-tp-compass-e2e-tests-compass-e2e-ns-adapter-local-0 -c ns-adapter-tests -- ./ns-adapter.test -test.run $(testName) -test.v
 
 sandbox-deploy-test:
-	env GOOS=linux go test -c ./tests -o ns-adapter.test
+	env GOOS=linux GOARCH=amd64 go test -c ./tests -o ns-adapter.test
 	kubectl cp ./ns-adapter.test kyma-system/oct-tp-compass-e2e-tests-compass-e2e-ns-adapter-local-0:/ -c ns-adapter-tests
 	rm ./ns-adapter.test
 

--- a/tests/ord-aggregator/Makefile
+++ b/tests/ord-aggregator/Makefile
@@ -24,7 +24,7 @@ run:
 	 @kubectl exec -n kyma-system oct-tp-compass-e2e-tests-compass-e2e-ord-aggregator-local-0 -c ord-aggregator-tests -- ./ord-aggregator.test -test.run $(testName) -test.v
 
 sandbox-deploy-test:
-	env GOOS=linux go test -c ./tests -o ord-aggregator.test
+	env GOOS=linux GOARCH=amd64 go test -c ./tests -o ord-aggregator.test
 	kubectl cp ./ord-aggregator.test kyma-system/oct-tp-compass-e2e-tests-compass-e2e-ord-aggregator-local-0:/ -c ord-aggregator-tests
 	rm ./ord-aggregator.test
 

--- a/tests/ord-service/Makefile
+++ b/tests/ord-service/Makefile
@@ -28,12 +28,12 @@ bench-run:
 	@kubectl exec -n kyma-system oct-tp-compass-e2e-tests-compass-e2e-ord-service-local-0 -c ord-service-tests -- ./ord-service.bench -test.bench $(testName) -test.v
 
 sandbox-deploy-test:
-	env GOOS=linux go test -c ./tests -o ord-service.test
+	env GOOS=linux GOARCH=amd64 go test -c ./tests -o ord-service.test
 	kubectl cp ./ord-service.test kyma-system/oct-tp-compass-e2e-tests-compass-e2e-ord-service-local-0:/ -c ord-service-tests
 	rm ./ord-service.test
 
 sandbox-deploy-bench-test:
-	env GOOS=linux go test -c ./bench -o ord-service.bench
+	env GOOS=linux GOARCH=amd64 go test -c ./bench -o ord-service.bench
 	kubectl cp ./ord-service.bench kyma-system/oct-tp-compass-e2e-tests-compass-e2e-ord-service-local-0:/ -c ord-service-tests
 	rm ./ord-service.bench
 

--- a/tests/pairing-adapter/Makefile
+++ b/tests/pairing-adapter/Makefile
@@ -25,7 +25,7 @@ run:
 	@kubectl exec -n kyma-system oct-tp-compass-e2e-tests-compass-e2e-pairing-adapter-local-0 -c pairing-adapter-tests -- ./pairing-adapter.test -test.run $(testName) -test.v
 
 sandbox-deploy-test:
-	env GOOS=linux go test -c ./tests -o pairing-adapter.test
+	env GOOS=linux GOARCH=amd64 go test -c ./tests -o pairing-adapter.test
 	kubectl cp ./pairing-adapter.test kyma-system/oct-tp-compass-e2e-tests-compass-e2e-pairing-adapter-local-0:/ -c pairing-adapter-tests
 	rm ./pairing-adapter.test
 

--- a/tests/system-broker/Makefile
+++ b/tests/system-broker/Makefile
@@ -22,7 +22,7 @@ run:
 	@kubectl exec -n kyma-system oct-tp-compass-e2e-tests-compass-e2e-system-broker-local-0 -c system-broker-tests -- ./system-broker.test -test.run $(testName) -test.v
 
 sandbox-deploy-test:
-	env GOOS=linux go test -c ./tests -o system-broker.test
+	env GOOS=linux GOARCH=amd64 go test -c ./tests -o system-broker.test
 	kubectl cp ./system-broker.test kyma-system/oct-tp-compass-e2e-tests-compass-e2e-system-broker-local-0:/ -c system-broker-tests
 	rm ./system-broker.test
 

--- a/tests/system-fetcher/Makefile
+++ b/tests/system-fetcher/Makefile
@@ -24,7 +24,7 @@ run:
 	@kubectl exec -n kyma-system oct-tp-compass-e2e-tests-compass-e2e-system-fetcher-local-0 -c system-fetcher-tests -- ./system-fetcher.test -test.run $(testName) -test.v
 
 sandbox-deploy-test:
-	env GOOS=linux go test -c ./tests -o system-fetcher.test
+	env GOOS=linux GOARCH=amd64 go test -c ./tests -o system-fetcher.test
 	kubectl cp ./system-fetcher.test kyma-system/oct-tp-compass-e2e-tests-compass-e2e-system-fetcher-local-0:/ -c system-fetcher-tests
 	rm ./system-fetcher.test
 

--- a/tests/tenant-fetcher/Makefile
+++ b/tests/tenant-fetcher/Makefile
@@ -24,7 +24,7 @@ run:
 	@kubectl exec -n kyma-system oct-tp-compass-e2e-tests-compass-e2e-tenant-fetcher-local-0 -c tenant-fetcher-tests -- ./tenant-fetcher.test -test.run $(testName) -test.v
 
 sandbox-deploy-test:
-	env GOOS=linux go test -c ./tests -o tenant-fetcher.test
+	env GOOS=linux GOARCH=amd64 go test -c ./tests -o tenant-fetcher.test
 	kubectl cp ./tenant-fetcher.test kyma-system/oct-tp-compass-e2e-tests-compass-e2e-tenant-fetcher-local-0:/ -c tenant-fetcher-tests
 	rm ./tenant-fetcher.test
 


### PR DESCRIPTION
# Specify GOARCH when building sandbox test Go binaries

**Description**

Changes proposed in this pull request:
- Specify GOARCH when building sandbox test Go binaries
- This is specifically necessary for M1 Mac because the default GOARCH value (probably arm64) corrupts the binary and it doesn't run in the cluster container later on

