### PR TITLE
Trim leading and trailing whitespace from ORD Validation errors

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -123,7 +123,7 @@ global:
       name: compass-pairing-adapter
     director:
       dir:
-      version: "PR-2689"
+      version: "PR-2697"
       name: compass-director
     hydrator:
       dir:

--- a/components/director/internal/open_resource_discovery/service.go
+++ b/components/director/internal/open_resource_discovery/service.go
@@ -798,6 +798,9 @@ func (s *Service) processWebhookAndDocuments(ctx context.Context, webhook *model
 
 				// the first item in the slice is the message 'invalid documents' for the wrapped errors
 				validationErrors = validationErrors[1:]
+				for i := range validationErrors {
+					validationErrors[i] = strings.TrimSpace(validationErrors[i])
+				}
 
 				log.C(ctx).WithError(ordValidationError.Err).WithField("validation_errors", validationErrors).Error("error processing ORD documents")
 			} else {


### PR DESCRIPTION
# Trim leading and trailing whitespace from ORD Validation errors

**Description**

Sometimes the ORD Validation errors might have unnecessary leading/trailing whitespace.
