### PR TITLE
Remove sleep from make-release target

### DIFF
--- a/components/connectivity-adapter/Makefile
+++ b/components/connectivity-adapter/Makefile
@@ -1,6 +1,5 @@
 APP_NAME = compass-connectivity-adapter
 APP_PATH = components/connectivity-adapter
-COMPONENT_BUILD_TIMEOUT = 15m
 ENTRYPOINT = cmd/main.go
 BUILDPACK = eu.gcr.io/kyma-project/test-infra/buildpack-golang:go1.18
 SCRIPTS_DIR = $(realpath $(shell pwd)/../..)/scripts

--- a/components/connector/Makefile
+++ b/components/connector/Makefile
@@ -1,6 +1,5 @@
 APP_NAME = compass-connector
 APP_PATH = components/connector
-COMPONENT_BUILD_TIMEOUT = 10m
 BUILDPACK = eu.gcr.io/kyma-project/test-infra/buildpack-golang:go1.18
 ENTRYPOINT = cmd/main.go
 SCRIPTS_DIR = $(realpath $(shell pwd)/../..)/scripts

--- a/components/director/Makefile
+++ b/components/director/Makefile
@@ -1,6 +1,5 @@
 APP_NAME = compass-director
 APP_PATH = components/director
-COMPONENT_BUILD_TIMEOUT = 12m
 BUILDPACK = eu.gcr.io/kyma-project/test-infra/buildpack-golang:go1.18
 NAMESPACE="compass-system"
 SCRIPTS_DIR = $(realpath $(shell pwd)/../..)/scripts

--- a/components/gateway/Makefile
+++ b/components/gateway/Makefile
@@ -1,6 +1,5 @@
 APP_NAME = compass-gateway
 APP_PATH = components/gateway
-COMPONENT_BUILD_TIMEOUT = 10m
 ENTRYPOINT = cmd/main.go
 BUILDPACK = eu.gcr.io/kyma-project/test-infra/buildpack-golang:go1.18
 SCRIPTS_DIR = $(realpath $(shell pwd)/../..)/scripts

--- a/components/hydrator/Makefile
+++ b/components/hydrator/Makefile
@@ -1,6 +1,5 @@
 APP_NAME = compass-hydrator
 APP_PATH = components/hydrator
-COMPONENT_BUILD_TIMEOUT = 15m
 BUILDPACK = eu.gcr.io/kyma-project/test-infra/buildpack-golang:go1.18
 ENTRYPOINT = cmd/main.go
 SCRIPTS_DIR = $(realpath $(shell pwd)/../..)/scripts

--- a/components/operations-controller/Makefile
+++ b/components/operations-controller/Makefile
@@ -1,6 +1,5 @@
 APP_NAME = compass-operations-controller
 APP_PATH = components/operations-controller
-COMPONENT_BUILD_TIMEOUT = 10m
 BUILDPACK = eu.gcr.io/kyma-project/test-infra/buildpack-golang:go1.18
 VERIFY_IGNORE := /vendor\|/automock\|/api/v1alpha1/zz_generated.deepcopy.go
 SCRIPTS_DIR = $(realpath $(shell pwd)/../..)/scripts

--- a/components/pairing-adapter/Makefile
+++ b/components/pairing-adapter/Makefile
@@ -1,6 +1,5 @@
 APP_NAME = pairing-adapter
 APP_PATH = components/pairing-adapter
-COMPONENT_BUILD_TIMEOUT = 10m
 ENTRYPOINT = cmd/main.go
 BUILDPACK = eu.gcr.io/kyma-project/test-infra/buildpack-golang:go1.18
 SCRIPTS_DIR = $(realpath $(shell pwd)/../..)/scripts

--- a/components/system-broker/Makefile
+++ b/components/system-broker/Makefile
@@ -1,6 +1,5 @@
 APP_NAME = compass-system-broker
 APP_PATH = components/system-broker
-COMPONENT_BUILD_TIMEOUT = 10m
 BUILDPACK = eu.gcr.io/kyma-project/test-infra/buildpack-golang:go1.18
 ADDITIONAL_COMPONENTS = director connector
 SCRIPTS_DIR = $(realpath $(shell pwd)/../..)/scripts

--- a/scripts/generic_make_go.mk
+++ b/scripts/generic_make_go.mk
@@ -56,13 +56,6 @@ ifneq (,$(shell go version 2>/dev/null))
 DOCKER_CREATE_OPTS := -v $(shell go env GOCACHE):$(IMG_GOCACHE):delegated -v $(shell go env GOPATH)/pkg/dep:$(IMG_GOPATH)/pkg/dep:delegated $(DOCKER_CREATE_OPTS)
 endif
 
-# BUILD_TIMEOUT is a timeout for build job, to fail fast in case of build stuck
-ifneq ($(strip $(COMPONENT_BUILD_TIMEOUT)),)
-BUILD_TIMEOUT := $(COMPONENT_BUILD_TIMEOUT)
-else
-BUILD_TIMEOUT = 6m
-endif
-
 .DEFAULT_GOAL := verify
 
 # Check if running with TTY
@@ -108,7 +101,7 @@ release: verify build-image
 build-image: pull-licenses
 	docker run --rm --privileged linuxkit/binfmt:v0.8 # https://stackoverflow.com/questions/70066249/docker-random-alpine-packages-fail-to-install
 	docker buildx create --name multi-arch-builder --use
-	( sleep $(BUILD_TIMEOUT) && docker buildx rm multi-arch-builder ) & docker buildx build --platform linux/amd64,linux/arm64 -t $(IMG_NAME):$(TAG) --push . 
+	docker buildx build --platform linux/amd64,linux/arm64 -t $(IMG_NAME):$(TAG) --push .
 docker-create-opts:
 	@echo $(DOCKER_CREATE_OPTS)
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,6 +1,5 @@
 APP_NAME = compass-tests
 APP_PATH = tests
-COMPONENT_BUILD_TIMEOUT = 15m
 LOCAL_PREFIX = k3d-kyma-registry:5001
 BUILDPACK = eu.gcr.io/kyma-project/test-infra/buildpack-golang:go1.18
 SCRIPTS_DIR = $(realpath $(shell pwd)/..)/scripts


### PR DESCRIPTION
# Remove sleep from make-release target

**Description**

Changes proposed in this pull request:
- The removed code was part of an attempt to workaround potentially docker-build getting stuck when doing multiarch builds and going idle until the default Prow 3h timeout
- This workaround code is no longer needed as we've introduced timeouts for all compass component jobs directly in prow: https://github.com/kyma-project/test-infra/pull/5885

