### PR TITLE
Bump Go version to 1.19 of main components

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -111,31 +111,31 @@ global:
       path: eu.gcr.io/kyma-project/incubator
     connector:
       dir:
-      version: "PR-2714"
+      version: "PR-2736"
       name: compass-connector
     connectivity_adapter:
       dir:
-      version: "PR-2714"
+      version: "PR-2736"
       name: compass-connectivity-adapter
     pairing_adapter:
       dir:
-      version: "PR-2714"
+      version: "PR-2736"
       name: compass-pairing-adapter
     director:
       dir:
-      version: "PR-2722"
+      version: "PR-2736"
       name: compass-director
     hydrator:
       dir:
-      version: "PR-2722"
+      version: "PR-2736"
       name: compass-hydrator
     gateway:
       dir:
-      version: "PR-2714"
+      version: "PR-2736"
       name: compass-gateway
     operations_controller:
       dir:
-      version: "PR-2714"
+      version: "PR-2736"
       name: compass-operations-controller
     ord_service:
       dir:
@@ -147,7 +147,7 @@ global:
       name: compass-schema-migrator
     system_broker:
       dir:
-      version: "PR-2714"
+      version: "PR-2736"
       name: compass-system-broker
     certs_setup_job:
       containerRegistry:
@@ -156,7 +156,7 @@ global:
       version: "0a651695"
     external_services_mock:
       dir:
-      version: "PR-2722"
+      version: "PR-2736"
       name: compass-external-services-mock
     console:
       dir:
@@ -164,7 +164,7 @@ global:
       name: compass-console
     e2e_tests:
       dir:
-      version: "PR-2722"
+      version: "PR-2736"
       name: compass-e2e-tests
   isLocalEnv: false
   isForTesting: false

--- a/components/connectivity-adapter/Dockerfile
+++ b/components/connectivity-adapter/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18.5-alpine3.16 as builder
+FROM golang:1.19.3-alpine3.16 as builder
 
 ENV BASE_APP_DIR /go/src/github.com/kyma-incubator/compass/components/connectivity-adapter
 WORKDIR ${BASE_APP_DIR}

--- a/components/connector/Dockerfile
+++ b/components/connector/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18.5-alpine3.16 as builder
+FROM golang:1.19.3-alpine3.16 as builder
 
 ENV BASE_APP_DIR /go/src/github.com/kyma-incubator/compass/components/connector
 WORKDIR ${BASE_APP_DIR}

--- a/components/director/Dockerfile
+++ b/components/director/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18.5-alpine3.16 as builder
+FROM golang:1.19.3-alpine3.16 as builder
 
 ENV BASE_APP_DIR /go/src/github.com/kyma-incubator/compass/components/director
 WORKDIR ${BASE_APP_DIR}

--- a/components/external-services-mock/Dockerfile
+++ b/components/external-services-mock/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18.5-alpine3.16 as builder
+FROM golang:1.19.3-alpine3.16 as builder
 
 ENV BASE_APP_DIR /go/src/github.com/kyma-incubator/compass/components/external-services-mock
 WORKDIR ${BASE_APP_DIR}

--- a/components/gateway/Dockerfile
+++ b/components/gateway/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18.5-alpine3.16 as builder
+FROM golang:1.19.3-alpine3.16 as builder
 
 ENV BASE_APP_DIR /go/src/github.com/kyma-incubator/compass/components/gateway
 WORKDIR ${BASE_APP_DIR}

--- a/components/hydrator/Dockerfile
+++ b/components/hydrator/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18.5-alpine3.16 as builder
+FROM golang:1.19.3-alpine3.16 as builder
 
 ENV BASE_APP_DIR /go/src/github.com/kyma-incubator/compass/components/hydrator
 WORKDIR ${BASE_APP_DIR}

--- a/components/operations-controller/Dockerfile
+++ b/components/operations-controller/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.18.5-alpine3.16 as builder
+FROM golang:1.19.3-alpine3.16 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/components/pairing-adapter/Dockerfile
+++ b/components/pairing-adapter/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18.5-alpine3.16 as builder
+FROM golang:1.19.3-alpine3.16 as builder
 
 ENV BASE_APP_DIR /go/src/github.com/kyma-incubator/compass/components/pairing-adapter
 WORKDIR ${BASE_APP_DIR}

--- a/components/system-broker/Dockerfile
+++ b/components/system-broker/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18.5-alpine3.16 as builder
+FROM golang:1.19.3-alpine3.16 as builder
 
 ENV BASE_APP_DIR /go/src/github.com/kyma-incubator/compass/components/system-broker
 WORKDIR ${BASE_APP_DIR}

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18.5-alpine3.16 as builder
+FROM golang:1.19.3-alpine3.16 as builder
 
 ENV BASE_TEST_DIR /go/src/github.com/kyma-incubator/compass/tests
 WORKDIR ${BASE_TEST_DIR}


### PR DESCRIPTION
# Bump Go version to 1.19 of main components

**Description**

Changes proposed in this pull request:
- Bump Go version to 1.19 of main components and thus address vulnerabilities in go runtime
