### PR TITLE
Assert explicitly the Certificate Issuer region in E2E tests when issuer is from another region

### DIFF
--- a/chart/compass/templates/tests/director/director-test.yaml
+++ b/chart/compass/templates/tests/director/director-test.yaml
@@ -212,6 +212,8 @@ spec:
               value: {{ .Values.global.externalCertConfiguration.ouCertSubaccountID }}
             - name: APP_EXTERNAL_CERT_TEST_INTEGRATION_SYSTEM_CN
               value: {{ .Values.global.tests.director.externalCertIntSystemCN }}
+            - name: APP_EXTERNAL_CLIENT_CERT_EXPECTED_ISSUER_LOCALITY_REGION2
+              value: {{ .Values.global.tests.externalCertConfiguration.issuerLocalityRegion2 }}
             - name: APP_CONSUMER_TOKEN_URL
               value: {{ .Values.global.tests.subscription.consumerTokenURL }}
             - name: APP_PROVIDER_CLIENT_ID

--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -164,7 +164,7 @@ global:
       name: compass-console
     e2e_tests:
       dir:
-      version: "PR-2608"
+      version: "PR-2612"
       name: compass-e2e-tests
   isLocalEnv: false
   isForTesting: false
@@ -863,6 +863,7 @@ global:
         skipSSLValidation: false
     externalCertConfiguration:
       ouCertSubaccountID: "bad76f69-e5c2-4d55-bca5-240944824b83"
+      issuerLocalityRegion2: "local"
     director:
       skipPattern: ""
       externalCertIntSystemCN: "integration-system-test"

--- a/tests/director/tests/application_templates_api_test.go
+++ b/tests/director/tests/application_templates_api_test.go
@@ -805,6 +805,7 @@ func createDirectorCertClientForAnotherRegion(t *testing.T, ctx context.Context)
 		TestExternalCertSubject:               conf.ExternalCertProviderConfig.TestExternalCertSubjectRegion2,
 		ExternalClientCertCertKey:             conf.ExternalCertProviderConfig.ExternalClientCertCertKey,
 		ExternalClientCertKeyKey:              conf.ExternalCertProviderConfig.ExternalClientCertKeyKey,
+		ExternalClientCertExpectedIssuerLocality: &conf.ExternalClientCertExpectedIssuerLocalityRegion2
 	}
 	providerClientKey, providerRawCertChain := certprovider.NewExternalCertFromConfig(t, ctx, externalCertProviderConfig)
 	return gql.NewCertAuthorizedGraphQLClientWithCustomURL(conf.DirectorExternalCertSecuredURL, providerClientKey, providerRawCertChain, conf.SkipSSLValidation)

