### PR TITLE
Fix formation mapping E2E tests

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -164,7 +164,7 @@ global:
       name: compass-console
     e2e_tests:
       dir:
-      version: "PR-2717"
+      version: "PR-2721"
       name: compass-e2e-tests
   isLocalEnv: false
   isForTesting: false

--- a/tests/director/tests/formation_mapping_api_test.go
+++ b/tests/director/tests/formation_mapping_api_test.go
@@ -6,12 +6,15 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
-	testingx "github.com/kyma-incubator/compass/tests/pkg/testing"
 	"io/ioutil"
 	"net/http"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/kyma-incubator/compass/tests/pkg/tenant"
+
+	testingx "github.com/kyma-incubator/compass/tests/pkg/testing"
 
 	"github.com/kyma-incubator/compass/tests/pkg/subscription"
 	"github.com/kyma-incubator/compass/tests/pkg/util"
@@ -22,7 +25,6 @@ import (
 	"github.com/kyma-incubator/compass/tests/pkg/fixtures"
 	"github.com/kyma-incubator/compass/tests/pkg/gql"
 	"github.com/kyma-incubator/compass/tests/pkg/ptr"
-	"github.com/kyma-incubator/compass/tests/pkg/tenant"
 	"github.com/kyma-incubator/compass/tests/pkg/tenantfetcher"
 	"github.com/kyma-incubator/compass/tests/pkg/testctx"
 	"github.com/kyma-incubator/compass/tests/pkg/token"
@@ -50,14 +52,18 @@ const (
 func Test_UpdateStatus(baseT *testing.T) {
 	t := testingx.NewT(baseT)
 	ctx := context.Background()
-	parentTenantID := tenant.TestTenants.GetDefaultTenantID()
-	subaccountID := tenant.TestTenants.GetIDByName(t, tenant.TestProviderSubaccount)
 
 	intSysName := "async-formation-int-system"
 	testConfig := `{"testCfgKey":"testCfgValue"}`
-	certSecuredHTTPClient := gql.NewCertAuthorizedHTTPClient(cc.Get()[conf.ExternalClientCertSecretName].PrivateKey, cc.Get()[conf.ExternalClientCertSecretName].Certificate, conf.SkipSSLValidation)
 
 	t.Run("Caller successfully updates formation assignment for himself", func(t *testing.T) {
+		// Prepare provider external client certificate and secret, and build graphql director client configured with certificate
+		providerClientKey, providerRawCertChain := certprovider.NewExternalCertFromConfig(t, ctx, conf.ExternalCertProviderConfig)
+		certSecuredHTTPClient := gql.NewCertAuthorizedHTTPClient(providerClientKey, providerRawCertChain, conf.SkipSSLValidation)
+
+		parentTenantID := conf.TestProviderAccountID
+		subaccountID := conf.TestProviderSubaccountID // in local set up the parent is testDefaultTenant
+
 		runtimeInput := graphql.RuntimeRegisterInput{
 			Name:        "selfRegisterRuntimeAsync",
 			Description: ptr.String("selfRegisterRuntimeAsync-description"),
@@ -76,12 +82,10 @@ func Test_UpdateStatus(baseT *testing.T) {
 		require.NotEmpty(t, app.ID)
 
 		asyncFormationTmplName := "async-formation-template-name"
-		t.Logf("Creating formation template with name: %q", asyncFormationTmplName)
 		ft := createFormationTemplate(t, ctx, asyncFormationTmplName, conf.KymaRuntimeTypeLabelValue, []string{appType}, graphql.ArtifactTypeEnvironmentInstance)
 		defer fixtures.CleanupFormationTemplate(t, ctx, certSecuredGraphQLClient, ft.ID)
 
 		asyncFormationName := "async-formation-name"
-		t.Logf("Creating formation with name: %q from template with name: %q", asyncFormationName, asyncFormationTmplName)
 		formation := fixtures.CreateFormationFromTemplateWithinTenant(t, ctx, certSecuredGraphQLClient, parentTenantID, asyncFormationName, &asyncFormationTmplName)
 		defer fixtures.DeleteFormationWithinTenant(t, ctx, certSecuredGraphQLClient, parentTenantID, asyncFormationName)
 		formationID := formation.ID
@@ -91,6 +95,7 @@ func Test_UpdateStatus(baseT *testing.T) {
 		assignReq := fixtures.FixAssignFormationRequest(app.ID, string(graphql.FormationObjectTypeApplication), asyncFormationName)
 		var assignedFormation graphql.Formation
 		err = testctx.Tc.RunOperationWithCustomTenant(ctx, certSecuredGraphQLClient, parentTenantID, assignReq, &assignedFormation)
+		defer fixtures.CleanupFormation(t, ctx, certSecuredGraphQLClient, graphql.FormationInput{Name: asyncFormationName}, app.ID, graphql.FormationObjectTypeApplication, parentTenantID)
 		require.NoError(t, err)
 		require.Equal(t, asyncFormationName, assignedFormation.Name)
 
@@ -212,12 +217,10 @@ func Test_UpdateStatus(baseT *testing.T) {
 
 		applicationType := "provider-async-app-type-1"
 		providerAsyncFormationTmplName := "provider-async-formation-template-name"
-		t.Logf("Creating formation template for the provider runtime type: %q with name: %q", conf.SubscriptionProviderAppNameValue, providerAsyncFormationTmplName)
 		ft := createFormationTemplate(t, ctx, providerAsyncFormationTmplName, conf.SubscriptionProviderAppNameValue, []string{applicationType}, graphql.ArtifactTypeSubscription)
 		defer fixtures.CleanupFormationTemplate(t, ctx, certSecuredGraphQLClient, ft.ID)
 
 		providerAsyncFormationName := "provider-async-formation-name"
-		t.Logf("Creating formation with name: %q from template with name: %q", providerAsyncFormationName, providerAsyncFormationTmplName)
 		formation := fixtures.CreateFormationFromTemplateWithinTenant(t, ctx, certSecuredGraphQLClient, subscriptionConsumerAccountID, providerAsyncFormationName, &providerAsyncFormationTmplName)
 		defer fixtures.DeleteFormationWithinTenant(t, ctx, certSecuredGraphQLClient, subscriptionConsumerAccountID, providerAsyncFormationName)
 		require.NotEmpty(t, formation.ID)
@@ -300,6 +303,7 @@ func Test_UpdateStatus(baseT *testing.T) {
 		assignReq := fixtures.FixAssignFormationRequest(asyncApp.ID, string(graphql.FormationObjectTypeApplication), providerAsyncFormationName)
 		var assignedFormation graphql.Formation
 		err = testctx.Tc.RunOperationWithCustomTenant(ctx, certSecuredGraphQLClient, subscriptionConsumerAccountID, assignReq, &assignedFormation)
+		defer fixtures.CleanupFormation(t, ctx, certSecuredGraphQLClient, graphql.FormationInput{Name: providerAsyncFormationName}, asyncApp.ID, graphql.FormationObjectTypeApplication, subscriptionConsumerAccountID)
 		require.NoError(t, err)
 		require.Equal(t, providerAsyncFormationName, assignedFormation.Name)
 
@@ -406,12 +410,10 @@ func Test_UpdateStatus(baseT *testing.T) {
 
 		providerAsyncFormationTmplName := "provider-async-formation-template-name"
 		providerAppTypes := []string{appTemplateName}
-		t.Logf("Creating formation template for the provider runtime type: %q with name: %q", conf.SubscriptionProviderAppNameValue, providerAsyncFormationTmplName)
 		ft := createFormationTemplate(t, ctx, providerAsyncFormationTmplName, conf.KymaRuntimeTypeLabelValue, providerAppTypes, graphql.ArtifactTypeEnvironmentInstance)
 		defer fixtures.CleanupFormationTemplate(t, ctx, certSecuredGraphQLClient, ft.ID)
 
 		providerAsyncFormationName := "provider-async-formation-name"
-		t.Logf("Creating formation with name: %q from template with name: %q", providerAsyncFormationName, providerAsyncFormationTmplName)
 		formation := fixtures.CreateFormationFromTemplateWithinTenant(t, ctx, certSecuredGraphQLClient, subscriptionConsumerAccountID, providerAsyncFormationName, &providerAsyncFormationTmplName)
 		defer fixtures.DeleteFormationWithinTenant(t, ctx, certSecuredGraphQLClient, subscriptionConsumerAccountID, providerAsyncFormationName)
 		require.NotEmpty(t, formation.ID)
@@ -421,6 +423,7 @@ func Test_UpdateStatus(baseT *testing.T) {
 		assignReq := fixtures.FixAssignFormationRequest(appID, string(graphql.FormationObjectTypeApplication), providerAsyncFormationName)
 		var assignedFormation graphql.Formation
 		err = testctx.Tc.RunOperationWithCustomTenant(ctx, certSecuredGraphQLClient, subscriptionConsumerAccountID, assignReq, &assignedFormation)
+		defer fixtures.CleanupFormation(t, ctx, certSecuredGraphQLClient, graphql.FormationInput{Name: providerAsyncFormationName}, appID, graphql.FormationObjectTypeApplication, subscriptionConsumerAccountID)
 		require.NoError(t, err)
 		require.Equal(t, providerAsyncFormationName, assignedFormation.Name)
 
@@ -440,6 +443,9 @@ func Test_UpdateStatus(baseT *testing.T) {
 	})
 
 	t.Run("Unauthorized call", func(t *testing.T) {
+		parentTenantID := tenant.TestTenants.GetDefaultTenantID()
+		subaccountID := tenant.TestTenants.GetIDByName(t, tenant.TestProviderSubaccount)
+
 		runtimeInput := graphql.RuntimeRegisterInput{
 			Name:        "selfRegisterRuntimeAsync",
 			Description: ptr.String("selfRegisterRuntimeAsync-description"),
@@ -458,12 +464,10 @@ func Test_UpdateStatus(baseT *testing.T) {
 		require.NotEmpty(t, app.ID)
 
 		asyncFormationTmplName := "async-formation-template-name"
-		t.Logf("Creating formation template with name: %q", asyncFormationTmplName)
 		ft := createFormationTemplate(t, ctx, asyncFormationTmplName, conf.KymaRuntimeTypeLabelValue, []string{appType}, graphql.ArtifactTypeEnvironmentInstance)
 		defer fixtures.CleanupFormationTemplate(t, ctx, certSecuredGraphQLClient, ft.ID)
 
 		asyncFormationName := "async-formation-name"
-		t.Logf("Creating formation with name: %q from template with name: %q", asyncFormationName, asyncFormationTmplName)
 		formation := fixtures.CreateFormationFromTemplateWithinTenant(t, ctx, certSecuredGraphQLClient, parentTenantID, asyncFormationName, &asyncFormationTmplName)
 		defer fixtures.DeleteFormationWithinTenant(t, ctx, certSecuredGraphQLClient, parentTenantID, asyncFormationName)
 		formationID := formation.ID
@@ -473,6 +477,7 @@ func Test_UpdateStatus(baseT *testing.T) {
 		assignReq := fixtures.FixAssignFormationRequest(app.ID, string(graphql.FormationObjectTypeApplication), asyncFormationName)
 		var assignedFormation graphql.Formation
 		err = testctx.Tc.RunOperationWithCustomTenant(ctx, certSecuredGraphQLClient, parentTenantID, assignReq, &assignedFormation)
+		defer fixtures.CleanupFormation(t, ctx, certSecuredGraphQLClient, graphql.FormationInput{Name: asyncFormationName}, app.ID, graphql.FormationObjectTypeApplication, parentTenantID)
 		require.NoError(t, err)
 		require.Equal(t, asyncFormationName, assignedFormation.Name)
 

--- a/tests/pkg/fixtures/application_template_requests.go
+++ b/tests/pkg/fixtures/application_template_requests.go
@@ -83,7 +83,7 @@ func FixApplicationTemplateWithoutWebhooks(name string) graphql.ApplicationTempl
 			"test": []interface{}{"test"},
 		},
 		ApplicationNamespace: &appNamespace,
-		AccessLevel: graphql.ApplicationTemplateAccessLevelGlobal,
+		AccessLevel:          graphql.ApplicationTemplateAccessLevelGlobal,
 	}
 	return appTemplateInput
 }


### PR DESCRIPTION
**Description**
Fix local/productive tenants that are used in the formation mapping E2E tests

Changes proposed in this pull request:
- Use tenants from configuration so they could be current in both local and productive setup

**Related issue(s)**
- https://github.com/kyma-incubator/compass/pull/2712
- https://github.com/kyma-incubator/compass/pull/2717

**Pull Request status**
- [x] Implementation
- [x] [N/A] Unit tests
- [x] Integration tests
- [x] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [x] [N/A] Mocks are regenerated, using the automated script
