### PR TITLE
Add imagePullSecret to Deployments when Portieris is enabled

### DIFF
--- a/chart/compass/charts/cockpit/templates/deployment.yaml
+++ b/chart/compass/charts/cockpit/templates/deployment.yaml
@@ -22,6 +22,10 @@ spec:
         reqlimit: {{ .Values.global.istio.ingressgateway.requestPayloadSizeLimit2MBLabel }}
         release: {{ .Release.Name }}
     spec:
+      {{ if eq .Values.global.portieris.isEnabled true}}
+      imagePullSecrets:
+      - name: .Values.global.portieris.imagePullSecretName
+      {{ end }}
       containers:
         - name: {{ .Chart.Name }}
           image: {{ .Values.global.images.containerRegistry.path }}/{{ .Values.global.images.console.dir }}compass-console:{{ .Values.global.images.console.version }}

--- a/chart/compass/charts/cockpit/templates/deployment.yaml
+++ b/chart/compass/charts/cockpit/templates/deployment.yaml
@@ -22,7 +22,7 @@ spec:
         reqlimit: {{ .Values.global.istio.ingressgateway.requestPayloadSizeLimit2MBLabel }}
         release: {{ .Release.Name }}
     spec:
-      {{ if eq .Values.global.portieris.isEnabled true}}
+      {{ if eq .Values.global.portieris.isEnabled true }}
       imagePullSecrets:
       - name: .Values.global.portieris.imagePullSecretName
       {{ end }}

--- a/chart/compass/charts/connectivity-adapter/templates/deployment.yaml
+++ b/chart/compass/charts/connectivity-adapter/templates/deployment.yaml
@@ -35,7 +35,7 @@ spec:
         {{- toYaml .Values.deployment.nodeSelector | nindent 8 }}
       {{ if eq .Values.global.portieris.isEnabled true }}
       imagePullSecrets:
-        - name: .Values.global.portieris.imagePullSecretName
+      - name: .Values.global.portieris.imagePullSecretName
       {{ end }}
       containers:
         - name: {{ .Chart.Name }}

--- a/chart/compass/charts/connectivity-adapter/templates/deployment.yaml
+++ b/chart/compass/charts/connectivity-adapter/templates/deployment.yaml
@@ -33,6 +33,10 @@ spec:
     spec:
       nodeSelector:
         {{- toYaml .Values.deployment.nodeSelector | nindent 8 }}
+      {{ if eq .Values.global.portieris.isEnabled true }}
+      imagePullSecrets:
+        - name: .Values.global.portieris.imagePullSecretName
+      {{ end }}
       containers:
         - name: {{ .Chart.Name }}
           image: {{ .Values.global.images.containerRegistry.path }}/{{ .Values.global.images.connectivity_adapter.dir }}compass-connectivity-adapter:{{ .Values.global.images.connectivity_adapter.version }}

--- a/chart/compass/charts/connector/templates/deployment.yaml
+++ b/chart/compass/charts/connector/templates/deployment.yaml
@@ -34,6 +34,10 @@ spec:
       serviceAccountName: {{ template "fullname" . }}
       nodeSelector:
         {{- toYaml .Values.deployment.nodeSelector | nindent 8 }}
+      {{ if eq .Values.global.portieris.isEnabled true }}
+      imagePullSecrets:
+        - name: .Values.global.portieris.imagePullSecretName
+      {{ end }}
       containers:
         - name: {{ .Chart.Name }}
           image: {{ .Values.global.images.containerRegistry.path }}/{{ .Values.global.images.connector.dir }}compass-connector:{{ .Values.global.images.connector.version }}

--- a/chart/compass/charts/connector/templates/deployment.yaml
+++ b/chart/compass/charts/connector/templates/deployment.yaml
@@ -36,7 +36,7 @@ spec:
         {{- toYaml .Values.deployment.nodeSelector | nindent 8 }}
       {{ if eq .Values.global.portieris.isEnabled true }}
       imagePullSecrets:
-        - name: .Values.global.portieris.imagePullSecretName
+      - name: .Values.global.portieris.imagePullSecretName
       {{ end }}
       containers:
         - name: {{ .Chart.Name }}

--- a/chart/compass/charts/director/templates/deployment.yaml
+++ b/chart/compass/charts/director/templates/deployment.yaml
@@ -39,6 +39,10 @@ spec:
       serviceAccountName: {{ template "fullname" . }}
       nodeSelector:
         {{- toYaml .Values.deployment.nodeSelector | nindent 8 }}
