### PR TITLE
[HOTFIX] Fix long running ord aggregator e2e tests

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -164,7 +164,7 @@ global:
       name: compass-console
     e2e_tests:
       dir:
-      version: "PR-2704"
+      version: "PR-2708"
       name: compass-e2e-tests
   isLocalEnv: false
   isForTesting: false

--- a/tests/ord-aggregator/tests/handler_test.go
+++ b/tests/ord-aggregator/tests/handler_test.go
@@ -340,8 +340,6 @@ func TestORDAggregator(stdT *testing.T) {
 			k8s.DeleteJob(t, ctx, k8sClient, jobName, namespace)
 		}()
 
-		k8s.WaitForJobToFinish(t, ctx, k8sClient, jobName, namespace)
-
 		scheduleTime, err := parseCronTime(testConfig.AggregatorSchedule)
 		require.NoError(t, err)
 
@@ -487,6 +485,8 @@ func TestORDAggregator(stdT *testing.T) {
 			return true
 		})
 		require.NoError(t, err)
+
+		t.Log("Successfully verified all ORD documents")
 	})
 	t.Run("Verifying ORD Document for subscribed tenant", func(t *testing.T) {
 		ctx := context.Background()
@@ -674,8 +674,6 @@ func TestORDAggregator(stdT *testing.T) {
 			k8s.DeleteJob(t, ctx, k8sClient, jobName, namespace)
 		}()
 
-		k8s.WaitForJobToFinish(t, ctx, k8sClient, jobName, namespace)
-
 		scheduleTime, err := parseCronTime(testConfig.AggregatorSchedule)
 		require.NoError(t, err)
 
@@ -817,6 +815,8 @@ func TestORDAggregator(stdT *testing.T) {
 			return true
 		})
 		require.NoError(t, err)
+
+		t.Log("Successfully verified all ORD documents")
 	})
 }
 

--- a/tests/pkg/k8s/jobs.go
+++ b/tests/pkg/k8s/jobs.go
@@ -120,10 +120,6 @@ func WaitForJob(t *testing.T, ctx context.Context, k8sClient *kubernetes.Clients
 	}
 }
 
-func WaitForJobToFinish(t *testing.T, ctx context.Context, k8sClient *kubernetes.Clientset, jobName, namespace string) {
-	getJobStatus(t, ctx, k8sClient, jobName, namespace)
-}
-
 func PrintJobLogs(t *testing.T, ctx context.Context, k8sClient *kubernetes.Clientset, jobName, namespace, containerName string, shouldJobFail bool) {
 	if shouldJobFail {
 		return


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:
- remove waiting of ord aggregator job to finish in e2e tests

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- ...

**Pull Request status**
<!-- Feel free to construct the checklist with whatever items seem most reasonable for your change. You could disassemble the Implementation part to even smaller separate checklist items if you're working on something big for example. But do make the effort to provide a checklist of some sort so that the core team as well as the community can have an idea about the progress of your Pull Request.
-->

- [ ] Implementation
- [ ] Unit tests
- [ ] Integration tests
- [ ] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [ ] Mocks are regenerated, using the automated script
