### PR TITLE
Ensure region is matching only for Consumer-provider flow

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -120,10 +120,10 @@ global:
       version: "PR-2501"
     director:
       dir:
-      version: "PR-2484"
+      version: "PR-2555"
     hydrator:
       dir:
-      version: "PR-2551"
+      version: "PR-2555"
     gateway:
       dir:
       version: "PR-2501"

--- a/components/director/internal/externaltenant/mapping.go
+++ b/components/director/internal/externaltenant/mapping.go
@@ -3,9 +3,10 @@ package externaltenant
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/kyma-incubator/compass/components/director/pkg/tenant"
 	"io/ioutil"
 	"path/filepath"
+
+	"github.com/kyma-incubator/compass/components/director/pkg/tenant"
 
 	"github.com/kyma-incubator/compass/components/director/pkg/apperrors"
 
@@ -39,7 +40,7 @@ func MapTenants(tenantsDirectoryPath, defaultTenantRegion string) ([]model.Busin
 
 		for i := range tenantsFromFile {
 			tenantsFromFile[i].Provider = f.Name()
-			if tenantsFromFile[i].Region == "" && tenantsFromFile[i].Type == tenant.Subaccount {
+			if tenantsFromFile[i].Region == "" && tenantsFromFile[i].Type == string(tenant.Subaccount) {
 				tenantsFromFile[i].Region = defaultTenantRegion
 			}
 		}

--- a/components/director/internal/externaltenant/mapping.go
+++ b/components/director/internal/externaltenant/mapping.go
@@ -3,6 +3,7 @@ package externaltenant
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/kyma-incubator/compass/components/director/pkg/tenant"
 	"io/ioutil"
 	"path/filepath"
 
@@ -38,7 +39,7 @@ func MapTenants(tenantsDirectoryPath, defaultTenantRegion string) ([]model.Busin
 
 		for i := range tenantsFromFile {
 			tenantsFromFile[i].Provider = f.Name()
-			if tenantsFromFile[i].Region == "" {
+			if tenantsFromFile[i].Region == "" && tenantsFromFile[i].Type == tenant.Subaccount {
 				tenantsFromFile[i].Region = defaultTenantRegion
 			}
 		}

--- a/components/director/internal/externaltenant/mapping_test.go
+++ b/components/director/internal/externaltenant/mapping_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/kyma-incubator/compass/components/director/pkg/tenant"
+
 	"github.com/kyma-incubator/compass/components/director/pkg/apperrors"
 
 	"github.com/kyma-incubator/compass/components/director/internal/model"
@@ -29,24 +31,24 @@ func TestMapTenants(t *testing.T) {
 			ExternalTenant: "id-default",
 			Provider:       firstProvider,
 			Region:         "eu-1",
+			Type:           string(tenant.Subaccount),
 		},
 		{
 			Name:           "foo",
 			ExternalTenant: "id-foo",
 			Provider:       firstProvider,
 			Region:         "eu-2",
+			Type:           string(tenant.Subaccount),
 		},
 		{
 			Name:           "bar",
 			ExternalTenant: "id-bar",
 			Provider:       secondProvider,
-			Region:         "eu-1",
 		},
 		{
 			Name:           "baz",
 			ExternalTenant: "id-baz",
 			Provider:       secondProvider,
-			Region:         "eu-3",
 		},
 	}
 

--- a/components/director/internal/externaltenant/testdata/tenants/valid_tenants.json
+++ b/components/director/internal/externaltenant/testdata/tenants/valid_tenants.json
@@ -1,11 +1,13 @@
 [
   {
     "id":"id-default",
-    "name":"default"
+    "name":"default",
+    "type": "subaccount"
   },
   {
     "id":"id-foo",
     "name":"foo",
-    "region": "eu-2"
+    "region": "eu-2",
+    "type": "subaccount"
   }
 ]

--- a/components/director/internal/externaltenant/testdata/tenants/valid_tenants2.json
+++ b/components/director/internal/externaltenant/testdata/tenants/valid_tenants2.json
@@ -5,7 +5,6 @@
   },
   {
     "id":"id-baz",
-    "name":"baz",
-    "region": "eu-3"
+    "name":"baz"
   }
 ]

--- a/components/hydrator/go.mod
+++ b/components/hydrator/go.mod
@@ -26,6 +26,7 @@ require (
 )
 
 require (
+	github.com/kyma-incubator/compass/tests v0.0.0-20220601144746-743a35267d22
 	github.com/prometheus/client_golang v1.11.0
 	golang.org/x/oauth2 v0.0.0-20220223155221-ee480838109b
 )
@@ -54,11 +55,13 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/huandu/xstrings v1.3.2 // indirect
 	github.com/imdario/mergo v0.3.12 // indirect
+	github.com/jmoiron/sqlx v1.3.4 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/lestrrat-go/backoff/v2 v2.0.8 // indirect
 	github.com/lestrrat-go/blackmagic v1.0.0 // indirect
 	github.com/lestrrat-go/httpcc v1.0.0 // indirect
 	github.com/lestrrat-go/option v1.0.0 // indirect
+	github.com/lib/pq v1.10.4 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
 	github.com/mitchellh/copystructure v1.1.2 // indirect
 	github.com/mitchellh/reflectwalk v1.0.1 // indirect

--- a/components/hydrator/go.sum
+++ b/components/hydrator/go.sum
@@ -174,6 +174,8 @@ github.com/go-openapi/swag v0.19.2/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh
 github.com/go-openapi/swag v0.19.5/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh66Z9tfKk=
 github.com/go-ozzo/ozzo-validation/v4 v4.3.0 h1:byhDUpfEwjsVQb1vBunvIjh2BHQ9ead57VkAEY4V+Es=
 github.com/go-ozzo/ozzo-validation/v4 v4.3.0/go.mod h1:2NKgrcHl3z6cJs+3Oo940FPRiTzuqKbvfrL2RxCj6Ew=
+github.com/go-sql-driver/mysql v1.5.0 h1:ozyZYNQW3x3HtqT1jira07DN2PArx2v7/mN66gGcHOs=
+github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/goccy/go-json v0.9.4 h1:L8MLKG2mvVXiQu07qB6hmfqeSYQdOnqPot2GhsIwIaI=
 github.com/goccy/go-json v0.9.4/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
@@ -302,6 +304,7 @@ github.com/imdario/mergo v0.3.12 h1:b6R2BslTbIEToALKP7LxUvijTsNI9TAe80pLWN2g/HU=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/jmoiron/sqlx v1.3.4 h1:wv+0IJZfL5z0uZoUjlpKgHkgaFSYD+r9CfrXjEXsO7w=
+github.com/jmoiron/sqlx v1.3.4/go.mod h1:2BljVx/86SuTyjE+aPYlHCTNvZrnJXghYGpNiXLBMCQ=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
@@ -337,6 +340,8 @@ github.com/kyma-incubator/compass/components/director v0.0.0-20220803145251-adcd
 github.com/kyma-incubator/compass/components/director v0.0.0-20220803145251-adcd4fea489b/go.mod h1:zrz0jznBKxiqBuiDD7qXnHoubLxzPjxceQPWc9seIIg=
 github.com/kyma-incubator/compass/components/system-broker v0.0.0-20220327143459-11b81bddcce9 h1:WftrXM5d9PtBBo4J+eyCnwNEoFi8KDtINUD7jSp0jCA=
 github.com/kyma-incubator/compass/components/system-broker v0.0.0-20220327143459-11b81bddcce9/go.mod h1:M30JDO6D3wgLgJ6leIFawaH1tv8k0m+GuroKv+0o38Y=
+github.com/kyma-incubator/compass/tests v0.0.0-20220601144746-743a35267d22 h1:1z54wjamx5X1pT1kdJ2Jb2CtgVwAxnRTvBdJGrX8hcw=
+github.com/kyma-incubator/compass/tests v0.0.0-20220601144746-743a35267d22/go.mod h1:HxbyQUT4u1nvafNE4fy5g7bIfGw5Kp4K3SLoHAHodQU=
 github.com/lestrrat-go/backoff/v2 v2.0.8 h1:oNb5E5isby2kiro9AgdHLv5N5tint1AnDVVf2E2un5A=
 github.com/lestrrat-go/backoff/v2 v2.0.8/go.mod h1:rHP/q/r9aT27n24JQLa7JhSQZCKBBOiM/uP402WwN8Y=
 github.com/lestrrat-go/blackmagic v1.0.0 h1:XzdxDbuQTz0RZZEmdU7cnQxUtFUzgCSPq8RCz4BxIi4=
@@ -349,7 +354,9 @@ github.com/lestrrat-go/jwx v1.2.19 h1:qxxLmAXNwZpTTvjc4PH21nT7I4wPK6lVv3lVNcZPnU
 github.com/lestrrat-go/jwx v1.2.19/go.mod h1:bWTBO7IHHVMtNunM8so9MT8wD+euEY1PzGEyCnuI2qM=
 github.com/lestrrat-go/option v1.0.0 h1:WqAWL8kh8VcSoD6xjSH34/1m8yxluXQbDeKNfvFeEO4=
 github.com/lestrrat-go/option v1.0.0/go.mod h1:5ZHFbivi4xwXxhxY9XHDe2FHo6/Z7WWmtT7T5nBBp3I=
+github.com/lib/pq v1.2.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lib/pq v1.10.4 h1:SO9z7FRPzA03QhHKJrH5BXA6HU1rS4V2nIVrrNC1iYk=
+github.com/lib/pq v1.10.4/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/logrusorgru/aurora v0.0.0-20200102142835-e9ef32dff381/go.mod h1:7rIyQOR62GCctdiQpZ/zOJlFyk6y+94wXzv6RNZgaR4=
 github.com/machinebox/graphql v0.2.3-0.20181106130121-3a9253180225 h1:guHWmqIKr4G+gQ4uYU5vcZjsUhhklRA2uOcGVfcfqis=
 github.com/machinebox/graphql v0.2.3-0.20181106130121-3a9253180225/go.mod h1:F+kbVMHuwrQ5tYgU9JXlnskM8nOaFxCAEolaQybkjWA=
@@ -366,6 +373,8 @@ github.com/mattn/go-isatty v0.0.4/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNx
 github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
+github.com/mattn/go-sqlite3 v1.14.6 h1:dNPt6NO46WmLVt2DLNpwczCmdV5boIZ6g/tlDrlRUbg=
+github.com/mattn/go-sqlite3 v1.14.6/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 h1:I0XW9+e1XWDxdcEniV4rQAIOPUGDq67JSCiRCgGCZLI=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=

--- a/components/hydrator/internal/tenantmapping/access_level_context_provider.go
+++ b/components/hydrator/internal/tenantmapping/access_level_context_provider.go
@@ -53,7 +53,7 @@ func (p *accessLevelContextProvider) GetObjectContext(ctx context.Context, reqDa
 			// tenant not in DB yet, might be because we have not imported all subaccounts yet
 			log.C(ctx).Warningf("Could not find tenant with external ID: %s, error: %s", externalTenantID, err.Error())
 			log.C(ctx).Infof("Returning tenant context with empty internal tenant ID and external ID %s", externalTenantID)
-			return NewObjectContext(NewTenantContext(externalTenantID, ""), p.tenantKeys, "", mergeWithOtherScopes, authDetails.Region,
+			return NewObjectContext(NewTenantContext(externalTenantID, ""), p.tenantKeys, "", mergeWithOtherScopes, "",
 				"", authDetails.AuthID, authDetails.AuthFlow, consumer.ConsumerType(consumerType), tenantmapping.CertServiceObjectContextProvider), nil
 		}
 		return ObjectContext{}, errors.Wrapf(err, "while getting external tenant mapping [ExternalTenantID=%s]", externalTenantID)

--- a/components/hydrator/internal/tenantmapping/cert_service_context_provider.go
+++ b/components/hydrator/internal/tenantmapping/cert_service_context_provider.go
@@ -62,7 +62,7 @@ func (p *certServiceContextProvider) GetObjectContext(ctx context.Context, reqDa
 			// tenant not in DB yet, might be because we have not imported all subaccounts yet
 			log.C(ctx).Warningf("Could not find tenant with external ID: %s, error: %s", externalTenantID, err.Error())
 			log.C(ctx).Infof("Returning tenant context with empty internal tenant ID and external ID %s", externalTenantID)
-			return NewObjectContext(NewTenantContext(externalTenantID, ""), p.tenantKeys, scopes, mergeWithOtherScopes, authDetails.Region, "", authDetails.AuthID, authDetails.AuthFlow, consumer.ExternalCertificate, tenantmapping.CertServiceObjectContextProvider), nil
+			return NewObjectContext(NewTenantContext(externalTenantID, ""), p.tenantKeys, scopes, mergeWithOtherScopes, "", "", authDetails.AuthID, authDetails.AuthFlow, consumer.ExternalCertificate, tenantmapping.CertServiceObjectContextProvider), nil
 		}
 		return ObjectContext{}, errors.Wrapf(err, "while getting external tenant mapping [ExternalTenantID=%s]", externalTenantID)
 	}

--- a/components/hydrator/internal/tenantmapping/cert_service_context_provider_test.go
+++ b/components/hydrator/internal/tenantmapping/cert_service_context_provider_test.go
@@ -31,7 +31,7 @@ func TestCertServiceContextProvider(t *testing.T) {
 
 	testError := errors.New("test error")
 	notFoundErr := apperrors.NewNotFoundErrorWithType(resource.Tenant)
-	tenantRegionNotFoundErr := fmt.Errorf("region label not found for tenant with ID: %q", tenantID)
+	subaccountRegionNotFoundErr := fmt.Errorf("region label not found for subaccount with ID: %q", tenantID)
 
 	authDetails := oathkeeper.AuthDetails{AuthID: tenantID, AuthFlow: oathkeeper.CertificateFlow, CertIssuer: oathkeeper.ExternalIssuer}
 
@@ -161,7 +161,7 @@ func TestCertServiceContextProvider(t *testing.T) {
 			ReqDataInput:     reqDataWithInternalConsumerID,
 			AuthDetailsInput: authDetails,
 			ExpectedScopes:   scopesString,
-			ExpectedErr:      tenantRegionNotFoundErr,
+			ExpectedErr:      subaccountRegionNotFoundErr,
 		},
 		{
 			Name:           "Error when can't get required scopes",

--- a/components/hydrator/internal/tenantmapping/consumer_context_provider.go
+++ b/components/hydrator/internal/tenantmapping/consumer_context_provider.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/kyma-incubator/compass/components/director/pkg/tenant"
+
 	cfg "github.com/kyma-incubator/compass/components/hydrator/internal/config"
 
 	"github.com/kyma-incubator/compass/components/director/pkg/apperrors"
@@ -123,9 +125,13 @@ func getTenantWithRegion(ctx context.Context, directorClient DirectorClient, ext
 		return nil, "", err
 	}
 
+	if tenantMapping.Type != string(tenant.Subaccount) {
+		return tenantMapping, "", nil
+	}
+
 	region, ok := tenantMapping.Labels["region"]
 	if !ok {
-		return nil, "", fmt.Errorf("region label not found for tenant with ID: %q", externalTenantID)
+		return nil, "", fmt.Errorf("region label not found for subaccount with ID: %q", externalTenantID)
 	}
 	regionStr, ok := region.(string)
 	if !ok {

--- a/components/hydrator/internal/tenantmapping/consumer_context_provider_test.go
+++ b/components/hydrator/internal/tenantmapping/consumer_context_provider_test.go
@@ -182,7 +182,7 @@ func TestConsumerContextProvider_GetObjectContext(t *testing.T) {
 			},
 			ReqDataInput:          reqDataFunc(userCtxHeaderWithAllProperties),
 			ExpectedObjectContext: tenantmapping.ObjectContext{},
-			ExpectedErrMsg:        fmt.Sprintf("region label not found for tenant with ID: %q", consumerTenantID),
+			ExpectedErrMsg:        fmt.Sprintf("region label not found for subaccount with ID: %q", consumerTenantID),
 		},
 		{
 			Name: "Returns error when region label type is not the expected one",

--- a/components/hydrator/internal/tenantmapping/handler.go
+++ b/components/hydrator/internal/tenantmapping/handler.go
@@ -304,7 +304,7 @@ func addConsumersToExtra(objectContexts []ObjectContext, reqData oathkeeper.ReqD
 // This is necessary due to the fact that some obj ctx providers might result with a non-existing tenant for which TenantID will be empty (conversely the region for them would also be empty).
 func deriveRegionFromObjectContexts(objectContext []ObjectContext) string {
 	for _, objCtx := range objectContext {
-		if objCtx.TenantID != "" {
+		if objCtx.Region != "" {
 			return objCtx.Region
 		}
 	}

--- a/components/hydrator/internal/tenantmapping/handler.go
+++ b/components/hydrator/internal/tenantmapping/handler.go
@@ -280,9 +280,11 @@ func addConsumersToExtra(objectContexts []ObjectContext, reqData oathkeeper.ReqD
 		c = getCertServiceObjectContextProviderConsumer(objectContexts)
 		c.OnBehalfOf = getOnBehalfConsumer(objectContexts)
 
-		for _, objCtx := range objectContexts {
-			if objCtx.TenantID != "" && objCtx.Region != region {
-				return errors.Errorf("mismatched region for consumer ID %s: actual %s, expected: %s)", objCtx.ConsumerID, objCtx.Region, region)
+		if c.OnBehalfOf != "" { // i.e. make sure that regions match only during consumer-provider flow
+			for _, objCtx := range objectContexts {
+				if objCtx.TenantID != "" && objCtx.Region != region {
+					return errors.Errorf("mismatched region for consumer ID %s: actual %s, expected: %s)", objCtx.ConsumerID, objCtx.Region, region)
+				}
 			}
 		}
 	}

--- a/components/hydrator/internal/tenantmapping/system_auth_context_provider_test.go
+++ b/components/hydrator/internal/tenantmapping/system_auth_context_provider_test.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/kyma-incubator/compass/tests/pkg/tenant"
+
 	"github.com/kyma-incubator/compass/components/director/pkg/apperrors"
 	"github.com/kyma-incubator/compass/components/director/pkg/resource"
 
@@ -379,7 +381,7 @@ func TestSystemAuthContextProvider(t *testing.T) {
 		mock.AssertExpectationsForObjects(t, directorClientMock, directorClientMock)
 	})
 
-	t.Run("returns error when unable to get tenant region in the Integration System SystemAuth case", func(t *testing.T) {
+	t.Run("returns error when tenant is subaccount and unable to get subaccount region in the Integration System SystemAuth case", func(t *testing.T) {
 		authID := uuid.New()
 		refObjID := uuid.New()
 		expectedTenantID := uuid.New()
@@ -395,6 +397,7 @@ func TestSystemAuthContextProvider(t *testing.T) {
 		testTenant := &graphql.Tenant{
 			ID:         expectedExternalTenantID,
 			InternalID: expectedTenantID.String(),
+			Type:       string(tenant.Subaccount),
 		}
 
 		reqData := oathkeeper.ReqData{
@@ -416,7 +419,7 @@ func TestSystemAuthContextProvider(t *testing.T) {
 		_, err := provider.GetObjectContext(context.TODO(), reqData, authDetails)
 
 		require.Error(t, err)
-		require.Contains(t, err.Error(), fmt.Sprintf("region label not found for tenant with ID: %q", expectedExternalTenantID))
+		require.Contains(t, err.Error(), fmt.Sprintf("region label not found for subaccount with ID: %q", expectedExternalTenantID))
 
 		mock.AssertExpectationsForObjects(t, directorClientMock, directorClientMock)
 	})
@@ -464,7 +467,7 @@ func TestSystemAuthContextProvider(t *testing.T) {
 		mock.AssertExpectationsForObjects(t, directorClientMock, scopesGetterMock)
 	})
 
-	t.Run("returns error when unable to get tenant region in the Application or Runtime SystemAuth case for Certificate flow", func(t *testing.T) {
+	t.Run("returns error when tenant is subaccount and unable to get subaccount region in the Application or Runtime SystemAuth case for Certificate flow", func(t *testing.T) {
 		authID := uuid.New()
 		refObjID := uuid.New()
 		expectedTenantID := uuid.New()
@@ -480,6 +483,7 @@ func TestSystemAuthContextProvider(t *testing.T) {
 		testTenant := &graphql.Tenant{
 			ID:         expectedExternalTenantID,
 			InternalID: expectedTenantID.String(),
+			Type:       string(tenant.Subaccount),
 		}
 
 		reqData := oathkeeper.ReqData{
@@ -503,7 +507,7 @@ func TestSystemAuthContextProvider(t *testing.T) {
 		_, err := provider.GetObjectContext(context.TODO(), reqData, authDetails)
 
 		require.Error(t, err)
-		require.Contains(t, err.Error(), fmt.Sprintf("region label not found for tenant with ID: %q", expectedExternalTenantID))
+		require.Contains(t, err.Error(), fmt.Sprintf("region label not found for subaccount with ID: %q", expectedExternalTenantID))
 
 		mock.AssertExpectationsForObjects(t, directorClientMock, scopesGetterMock)
 	})

--- a/components/hydrator/internal/tenantmapping/user_context_provider.go
+++ b/components/hydrator/internal/tenantmapping/user_context_provider.go
@@ -69,7 +69,7 @@ func (m *userContextProvider) GetObjectContext(ctx context.Context, reqData oath
 			log.C(ctx).Warningf("Could not find tenant with external ID: %s, error: %s", externalTenantID, err.Error())
 
 			log.C(ctx).Infof("Returning tenant context with empty internal tenant ID and external ID %s", externalTenantID)
-			return NewObjectContext(NewTenantContext(externalTenantID, ""), m.tenantKeys, scopes, intersectWithOtherScopes, authDetails.Region, "", authDetails.AuthID, authDetails.AuthFlow, consumer.User, tenantmapping.UserObjectContextProvider), nil
+			return NewObjectContext(NewTenantContext(externalTenantID, ""), m.tenantKeys, scopes, intersectWithOtherScopes, "", "", authDetails.AuthID, authDetails.AuthFlow, consumer.User, tenantmapping.UserObjectContextProvider), nil
 		}
 		return ObjectContext{}, errors.Wrapf(err, "while getting external tenant mapping [ExternalTenantID=%s]", externalTenantID)
 	}


### PR DESCRIPTION
# Ensure region is matching only for Consumer-provider flow

**Description**

Changes proposed in this pull request:
- ensure region is matching only for Consumer-provider flow
- make tenant loader set default region only for subaccounts