+      {{ if eq .Values.global.portieris.isEnabled true }}
+      imagePullSecrets:
+        - name: .Values.global.portieris.imagePullSecretName
+      {{ end }}
       containers:
         - name: {{ .Chart.Name }}
           image: {{ $.Values.global.images.containerRegistry.path }}/{{ $.Values.global.images.director.dir }}compass-director:{{ $.Values.global.images.director.version }}

--- a/chart/compass/charts/director/templates/deployment.yaml
+++ b/chart/compass/charts/director/templates/deployment.yaml
@@ -41,7 +41,7 @@ spec:
         {{- toYaml .Values.deployment.nodeSelector | nindent 8 }}
       {{ if eq .Values.global.portieris.isEnabled true }}
       imagePullSecrets:
-        - name: .Values.global.portieris.imagePullSecretName
+      - name: .Values.global.portieris.imagePullSecretName
       {{ end }}
       containers:
         - name: {{ .Chart.Name }}

--- a/chart/compass/charts/director/templates/oauth-clients-scopes-sync-job.yaml
+++ b/chart/compass/charts/director/templates/oauth-clients-scopes-sync-job.yaml
@@ -31,6 +31,10 @@ spec:
       serviceAccountName: {{ template "fullname" . }}
       restartPolicy: Never
       shareProcessNamespace: true
+    {{ if eq .Values.global.portieris.isEnabled true }}
+      imagePullSecrets:
+      - name: .Values.global.portieris.imagePullSecretName
+    {{ end }}
       containers:
         - name: sync
           image: {{ $.Values.global.images.containerRegistry.path }}/{{ $.Values.global.images.director.dir }}compass-director:{{ $.Values.global.images.director.version }}

--- a/chart/compass/charts/director/templates/tenant-loader-cronjob-external.yaml
+++ b/chart/compass/charts/director/templates/tenant-loader-cronjob-external.yaml
@@ -21,6 +21,10 @@ spec:
                     serviceAccountName: {{ template "fullname" . }}
                     restartPolicy: Never
                     shareProcessNamespace: true
+                  {{ if eq .Values.global.portieris.isEnabled true }}
+                    imagePullSecrets:
+                    - name: .Values.global.portieris.imagePullSecretName
+                  {{ end }}
                     containers:
                         - name: loader
                           image: {{ $.Values.global.images.containerRegistry.path }}/{{ $.Values.global.images.director.dir }}compass-director:{{ $.Values.global.images.director.version }}

--- a/chart/compass/charts/director/templates/tenant-loader-job-default.yaml
+++ b/chart/compass/charts/director/templates/tenant-loader-job-default.yaml
@@ -22,6 +22,10 @@ spec:
             serviceAccountName: {{ template "fullname" . }}
             restartPolicy: Never
             shareProcessNamespace: true
+          {{ if eq .Values.global.portieris.isEnabled true }}
+            imagePullSecrets:
+            - name: .Values.global.portieris.imagePullSecretName
+          {{ end }}
             containers:
                 - name: loader
                   image: {{ $.Values.global.images.containerRegistry.path }}/{{ $.Values.global.images.director.dir }}compass-director:{{ $.Values.global.images.director.version }}

--- a/chart/compass/charts/external-services-mock/templates/deployment.yaml
+++ b/chart/compass/charts/external-services-mock/templates/deployment.yaml
@@ -19,6 +19,10 @@ spec:
                 app: {{ .Chart.Name }}
                 release: {{ .Release.Name }}
         spec:
+            {{ if eq .Values.global.portieris.isEnabled true }}
+            imagePullSecrets:
+            - name: .Values.global.portieris.imagePullSecretName
+            {{ end }}
             containers:
             - name: {{ .Chart.Name }}
               image: {{ .Values.global.images.containerRegistry.path }}/{{ .Values.global.images.external_services_mock.dir }}compass-external-services-mock:{{ .Values.global.images.external_services_mock.version }}

--- a/chart/compass/charts/gateway/templates/deployment.yaml
+++ b/chart/compass/charts/gateway/templates/deployment.yaml
@@ -26,6 +26,10 @@ spec:
     spec:
       nodeSelector:
         {{- toYaml .Values.deployment.nodeSelector | nindent 8 }}
+      {{ if eq .Values.global.portieris.isEnabled true }}
+      imagePullSecrets:
+        - name: .Values.global.portieris.imagePullSecretName
+      {{ end }}
       containers:
         - name: {{ .Chart.Name }}
           image: {{ .Values.global.images.containerRegistry.path }}/{{ .Values.global.images.gateway.dir }}compass-gateway:{{ .Values.global.images.gateway.version }}

