### PR TITLE
Do not require selfReg label of the app template on the formation notification status API

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -123,7 +123,7 @@ global:
       name: compass-pairing-adapter
     director:
       dir:
-      version: "PR-2739"
+      version: "PR-2746"
       name: compass-director
     hydrator:
       dir:
@@ -143,7 +143,7 @@ global:
       name: compass-ord-service
     schema_migrator:
       dir:
-      version: "PR-2722"
+      version: "PR-2746"
       name: compass-schema-migrator
     system_broker:
       dir:

--- a/components/director/cmd/director/main.go
+++ b/components/director/cmd/director/main.go
@@ -879,7 +879,7 @@ func createFormationMappingAuthenticator(transact persistence.Transactioner, cfg
 	notificationSvc := formation.NewNotificationService(appRepo, appTemplateRepo, runtimeRepo, runtimeContextRepo, labelRepo, webhookRepo, webhookConverter, webhookClient, webhookDataInputBuilder)
 	formationAssignmentSvc := formationassignment.NewService(formationAssignmentRepo, uid.NewService(), appRepo, runtimeRepo, runtimeContextRepo, formationAssignmentConv, notificationSvc)
 
-	return formationmapping.NewFormationMappingAuthenticator(transact, formationAssignmentSvc, runtimeRepo, runtimeContextRepo, appRepo, appTemplateRepo, labelRepo, cfg.SelfRegConfig.SelfRegisterDistinguishLabelKey, cfg.SubscriptionConfig.ConsumerSubaccountLabelKey)
+	return formationmapping.NewFormationMappingAuthenticator(transact, formationAssignmentSvc, runtimeRepo, runtimeContextRepo, appRepo, appTemplateRepo, labelRepo, cfg.SubscriptionConfig.ConsumerSubaccountLabelKey)
 }
 
 func createFormationMappingHandler(transact persistence.Transactioner, appRepo application.ApplicationRepository, cfg config, securedHTTPClient, mtlsHTTPClient, extSvcMtlsHTTPClient *http.Client) *formationmapping.Handler {

--- a/components/director/internal/formationmapping/auth_middleware.go
+++ b/components/director/internal/formationmapping/auth_middleware.go
@@ -108,7 +108,6 @@ type Authenticator struct {
 	appRepo                    ApplicationRepository
 	appTemplateRepo            ApplicationTemplateRepository
 	labelRepo                  LabelRepository
-	selfRegDistinguishLabelKey string
 	consumerSubaccountLabelKey string
 }
 
@@ -121,7 +120,6 @@ func NewFormationMappingAuthenticator(
 	appRepo ApplicationRepository,
 	appTemplateRepo ApplicationTemplateRepository,
 	labelRepo LabelRepository,
-	selfRegDistinguishLabelKey,
 	consumerSubaccountLabelKey string,
 ) *Authenticator {
 	return &Authenticator{
@@ -132,7 +130,6 @@ func NewFormationMappingAuthenticator(
 		appRepo:                    appRepo,
 		appTemplateRepo:            appTemplateRepo,
 		labelRepo:                  labelRepo,
-		selfRegDistinguishLabelKey: selfRegDistinguishLabelKey,
 		consumerSubaccountLabelKey: consumerSubaccountLabelKey,
 	}
 }
@@ -314,11 +311,10 @@ func (a *Authenticator) validateSubscriptionProvider(ctx context.Context, tx per
 		return false, http.StatusInternalServerError, errors.Wrapf(err, "while getting labels for application template with ID: %q", *appTemplateID)
 	}
 
-	_, selfRegLblExists := labels[a.selfRegDistinguishLabelKey]
 	consumerSubaccountLbl, consumerSubaccountLblExists := labels[a.consumerSubaccountLabelKey]
 
-	if !selfRegLblExists || !consumerSubaccountLblExists {
-		return false, http.StatusUnauthorized, errors.Errorf("both %q and %q labels should be provided as part of the provider's application template", a.selfRegDistinguishLabelKey, a.consumerSubaccountLabelKey)
+	if !consumerSubaccountLblExists {
+		return false, http.StatusUnauthorized, errors.Errorf("%q label should exist as part of the provider's application template", a.consumerSubaccountLabelKey)
 	}
 
 	consumerSubaccountLblValue, ok := consumerSubaccountLbl.Value.(string)

--- a/components/hydrator/internal/tenantmapping/consumer_context_provider.go
+++ b/components/hydrator/internal/tenantmapping/consumer_context_provider.go
@@ -88,17 +88,11 @@ func (c *consumerContextProvider) Match(_ context.Context, data oathkeeper.ReqDa
 		return false, nil, nil
 	}
 
-	decodedUserContextHeader, err := url.QueryUnescape(userContextHeader)
-	if err != nil {
-		authID := gjson.Get(userContextHeader, c.consumerClaimsKeysConfig.UserNameKey).String()
-		if authID == "" {
-			return false, nil, apperrors.NewInvalidDataError(fmt.Sprintf("could not find %s property", c.consumerClaimsKeysConfig.UserNameKey))
-		}
-
-		return true, &oathkeeper.AuthDetails{AuthID: authID, AuthFlow: oathkeeper.ConsumerProviderFlow}, nil
+	if decodedUserContextHeader, err := url.QueryUnescape(userContextHeader); err == nil {
+		userContextHeader = decodedUserContextHeader
 	}
 
-	authID := gjson.Get(decodedUserContextHeader, c.consumerClaimsKeysConfig.UserNameKey).String()
+	authID := gjson.Get(userContextHeader, c.consumerClaimsKeysConfig.UserNameKey).String()
 	if authID == "" {
 		return false, nil, apperrors.NewInvalidDataError(fmt.Sprintf("could not find %s property", c.consumerClaimsKeysConfig.UserNameKey))
 	}
@@ -107,30 +101,16 @@ func (c *consumerContextProvider) Match(_ context.Context, data oathkeeper.ReqDa
 }
 
 func (c *consumerContextProvider) getUserContextData(userContextHeader string) (*userContextData, error) {
-	decodedUserContextHeader, err := url.QueryUnescape(userContextHeader)
-	if err != nil {
-		clientID := gjson.Get(userContextHeader, c.consumerClaimsKeysConfig.ClientIDKey)
-		if !clientID.Exists() {
-			return &userContextData{}, apperrors.NewInvalidDataError(fmt.Sprintf("property %q is mandatory", c.consumerClaimsKeysConfig.ClientIDKey))
-		}
-
-		externalTenantID := gjson.Get(userContextHeader, c.consumerClaimsKeysConfig.TenantIDKey)
-		if !externalTenantID.Exists() {
-			return &userContextData{}, apperrors.NewInvalidDataError(fmt.Sprintf("property %q is mandatory", c.consumerClaimsKeysConfig.TenantIDKey))
-		}
-
-		return &userContextData{
-			clientID:         clientID.String(),
-			externalTenantID: externalTenantID.String(),
-		}, nil
+	if decodedUserContextHeader, err := url.QueryUnescape(userContextHeader); err == nil {
+		userContextHeader = decodedUserContextHeader
 	}
 
-	clientID := gjson.Get(decodedUserContextHeader, c.consumerClaimsKeysConfig.ClientIDKey)
+	clientID := gjson.Get(userContextHeader, c.consumerClaimsKeysConfig.ClientIDKey)
 	if !clientID.Exists() {
 		return &userContextData{}, apperrors.NewInvalidDataError(fmt.Sprintf("property %q is mandatory", c.consumerClaimsKeysConfig.ClientIDKey))
 	}
 
-	externalTenantID := gjson.Get(decodedUserContextHeader, c.consumerClaimsKeysConfig.TenantIDKey)
+	externalTenantID := gjson.Get(userContextHeader, c.consumerClaimsKeysConfig.TenantIDKey)
 	if !externalTenantID.Exists() {
 		return &userContextData{}, apperrors.NewInvalidDataError(fmt.Sprintf("property %q is mandatory", c.consumerClaimsKeysConfig.TenantIDKey))
 	}

--- a/components/schema-migrator/migrations/director/20221117122326_adjust-foreign-keys.down.sql
+++ b/components/schema-migrator/migrations/director/20221117122326_adjust-foreign-keys.down.sql
@@ -1,0 +1,10 @@
+BEGIN;
+
+ALTER TABLE formations DROP CONSTRAINT formations_formation_template_id_fkey;
+ALTER TABLE formations ADD CONSTRAINT formations_formation_template_id_fkey
+    FOREIGN KEY (formation_template_id) REFERENCES formation_templates(id) ON DELETE CASCADE;
+
+ALTER TABLE formation_assignments DROP CONSTRAINT formation_assignments_formation_id_only_fk;
+ALTER TABLE formation_assignments DROP CONSTRAINT formation_assignments_tenant_id_fk;
+
+COMMIT;

--- a/components/schema-migrator/migrations/director/20221117122326_adjust-foreign-keys.up.sql
+++ b/components/schema-migrator/migrations/director/20221117122326_adjust-foreign-keys.up.sql
@@ -1,0 +1,14 @@
+BEGIN;
+
+-- Remove ON DELETE CASCADE
+ALTER TABLE formations DROP CONSTRAINT formations_formation_template_id_fkey;
+ALTER TABLE formations ADD CONSTRAINT formations_formation_template_id_fkey
+    FOREIGN KEY (formation_template_id) REFERENCES formation_templates(id);
+
+ALTER TABLE formation_assignments ADD CONSTRAINT formation_assignments_formation_id_only_fk
+    FOREIGN KEY (formation_id) REFERENCES formations(id) ON DELETE CASCADE;
+
+ALTER TABLE formation_assignments ADD CONSTRAINT formation_assignments_tenant_id_fk
+    FOREIGN KEY (tenant_id) REFERENCES business_tenant_mappings(id) ON DELETE CASCADE;
+
+COMMIT;


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:
- Do not require selfReg label of the app template on the formation notification status API
- Fix code duplication with the unescaping of user_context header
- Adjust foreign keys of formations and formation_assignments tables


**Pull Request status**
<!-- Feel free to construct the checklist with whatever items seem most reasonable for your change. You could disassemble the Implementation part to even smaller separate checklist items if you're working on something big for example. But do make the effort to provide a checklist of some sort so that the core team as well as the community can have an idea about the progress of your Pull Request.
-->

- [x] Implementation
- [x] Unit tests
- N/A Integration tests
- [x] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [ ] Mocks are regenerated, using the automated script
