### PR TITLE
replace buildx with img

### DIFF
--- a/scripts/generic_make_go.mk
+++ b/scripts/generic_make_go.mk
@@ -99,10 +99,8 @@ release: verify build-image
 
 .PHONY: build-image
 build-image: pull-licenses
-	docker run --rm --privileged linuxkit/binfmt:v0.8 # https://stackoverflow.com/questions/70066249/docker-random-alpine-packages-fail-to-install
-	docker buildx create --name multi-arch-builder --use
-	docker buildx build --platform linux/amd64,linux/arm64 -t $(IMG_NAME):$(TAG) --push .
-	docker buildx rm multi-arch-builder
+	img build --platform linux/amd64,linux/arm64 -t $(IMG_NAME):$(TAG) .
+	img push $(IMG_NAME):$(TAG)
 docker-create-opts:
 	@echo $(DOCKER_CREATE_OPTS)
 


### PR DESCRIPTION
With Prow we aim to reduce the number of privileged containers, so we have to tackle the problem of building images without docker. `img` should be a drop-in replace for buildx that doesn't require privileged mode.

In the future I'll be working on removing this workaround and introduce a new centrally managed build infrastructure 