--- a/chart/compass/charts/gateway/templates/deployment.yaml
+++ b/chart/compass/charts/gateway/templates/deployment.yaml
@@ -28,7 +28,7 @@ spec:
         {{- toYaml .Values.deployment.nodeSelector | nindent 8 }}
       {{ if eq .Values.global.portieris.isEnabled true }}
       imagePullSecrets:
-        - name: .Values.global.portieris.imagePullSecretName
+      - name: .Values.global.portieris.imagePullSecretName
       {{ end }}
       containers:
         - name: {{ .Chart.Name }}

--- a/chart/compass/charts/hydrator/templates/deployment.yaml
+++ b/chart/compass/charts/hydrator/templates/deployment.yaml
@@ -38,6 +38,10 @@ spec:
       serviceAccountName: {{ template "fullname" . }}
       nodeSelector:
         {{- toYaml .Values.deployment.nodeSelector | nindent 8 }}
+      {{ if eq .Values.global.portieris.isEnabled true }}
+      imagePullSecrets:
+        - name: .Values.global.portieris.imagePullSecretName
+      {{ end }}
       containers:
         - name: {{ .Chart.Name }}
           image: {{ $.Values.global.images.containerRegistry.path }}/{{ $.Values.global.images.hydrator.dir }}compass-hydrator:{{ $.Values.global.images.hydrator.version }}

--- a/chart/compass/charts/hydrator/templates/deployment.yaml
+++ b/chart/compass/charts/hydrator/templates/deployment.yaml
@@ -40,7 +40,7 @@ spec:
         {{- toYaml .Values.deployment.nodeSelector | nindent 8 }}
       {{ if eq .Values.global.portieris.isEnabled true }}
       imagePullSecrets:
-        - name: .Values.global.portieris.imagePullSecretName
+      - name: .Values.global.portieris.imagePullSecretName
       {{ end }}
       containers:
         - name: {{ .Chart.Name }}

--- a/chart/compass/charts/ns-adapter/templates/deployment.yaml
+++ b/chart/compass/charts/ns-adapter/templates/deployment.yaml
@@ -39,6 +39,10 @@ spec:
       serviceAccountName: {{ template "fullname" . }}
       nodeSelector:
         {{- toYaml .Values.deployment.nodeSelector | nindent 8 }}
+      {{ if eq .Values.global.portieris.isEnabled true }}
+      imagePullSecrets:
+        - name: .Values.global.portieris.imagePullSecretName
+      {{ end }}
       containers:
         - name: {{ .Chart.Name }}
           image: {{ $.Values.global.images.containerRegistry.path }}/{{ $.Values.global.images.director.dir }}compass-director:{{ $.Values.global.images.director.version }}

--- a/chart/compass/charts/ns-adapter/templates/deployment.yaml
+++ b/chart/compass/charts/ns-adapter/templates/deployment.yaml
@@ -41,7 +41,7 @@ spec:
         {{- toYaml .Values.deployment.nodeSelector | nindent 8 }}
       {{ if eq .Values.global.portieris.isEnabled true }}
       imagePullSecrets:
-        - name: .Values.global.portieris.imagePullSecretName
+      - name: .Values.global.portieris.imagePullSecretName
       {{ end }}
       containers:
         - name: {{ .Chart.Name }}

--- a/chart/compass/charts/operations-controller/templates/deployment.yaml
+++ b/chart/compass/charts/operations-controller/templates/deployment.yaml
@@ -25,7 +25,7 @@ spec:
       serviceAccountName: {{ template "fullname" . }}
       {{ if eq .Values.global.portieris.isEnabled true }}
       imagePullSecrets:
-        - name: .Values.global.portieris.imagePullSecretName
+      - name: .Values.global.portieris.imagePullSecretName
       {{ end }}
       containers:
       - args:

--- a/chart/compass/charts/operations-controller/templates/deployment.yaml
+++ b/chart/compass/charts/operations-controller/templates/deployment.yaml
@@ -23,6 +23,10 @@ spec:
         control-plane: controller-manager
     spec:
       serviceAccountName: {{ template "fullname" . }}
+      {{ if eq .Values.global.portieris.isEnabled true }}
+      imagePullSecrets:
+        - name: .Values.global.portieris.imagePullSecretName
+      {{ end }}
       containers:
       - args:
         - --secure-listen-address=0.0.0.0:8443

--- a/chart/compass/charts/ord-service/templates/deployment.yaml
+++ b/chart/compass/charts/ord-service/templates/deployment.yaml
@@ -38,6 +38,10 @@ spec:
       serviceAccountName: {{ template "fullname" . }}
       nodeSelector:
         {{- toYaml .Values.deployment.nodeSelector | nindent 8 }}
