### PR TITLE
Add cleanup defer in the e2e test

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -164,7 +164,7 @@ global:
       name: compass-console
     e2e_tests:
       dir:
-      version: "PR-2591"
+      version: "PR-2608"
       name: compass-e2e-tests
   isLocalEnv: false
   isForTesting: false

--- a/tests/director/tests/runtime_api_test.go
+++ b/tests/director/tests/runtime_api_test.go
@@ -827,11 +827,13 @@ func TestRuntimeTypeImmutability(t *testing.T) {
 	}
 	runtimeUpdateInGQL, err := testctx.Tc.Graphqlizer.RuntimeUpdateInputToGQL(updateRuntimeInput)
 	require.NoError(t, err)
+
 	updateRuntimeReq := fixtures.FixUpdateRuntimeRequest(runtime.ID, runtimeUpdateInGQL)
 	t.Logf("Updating runtime with labels %q and %q...", conf.RuntimeTypeLabelKey, tenantfetcher.RegionKey)
-
 	updatedRuntime := graphql.RuntimeExt{}
 	err = testctx.Tc.RunOperationWithoutTenant(ctx, certSecuredGraphQLClient, updateRuntimeReq, &updatedRuntime)
+	defer fixtures.CleanupRuntimeWithoutTenant(t, ctx, certSecuredGraphQLClient, &updatedRuntime)
+
 	require.NoError(t, err)
 	require.Equal(t, "updated-runtime", updatedRuntime.Name)
 	require.Equal(t, "updated-runtime-description", *updatedRuntime.Description)


### PR DESCRIPTION
**Description**
Add missing defer for cleanup


**Pull Request status**
- [x] Implementation
- [x] [N/A] Unit tests
- [x] Integration tests
- [x] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [x] [N/A] Mocks are regenerated, using the automated script
