### PR TITLE
Fix e2e tests for region2 when issueing a certificate

### DIFF
--- a/chart/compass/templates/tests/director/director-test.yaml
+++ b/chart/compass/templates/tests/director/director-test.yaml
@@ -117,6 +117,8 @@ spec:
               value: {{ .Values.global.tests.subscription.certSvcInstanceTestRegion2SecretName }}
             - name: EXTERNAL_CERT_CRONJOB_CONTAINER_NAME
               value: {{ .Values.global.externalCertConfiguration.rotationCronjob.containerName }}
+            - name: EXTERNAL_CERT_EXPECTED_ISSUER_LOCALITY
+              value: {{ .Values.global.externalCertConfiguration.issuerLocality }}
             - name: APP_RUNTIME_TYPE_LABEL_KEY
               value: {{ .Values.global.director.runtimeTypeLabelKey }}
             - name: APP_KYMA_RUNTIME_TYPE_LABEL_VALUE

--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -164,7 +164,7 @@ global:
       name: compass-console
     e2e_tests:
       dir:
-      version: "PR-2577"
+      version: "PR-2585"
       name: compass-e2e-tests
   isLocalEnv: false
   isForTesting: false

--- a/tests/director/tests/application_templates_api_test.go
+++ b/tests/director/tests/application_templates_api_test.go
@@ -805,7 +805,8 @@ func createDirectorCertClientForAnotherRegion(t *testing.T, ctx context.Context)
 		TestExternalCertSubject:               conf.ExternalCertProviderConfig.TestExternalCertSubjectRegion2,
 		ExternalClientCertCertKey:             conf.ExternalCertProviderConfig.ExternalClientCertCertKey,
 		ExternalClientCertKeyKey:              conf.ExternalCertProviderConfig.ExternalClientCertKeyKey,
-		ExpectedIssuerLocality:                &conf.SubscriptionConfig.SelfRegRegion2,
+		ExpectedIssuerLocality:                conf.ExternalCertProviderConfig.ExpectedIssuerLocality,
+		IssuerLocalityRegion2:                 &conf.SubscriptionConfig.SelfRegRegion2,
 	}
 	providerClientKey, providerRawCertChain := certprovider.NewExternalCertFromConfig(t, ctx, externalCertProviderConfig)
 	return gql.NewCertAuthorizedGraphQLClientWithCustomURL(conf.DirectorExternalCertSecuredURL, providerClientKey, providerRawCertChain, conf.SkipSSLValidation)

--- a/tests/director/tests/application_templates_api_test.go
+++ b/tests/director/tests/application_templates_api_test.go
@@ -805,6 +805,7 @@ func createDirectorCertClientForAnotherRegion(t *testing.T, ctx context.Context)
 		TestExternalCertSubject:               conf.ExternalCertProviderConfig.TestExternalCertSubjectRegion2,
 		ExternalClientCertCertKey:             conf.ExternalCertProviderConfig.ExternalClientCertCertKey,
 		ExternalClientCertKeyKey:              conf.ExternalCertProviderConfig.ExternalClientCertKeyKey,
+		ExpectedIssuerLocality:                &conf.SubscriptionConfig.SelfRegRegion2,
 	}
 	providerClientKey, providerRawCertChain := certprovider.NewExternalCertFromConfig(t, ctx, externalCertProviderConfig)
 	return gql.NewCertAuthorizedGraphQLClientWithCustomURL(conf.DirectorExternalCertSecuredURL, providerClientKey, providerRawCertChain, conf.SkipSSLValidation)

