### PR TITLE
[Tenants Aggregator] Create Jobs PrometeusRule conditionally

### DIFF
--- a/chart/compass/charts/tenant-fetcher/templates/tnt-resync-prometheus-rules.yaml
+++ b/chart/compass/charts/tenant-fetcher/templates/tnt-resync-prometheus-rules.yaml
@@ -1,3 +1,10 @@
+{{- $enabledTFCnt := 0 }}
+{{- range $tenantFetcher, $config := .Values.global.tenantFetchers }}
+  {{- if eq $config.enabled true }}
+    {{ $enabledTFCnt =  add 1 $enabledTFCnt }}
+  {{- end }}
+{{- end }}
+{{- if ne $enabledTFCnt 0 }} # there is at least one TF Job enabled
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
@@ -10,7 +17,7 @@ spec:
     - name: {{ template "fullname" . }}-rules
       rules:
         {{- range $tenantFetcher, $config := .Values.global.tenantFetchers }}
-        {{if eq $config.enabled true}}
+        {{- if eq $config.enabled true }}
         - alert: CompassTenantResync{{ $tenantFetcher }}JobFailure
           annotations:
             description: Failure for {{ $tenantFetcher }} tenant resync job
@@ -20,3 +27,4 @@ spec:
             severity: critical
         {{- end }}
         {{- end }}
+{{- end }}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:
- Create the alerts prometheus rule only if at least one job is enabled, otherwise we get the following error and the installation breaks:
   ```bash
    Error: unable to build kubernetes objects from release manifest: error validating "": error validating data: ValidationError(PrometheusRule.spec.groups[0]): missing required field "rules" in com.coreos.monitoring.v1.PrometheusRule.spec.groups
   ```

PS: The benchmark is expected to fail now, it should be fine in the PRs that follow this one

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- The Benchmark tests are broken :)
