### PR TITLE
Remove legacy client secret config for external certificate service

### DIFF
--- a/chart/compass/charts/external-services-mock/templates/oauth-credentials-secret.yaml
+++ b/chart/compass/charts/external-services-mock/templates/oauth-credentials-secret.yaml
@@ -22,7 +22,6 @@ metadata:
 type: Opaque
 data:
   {{ .Values.global.externalCertConfiguration.secrets.externalCertSvcSecret.clientIdKey }}: {{ "client_id" | b64enc | quote }}
-  {{ .Values.global.externalCertConfiguration.secrets.externalCertSvcSecret.clientSecretKey }}: {{ "client_secret" | b64enc | quote }}
   {{ .Values.global.externalCertConfiguration.secrets.externalCertSvcSecret.oauthUrlKey }}: {{ printf "https://%s.%s:%s" .Values.global.externalServicesMock.certSecuredHost .Values.global.ingress.domainName (.Values.service.certPort | toString) | b64enc | quote }}
   {{ .Values.global.externalCertConfiguration.secrets.externalCertSvcSecret.csrEndpointKey }}: {{ "http://compass-external-services-mock.compass-system.svc.cluster.local:8080" | b64enc | quote }}
   {{ .Values.global.externalCertConfiguration.secrets.externalCertSvcSecret.clientCert }}: {{ .Values.global.connector.caCertificate | b64enc | quote }}
@@ -38,7 +37,6 @@ metadata:
 type: Opaque
 data:
   {{ .Values.global.externalCertConfiguration.secrets.externalCertSvcSecret.clientIdKey }}: {{ "client_id" | b64enc | quote }}
-  {{ .Values.global.externalCertConfiguration.secrets.externalCertSvcSecret.clientSecretKey }}: {{ "client_secret" | b64enc | quote }}
   {{ .Values.global.externalCertConfiguration.secrets.externalCertSvcSecret.oauthUrlKey }}: {{ printf "https://%s.%s:%s" .Values.global.externalServicesMock.certSecuredHost .Values.global.ingress.domainName (.Values.service.certPort | toString) | b64enc | quote }}
   {{ .Values.global.externalCertConfiguration.secrets.externalCertSvcSecret.csrEndpointKey }}: {{ "http://compass-external-services-mock.compass-system.svc.cluster.local:8080" | b64enc | quote }}
   {{ .Values.global.externalCertConfiguration.secrets.externalCertSvcSecret.clientCert }}: {{ .Values.global.connector.caCertificate | b64enc | quote }}

--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -642,7 +642,6 @@ global:
         manage: false
         name: "cert-svc-secret"
         clientIdKey: client-id
-        clientSecretKey: client-secret
         oauthUrlKey: url
         csrEndpointKey: csr-endpoint
         clientCert: client-cert


### PR DESCRIPTION
# Remove legacy client secret config for external certificate service

Seems to no longer be needed as we always request tokens with client_id + certificate + key (no longer standard oauth id + secret).