### PR TITLE
Make tech client e2e test skippable

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -164,7 +164,7 @@ global:
       name: compass-console
     e2e_tests:
       dir:
-      version: "PR-2676"
+      version: "PR-2679"
       name: compass-e2e-tests
   isLocalEnv: false
   isForTesting: false

--- a/tests/director/tests/technical_client_test.go
+++ b/tests/director/tests/technical_client_test.go
@@ -17,24 +17,24 @@ func TestTechnicalClient(stdT *testing.T) {
 	t := testingx.NewT(stdT)
 	ctx := context.Background()
 
-	replacer := strings.NewReplacer(conf.TestProviderSubaccountID, conf.ExternalCertTestIntSystemOUSubaccount, conf.ExternalCertCommonName, "technical-client-test")
-
-	externalCertProviderConfig := certprovider.ExternalCertProviderConfig{
-		ExternalClientCertTestSecretName:      conf.ExternalCertProviderConfig.ExternalClientCertTestSecretName,
-		ExternalClientCertTestSecretNamespace: conf.ExternalCertProviderConfig.ExternalClientCertTestSecretNamespace,
-		CertSvcInstanceTestSecretName:         conf.CertSvcInstanceTestIntSystemSecretName,
-		ExternalCertCronjobContainerName:      conf.ExternalCertProviderConfig.ExternalCertCronjobContainerName,
-		ExternalCertTestJobName:               conf.ExternalCertProviderConfig.ExternalCertTestJobName,
-		TestAtomExternalCertSubject:           replacer.Replace(conf.ExternalCertProviderConfig.TestAtomExternalCertSubject),
-		ExternalClientCertCertKey:             conf.ExternalCertProviderConfig.ExternalClientCertCertKey,
-		ExternalClientCertKeyKey:              conf.ExternalCertProviderConfig.ExternalClientCertKeyKey,
-		ExternalCertProvider:                  certprovider.Atom,
-	}
-
-	pk, cert := certprovider.NewExternalCertFromConfig(stdT, ctx, externalCertProviderConfig)
-	directorCertSecuredClient := gql.NewCertAuthorizedGraphQLClientWithCustomURL(conf.DirectorExternalCertSecuredURL, pk, cert, conf.SkipSSLValidation)
-
 	t.Run("Successfully list tenants", func(stdT *testing.T) {
+		replacer := strings.NewReplacer(conf.TestProviderSubaccountID, conf.ExternalCertTestIntSystemOUSubaccount, conf.ExternalCertCommonName, "technical-client-test")
+
+		externalCertProviderConfig := certprovider.ExternalCertProviderConfig{
+			ExternalClientCertTestSecretName:      conf.ExternalCertProviderConfig.ExternalClientCertTestSecretName,
+			ExternalClientCertTestSecretNamespace: conf.ExternalCertProviderConfig.ExternalClientCertTestSecretNamespace,
+			CertSvcInstanceTestSecretName:         conf.CertSvcInstanceTestIntSystemSecretName,
+			ExternalCertCronjobContainerName:      conf.ExternalCertProviderConfig.ExternalCertCronjobContainerName,
+			ExternalCertTestJobName:               conf.ExternalCertProviderConfig.ExternalCertTestJobName,
+			TestAtomExternalCertSubject:           replacer.Replace(conf.ExternalCertProviderConfig.TestAtomExternalCertSubject),
+			ExternalClientCertCertKey:             conf.ExternalCertProviderConfig.ExternalClientCertCertKey,
+			ExternalClientCertKeyKey:              conf.ExternalCertProviderConfig.ExternalClientCertKeyKey,
+			ExternalCertProvider:                  certprovider.Atom,
+		}
+
+		pk, cert := certprovider.NewExternalCertFromConfig(stdT, ctx, externalCertProviderConfig)
+		directorCertSecuredClient := gql.NewCertAuthorizedGraphQLClientWithCustomURL(conf.DirectorExternalCertSecuredURL, pk, cert, conf.SkipSSLValidation)
+	
 		tenants, err := fixtures.GetTenants(directorCertSecuredClient)
 		require.NoError(t, err)
 		require.NotEmpty(t, tenants)

--- a/tests/director/tests/technical_client_test.go
+++ b/tests/director/tests/technical_client_test.go
@@ -34,7 +34,7 @@ func TestTechnicalClient(stdT *testing.T) {
 
 		pk, cert := certprovider.NewExternalCertFromConfig(stdT, ctx, externalCertProviderConfig)
 		directorCertSecuredClient := gql.NewCertAuthorizedGraphQLClientWithCustomURL(conf.DirectorExternalCertSecuredURL, pk, cert, conf.SkipSSLValidation)
-	
+
 		tenants, err := fixtures.GetTenants(directorCertSecuredClient)
 		require.NoError(t, err)
 		require.NotEmpty(t, tenants)


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
The E2E test on dev-main keeps running, because the skippable part is only the validation, but the part that fails is actually the API client preparation - the issuing of its certificate.

Changes proposed in this pull request:
- Move the entire test logic into the "test" scope - that way the cert issuing can be skipped, along with the validation

**Pull Request status**
<!-- Feel free to construct the checklist with whatever items seem most reasonable for your change. You could disassemble the Implementation part to even smaller separate checklist items if you're working on something big for example. But do make the effort to provide a checklist of some sort so that the core team as well as the community can have an idea about the progress of your Pull Request.
-->

- [x] Implementation
- [n/a] Unit tests
- [x] Integration tests
- [x] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [n/a] Mocks are regenerated, using the automated script