+      {{ if eq .Values.global.portieris.isEnabled true }}
+      imagePullSecrets:
+        - name: .Values.global.portieris.imagePullSecretName
+      {{ end }}
       containers:
         - name: {{ .Chart.Name }}
           image: {{ .Values.global.images.containerRegistry.path }}/{{ .Values.global.images.ord_service.dir }}compass-ord-service:{{ .Values.global.images.ord_service.version }}

--- a/chart/compass/charts/ord-service/templates/deployment.yaml
+++ b/chart/compass/charts/ord-service/templates/deployment.yaml
@@ -38,10 +38,10 @@ spec:
       serviceAccountName: {{ template "fullname" . }}
       nodeSelector:
         {{- toYaml .Values.deployment.nodeSelector | nindent 8 }}
-      {{ if eq .Values.global.portieris.isEnabled true }}
+    {{ if eq .Values.global.portieris.isEnabled true }}
       imagePullSecrets:
-        - name: .Values.global.portieris.imagePullSecretName
-      {{ end }}
+      - name: .Values.global.portieris.imagePullSecretName
+    {{ end }}
       containers:
         - name: {{ .Chart.Name }}
           image: {{ .Values.global.images.containerRegistry.path }}/{{ .Values.global.images.ord_service.dir }}compass-ord-service:{{ .Values.global.images.ord_service.version }}

--- a/chart/compass/charts/pairing-adapter/templates/deployment.yaml
+++ b/chart/compass/charts/pairing-adapter/templates/deployment.yaml
@@ -36,7 +36,7 @@ spec:
               {{- toYaml $.Values.deployment.nodeSelector | nindent 14 }}
           {{ if eq $.Values.global.portieris.isEnabled true }}
             imagePullSecrets:
-              - name: .Values.global.portieris.imagePullSecretName
+            - name: .Values.global.portieris.imagePullSecretName
           {{ end }}
             containers:
             - name: {{ $.Chart.Name }}

--- a/chart/compass/charts/pairing-adapter/templates/deployment.yaml
+++ b/chart/compass/charts/pairing-adapter/templates/deployment.yaml
@@ -34,6 +34,10 @@ spec:
             serviceAccountName: {{ $.Release.Name }}-pairing-adapter
             nodeSelector:
               {{- toYaml $.Values.deployment.nodeSelector | nindent 14 }}
+          {{ if eq .Values.global.portieris.isEnabled true }}
+            imagePullSecrets:
+              - name: .Values.global.portieris.imagePullSecretName
+          {{ end }}
             containers:
             - name: {{ $.Chart.Name }}
               image: {{ $.Values.global.images.containerRegistry.path }}/{{ $.Values.global.images.pairing_adapter.dir }}compass-pairing-adapter:{{ $.Values.global.images.pairing_adapter.version }}

--- a/chart/compass/charts/pairing-adapter/templates/deployment.yaml
+++ b/chart/compass/charts/pairing-adapter/templates/deployment.yaml
@@ -34,7 +34,7 @@ spec:
             serviceAccountName: {{ $.Release.Name }}-pairing-adapter
             nodeSelector:
               {{- toYaml $.Values.deployment.nodeSelector | nindent 14 }}
-          {{ if eq .Values.global.portieris.isEnabled true }}
+          {{ if eq $.Values.global.portieris.isEnabled true }}
             imagePullSecrets:
               - name: .Values.global.portieris.imagePullSecretName
           {{ end }}

--- a/chart/compass/charts/prometheus-postgres-exporter/templates/deployment.yaml
+++ b/chart/compass/charts/prometheus-postgres-exporter/templates/deployment.yaml
@@ -32,6 +32,10 @@ spec:
 {{- end }}
     spec:
       serviceAccountName: {{ template "prometheus-postgres-exporter.serviceAccountName" . }}
+      {{ if eq .Values.global.portieris.isEnabled true }}
+      imagePullSecrets:
+      - name: .Values.global.portieris.imagePullSecretName
+      {{ end }}
       containers:
         - name: {{ .Chart.Name }}
           args:

--- a/chart/compass/charts/system-broker/templates/deployment.yaml
+++ b/chart/compass/charts/system-broker/templates/deployment.yaml
@@ -26,6 +26,10 @@ spec:
       serviceAccountName: {{ template "fullname" . }}
       nodeSelector:
         {{- toYaml .Values.deployment.nodeSelector | nindent 8 }}
+      {{ if eq .Values.global.portieris.isEnabled true }}
+      imagePullSecrets:
+        - name: .Values.global.portieris.imagePullSecretName
+      {{ end }}
       containers:
         - name: {{ .Chart.Name }}
           image: {{ .Values.global.images.containerRegistry.path }}/{{ .Values.global.images.system_broker.dir }}compass-system-broker:{{ .Values.global.images.system_broker.version }}

