### PR TITLE
Introduce skip pattern in the formation mapping tests

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -164,7 +164,7 @@ global:
       name: compass-console
     e2e_tests:
       dir:
-      version: "PR-2712"
+      version: "PR-2717"
       name: compass-e2e-tests
   isLocalEnv: false
   isForTesting: false

--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -123,7 +123,7 @@ global:
       name: compass-pairing-adapter
     director:
       dir:
-      version: "PR-2712"
+      version: "PR-2717"
       name: compass-director
     hydrator:
       dir:

--- a/components/director/pkg/graphql/schema_gen.go
+++ b/components/director/pkg/graphql/schema_gen.go
@@ -4455,6 +4455,12 @@ enum FetchRequestStatusCondition {
 	FAILED
 }
 
+enum FormationAssignmentType {
+	APPLICATION
+	RUNTIME
+	RUNTIME_CONTEXT
+}
+
 enum FormationObjectType {
 	APPLICATION
 	TENANT
@@ -4524,12 +4530,6 @@ enum WebhookType {
 	REGISTER_APPLICATION
 	UNREGISTER_APPLICATION
 	OPEN_RESOURCE_DISCOVERY
-}
-
-enum FormationAssignmentType {
-	APPLICATION
-	RUNTIME
-	RUNTIME_CONTEXT
 }
 
 interface OneTimeToken {
@@ -6057,6 +6057,7 @@ type Mutation {
 	"""
 	updateFormationTemplate(id: ID!, in: FormationTemplateInput! @validate): FormationTemplate @hasScopes(path: "graphql.mutation.updateFormationTemplate")
 }
+
 `, BuiltIn: false},
 }
 var parsedSchema = gqlparser.MustLoadSchema(sources...)

--- a/tests/director/tests/formation_mapping_api_test.go
+++ b/tests/director/tests/formation_mapping_api_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
+	testingx "github.com/kyma-incubator/compass/tests/pkg/testing"
 	"io/ioutil"
 	"net/http"
 	"strings"
@@ -46,7 +47,8 @@ const (
 	formationAssignmentIDPathParam = "ucl-assignment-id"
 )
 
-func Test_UpdateStatus(t *testing.T) {
+func Test_UpdateStatus(baseT *testing.T) {
+	t := testingx.NewT(baseT)
 	ctx := context.Background()
 	parentTenantID := tenant.TestTenants.GetDefaultTenantID()
 	subaccountID := tenant.TestTenants.GetIDByName(t, tenant.TestProviderSubaccount)


### PR DESCRIPTION
**Description**
Using our skip functionalities for the formation mapping E2E tests that contain subscriptions.

Changes proposed in this pull request:
- Skip part of the E2E tests that made subscriptions

**Related issue(s)**
- https://github.com/kyma-incubator/compass/pull/2712

**Pull Request status**
- [x] Implementation
- [x] [N/A] Unit tests
- [x] Integration tests
- [x] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [x] [N/A] Mocks are regenerated, using the automated script
