### PR TITLE
Fix generate examples script

### DIFF
--- a/tests/director/generate_examples.sh
+++ b/tests/director/generate_examples.sh
@@ -3,4 +3,10 @@
 make e2e-test
 docker cp k3d-kyma-agent-0:/examples/ ../../components/director/
 
+if [[ $? != 0 ]]
+then
+  echo "Searching examples in k3d-kyma-server-0..."
+  docker cp k3d-kyma-server-0:/examples/ ../../components/director/
+fi
+
 ../../components/director/hack/prettify-examples.sh


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Currently, with the new k3d cluster the pods can be run both on the server and agent docker containers. When running make e2e-tests the examples are generated in the docker container running the tests which can now be either k3d-kyma-agent-0 or k3d-kyma-server-0 chosen at random. The script expects the examples to be generated on k3d-kyma-agent-0 and fails when it's on the other container.

Changes proposed in this pull request:
- If the examples aren't present in k3d-kyma-agent-0, check k3d-kyma-server-0.

**Pull Request status**
<!-- Feel free to construct the checklist with whatever items seem most reasonable for your change. You could disassemble the Implementation part to even smaller separate checklist items if you're working on something big for example. But do make the effort to provide a checklist of some sort so that the core team as well as the community can have an idea about the progress of your Pull Request.
-->

- [x] Implementation
- [ ] Unit tests
- [ ] Integration tests
- [ ] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [ ] Mocks are regenerated, using the automated script