--- a/chart/compass/charts/system-broker/templates/deployment.yaml
+++ b/chart/compass/charts/system-broker/templates/deployment.yaml
@@ -28,7 +28,7 @@ spec:
         {{- toYaml .Values.deployment.nodeSelector | nindent 8 }}
       {{ if eq .Values.global.portieris.isEnabled true }}
       imagePullSecrets:
-        - name: .Values.global.portieris.imagePullSecretName
+      - name: .Values.global.portieris.imagePullSecretName
       {{ end }}
       containers:
         - name: {{ .Chart.Name }}

--- a/chart/compass/charts/tenant-fetcher/templates/deployment.yaml
+++ b/chart/compass/charts/tenant-fetcher/templates/deployment.yaml
@@ -39,10 +39,10 @@ spec:
       serviceAccountName: {{ template "fullname" . }}
       nodeSelector:
         {{- toYaml .Values.deployment.nodeSelector | nindent 8 }}
-      {{ if eq .Values.global.portieris.isEnabled true }}
+    {{ if eq .Values.global.portieris.isEnabled true }}
       imagePullSecrets:
-        - name: .Values.global.portieris.imagePullSecretName
-      {{ end }}
+      - name: .Values.global.portieris.imagePullSecretName
+    {{ end }}
       volumes:
       - name: dependencies-config
         secret:

--- a/chart/compass/charts/tenant-fetcher/templates/deployment.yaml
+++ b/chart/compass/charts/tenant-fetcher/templates/deployment.yaml
@@ -39,6 +39,10 @@ spec:
       serviceAccountName: {{ template "fullname" . }}
       nodeSelector:
         {{- toYaml .Values.deployment.nodeSelector | nindent 8 }}
+      {{ if eq .Values.global.portieris.isEnabled true }}
+      imagePullSecrets:
+        - name: .Values.global.portieris.imagePullSecretName
+      {{ end }}
       volumes:
       - name: dependencies-config
         secret:

--- a/chart/compass/templates/bench/director/director-bench.yaml
+++ b/chart/compass/templates/bench/director/director-bench.yaml
@@ -22,6 +22,10 @@ spec:
         app: {{ .Chart.Name }}-director-bench-app
     spec:
       serviceAccountName: {{ .Chart.Name }}-director-bench-app
+    {{ if eq .Values.global.portieris.isEnabled true }}
+      imagePullSecrets:
+      - name: .Values.global.portieris.imagePullSecretName
+    {{ end }}
       nodeSelector:
         benchmark: "true" # This guarantees that benchmark tests will be executed on one and the same node. The gke-benchamrk job adds the benchmark=true label to the node with the lowest cpu load.
       containers:

--- a/chart/compass/templates/bench/ord-service/ord-service-bench.yaml
+++ b/chart/compass/templates/bench/ord-service/ord-service-bench.yaml
@@ -22,6 +22,10 @@ spec:
         app: {{ .Chart.Name }}-ord-service-bench-app
     spec:
       serviceAccountName: {{ .Chart.Name }}-ord-service-bench-app
+    {{ if eq .Values.global.portieris.isEnabled true }}
+      imagePullSecrets:
+      - name: .Values.global.portieris.imagePullSecretName
+    {{ end }}
       nodeSelector:
         benchmark: "true" # This guarantees that benchmark tests will be executed on one and the same node. The gke-benchamrk job adds the benchmark=true label to the node with the lowest cpu load.
       containers:

--- a/chart/compass/templates/migrator-down-job.yaml
+++ b/chart/compass/templates/migrator-down-job.yaml
@@ -25,6 +25,10 @@ spec:
       {{- end }}
       restartPolicy: Never
       shareProcessNamespace: true
+    {{ if eq .Values.global.portieris.isEnabled true }}
+      imagePullSecrets:
+      - name: .Values.global.portieris.imagePullSecretName
+    {{ end }}
       containers:
         {{- if eq .Values.global.database.embedded.enabled false }}
         - name: cloudsql-proxy

--- a/chart/compass/templates/migrator-job.yaml
+++ b/chart/compass/templates/migrator-job.yaml
@@ -21,6 +21,10 @@ spec:
         {{- end }}
         restartPolicy: Never
         shareProcessNamespace: true
+      {{ if eq .Values.global.portieris.isEnabled true }}
+        imagePullSecrets:
+        - name: .Values.global.portieris.imagePullSecretName
+      {{ end }}
         containers:
           {{ if eq .Values.global.database.embedded.enabled false }}
           - name: cloudsql-proxy

