### PR TITLE
Update k3d CLI in the local director script

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -123,7 +123,7 @@ global:
       name: compass-pairing-adapter
     director:
       dir:
-      version: "PR-2617"
+      version: "PR-2645"
       name: compass-director
     hydrator:
       dir:

--- a/components/director/run.sh
+++ b/components/director/run.sh
@@ -118,7 +118,6 @@ function cleanup() {
 trap cleanup EXIT
 
 echo -e "${GREEN}Creating k3d cluster...${NC}"
-curl -s https://raw.githubusercontent.com/rancher/k3d/main/install.sh | TAG=v5.2.0 bash
 k3d cluster create k3d-cluster --api-port 6550 --servers 1 --port 443:443@loadbalancer --image rancher/k3s:v1.22.4-k3s1 --kubeconfig-update-default --wait
 
 if [[ ${REUSE_DB} = true ]]; then

--- a/components/director/run.sh
+++ b/components/director/run.sh
@@ -118,6 +118,7 @@ function cleanup() {
 trap cleanup EXIT
 
 echo -e "${GREEN}Creating k3d cluster...${NC}"
+curl -s https://raw.githubusercontent.com/rancher/k3d/main/install.sh | TAG=v5.2.2 bash
 k3d cluster create k3d-cluster --api-port 6550 --servers 1 --port 443:443@loadbalancer --image rancher/k3s:v1.22.4-k3s1 --kubeconfig-update-default --wait
 
 if [[ ${REUSE_DB} = true ]]; then


### PR DESCRIPTION
**Description**
Currently, we rely on having k3d CLI with version **_v5.2.2_** for the other tools we're using. But in the local director script, we're installing **_v5.2.0_** and that breaks the CLI and the director installation fails.
In this PR we're removing the k3d CLI installation assuming there is already available k3d CLI with the correct version.

Changes proposed in this pull request:
- Remove k3d CLI installation from the director script


**Pull Request status**
- [x] Implementation
- [x] [N/A] Unit tests
- [x] [N/A] Integration tests
- [x] [N/A] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [x] [N/A] Mocks are regenerated, using the automated script
