### PR TITLE
API validation rules adjusted

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -123,7 +123,7 @@ global:
       name: compass-pairing-adapter
     director:
       dir:
-      version: "PR-2653"
+      version: "PR-2671"
       name: compass-director
     hydrator:
       dir:

--- a/components/director/internal/open_resource_discovery/validation.go
+++ b/components/director/internal/open_resource_discovery/validation.go
@@ -178,7 +178,6 @@ var (
 var shortDescriptionRules = []validation.Rule{
 	validation.Required, validation.Length(1, 256), validation.NewStringRule(noNewLines, "short description should not contain line breaks"),
 }
-
 var optionalShortDescriptionRules = []validation.Rule{
 	validation.NilOrNotEmpty, validation.Length(1, 2048), validation.NewStringRule(noNewLines, "short description should not contain line breaks"),
 }
@@ -289,8 +288,8 @@ func validateAPIInput(api *model.APIDefinitionInput, packagePolicyLevels map[str
 	return validation.ValidateStruct(api,
 		validation.Field(&api.OrdID, validation.Required, validation.Match(regexp.MustCompile(APIOrdIDRegex))),
 		validation.Field(&api.Name, validation.Required),
-		validation.Field(&api.ShortDescription, shortDescriptionRules...),
-		validation.Field(&api.Description, validation.Required, validation.Length(MinDescriptionLength, MaxDescriptionLength)),
+		validation.Field(&api.ShortDescription, validation.Length(0, 256), validation.NewStringRule(noNewLines, "short description should not contain line breaks")),
+		validation.Field(&api.Description, validation.Length(0, MaxDescriptionLength)),
 		validation.Field(&api.VersionInput.Value, validation.Required, validation.Match(regexp.MustCompile(SemVerRegex)), validation.By(func(value interface{}) error {
 			return validateAPIDefinitionVersionInput(value, *api, apisFromDB, apiHashes)
 		})),

--- a/components/director/internal/open_resource_discovery/validation_test.go
+++ b/components/director/internal/open_resource_discovery/validation_test.go
@@ -1923,6 +1923,7 @@ func TestDocuments_ValidateAPI(t *testing.T) {
 
 				return []*ord.Document{doc}
 			},
+			ExpectedToBeValid: true,
 		}, {
 			Name: "Exceeded length of `shortDescription` field for API",
 			DocumentProvider: func() []*ord.Document {
@@ -1932,13 +1933,13 @@ func TestDocuments_ValidateAPI(t *testing.T) {
 				return []*ord.Document{doc}
 			},
 		}, {
-			Name: "Invalid empty `shortDescription` field for API",
+			Name: "Valid empty `shortDescription` field for API",
 			DocumentProvider: func() []*ord.Document {
 				doc := fixORDDocument()
 				doc.APIResources[0].ShortDescription = str.Ptr("")
-
 				return []*ord.Document{doc}
 			},
+			ExpectedToBeValid: true,
 		}, {
 			Name: "New lines in `shortDescription` field for API",
 			DocumentProvider: func() []*ord.Document {
@@ -1955,6 +1956,7 @@ func TestDocuments_ValidateAPI(t *testing.T) {
 
 				return []*ord.Document{doc}
 			},
+			ExpectedToBeValid: true,
 		}, {
 			Name: "Invalid `description` field with exceeding max length for API",
 			DocumentProvider: func() []*ord.Document {


### PR DESCRIPTION
**Description**
API validation rules changed a little bit. 
- shot description and description can be empty

Changes proposed in this pull request:
- API validation rules adjusted

**Pull Request status**
- [x] Implementation
- [x] Unit tests
- [x] Integration tests
- [x] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [x] Mocks are regenerated, using the automated script