--- a/chart/compass/templates/ord-aggregator-job.yaml
+++ b/chart/compass/templates/ord-aggregator-job.yaml
@@ -23,6 +23,10 @@ spec:
             cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
         spec:
           serviceAccountName: {{ $.Chart.Name }}-ord-aggregator
+        {{ if eq .Values.global.portieris.isEnabled true }}
+          imagePullSecrets:
+          - name: .Values.global.portieris.imagePullSecretName
+        {{ end }}
           containers:
             - name: {{ .Values.global.ordAggregator.containerName }}
               image: {{ $.Values.global.images.containerRegistry.path }}/{{ $.Values.global.images.director.dir }}compass-director:{{ $.Values.global.images.director.version }}

--- a/chart/compass/templates/system-fetcher-job.yaml
+++ b/chart/compass/templates/system-fetcher-job.yaml
@@ -21,6 +21,10 @@ spec:
             cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
         spec:
           serviceAccountName: {{ $.Chart.Name }}-system-fetcher
+        {{ if eq .Values.global.portieris.isEnabled true }}
+          imagePullSecrets:
+          - name: .Values.global.portieris.imagePullSecretName
+        {{ end }}
           containers:
             - name: {{ .Values.global.systemFetcher.containerName }}
               image: {{ $.Values.global.images.containerRegistry.path }}/{{ $.Values.global.images.director.dir }}compass-director:{{ $.Values.global.images.director.version }}

--- a/chart/compass/templates/tests/connectivity-adapter/connectivity-adapter-test.yaml
+++ b/chart/compass/templates/tests/connectivity-adapter/connectivity-adapter-test.yaml
@@ -22,6 +22,10 @@ spec:
         app: {{ .Chart.Name }}-connectivity-adapter-tests-app
     spec:
       serviceAccountName: {{ .Chart.Name }}-e2e-connectivity-adapter
+    {{ if eq .Values.global.portieris.isEnabled true }}
+      imagePullSecrets:
+      - name: .Values.global.portieris.imagePullSecretName
+    {{ end }}
       containers:
         - name: connectivity-adapter-tests
           image: {{ .Values.global.images.containerRegistry.path }}/{{ .Values.global.images.e2e_tests.dir }}compass-e2e-tests:{{ .Values.global.images.e2e_tests.version }}

--- a/chart/compass/templates/tests/connector/connector-test.yaml
+++ b/chart/compass/templates/tests/connector/connector-test.yaml
@@ -21,6 +21,10 @@ spec:
         app: {{ .Chart.Name }}-connector-tests-app
     spec:
       serviceAccountName: {{ .Chart.Name }}-e2e-connector
+    {{ if eq .Values.global.portieris.isEnabled true }}
+      imagePullSecrets:
+      - name: .Values.global.portieris.imagePullSecretName
+    {{ end }}
       containers:
       - name: connector-tests
         image: {{ .Values.global.images.containerRegistry.path }}/{{ .Values.global.images.e2e_tests.dir }}compass-e2e-tests:{{ .Values.global.images.e2e_tests.version }}

--- a/chart/compass/templates/tests/director/director-test.yaml
+++ b/chart/compass/templates/tests/director/director-test.yaml
@@ -21,6 +21,10 @@ spec:
         app: {{ .Chart.Name }}-director-tests-app
     spec:
       serviceAccountName: {{ .Chart.Name }}-e2e-director
+    {{ if eq .Values.global.portieris.isEnabled true }}
+      imagePullSecrets:
+      - name: .Values.global.portieris.imagePullSecretName
+    {{ end }}
       containers:
         - name: director-tests
           image: {{ .Values.global.images.containerRegistry.path }}/{{ .Values.global.images.e2e_tests.dir }}compass-e2e-tests:{{ .Values.global.images.e2e_tests.version }}

--- a/chart/compass/templates/tests/external-services-mock/external-services-mock-test.yaml
+++ b/chart/compass/templates/tests/external-services-mock/external-services-mock-test.yaml
@@ -21,6 +21,10 @@ spec:
       labels:
         app: {{ .Chart.Name }}-external-services-mock-tests-app
     spec:
+    {{ if eq .Values.global.portieris.isEnabled true }}
+      imagePullSecrets:
+      - name: .Values.global.portieris.imagePullSecretName
+    {{ end }}
       containers:
         - name: external-services-mock-tests
           image: {{ .Values.global.images.containerRegistry.path }}/{{ .Values.global.images.e2e_tests.dir }}compass-e2e-tests:{{ .Values.global.images.e2e_tests.version }}

--- a/chart/compass/templates/tests/gateway/gateway-test.yaml
+++ b/chart/compass/templates/tests/gateway/gateway-test.yaml
@@ -21,6 +21,10 @@ spec:
         app: {{ .Chart.Name }}-gateway-tests-app
     spec:
       serviceAccountName: {{ .Chart.Name }}-e2e-gateway
