### PR TITLE
Make probing endpoints log on debug

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -115,7 +115,7 @@ global:
       name: compass-connector
     connectivity_adapter:
       dir:
-      version: "PR-2575"
+      version: "PR-2587"
       name: compass-connectivity-adapter
     pairing_adapter:
       dir:
@@ -123,15 +123,15 @@ global:
       name: compass-pairing-adapter
     director:
       dir:
-      version: "PR-2570"
+      version: "PR-2587"
       name: compass-director
     hydrator:
       dir:
-      version: "PR-2575"
+      version: "PR-2587"
       name: compass-hydrator
     gateway:
       dir:
-      version: "PR-2575"
+      version: "PR-2587"
       name: compass-gateway
     operations_controller:
       dir:
@@ -147,7 +147,7 @@ global:
       name: compass-schema-migrator
     system_broker:
       dir:
-      version: "PR-2575"
+      version: "PR-2587"
       name: compass-system-broker
     certs_setup_job:
       containerRegistry:

--- a/components/connectivity-adapter/cmd/main.go
+++ b/components/connectivity-adapter/cmd/main.go
@@ -67,9 +67,9 @@ func main() {
 
 func initAPIHandler(cfg config) (http.Handler, error) {
 	router := mux.NewRouter()
-	router.HandleFunc("/v1/health", health.HandleFunc).Methods(http.MethodGet)
-
-	router.Use(correlation.AttachCorrelationIDToContext(), log.RequestLogger())
+	const healthEndpoint = "/v1/health"
+	router.HandleFunc(healthEndpoint, health.HandleFunc).Methods(http.MethodGet)
+	router.Use(correlation.AttachCorrelationIDToContext(), log.RequestLogger(healthEndpoint))
 
 	applicationRegistryRouter := router.PathPrefix("/{app-name}/v1").Subrouter()
 	connectorRouter := router.PathPrefix("/v1/applications").Subrouter()

--- a/components/director/cmd/director/main.go
+++ b/components/director/cmd/director/main.go
@@ -300,10 +300,18 @@ func main() {
 
 	statusMiddleware := statusupdate.New(transact, statusupdate.NewRepository())
 
+	const (
+		healthzEndpoint = "/healthz"
+		livezEndpoint   = "/livez"
+		readyzEndpoint  = "/readyz"
+	)
+
 	mainRouter := mux.NewRouter()
 	mainRouter.HandleFunc("/", playground.Handler("Dataloader", cfg.PlaygroundAPIEndpoint))
 
-	mainRouter.Use(panicrecovery.NewPanicRecoveryMiddleware(), correlation.AttachCorrelationIDToContext(), log.RequestLogger(), header.AttachHeadersToContext())
+	mainRouter.Use(panicrecovery.NewPanicRecoveryMiddleware(), correlation.AttachCorrelationIDToContext(), log.RequestLogger(
+		healthzEndpoint, livezEndpoint, readyzEndpoint,
+	), header.AttachHeadersToContext())
 	presenter := errorpresenter.NewPresenter(uid.NewService())
 
 	gqlAPIRouter := mainRouter.PathPrefix(cfg.APIEndpoint).Subrouter()
@@ -355,16 +363,16 @@ func main() {
 	logger.Infof("Registering readiness endpoint...")
 	schemaRepo := schema.NewRepository()
 	ready := healthz.NewReady(transact, cfg.ReadyConfig, schemaRepo)
-	mainRouter.HandleFunc("/readyz", healthz.NewReadinessHandler(ready))
+	mainRouter.HandleFunc(readyzEndpoint, healthz.NewReadinessHandler(ready))
 
 	logger.Infof("Registering liveness endpoint...")
-	mainRouter.HandleFunc("/livez", healthz.NewLivenessHandler())
+	mainRouter.HandleFunc(livezEndpoint, healthz.NewLivenessHandler())
 
 	logger.Infof("Registering health endpoint...")
 	health, err := healthz.New(ctx, cfg.HealthConfig)
 	exitOnError(err, "Could not initialize health")
 	health.RegisterIndicator(healthz.NewIndicator(healthz.DBIndicatorName, healthz.NewDBIndicatorFunc(transact))).Start()
-	mainRouter.HandleFunc("/healthz", healthz.NewHealthHandler(health))
+	mainRouter.HandleFunc(healthzEndpoint, healthz.NewHealthHandler(health))
 
 	logger.Infof("Registering info endpoint...")
 	mainRouter.HandleFunc(cfg.InfoConfig.APIEndpoint, info.NewInfoHandler(ctx, cfg.InfoConfig, certCache))

--- a/components/gateway/cmd/main.go
+++ b/components/gateway/cmd/main.go
@@ -59,8 +59,9 @@ func main() {
 	err := envconfig.InitWithPrefix(&cfg, "APP")
 	exitOnError(err, "Error while loading app config")
 
+	const healthzEndpoint = "/healthz"
 	router := mux.NewRouter()
-	router.Use(correlation.AttachCorrelationIDToContext(), log.RequestLogger())
+	router.Use(correlation.AttachCorrelationIDToContext(), log.RequestLogger(healthzEndpoint))
 	metricsCollector := metrics.NewAuditlogMetricCollector()
 	prometheus.MustRegister(metricsCollector)
 
@@ -96,7 +97,7 @@ func main() {
 	err = proxyRequestsForComponent(ctx, router, "/nsadapter", cfg.NsadapterOrigin, adapterTr, cfg.NsAdapterTimeout)
 	exitOnError(err, "Error while initializing proxy for NSAdapter")
 
-	router.HandleFunc("/healthz", func(writer http.ResponseWriter, request *http.Request) {
+	router.HandleFunc(healthzEndpoint, func(writer http.ResponseWriter, request *http.Request) {
 		writer.WriteHeader(200)
 		_, err := writer.Write([]byte("ok"))
 		if err != nil {

--- a/components/system-broker/pkg/server/server.go
+++ b/components/system-broker/pkg/server/server.go
@@ -47,11 +47,16 @@ func New(c *Config, middlewares []mux.MiddlewareFunc, routesProvider ...func(rou
 
 	router := mux.NewRouter()
 
-	router.Handle("/healthz", s.livenessHandler())
-	router.Handle("/readyz", s.readinessHandler())
+	const (
+		healthzEndpoint = "/healthz"
+		readyzEndpoint  = "/readyz"
+	)
+
+	router.Handle(healthzEndpoint, s.livenessHandler())
+	router.Handle(readyzEndpoint, s.readinessHandler())
 
 	router.Use(correlation.AttachCorrelationIDToContext())
-	router.Use(log.RequestLogger())
+	router.Use(log.RequestLogger(healthzEndpoint, readyzEndpoint))
 	router.Use(panic_recovery.NewRecoveryMiddleware())
 
 	for _, m := range middlewares {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:
- Probing requests will be logged on debug instead of info. This way the logs will not be flooded by logs coming from k8s probes. 

**Pull Request status**
<!-- Feel free to construct the checklist with whatever items seem most reasonable for your change. You could disassemble the Implementation part to even smaller separate checklist items if you're working on something big for example. But do make the effort to provide a checklist of some sort so that the core team as well as the community can have an idea about the progress of your Pull Request.
-->

- [x] Implementation
- [x] Unit tests
- [ ] Integration tests
- [x] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [x] Mocks are regenerated, using the automated script
