### PR TITLE
Enrich application template already exists error message with region

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -118,7 +118,7 @@ global:
       version: "PR-2501"
     director:
       dir:
-      version: "PR-2539"
+      version: "PR-2541"
     hydrator:
       dir:
       version: "PR-2501"

--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -150,7 +150,7 @@ global:
       version: "PR-68"
     e2e_tests:
       dir:
-      version: "PR-2522"
+      version: "PR-2541"
   isLocalEnv: false
   isForTesting: false
   oauth2:

--- a/components/director/internal/domain/apptemplate/service.go
+++ b/components/director/internal/domain/apptemplate/service.go
@@ -106,12 +106,13 @@ func (s *service) Create(ctx context.Context, in model.ApplicationTemplateInput)
 	}
 	in.ApplicationInputJSON = appInputJSON
 
-	_, err = s.GetByNameAndRegion(ctx, in.Name, in.Labels[tenant.RegionLabelKey])
+	region := in.Labels[tenant.RegionLabelKey]
+	_, err = s.GetByNameAndRegion(ctx, in.Name, region)
 	if err != nil && !apperrors.IsNotFoundError(err) {
-		return "", errors.Wrapf(err, "while checking if application template with name %q exists", in.Name)
+		return "", errors.Wrapf(err, "while checking if application template with name %q and region %v exists", in.Name, region)
 	}
 	if err == nil {
-		return "", fmt.Errorf("application template with name %q already exists", in.Name)
+		return "", fmt.Errorf("application template with name %q and region %v already exists", in.Name, region)
 	}
 
 	appTemplate := in.ToApplicationTemplate(appTemplateID)
@@ -292,10 +293,10 @@ func (s *service) Update(ctx context.Context, id string, in model.ApplicationTem
 	if oldAppTemplate.Name != in.Name {
 		_, err := s.GetByNameAndRegion(ctx, in.Name, region)
 		if err != nil && !apperrors.IsNotFoundError(err) {
-			return errors.Wrapf(err, "while checking if application template with name %q exists", in.Name)
+			return errors.Wrapf(err, "while checking if application template with name %q and region %v exists", in.Name, region)
 		}
 		if err == nil {
-			return fmt.Errorf("application template with name %q already exists", in.Name)
+			return fmt.Errorf("application template with name %q and region %v already exists", in.Name, region)
 		}
 	}
 

--- a/components/director/internal/domain/apptemplate/service_test.go
+++ b/components/director/internal/domain/apptemplate/service_test.go
@@ -283,7 +283,7 @@ func TestService_Create(t *testing.T) {
 				labelRepo.On("GetByKey", ctx, "", model.AppTemplateLabelableObject, modelAppTemplate.ID, "region").Return(nil, apperrors.NewNotFoundError(resource.Label, "id")).Once()
 				return labelRepo
 			},
-			ExpectedError: errors.New("application template with name \"bar\" already exists"),
+			ExpectedError: errors.New("application template with name \"bar\" and region <nil> already exists"),
 		},
 		{
 			Name: "Error when creating webhooks",
@@ -1301,7 +1301,7 @@ func TestService_Update(t *testing.T) {
 				labelRepo.On("GetByKey", ctx, "", model.AppTemplateLabelableObject, modelAppTemplate.ID, "region").Return(nil, apperrors.NewNotFoundError(resource.Label, "id")).Once()
 				return labelRepo
 			},
-			ExpectedError: errors.New("application template with name \"bartest\" already exists"),
+			ExpectedError: errors.New("application template with name \"bartest\" and region <nil> already exists"),
 		},
 		{
 			Name: "Error when updating application template - update failed",

--- a/tests/director/tests/application_templates_api_test.go
+++ b/tests/director/tests/application_templates_api_test.go
@@ -182,7 +182,7 @@ func TestCreateApplicationTemplate_SameNamesAndRegion(t *testing.T) {
 	defer fixtures.CleanupApplicationTemplate(t, ctx, certSecuredGraphQLClient, tenant.TestTenants.GetDefaultTenantID(), &appTemplateTwo)
 
 	require.NotNil(t, err)
-	require.Contains(t, err.Error(), "application template with name \"SAP app-template\" already exists")
+	require.Contains(t, err.Error(), "application template with name \"SAP app-template\" and region eu-1 already exists")
 }
 
 func TestCreateApplicationTemplate_SameNamesAndDifferentRegions(t *testing.T) {
@@ -396,7 +396,7 @@ func TestUpdateApplicationTemplate_AlreadyExistsInTheSameRegion(t *testing.T) {
 	err = testctx.Tc.RunOperation(ctx, certSecuredGraphQLClient, updateAppTemplateRequest, &updateOutput)
 
 	require.NotNil(t, err)
-	require.Contains(t, err.Error(), "application template with name \"SAP app-template\" already exists")
+	require.Contains(t, err.Error(), "application template with name \"SAP app-template\" and region eu-1 already exists")
 }
 
 func TestUpdateApplicationTemplate_NotValid(t *testing.T) {


### PR DESCRIPTION

**Description**

Changes proposed in this pull request:
- Enrich application template already exists error message with region

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- ...

**Pull Request status**
<!-- Feel free to construct the checklist with whatever items seem most reasonable for your change. You could disassemble the Implementation part to even smaller separate checklist items if you're working on something big for example. But do make the effort to provide a checklist of some sort so that the core team as well as the community can have an idea about the progress of your Pull Request.
-->

- [ ] Implementation
- [ ] Unit tests
- [ ] Integration tests
- [x] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [ ] Mocks are regenerated, using the automated script