--- a/tests/pkg/certs/certprovider/ext_cert_provider.go
+++ b/tests/pkg/certs/certprovider/ext_cert_provider.go
@@ -3,6 +3,7 @@ package certprovider
 import (
 	"context"
 	"crypto/rsa"
+	"fmt"
 	"testing"
 	"time"
 
@@ -27,7 +28,8 @@ type ExternalCertProviderConfig struct {
 	TestExternalCertCN                    string  `envconfig:"TEST_EXTERNAL_CERT_CN"`
 	ExternalClientCertCertKey             string  `envconfig:"APP_EXTERNAL_CLIENT_CERT_KEY"`
 	ExternalClientCertKeyKey              string  `envconfig:"APP_EXTERNAL_CLIENT_KEY_KEY"`
-	ExpectedIssuerLocality                *string `envconfig:"-"`
+	ExpectedIssuerLocality                string  `envconfig:"EXTERNAL_CERT_EXPECTED_ISSUER_LOCALITY"`
+	IssuerLocalityRegion2                 *string `envconfig:"-"`
 }
 
 func NewExternalCertFromConfig(t *testing.T, ctx context.Context, testConfig ExternalCertProviderConfig) (*rsa.PrivateKey, [][]byte) {
@@ -79,8 +81,8 @@ func createExtCertJob(t *testing.T, ctx context.Context, k8sClient *kubernetes.C
 						env.ValueFrom.SecretKeyRef.Name = testConfig.CertSvcInstanceTestRegion2SecretName // external certificate credentials used to execute consumer-provider test
 					}
 				}
-				if env.Name == "EXPECTED_ISSUER_LOCALITY" && testConfig.ExpectedIssuerLocality != nil {
-					env.Value = *testConfig.ExpectedIssuerLocality
+				if env.Name == "EXPECTED_ISSUER_LOCALITY" && testConfig.IssuerLocalityRegion2 != nil {
+					env.Value = fmt.Sprintf("%s,%s", testConfig.ExpectedIssuerLocality, *testConfig.IssuerLocalityRegion2)
 				}
 			}
 			break

--- a/tests/pkg/certs/certprovider/ext_cert_provider.go
+++ b/tests/pkg/certs/certprovider/ext_cert_provider.go
@@ -16,17 +16,18 @@ import (
 )
 
 type ExternalCertProviderConfig struct {
-	ExternalClientCertTestSecretName      string `envconfig:"EXTERNAL_CLIENT_CERT_TEST_SECRET_NAME"`
-	ExternalClientCertTestSecretNamespace string `envconfig:"EXTERNAL_CLIENT_CERT_TEST_SECRET_NAMESPACE"`
-	CertSvcInstanceTestSecretName         string `envconfig:"CERT_SVC_INSTANCE_TEST_SECRET_NAME"`
-	CertSvcInstanceTestRegion2SecretName  string `envconfig:"CERT_SVC_INSTANCE_TEST_REGION2_SECRET_NAME"`
-	ExternalCertCronjobContainerName      string `envconfig:"EXTERNAL_CERT_CRONJOB_CONTAINER_NAME"`
-	ExternalCertTestJobName               string `envconfig:"EXTERNAL_CERT_TEST_JOB_NAME"`
-	TestExternalCertSubject               string `envconfig:"TEST_EXTERNAL_CERT_SUBJECT"`
-	TestExternalCertSubjectRegion2        string `envconfig:"TEST_EXTERNAL_CERT_SUBJECT_REGION2"`
-	TestExternalCertCN                    string `envconfig:"TEST_EXTERNAL_CERT_CN"`
-	ExternalClientCertCertKey             string `envconfig:"APP_EXTERNAL_CLIENT_CERT_KEY"`
-	ExternalClientCertKeyKey              string `envconfig:"APP_EXTERNAL_CLIENT_KEY_KEY"`
+	ExternalClientCertTestSecretName      string  `envconfig:"EXTERNAL_CLIENT_CERT_TEST_SECRET_NAME"`
+	ExternalClientCertTestSecretNamespace string  `envconfig:"EXTERNAL_CLIENT_CERT_TEST_SECRET_NAMESPACE"`
+	CertSvcInstanceTestSecretName         string  `envconfig:"CERT_SVC_INSTANCE_TEST_SECRET_NAME"`
+	CertSvcInstanceTestRegion2SecretName  string  `envconfig:"CERT_SVC_INSTANCE_TEST_REGION2_SECRET_NAME"`
+	ExternalCertCronjobContainerName      string  `envconfig:"EXTERNAL_CERT_CRONJOB_CONTAINER_NAME"`
+	ExternalCertTestJobName               string  `envconfig:"EXTERNAL_CERT_TEST_JOB_NAME"`
+	TestExternalCertSubject               string  `envconfig:"TEST_EXTERNAL_CERT_SUBJECT"`
+	TestExternalCertSubjectRegion2        string  `envconfig:"TEST_EXTERNAL_CERT_SUBJECT_REGION2"`
+	TestExternalCertCN                    string  `envconfig:"TEST_EXTERNAL_CERT_CN"`
+	ExternalClientCertCertKey             string  `envconfig:"APP_EXTERNAL_CLIENT_CERT_KEY"`
+	ExternalClientCertKeyKey              string  `envconfig:"APP_EXTERNAL_CLIENT_KEY_KEY"`
+	ExpectedIssuerLocality                *string `envconfig:"-"`
 }
 
 func NewExternalCertFromConfig(t *testing.T, ctx context.Context, testConfig ExternalCertProviderConfig) (*rsa.PrivateKey, [][]byte) {
@@ -77,6 +78,9 @@ func createExtCertJob(t *testing.T, ctx context.Context, k8sClient *kubernetes.C
 					} else if testConfig.CertSvcInstanceTestRegion2SecretName != "" {
 						env.ValueFrom.SecretKeyRef.Name = testConfig.CertSvcInstanceTestRegion2SecretName // external certificate credentials used to execute consumer-provider test
 					}
+				}
+				if env.Name == "EXPECTED_ISSUER_LOCALITY" && testConfig.ExpectedIssuerLocality != nil {
+					env.Value = *testConfig.ExpectedIssuerLocality
 				}
 			}
 			break


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:
- The cert svc has added a functionality to create certificates with issuer per landscape. So we need to change how we issue certs in tests

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- ...

**Pull Request status**
<!-- Feel free to construct the checklist with whatever items seem most reasonable for your change. You could disassemble the Implementation part to even smaller separate checklist items if you're working on something big for example. But do make the effort to provide a checklist of some sort so that the core team as well as the community can have an idea about the progress of your Pull Request.
-->

- [ ] Implementation
- [ ] Unit tests
- [x] Integration tests
- [x] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [ ] Mocks are regenerated, using the automated script