+    {{ if eq .Values.global.portieris.isEnabled true }}
+      imagePullSecrets:
+      - name: .Values.global.portieris.imagePullSecretName
+    {{ end }}
       containers:
         - name: gateway-tests
           image: {{ .Values.global.images.containerRegistry.path }}/{{ .Values.global.images.e2e_tests.dir }}compass-e2e-tests:{{ .Values.global.images.e2e_tests.version }}

--- a/chart/compass/templates/tests/istio/istio-test.yaml
+++ b/chart/compass/templates/tests/istio/istio-test.yaml
@@ -21,6 +21,10 @@ spec:
         app: {{ .Chart.Name }}-istio-tests-app
     spec:
       serviceAccountName: {{ .Chart.Name }}-e2e-istio
+    {{ if eq .Values.global.portieris.isEnabled true }}
+      imagePullSecrets:
+      - name: .Values.global.portieris.imagePullSecretName
+    {{ end }}
       containers:
         - name: istio-tests
           image: {{ .Values.global.images.containerRegistry.path }}/{{ .Values.global.images.e2e_tests.dir }}compass-e2e-tests:{{ .Values.global.images.e2e_tests.version }}

--- a/chart/compass/templates/tests/ns-adapter/ns-adapter-test.yaml
+++ b/chart/compass/templates/tests/ns-adapter/ns-adapter-test.yaml
@@ -21,6 +21,10 @@ spec:
         app: {{ .Chart.Name }}-ns-adapter-tests-app
     spec:
       serviceAccountName: {{ .Chart.Name }}-e2e-ns-adapter
+    {{ if eq .Values.global.portieris.isEnabled true }}
+      imagePullSecrets:
+      - name: .Values.global.portieris.imagePullSecretName
+    {{ end }}
       containers:
         - name: ns-adapter-tests
           image: {{ .Values.global.images.containerRegistry.path }}/{{ .Values.global.images.e2e_tests.dir }}compass-e2e-tests:{{ .Values.global.images.e2e_tests.version }}

--- a/chart/compass/templates/tests/ord-aggregator/ord-aggregator-test.yaml
+++ b/chart/compass/templates/tests/ord-aggregator/ord-aggregator-test.yaml
@@ -21,6 +21,10 @@ spec:
         app: {{ .Chart.Name }}-ord-aggregator-tests-app
     spec:
       serviceAccountName: {{ $.Chart.Name }}-e2e-ord-aggregator
+    {{ if eq .Values.global.portieris.isEnabled true }}
+      imagePullSecrets:
+      - name: .Values.global.portieris.imagePullSecretName
+    {{ end }}
       containers:
         - name: {{ .Values.global.ordAggregator.containerName }}-tests
           image: {{ .Values.global.images.containerRegistry.path }}/{{ .Values.global.images.e2e_tests.dir }}compass-e2e-tests:{{ .Values.global.images.e2e_tests.version }}

--- a/chart/compass/templates/tests/ord-service/ord-service-test.yaml
+++ b/chart/compass/templates/tests/ord-service/ord-service-test.yaml
@@ -21,6 +21,10 @@ spec:
         app: {{ .Chart.Name }}-ord-service-tests-app
     spec:
       serviceAccountName: {{ .Chart.Name }}-e2e-ord-service
+    {{ if eq .Values.global.portieris.isEnabled true }}
+      imagePullSecrets:
+      - name: .Values.global.portieris.imagePullSecretName
+    {{ end }}
       containers:
         - name: ord-service-tests
           image: {{ .Values.global.images.containerRegistry.path }}/{{ .Values.global.images.e2e_tests.dir }}compass-e2e-tests:{{ .Values.global.images.e2e_tests.version }}

--- a/chart/compass/templates/tests/pairing-adapter/pairing-adapter-test.yaml
+++ b/chart/compass/templates/tests/pairing-adapter/pairing-adapter-test.yaml
@@ -21,6 +21,10 @@ spec:
         app: {{ .Chart.Name }}-pairing-adapter-tests-app
     spec:
       serviceAccountName: {{ $.Chart.Name }}-e2e-pairing-adapter
+    {{ if eq .Values.global.portieris.isEnabled true }}
+      imagePullSecrets:
+      - name: .Values.global.portieris.imagePullSecretName
+    {{ end }}
       containers:
         {{if eq .Values.global.database.embedded.enabled false}}
         - name: cloudsql-proxy