--- a/tests/director/tests/application_templates_api_test.go
+++ b/tests/director/tests/application_templates_api_test.go
@@ -797,15 +797,15 @@ func TestAddWebhookToApplicationTemplate(t *testing.T) {
 func createDirectorCertClientForAnotherRegion(t *testing.T, ctx context.Context) *gcli.Client {
 	// Prepare provider external client certificate and secret and Build graphql director client configured with certificate
 	externalCertProviderConfig := certprovider.ExternalCertProviderConfig{
-		ExternalClientCertTestSecretName:      conf.ExternalCertProviderConfig.ExternalClientCertTestSecretName,
-		ExternalClientCertTestSecretNamespace: conf.ExternalCertProviderConfig.ExternalClientCertTestSecretNamespace,
-		CertSvcInstanceTestRegion2SecretName:  conf.ExternalCertProviderConfig.CertSvcInstanceTestRegion2SecretName,
-		ExternalCertCronjobContainerName:      conf.ExternalCertProviderConfig.ExternalCertCronjobContainerName,
-		ExternalCertTestJobName:               conf.ExternalCertProviderConfig.ExternalCertTestJobName,
-		TestExternalCertSubject:               conf.ExternalCertProviderConfig.TestExternalCertSubjectRegion2,
-		ExternalClientCertCertKey:             conf.ExternalCertProviderConfig.ExternalClientCertCertKey,
-		ExternalClientCertKeyKey:              conf.ExternalCertProviderConfig.ExternalClientCertKeyKey,
-		ExternalClientCertExpectedIssuerLocality: &conf.ExternalClientCertExpectedIssuerLocalityRegion2
+		ExternalClientCertTestSecretName:         conf.ExternalCertProviderConfig.ExternalClientCertTestSecretName,
+		ExternalClientCertTestSecretNamespace:    conf.ExternalCertProviderConfig.ExternalClientCertTestSecretNamespace,
+		CertSvcInstanceTestRegion2SecretName:     conf.ExternalCertProviderConfig.CertSvcInstanceTestRegion2SecretName,
+		ExternalCertCronjobContainerName:         conf.ExternalCertProviderConfig.ExternalCertCronjobContainerName,
+		ExternalCertTestJobName:                  conf.ExternalCertProviderConfig.ExternalCertTestJobName,
+		TestExternalCertSubject:                  conf.ExternalCertProviderConfig.TestExternalCertSubjectRegion2,
+		ExternalClientCertCertKey:                conf.ExternalCertProviderConfig.ExternalClientCertCertKey,
+		ExternalClientCertKeyKey:                 conf.ExternalCertProviderConfig.ExternalClientCertKeyKey,
+		ExternalClientCertExpectedIssuerLocality: &conf.ExternalClientCertExpectedIssuerLocalityRegion2,
 	}
 	providerClientKey, providerRawCertChain := certprovider.NewExternalCertFromConfig(t, ctx, externalCertProviderConfig)
 	return gql.NewCertAuthorizedGraphQLClientWithCustomURL(conf.DirectorExternalCertSecuredURL, providerClientKey, providerRawCertChain, conf.SkipSSLValidation)

--- a/tests/director/tests/main_test.go
+++ b/tests/director/tests/main_test.go
@@ -33,31 +33,32 @@ type DirectorConfig struct {
 	ConsumerID                     string `envconfig:"APP_INFO_CERT_CONSUMER_ID"`
 	CertLoaderConfig               certloader.Config
 	certprovider.ExternalCertProviderConfig
-	SubscriptionConfig                     subscription.Config
-	TestProviderAccountID                  string
-	TestProviderSubaccountID               string
-	TestConsumerAccountID                  string
-	TestConsumerSubaccountID               string
-	TestConsumerTenantID                   string
-	TestProviderSubaccountIDRegion2        string
-	ExternalServicesMockBaseURL            string
-	ExternalServicesMockMtlsSecuredURL     string
-	TokenPath                              string
-	SubscriptionProviderAppNameValue       string
-	ConsumerSubaccountLabelKey             string
-	SubscriptionLabelKey                   string
-	RuntimeTypeLabelKey                    string
-	ApplicationTypeLabelKey                string `envconfig:"APP_APPLICATION_TYPE_LABEL_KEY,default=applicationType"`
-	KymaRuntimeTypeLabelValue              string
-	ConsumerTokenURL                       string
-	ProviderClientID                       string
-	ProviderClientSecret                   string
-	BasicUsername                          string
-	BasicPassword                          string
-	ExternalCertCommonName                 string `envconfig:"EXTERNAL_CERT_COMMON_NAME"`
-	CertSvcInstanceTestIntSystemSecretName string `envconfig:"CERT_SVC_INSTANCE_TEST_INTEGRATION_SYSTEM_SECRET_NAME"`
-	ExternalCertTestIntSystemOUSubaccount  string `envconfig:"APP_EXTERNAL_CERT_TEST_INTEGRATION_SYSTEM_OU_SUBACCOUNT"`
-	ExternalCertTestIntSystemCommonName    string `envconfig:"APP_EXTERNAL_CERT_TEST_INTEGRATION_SYSTEM_CN"`
+	SubscriptionConfig                              subscription.Config
+	TestProviderAccountID                           string
+	TestProviderSubaccountID                        string
+	TestConsumerAccountID                           string
+	TestConsumerSubaccountID                        string
+	TestConsumerTenantID                            string
+	TestProviderSubaccountIDRegion2                 string
+	ExternalServicesMockBaseURL                     string
+	ExternalServicesMockMtlsSecuredURL              string
+	TokenPath                                       string
+	SubscriptionProviderAppNameValue                string
+	ConsumerSubaccountLabelKey                      string
+	SubscriptionLabelKey                            string
+	RuntimeTypeLabelKey                             string
+	ApplicationTypeLabelKey                         string `envconfig:"APP_APPLICATION_TYPE_LABEL_KEY,default=applicationType"`
+	KymaRuntimeTypeLabelValue                       string
+	ConsumerTokenURL                                string
+	ProviderClientID                                string
+	ProviderClientSecret                            string
+	BasicUsername                                   string
+	BasicPassword                                   string
+	ExternalCertCommonName                          string `envconfig:"EXTERNAL_CERT_COMMON_NAME"`
+	CertSvcInstanceTestIntSystemSecretName          string `envconfig:"CERT_SVC_INSTANCE_TEST_INTEGRATION_SYSTEM_SECRET_NAME"`
+	ExternalCertTestIntSystemOUSubaccount           string `envconfig:"APP_EXTERNAL_CERT_TEST_INTEGRATION_SYSTEM_OU_SUBACCOUNT"`
+	ExternalCertTestIntSystemCommonName             string `envconfig:"APP_EXTERNAL_CERT_TEST_INTEGRATION_SYSTEM_CN"`
+	ExternalClientCertExpectedIssuerLocalityRegion2 string `envconfig:"APP_EXTERNAL_CLIENT_CERT_EXPECTED_ISSUER_LOCALITY_REGION2"`
 }
 
 type BaseDirectorConfig struct {

--- a/tests/pkg/certs/certprovider/ext_cert_provider.go
+++ b/tests/pkg/certs/certprovider/ext_cert_provider.go
@@ -16,17 +16,18 @@ import (
 )
 
 type ExternalCertProviderConfig struct {
-	ExternalClientCertTestSecretName      string `envconfig:"EXTERNAL_CLIENT_CERT_TEST_SECRET_NAME"`
-	ExternalClientCertTestSecretNamespace string `envconfig:"EXTERNAL_CLIENT_CERT_TEST_SECRET_NAMESPACE"`
-	CertSvcInstanceTestSecretName         string `envconfig:"CERT_SVC_INSTANCE_TEST_SECRET_NAME"`
-	CertSvcInstanceTestRegion2SecretName  string `envconfig:"CERT_SVC_INSTANCE_TEST_REGION2_SECRET_NAME"`
-	ExternalCertCronjobContainerName      string `envconfig:"EXTERNAL_CERT_CRONJOB_CONTAINER_NAME"`
-	ExternalCertTestJobName               string `envconfig:"EXTERNAL_CERT_TEST_JOB_NAME"`
-	TestExternalCertSubject               string `envconfig:"TEST_EXTERNAL_CERT_SUBJECT"`
-	TestExternalCertSubjectRegion2        string `envconfig:"TEST_EXTERNAL_CERT_SUBJECT_REGION2"`
-	TestExternalCertCN                    string `envconfig:"TEST_EXTERNAL_CERT_CN"`
-	ExternalClientCertCertKey             string `envconfig:"APP_EXTERNAL_CLIENT_CERT_KEY"`
-	ExternalClientCertKeyKey              string `envconfig:"APP_EXTERNAL_CLIENT_KEY_KEY"`
+	ExternalClientCertTestSecretName         string  `envconfig:"EXTERNAL_CLIENT_CERT_TEST_SECRET_NAME"`
+	ExternalClientCertTestSecretNamespace    string  `envconfig:"EXTERNAL_CLIENT_CERT_TEST_SECRET_NAMESPACE"`
+	CertSvcInstanceTestSecretName            string  `envconfig:"CERT_SVC_INSTANCE_TEST_SECRET_NAME"`
+	CertSvcInstanceTestRegion2SecretName     string  `envconfig:"CERT_SVC_INSTANCE_TEST_REGION2_SECRET_NAME"`
+	ExternalCertCronjobContainerName         string  `envconfig:"EXTERNAL_CERT_CRONJOB_CONTAINER_NAME"`
+	ExternalCertTestJobName                  string  `envconfig:"EXTERNAL_CERT_TEST_JOB_NAME"`
+	TestExternalCertSubject                  string  `envconfig:"TEST_EXTERNAL_CERT_SUBJECT"`
+	TestExternalCertSubjectRegion2           string  `envconfig:"TEST_EXTERNAL_CERT_SUBJECT_REGION2"`
+	TestExternalCertCN                       string  `envconfig:"TEST_EXTERNAL_CERT_CN"`
+	ExternalClientCertCertKey                string  `envconfig:"APP_EXTERNAL_CLIENT_CERT_KEY"`
+	ExternalClientCertKeyKey                 string  `envconfig:"APP_EXTERNAL_CLIENT_KEY_KEY"`
+	ExternalClientCertExpectedIssuerLocality *string `envconfig:"-"`
 }
 
 func NewExternalCertFromConfig(t *testing.T, ctx context.Context, testConfig ExternalCertProviderConfig) (*rsa.PrivateKey, [][]byte) {
@@ -65,6 +66,9 @@ func createExtCertJob(t *testing.T, ctx context.Context, k8sClient *kubernetes.C
 		if container.Name == testConfig.ExternalCertCronjobContainerName {
 			for eIndex := range container.Env {
 				env := &container.Env[eIndex]
+				if env.Name == "EXPECTED_ISSUER_LOCALITY" && testConfig.ExternalClientCertExpectedIssuerLocality {
+					env.Value = testConfig.ExternalClientCertExpectedIssuerLocality
+				}
 				if env.Name == "CLIENT_CERT_SECRET_NAME" {
 					env.Value = testConfig.ExternalClientCertTestSecretName
 				}

--- a/tests/pkg/certs/certprovider/ext_cert_provider.go
+++ b/tests/pkg/certs/certprovider/ext_cert_provider.go
@@ -66,8 +66,8 @@ func createExtCertJob(t *testing.T, ctx context.Context, k8sClient *kubernetes.C
 		if container.Name == testConfig.ExternalCertCronjobContainerName {
 			for eIndex := range container.Env {
 				env := &container.Env[eIndex]
-				if env.Name == "EXPECTED_ISSUER_LOCALITY" && testConfig.ExternalClientCertExpectedIssuerLocality {
-					env.Value = testConfig.ExternalClientCertExpectedIssuerLocality
+				if env.Name == "EXPECTED_ISSUER_LOCALITY" && testConfig.ExternalClientCertExpectedIssuerLocality != nil {
+					env.Value = *testConfig.ExternalClientCertExpectedIssuerLocality
 				}
 				if env.Name == "CLIENT_CERT_SECRET_NAME" {
 					env.Value = testConfig.ExternalClientCertTestSecretName


### PR DESCRIPTION
# Assert explicitly the Certificate Issuer region in E2E tests when issuer is from another region

Previously we overrode the `global.externalCertConfiguration.issuerLocality` which was not a good approach.
