### PR TITLE
Fix Tenants Aggregator prometheus rules

### DIFF
--- a/chart/compass/charts/tenant-fetcher/templates/tnt-resync-prometheus-rules.yaml
+++ b/chart/compass/charts/tenant-fetcher/templates/tnt-resync-prometheus-rules.yaml
@@ -10,11 +10,13 @@ spec:
     - name: {{ template "fullname" . }}-rules
       rules:
         {{- range $tenantFetcher, $config := .Values.global.tenantFetchers }}
+        {{if eq $config.enabled true}}
         - alert: CompassTenantResync{{ $tenantFetcher }}JobFailure
           annotations:
             description: Failure for {{ $tenantFetcher }} tenant resync job
-          expr: max(delta(compass_tenantfetcher_{{ $tenantFetcher }}_job_sync_failure_number[{{ $config.job.interval }}])) >= 1
+          expr: max(delta(compass_tenantfetcher_{{ regexReplaceAll "-" $tenantFetcher "_" }}_job_sync_failure_number[{{ $config.job.interval }}])) >= 1
           for: 1s
           labels:
             severity: critical
+        {{- end }}
         {{- end }}

--- a/chart/compass/templates/additional-prometheus-rules.yaml
+++ b/chart/compass/templates/additional-prometheus-rules.yaml
@@ -9,28 +9,6 @@ spec:
   groups:
     - name: custom-mps-rules
       rules:
-        - alert: CompassTenantFetcherCIS1JobFailure
-          annotations:
-            description: Failure for cis1 tenant fetcher job
-              minutes
-          expr: max(delta(compass_tenantfetcher_cis1_job_sync_failure_number[5m])) >= 1
-          for: 1m
-          labels:
-            severity: critical
-        - alert: CompassTenantFetcherCIS2JobFailure
-          annotations:
-            description: Failure for cis2 tenant fetcher job
-          expr: max(delta(compass_tenantfetcher_cis2_job_sync_failure_number[5m])) >= 1
-          for: 1m
-          labels:
-            severity: critical
-        - alert: CompassTenantFetcherCIS2SubaccountsJobFailure
-          annotations:
-            description: Failure for cis2 subaccounts tenant fetcher job
-          expr: max(delta(compass_tenantfetcher_cis2_subaccounts_job_sync_failure_number[5m])) >= 1
-          for: 1m
-          labels:
-            severity: critical
         - alert: IstioRequests-WorkloadFailures-5xx
           annotations:
             description: From source_workload={{`{{`}} $labels.source_workload {{`}}`}} to destination_workload={{`{{`}}

--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -123,7 +123,7 @@ global:
       name: compass-pairing-adapter
     director:
       dir:
-      version: "PR-2651"
+      version: "PR-2657"
       name: compass-director
     hydrator:
       dir:

--- a/components/director/internal/tenantfetchersvc/resync/config.go
+++ b/components/director/internal/tenantfetchersvc/resync/config.go
@@ -181,12 +181,6 @@ func (j *job) ReadJobConfig() (*JobConfig, error) {
 	}
 
 	j.jobConfig = &jc
-
-	configg, err := json.Marshal(jc)
-	if err != nil {
-		log.D().Error(err)
-	}
-	log.D().Infof("CONFIG IS: %s", string(configg))
 	return j.jobConfig, nil
 }
 

--- a/components/director/internal/tenantfetchersvc/resync/config.go
+++ b/components/director/internal/tenantfetchersvc/resync/config.go
@@ -2,7 +2,6 @@ package resync
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"regexp"
@@ -10,7 +9,6 @@ import (
 	"time"
 
 	"github.com/kelseyhightower/envconfig"
-	"github.com/kyma-incubator/compass/components/director/pkg/log"
 	"github.com/kyma-incubator/compass/components/director/pkg/oauth"
 	"github.com/kyma-incubator/compass/components/director/pkg/tenant"
 	"github.com/pkg/errors"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:
- Fix generated prometheus rules of tenant fetcher jobs
- Remove leftover prometheus rules in old config
- Remove leftover config log

**Validation**
```yaml
# ❯ helm template -s charts/tenant-fetcher/templates/tnt-resync-prometheus-rules.yaml .
# Source: compass/charts/tenant-fetcher/templates/tnt-resync-prometheus-rules.yaml
---
apiVersion: monitoring.coreos.com/v1
kind: PrometheusRule
metadata:
  labels:
    app: monitoring
  name: release-name-tenant-fetcher-rules
  namespace: kyma-system
spec:
  groups:
    - name: release-name-tenant-fetcher-rules
      rules:

        - alert: CompassTenantResynccis2-subaccountsJobFailure
          annotations:
            description: Failure for cis2-subaccounts tenant resync job
          expr: max(delta(compass_tenantfetcher_cis2_subaccounts_job_sync_failure_number[5m])) >= 1
          for: 1s
          labels:
            severity: critical
```

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- Currently the Monitoring stack is broken thanks to wrong name of the alert :)

**Pull Request status**
<!-- Feel free to construct the checklist with whatever items seem most reasonable for your change. You could disassemble the Implementation part to even smaller separate checklist items if you're working on something big for example. But do make the effort to provide a checklist of some sort so that the core team as well as the community can have an idea about the progress of your Pull Request.
-->

- [x] Implementation
- [n/a] Unit tests
- [n/a] Integration tests
- [x] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [n/a] Mocks are regenerated, using the automated script
