### PR TITLE
Ensure App Provider subscriptions tests use dedicated provider cert client during double auth

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -150,7 +150,7 @@ global:
       version: "PR-68"
     e2e_tests:
       dir:
-      version: "PR-2475"
+      version: "PR-2524"
   isLocalEnv: false
   isForTesting: false
   oauth2:

--- a/tests/director/tests/application_templates_subscription_test.go
+++ b/tests/director/tests/application_templates_subscription_test.go
@@ -137,6 +137,7 @@ func TestSubscriptionApplicationTemplateFlow(stdT *testing.T) {
 
 			// Create Bundle
 			bndlInput := fixtures.FixBundleCreateInputWithRelatedObjects(t, "bndl-app-1")
+			stripSensitiveFieldValues(&bndlInput) // because it would be stripped in the bundleOutput when making the request w/t appProviderDirectorCertSecuredClient later and the AssertBundle would fail
 			bndl, err := testctx.Tc.Graphqlizer.BundleCreateInputToGQL(bndlInput)
 			require.NoError(t, err)
 			addBndlRequest := fixtures.FixAddBundleRequest(subscribedApplication.ID, bndl)
@@ -150,7 +151,6 @@ func TestSubscriptionApplicationTemplateFlow(stdT *testing.T) {
 			require.NoError(t, err)
 			require.NotEmpty(t, bundleOutput.ID)
 
-			stripSensitiveFieldValues(&bndlInput, &bundleOutput) // because it would be stripped in the bundleOutput when making the request w/t appProviderDirectorCertSecuredClient
 			assertions.AssertBundle(t, &bndlInput, &bundleOutput)
 
 			// Ensure fetching application returns also the added bundle
@@ -292,7 +292,7 @@ func buildSubscriptionRequest(t *testing.T, ctx context.Context, subscriptionCon
 	return subscribeReq
 }
 
-func stripSensitiveFieldValues(bundleInput *graphql.BundleCreateInput, bundleOuput *graphql.BundleExt) {
+func stripSensitiveFieldValues(bundleInput *graphql.BundleCreateInput) {
 	for i := range bundleInput.Documents {
 		bundleInput.Documents[i].FetchRequest = nil
 	}
@@ -301,15 +301,5 @@ func stripSensitiveFieldValues(bundleInput *graphql.BundleCreateInput, bundleOup
 	}
 	for i := range bundleInput.EventDefinitions {
 		bundleInput.EventDefinitions[i].Spec.FetchRequest = nil
-	}
-
-	for i := range bundleOuput.Documents.Data {
-		bundleOuput.Documents.Data[i].FetchRequest = nil
-	}
-	for i := range bundleOuput.APIDefinitions.Data {
-		bundleOuput.APIDefinitions.Data[i].Spec.FetchRequest = nil
-	}
-	for i := range bundleOuput.EventDefinitions.Data {
-		bundleOuput.EventDefinitions.Data[i].Spec.FetchRequest = nil
 	}
 }

--- a/tests/director/tests/application_templates_subscription_test.go
+++ b/tests/director/tests/application_templates_subscription_test.go
@@ -199,7 +199,7 @@ func TestSubscriptionApplicationTemplateFlow(stdT *testing.T) {
 			require.Contains(t, err.Error(), expectedErrMsg)
 		})
 
-		t.Run("Application Provider in one region is denied querying and pushing consumer app metadata (bundle) for application created from subscription in different region", func(t *testing.T) {
+		t.Run("Application Provider in one region is denied querying and pushing consumer app bundle metadata for application created from subscription in different region", func(t *testing.T) {
 			//GIVEN
 			subscriptionToken := token.GetClientCredentialsToken(t, ctx, conf.SubscriptionConfig.TokenURL+conf.TokenPath, conf.SubscriptionConfig.ClientID, conf.SubscriptionConfig.ClientSecret, "tenantFetcherClaims")
 

--- a/tests/director/tests/application_templates_subscription_test.go
+++ b/tests/director/tests/application_templates_subscription_test.go
@@ -168,7 +168,7 @@ func TestSubscriptionApplicationTemplateFlow(stdT *testing.T) {
 
 		})
 
-		t.Run("Application Provider is denied querying and pushing consumer app metadata (bundle) without previously created subscription", func(t *testing.T) {
+		t.Run("Application Provider is denied querying and pushing consumer app bundle metadata without previously created subscription", func(t *testing.T) {
 			// Create consumer token
 			consumerToken := token.GetUserToken(t, ctx, conf.ConsumerTokenURL+conf.TokenPath, conf.ProviderClientID, conf.ProviderClientSecret, conf.BasicUsername, conf.BasicPassword, "subscriptionClaims")
 			headers := map[string][]string{subscription.AuthorizationHeader: {fmt.Sprintf("Bearer %s", consumerToken)}}
@@ -177,7 +177,7 @@ func TestSubscriptionApplicationTemplateFlow(stdT *testing.T) {
 			actualAppPage := graphql.ApplicationPage{}
 			getSrcAppReq := fixtures.FixGetApplicationsRequestWithPagination()
 			getSrcAppReq.Header = headers
-			err = testctx.Tc.RunOperation(ctx, certSecuredGraphQLClient, getSrcAppReq, &actualAppPage)
+			err = testctx.Tc.RunOperation(ctx, appProviderDirectorCertSecuredClient, getSrcAppReq, &actualAppPage)
 			require.Error(t, err)
 
 			expectedErrMsg := fmt.Sprintf("Consumer's external tenant %s was not found as subscription record in the applications table for any application templates in the provider tenant", subscriptionConsumerSubaccountID)


### PR DESCRIPTION
# Ensure App Provider subscriptions tests use dedicated provider cert client during double auth

**Description**

Changes proposed in this pull request:
- Ensure App Provider subscriptions tests use dedicated provider cert client during double auth
- Fix is necessary on real env
