### PR TITLE
Rename internal Tenant Fecher subscription function to a more general name

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -123,7 +123,7 @@ global:
       name: compass-pairing-adapter
     director:
       dir:
-      version: "PR-2644"
+      version: "PR-2677"
       name: compass-director
     hydrator:
       dir:

--- a/components/director/internal/tenantfetchersvc/subscriber.go
+++ b/components/director/internal/tenantfetchersvc/subscriber.go
@@ -25,21 +25,21 @@ func NewSubscriber(directorClient DirectorGraphQLClient, provisioner TenantProvi
 	}
 }
 
-// Subscribe subscribes tenant to runtime. If the tenant does not exist it will be created
+// Subscribe subscribes tenant to appTemplate/runtime. If the tenant does not exist it will be created
 func (s *subscriber) Subscribe(ctx context.Context, tenantSubscriptionRequest *TenantSubscriptionRequest) error {
 	if err := s.provisioner.ProvisionTenants(ctx, tenantSubscriptionRequest); err != nil {
 		return err
 	}
 
-	return s.applyRuntimesSubscriptionChange(ctx, tenantSubscriptionRequest.SubscriptionProviderID, tenantSubscriptionRequest.SubaccountTenantID, tenantSubscriptionRequest.ProviderSubaccountID, tenantSubscriptionRequest.ConsumerTenantID, tenantSubscriptionRequest.Region, tenantSubscriptionRequest.SubscriptionProviderAppName, true)
+	return s.applySubscriptionChange(ctx, tenantSubscriptionRequest.SubscriptionProviderID, tenantSubscriptionRequest.SubaccountTenantID, tenantSubscriptionRequest.ProviderSubaccountID, tenantSubscriptionRequest.ConsumerTenantID, tenantSubscriptionRequest.Region, tenantSubscriptionRequest.SubscriptionProviderAppName, true)
 }
 
-// Unsubscribe unsubscribes tenant from runtime.
+// Unsubscribe unsubscribes tenant from appTemplate/runtime.
 func (s *subscriber) Unsubscribe(ctx context.Context, tenantSubscriptionRequest *TenantSubscriptionRequest) error {
-	return s.applyRuntimesSubscriptionChange(ctx, tenantSubscriptionRequest.SubscriptionProviderID, tenantSubscriptionRequest.SubaccountTenantID, tenantSubscriptionRequest.ProviderSubaccountID, tenantSubscriptionRequest.ConsumerTenantID, tenantSubscriptionRequest.Region, tenantSubscriptionRequest.SubscriptionProviderAppName, false)
+	return s.applySubscriptionChange(ctx, tenantSubscriptionRequest.SubscriptionProviderID, tenantSubscriptionRequest.SubaccountTenantID, tenantSubscriptionRequest.ProviderSubaccountID, tenantSubscriptionRequest.ConsumerTenantID, tenantSubscriptionRequest.Region, tenantSubscriptionRequest.SubscriptionProviderAppName, false)
 }
 
-func (s *subscriber) applyRuntimesSubscriptionChange(ctx context.Context, subscriptionProviderID, subaccountTenantID, providerSubaccountID, consumerTenantID, region, subscriptionProviderAppName string, subscribe bool) error {
+func (s *subscriber) applySubscriptionChange(ctx context.Context, subscriptionProviderID, subaccountTenantID, providerSubaccountID, consumerTenantID, region, subscriptionProviderAppName string, subscribe bool) error {
 	var err error
 
 	if subscribe {


### PR DESCRIPTION
# Rename internal Tenant Fecher subscription function to a more general name

Cosmetic change.