### PR TITLE
[HOTFIX DEV] Add explicit protocol for compass services

### DIFF
--- a/chart/compass/charts/director/templates/service.yaml
+++ b/chart/compass/charts/director/templates/service.yaml
@@ -39,6 +39,7 @@ spec:
   ports:
     - port: {{ .Values.global.director.metrics.port }}
       protocol: TCP
+      appProtocol: http
       name: metrics
   selector:
     app: {{ .Chart.Name }}

--- a/chart/compass/charts/gateway/templates/service.yaml
+++ b/chart/compass/charts/gateway/templates/service.yaml
@@ -33,6 +33,7 @@ spec:
   ports:
     - port: {{ .Values.metrics.port }}
       protocol: TCP
+      appProtocol: http
       name: metrics
   selector:
     app: {{ .Chart.Name }}

--- a/chart/compass/charts/hydrator/templates/service.yaml
+++ b/chart/compass/charts/hydrator/templates/service.yaml
@@ -33,6 +33,7 @@ spec:
   ports:
     - port: {{ .Values.global.hydrator.metrics.port }}
       protocol: TCP
+      appProtocol: http
       name: metrics
   selector:
     app: {{ .Chart.Name }}

--- a/chart/compass/charts/operations-controller/templates/service.yaml
+++ b/chart/compass/charts/operations-controller/templates/service.yaml
@@ -12,6 +12,7 @@ spec:
   ports:
     - port: {{ .Values.metrics.port }}
       protocol: TCP
+      appProtocol: http
       name: metrics
   selector:
     app: {{ .Chart.Name }}

--- a/chart/compass/charts/system-broker/templates/service.yaml
+++ b/chart/compass/charts/system-broker/templates/service.yaml
@@ -33,6 +33,7 @@ spec:
   ports:
     - port: {{ .Values.metrics.port }}
       protocol: TCP
+      appProtocol: http
       name: metrics
   selector:
     app: {{ .Chart.Name }}


### PR DESCRIPTION
**Description**
Currently, we do not have an explicit `appProtocol` for our services. That introduced problems with the new istio version and part of the monitoring dashboards were broken.

Changes proposed in this pull request:
- Add explicit appProtocol for the K8S services

**Pull Request status**
- [x] Implementation
- [x] [N/A] Unit tests
- [x] [N/A] Integration tests
- [x] [N/A] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [x] [N/A] Mocks are regenerated, using the automated script
