### PR TITLE
Tweak Director e2e test when registering app template

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -152,7 +152,7 @@ global:
       version: "PR-68"
     e2e_tests:
       dir:
-      version: "PR-2527"
+      version: "PR-2556"
   isLocalEnv: false
   isForTesting: false
   oauth2:

--- a/tests/director/tests/application_templates_api_test.go
+++ b/tests/director/tests/application_templates_api_test.go
@@ -721,7 +721,7 @@ func TestAddWebhookToApplicationTemplate(t *testing.T) {
 	oauthGraphQLClient := gql.NewAuthorizedGraphQLClientWithCustomURL(accessToken, conf.GatewayOauth)
 
 	t.Log("Create application template")
-	appTmplInput := fixAppTemplateInputWithDefaultDistinguishLabel(name)
+	appTmplInput := fixtures.FixApplicationTemplate(name)
 	appTemplate, err := fixtures.CreateApplicationTemplateFromInput(t, ctx, oauthGraphQLClient, tenantId, appTmplInput)
 	defer fixtures.CleanupApplicationTemplate(t, ctx, oauthGraphQLClient, tenantId, &appTemplate)
 	require.NoError(t, err)


### PR DESCRIPTION
# Tweak Director e2e test when registering app template

The test should not have provided the distinguished label because the registration is not made with certificate flow (it's made with int system flow). The end result of this mistake was that the deferred deletion of the app template failed (silently) and left garbage record in DB. The failed deletion is caused by the fact that whenever a distinguished label is present in app template, then during the template deletion the `region` label is looked up of the app template in order to delete the respective clone resources. But the region label is not present because auth is not cert flow, rather it's int system flow, which is not associated with a subaccount and the created app template results in not having a region label, but having a distinguished label, which breaks here:
`components/director/internal/domain/apptemplate/resolver.go:480`