--- a/chart/compass/templates/tests/system-broker/system-broker-test.yaml
+++ b/chart/compass/templates/tests/system-broker/system-broker-test.yaml
@@ -21,6 +21,10 @@ spec:
         app: {{ .Chart.Name }}-system-broker-tests-app
     spec:
       serviceAccountName: {{ .Chart.Name }}-e2e-system-broker
+    {{ if eq .Values.global.portieris.isEnabled true }}
+      imagePullSecrets:
+      - name: .Values.global.portieris.imagePullSecretName
+    {{ end }}
       containers:
         - name: system-broker-tests
           image: {{ .Values.global.images.containerRegistry.path }}/{{ .Values.global.images.e2e_tests.dir}}compass-e2e-tests:{{ .Values.global.images.e2e_tests.version }}

--- a/chart/compass/templates/tests/system-fetcher/system-fetcher-test.yaml
+++ b/chart/compass/templates/tests/system-fetcher/system-fetcher-test.yaml
@@ -22,6 +22,10 @@ spec:
         app: {{ .Chart.Name }}-system-fetcher-tests-app
     spec:
       serviceAccountName: {{ .Chart.Name }}-e2e-system-fetcher
+    {{ if eq .Values.global.portieris.isEnabled true }}
+      imagePullSecrets:
+      - name: .Values.global.portieris.imagePullSecretName
+    {{ end }}
       containers:
         - name: {{ .Values.global.systemFetcher.containerName }}
           image: {{ .Values.global.images.containerRegistry.path }}/{{ .Values.global.images.e2e_tests.dir }}compass-e2e-tests:{{ .Values.global.images.e2e_tests.version }}

--- a/chart/compass/templates/tests/tenant-fetcher/tenant-fetcher-test.yaml
+++ b/chart/compass/templates/tests/tenant-fetcher/tenant-fetcher-test.yaml
@@ -21,6 +21,10 @@ spec:
         app: {{ .Chart.Name }}-tenant-fetcher-tests-app
     spec:
       serviceAccountName: {{ .Chart.Name }}-e2e-tenant-fetcher
+    {{ if eq .Values.global.portieris.isEnabled true }}
+      imagePullSecrets:
+      - name: .Values.global.portieris.imagePullSecretName
+    {{ end }}
       containers:
         - name: tenant-fetcher-tests
           image: {{ .Values.global.images.containerRegistry.path }}/{{ .Values.global.images.e2e_tests.dir }}compass-e2e-tests:{{ .Values.global.images.e2e_tests.version }}

--- a/chart/compass/templates/update-expected-schema-version-job.yaml
+++ b/chart/compass/templates/update-expected-schema-version-job.yaml
@@ -62,6 +62,10 @@ spec:
       serviceAccountName: update-expected-schema-version
       restartPolicy: Never
       shareProcessNamespace: true
+    {{ if eq .Values.global.portieris.isEnabled true }}
+      imagePullSecrets:
+      - name: .Values.global.portieris.imagePullSecretName
+    {{ end }}
       containers:
       - name: editor
         image: {{ .Values.global.images.containerRegistry.path }}/{{ .Values.global.images.schema_migrator.dir }}compass-schema-migrator:{{ .Values.global.images.schema_migrator.version }}

--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -181,7 +181,7 @@ global:
   agentPreconfiguration: false
   portieris:
     isEnabled: false
-    imagePullSecretName: "compass"
+    imagePullSecretName: "portieris-dummy-image-pull-secret"
   nsAdapter:
     external:
       port: 3005

--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -179,6 +179,9 @@ global:
     timeoutSeconds: 1
     periodSeconds: 2
   agentPreconfiguration: false
+  portieris:
+    isEnabled: false
+    imagePullSecretName: "compass"
   nsAdapter:
     external:
       port: 3005


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
For Portieris to work ImagePullSecret needs to exist. Because of that when Portieris is enabled(productive setup) we are adding the 'compass' imagePullSecret to all deployments. Also, the 'compass' secret contains dummy data because this ImagePullSecret is just a formality, it needs to exist but its data is not actually used.

Changes proposed in this pull request:
- Add imagePullSecret to all resources in compass-system namespace when Portieris is enabled which have an image like this - `eu.gcr.io/kyma-project/incubator/compass-*`

**Pull Request status**
<!-- Feel free to construct the checklist with whatever items seem most reasonable for your change. You could disassemble the Implementation part to even smaller separate checklist items if you're working on something big for example. But do make the effort to provide a checklist of some sort so that the core team as well as the community can have an idea about the progress of your Pull Request.
-->

- [x] Implementation
- [x] [N/A] Unit tests
- [x] [N/A] Integration tests
- [x] [N/A] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [x] [N/A] Mocks are regenerated, using the automated script
