### PR TITLE
Temporary disable specs retrieval

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -123,7 +123,7 @@ global:
       name: compass-pairing-adapter
     director:
       dir:
-      version: "PR-2743"
+      version: "PR-2751"
       name: compass-director
     hydrator:
       dir:

--- a/components/director/internal/domain/bundle/resolver.go
+++ b/components/director/internal/domain/bundle/resolver.go
@@ -391,17 +391,18 @@ func (r *Resolver) APIDefinition(ctx context.Context, obj *graphql.Bundle, id st
 		return nil, err
 	}
 
-	spec, err := r.specService.GetByReferenceObjectID(ctx, model.APISpecReference, api.ID)
-	if err != nil {
-		return nil, errors.Wrapf(err, "while getting spec for APIDefinition with id %q", api.ID)
-	}
+	// TODO Revert when specs are fetched via subresolvers
+	//spec, err := r.specService.GetByReferenceObjectID(ctx, model.APISpecReference, api.ID)
+	//if err != nil {
+	//	return nil, errors.Wrapf(err, "while getting spec for APIDefinition with id %q", api.ID)
+	//}
 
 	bndlRef, err := r.bundleReferenceSvc.GetForBundle(ctx, model.BundleAPIReference, &api.ID, nil)
 	if err != nil {
 		return nil, errors.Wrapf(err, "while getting bundle reference for APIDefinition with id %q", api.ID)
 	}
 
-	gqlAPI, err := r.apiConverter.ToGraphQL(api, spec, bndlRef)
+	gqlAPI, err := r.apiConverter.ToGraphQL(api, nil, bndlRef)
 	if err != nil {
 		return nil, errors.Wrapf(err, "while converting APIDefinition with id %q to graphQL", api.ID)
 	}
@@ -463,10 +464,12 @@ func (r *Resolver) APIDefinitionsDataLoader(keys []dataloader.ParamAPIDef) ([]*g
 		}
 	}
 
-	specs, err := r.specService.ListByReferenceObjectIDs(ctx, model.APISpecReference, apiDefIDs)
-	if err != nil {
-		return nil, []error{err}
-	}
+	// TODO Revert when specs are fetched via subresolvers
+	//specs, err := r.specService.ListByReferenceObjectIDs(ctx, model.APISpecReference, apiDefIDs)
+	//if err != nil {
+	//	return nil, []error{err}
+	//}
+	specs := make([]*model.Spec, 0)
 
 	references, _, err := r.bundleReferenceSvc.ListByBundleIDs(ctx, model.BundleAPIReference, bundleIDs, *first, cursor)
 	if err != nil {
@@ -535,17 +538,18 @@ func (r *Resolver) EventDefinition(ctx context.Context, obj *graphql.Bundle, id 
 		return nil, err
 	}
 
-	spec, err := r.specService.GetByReferenceObjectID(ctx, model.EventSpecReference, eventAPI.ID)
-	if err != nil {
-		return nil, errors.Wrapf(err, "while getting spec for EventDefinition with id %q", eventAPI.ID)
-	}
+	// TODO Revert when specs are fetched via subresolvers
+	//spec, err := r.specService.GetByReferenceObjectID(ctx, model.EventSpecReference, eventAPI.ID)
+	//if err != nil {
+	//	return nil, errors.Wrapf(err, "while getting spec for EventDefinition with id %q", eventAPI.ID)
+	//}
 
 	bndlRef, err := r.bundleReferenceSvc.GetForBundle(ctx, model.BundleEventReference, &eventAPI.ID, nil)
 	if err != nil {
 		return nil, errors.Wrapf(err, "while getting bundle reference for EventDefinition with id %q", eventAPI.ID)
 	}
 
-	gqlEvent, err := r.eventConverter.ToGraphQL(eventAPI, spec, bndlRef)
+	gqlEvent, err := r.eventConverter.ToGraphQL(eventAPI, nil, bndlRef)
 	if err != nil {
 		return nil, errors.Wrapf(err, "while converting EventDefinition with id %q to graphQL", eventAPI.ID)
 	}
@@ -607,10 +611,12 @@ func (r *Resolver) EventDefinitionsDataLoader(keys []dataloader.ParamEventDef) (
 		}
 	}
 
-	specs, err := r.specService.ListByReferenceObjectIDs(ctx, model.EventSpecReference, eventAPIDefIDs)
-	if err != nil {
-		return nil, []error{err}
-	}
+	// TODO Revert when specs are fetched via subresolvers
+	//specs, err := r.specService.ListByReferenceObjectIDs(ctx, model.EventSpecReference, eventAPIDefIDs)
+	//if err != nil {
+	//	return nil, []error{err}
+	//}
+	specs := make([]*model.Spec, 0)
 
 	references, _, err := r.bundleReferenceSvc.ListByBundleIDs(ctx, model.BundleEventReference, bundleIDs, *first, cursor)
 	if err != nil {

--- a/components/director/internal/domain/bundle/resolver.go
+++ b/components/director/internal/domain/bundle/resolver.go
@@ -392,10 +392,10 @@ func (r *Resolver) APIDefinition(ctx context.Context, obj *graphql.Bundle, id st
 	}
 
 	// TODO Revert when specs are fetched via subresolvers
-	//spec, err := r.specService.GetByReferenceObjectID(ctx, model.APISpecReference, api.ID)
-	//if err != nil {
+	// spec, err := r.specService.GetByReferenceObjectID(ctx, model.APISpecReference, api.ID)
+	// if err != nil {
 	//	return nil, errors.Wrapf(err, "while getting spec for APIDefinition with id %q", api.ID)
-	//}
+	// }
 
 	bndlRef, err := r.bundleReferenceSvc.GetForBundle(ctx, model.BundleAPIReference, &api.ID, nil)
 	if err != nil {
@@ -465,10 +465,10 @@ func (r *Resolver) APIDefinitionsDataLoader(keys []dataloader.ParamAPIDef) ([]*g
 	}
 
 	// TODO Revert when specs are fetched via subresolvers
-	//specs, err := r.specService.ListByReferenceObjectIDs(ctx, model.APISpecReference, apiDefIDs)
-	//if err != nil {
-	//	return nil, []error{err}
-	//}
+	// specs, err := r.specService.ListByReferenceObjectIDs(ctx, model.APISpecReference, apiDefIDs)
+	// if err != nil {
+	// 	return nil, []error{err}
+	// }
 	specs := make([]*model.Spec, 0)
 
 	references, _, err := r.bundleReferenceSvc.ListByBundleIDs(ctx, model.BundleAPIReference, bundleIDs, *first, cursor)
@@ -539,10 +539,10 @@ func (r *Resolver) EventDefinition(ctx context.Context, obj *graphql.Bundle, id 
 	}
 
 	// TODO Revert when specs are fetched via subresolvers
-	//spec, err := r.specService.GetByReferenceObjectID(ctx, model.EventSpecReference, eventAPI.ID)
-	//if err != nil {
+	// spec, err := r.specService.GetByReferenceObjectID(ctx, model.EventSpecReference, eventAPI.ID)
+	// if err != nil {
 	//	return nil, errors.Wrapf(err, "while getting spec for EventDefinition with id %q", eventAPI.ID)
-	//}
+	// }
 
 	bndlRef, err := r.bundleReferenceSvc.GetForBundle(ctx, model.BundleEventReference, &eventAPI.ID, nil)
 	if err != nil {
@@ -612,10 +612,10 @@ func (r *Resolver) EventDefinitionsDataLoader(keys []dataloader.ParamEventDef) (
 	}
 
 	// TODO Revert when specs are fetched via subresolvers
-	//specs, err := r.specService.ListByReferenceObjectIDs(ctx, model.EventSpecReference, eventAPIDefIDs)
-	//if err != nil {
+	// specs, err := r.specService.ListByReferenceObjectIDs(ctx, model.EventSpecReference, eventAPIDefIDs)
+	// if err != nil {
 	//	return nil, []error{err}
-	//}
+	// }
 	specs := make([]*model.Spec, 0)
 
 	references, _, err := r.bundleReferenceSvc.ListByBundleIDs(ctx, model.BundleEventReference, bundleIDs, *first, cursor)

--- a/components/director/internal/domain/bundle/resolver_test.go
+++ b/components/director/internal/domain/bundle/resolver_test.go
@@ -30,11 +30,15 @@ func TestResolver_API(t *testing.T) {
 		bndlID := "1"
 		var nilBundleID *string
 		modelAPI := fixModelAPIDefinition(id, "name", "bar", "test")
-		modelSpec := &model.Spec{
-			ID:         id,
-			ObjectType: model.APISpecReference,
-			ObjectID:   id,
-		}
+
+		// TODO Revert when specs are fetched via subresolvers
+		//modelSpec := &model.Spec{
+		//	ID:         id,
+		//	ObjectType: model.APISpecReference,
+		//	ObjectID:   id,
+		//}
+		var modelSpec *model.Spec
+
 		modelBundleRef := &model.BundleReference{
 			BundleID:            &bndlID,
 			ObjectType:          model.BundleAPIReference,
@@ -69,7 +73,8 @@ func TestResolver_API(t *testing.T) {
 				},
 				SpecServiceFn: func() *automock.SpecService {
 					svc := &automock.SpecService{}
-					svc.On("GetByReferenceObjectID", txtest.CtxWithDBMatcher(), model.APISpecReference, modelAPI.ID).Return(modelSpec, nil).Once()
+					// TODO Revert when specs are fetched via subresolvers
+					//svc.On("GetByReferenceObjectID", txtest.CtxWithDBMatcher(), model.APISpecReference, modelAPI.ID).Return(modelSpec, nil).Once()
 					return svc
 				},
 				BundleReferenceServiceFn: func() *automock.BundleReferenceService {
@@ -132,31 +137,32 @@ func TestResolver_API(t *testing.T) {
 				ExpectedAPI: nil,
 				ExpectedErr: nil,
 			},
-			{
-				Name:            "Returns error when Spec retrieval failed",
-				TransactionerFn: txGen.ThatDoesntExpectCommit,
-				ServiceFn: func() *automock.APIService {
-					svc := &automock.APIService{}
-					svc.On("GetForBundle", txtest.CtxWithDBMatcher(), "foo", "foo").Return(modelAPI, nil).Once()
-
-					return svc
-				},
-				SpecServiceFn: func() *automock.SpecService {
-					svc := &automock.SpecService{}
-					svc.On("GetByReferenceObjectID", txtest.CtxWithDBMatcher(), model.APISpecReference, modelAPI.ID).Return(nil, testErr).Once()
-					return svc
-				},
-				BundleReferenceServiceFn: func() *automock.BundleReferenceService {
-					return &automock.BundleReferenceService{}
-				},
-				ConverterFn: func() *automock.APIConverter {
-					return &automock.APIConverter{}
-				},
-				InputID:     "foo",
-				Bundle:      app,
-				ExpectedAPI: nil,
-				ExpectedErr: testErr,
-			},
+			// TODO Revert when specs are fetched via subresolvers
+			//{
+			//	Name:            "Returns error when Spec retrieval failed",
+			//	TransactionerFn: txGen.ThatDoesntExpectCommit,
+			//	ServiceFn: func() *automock.APIService {
+			//		svc := &automock.APIService{}
+			//		svc.On("GetForBundle", txtest.CtxWithDBMatcher(), "foo", "foo").Return(modelAPI, nil).Once()
+			//
+			//		return svc
+			//	},
+			//	SpecServiceFn: func() *automock.SpecService {
+			//		svc := &automock.SpecService{}
+			//		svc.On("GetByReferenceObjectID", txtest.CtxWithDBMatcher(), model.APISpecReference, modelAPI.ID).Return(nil, testErr).Once()
+			//		return svc
+			//	},
+			//	BundleReferenceServiceFn: func() *automock.BundleReferenceService {
+			//		return &automock.BundleReferenceService{}
+			//	},
+			//	ConverterFn: func() *automock.APIConverter {
+			//		return &automock.APIConverter{}
+			//	},
+			//	InputID:     "foo",
+			//	Bundle:      app,
+			//	ExpectedAPI: nil,
+			//	ExpectedErr: testErr,
+			//},
 			{
 				Name:            "Returns error when BundleReference retrieval failed",
 				TransactionerFn: txGen.ThatDoesntExpectCommit,
@@ -168,7 +174,8 @@ func TestResolver_API(t *testing.T) {
 				},
 				SpecServiceFn: func() *automock.SpecService {
 					svc := &automock.SpecService{}
-					svc.On("GetByReferenceObjectID", txtest.CtxWithDBMatcher(), model.APISpecReference, modelAPI.ID).Return(modelSpec, nil).Once()
+					// TODO Revert when specs are fetched via subresolvers
+					//svc.On("GetByReferenceObjectID", txtest.CtxWithDBMatcher(), model.APISpecReference, modelAPI.ID).Return(modelSpec, nil).Once()
 					return svc
 				},
 				BundleReferenceServiceFn: func() *automock.BundleReferenceService {
@@ -195,7 +202,8 @@ func TestResolver_API(t *testing.T) {
 				},
 				SpecServiceFn: func() *automock.SpecService {
 					svc := &automock.SpecService{}
-					svc.On("GetByReferenceObjectID", txtest.CtxWithDBMatcher(), model.APISpecReference, modelAPI.ID).Return(modelSpec, nil).Once()
+					// TODO Revert when specs are fetched via subresolvers
+					//svc.On("GetByReferenceObjectID", txtest.CtxWithDBMatcher(), model.APISpecReference, modelAPI.ID).Return(modelSpec, nil).Once()
 					return svc
 				},
 				BundleReferenceServiceFn: func() *automock.BundleReferenceService {
@@ -244,7 +252,8 @@ func TestResolver_API(t *testing.T) {
 				},
 				SpecServiceFn: func() *automock.SpecService {
 					svc := &automock.SpecService{}
-					svc.On("GetByReferenceObjectID", txtest.CtxWithDBMatcher(), model.APISpecReference, modelAPI.ID).Return(modelSpec, nil).Once()
+					// TODO Revert when specs are fetched via subresolvers
+					//svc.On("GetByReferenceObjectID", txtest.CtxWithDBMatcher(), model.APISpecReference, modelAPI.ID).Return(modelSpec, nil).Once()
 					return svc
 				},
 				BundleReferenceServiceFn: func() *automock.BundleReferenceService {
@@ -309,9 +318,10 @@ func TestResolver_APIs(t *testing.T) {
 	bundleIDs := []string{firstBundleID, secondBundleID}
 	firstAPIID := "apiID"
 	secondAPIID := "apiID2"
-	apiIDs := []string{firstAPIID, secondAPIID}
-	firstSpecID := "specID"
-	secondSpecID := "specID2"
+	// TODO Revert when specs are fetched via subresolvers
+	//apiIDs := []string{firstAPIID, secondAPIID}
+	//firstSpecID := "specID"
+	//secondSpecID := "specID2"
 
 	// model APIDefs
 	apiDefFirstBundle := fixModelAPIDefinition(firstAPIID, "Foo", "Lorem Ipsum", group)
@@ -346,11 +356,12 @@ func TestResolver_APIs(t *testing.T) {
 	totalCounts := map[string]int{firstBundleID: numberOfAPIsInFirstBundle, secondBundleID: numberOfAPIsInSecondBundle}
 
 	// API Specs
-	apiDefFirstSpec := &model.Spec{ID: firstSpecID, ObjectType: model.APISpecReference, ObjectID: firstAPIID}
-	apiDefSecondSpec := &model.Spec{ID: secondSpecID, ObjectType: model.APISpecReference, ObjectID: secondAPIID}
-	specsFirstAPI := []*model.Spec{apiDefFirstSpec}
-	specsSecondAPI := []*model.Spec{apiDefSecondSpec}
-	specs := []*model.Spec{apiDefFirstSpec, apiDefSecondSpec}
+	// TODO Revert when specs are fetched via subresolvers
+	//apiDefFirstSpec := &model.Spec{ID: firstSpecID, ObjectType: model.APISpecReference, ObjectID: firstAPIID}
+	//apiDefSecondSpec := &model.Spec{ID: secondSpecID, ObjectType: model.APISpecReference, ObjectID: secondAPIID}
+	//specs := []*model.Spec{nil}
+	specsFirstAPI := []*model.Spec{nil}
+	specsSecondAPI := []*model.Spec{nil}
 
 	txGen := txtest.NewTransactionContextGenerator(testErr)
 
@@ -378,7 +389,8 @@ func TestResolver_APIs(t *testing.T) {
 			},
 			SpecServiceFn: func() *automock.SpecService {
 				svc := &automock.SpecService{}
-				svc.On("ListByReferenceObjectIDs", txtest.CtxWithDBMatcher(), model.APISpecReference, apiIDs).Return(specs, nil).Once()
+				// TODO Revert when specs are fetched via subresolvers
+				//svc.On("ListByReferenceObjectIDs", txtest.CtxWithDBMatcher(), model.APISpecReference, apiIDs).Return(specs, nil).Once()
 				return svc
 			},
 			BundleReferenceFn: func() *automock.BundleReferenceService {
@@ -433,28 +445,29 @@ func TestResolver_APIs(t *testing.T) {
 			ExpectedResult: nil,
 			ExpectedErr:    []error{testErr},
 		},
-		{
-			Name:            "Returns error when Specs retrieval failed",
-			TransactionerFn: txGen.ThatDoesntExpectCommit,
-			ServiceFn: func() *automock.APIService {
-				svc := &automock.APIService{}
-				svc.On("ListByBundleIDs", txtest.CtxWithDBMatcher(), bundleIDs, first, after).Return(apiDefPages, nil).Once()
-				return svc
-			},
-			SpecServiceFn: func() *automock.SpecService {
-				svc := &automock.SpecService{}
-				svc.On("ListByReferenceObjectIDs", txtest.CtxWithDBMatcher(), model.APISpecReference, apiIDs).Return(nil, testErr).Once()
-				return svc
-			},
-			BundleReferenceFn: func() *automock.BundleReferenceService {
-				return &automock.BundleReferenceService{}
-			},
-			ConverterFn: func() *automock.APIConverter {
-				return &automock.APIConverter{}
-			},
-			ExpectedResult: nil,
-			ExpectedErr:    []error{testErr},
-		},
+		// TODO Revert when specs are fetched via subresolvers
+		//{
+		//	Name:            "Returns error when Specs retrieval failed",
+		//	TransactionerFn: txGen.ThatDoesntExpectCommit,
+		//	ServiceFn: func() *automock.APIService {
+		//		svc := &automock.APIService{}
+		//		svc.On("ListByBundleIDs", txtest.CtxWithDBMatcher(), bundleIDs, first, after).Return(apiDefPages, nil).Once()
+		//		return svc
+		//	},
+		//	SpecServiceFn: func() *automock.SpecService {
+		//		svc := &automock.SpecService{}
+		//		svc.On("ListByReferenceObjectIDs", txtest.CtxWithDBMatcher(), model.APISpecReference, apiIDs).Return(nil, testErr).Once()
+		//		return svc
+		//	},
+		//	BundleReferenceFn: func() *automock.BundleReferenceService {
+		//		return &automock.BundleReferenceService{}
+		//	},
+		//	ConverterFn: func() *automock.APIConverter {
+		//		return &automock.APIConverter{}
+		//	},
+		//	ExpectedResult: nil,
+		//	ExpectedErr:    []error{testErr},
+		//},
 		{
 			Name:            "Returns error when BundleReferences retrieval failed",
 			TransactionerFn: txGen.ThatDoesntExpectCommit,
@@ -465,7 +478,8 @@ func TestResolver_APIs(t *testing.T) {
 			},
 			SpecServiceFn: func() *automock.SpecService {
 				svc := &automock.SpecService{}
-				svc.On("ListByReferenceObjectIDs", txtest.CtxWithDBMatcher(), model.APISpecReference, apiIDs).Return(specs, nil).Once()
+				// TODO Revert when specs are fetched via subresolvers
+				//svc.On("ListByReferenceObjectIDs", txtest.CtxWithDBMatcher(), model.APISpecReference, apiIDs).Return(specs, nil).Once()
 				return svc
 			},
 			BundleReferenceFn: func() *automock.BundleReferenceService {
@@ -489,7 +503,8 @@ func TestResolver_APIs(t *testing.T) {
 			},
 			SpecServiceFn: func() *automock.SpecService {
 				svc := &automock.SpecService{}
-				svc.On("ListByReferenceObjectIDs", txtest.CtxWithDBMatcher(), model.APISpecReference, apiIDs).Return(specs, nil).Once()
+				// TODO Revert when specs are fetched via subresolvers
+				//svc.On("ListByReferenceObjectIDs", txtest.CtxWithDBMatcher(), model.APISpecReference, apiIDs).Return(specs, nil).Once()
 				return svc
 			},
 			BundleReferenceFn: func() *automock.BundleReferenceService {
@@ -515,7 +530,8 @@ func TestResolver_APIs(t *testing.T) {
 			},
 			SpecServiceFn: func() *automock.SpecService {
 				svc := &automock.SpecService{}
-				svc.On("ListByReferenceObjectIDs", txtest.CtxWithDBMatcher(), model.APISpecReference, apiIDs).Return(specs, nil).Once()
+				// TODO Revert when specs are fetched via subresolvers
+				//svc.On("ListByReferenceObjectIDs", txtest.CtxWithDBMatcher(), model.APISpecReference, apiIDs).Return(specs, nil).Once()
 				return svc
 			},
 			BundleReferenceFn: func() *automock.BundleReferenceService {
@@ -541,7 +557,8 @@ func TestResolver_APIs(t *testing.T) {
 			},
 			SpecServiceFn: func() *automock.SpecService {
 				svc := &automock.SpecService{}
-				svc.On("ListByReferenceObjectIDs", txtest.CtxWithDBMatcher(), model.APISpecReference, apiIDs).Return(specs, nil).Once()
+				// TODO Revert when specs are fetched via subresolvers
+				//svc.On("ListByReferenceObjectIDs", txtest.CtxWithDBMatcher(), model.APISpecReference, apiIDs).Return(specs, nil).Once()
 				return svc
 			},
 			BundleReferenceFn: func() *automock.BundleReferenceService {
@@ -623,11 +640,14 @@ func TestResolver_Event(t *testing.T) {
 		bndlID := "1"
 		var nilBundleID *string
 		modelEvent := fixModelEventAPIDefinition(id, "name", "bar", "test")
-		modelSpec := &model.Spec{
-			ID:         id,
-			ObjectType: model.EventSpecReference,
-			ObjectID:   id,
-		}
+		// TODO Revert when specs are fetched via subresolvers
+		//modelSpec := &model.Spec{
+		//	ID:         id,
+		//	ObjectType: model.EventSpecReference,
+		//	ObjectID:   id,
+		//}
+		var modelSpec *model.Spec
+
 		modelBundleRef := &model.BundleReference{
 			BundleID:   &bndlID,
 			ObjectType: model.BundleEventReference,
@@ -661,7 +681,8 @@ func TestResolver_Event(t *testing.T) {
 				},
 				SpecServiceFn: func() *automock.SpecService {
 					svc := &automock.SpecService{}
-					svc.On("GetByReferenceObjectID", txtest.CtxWithDBMatcher(), model.EventSpecReference, modelEvent.ID).Return(modelSpec, nil).Once()
+					// TODO Revert when specs are fetched via subresolvers
+					//svc.On("GetByReferenceObjectID", txtest.CtxWithDBMatcher(), model.EventSpecReference, modelEvent.ID).Return(modelSpec, nil).Once()
 					return svc
 				},
 				BundleRefServiceFn: func() *automock.BundleReferenceService {
@@ -724,31 +745,32 @@ func TestResolver_Event(t *testing.T) {
 				ExpectedEvent: nil,
 				ExpectedErr:   nil,
 			},
-			{
-				Name:            "Returns error when Spec retrieval failed",
-				TransactionerFn: txGen.ThatDoesntExpectCommit,
-				ServiceFn: func() *automock.EventService {
-					svc := &automock.EventService{}
-					svc.On("GetForBundle", txtest.CtxWithDBMatcher(), "foo", "foo").Return(modelEvent, nil).Once()
-
-					return svc
-				},
-				SpecServiceFn: func() *automock.SpecService {
-					svc := &automock.SpecService{}
-					svc.On("GetByReferenceObjectID", txtest.CtxWithDBMatcher(), model.EventSpecReference, modelEvent.ID).Return(nil, testErr).Once()
-					return svc
-				},
-				BundleRefServiceFn: func() *automock.BundleReferenceService {
-					return &automock.BundleReferenceService{}
-				},
-				ConverterFn: func() *automock.EventConverter {
-					return &automock.EventConverter{}
-				},
-				InputID:       "foo",
-				Bundle:        app,
-				ExpectedEvent: nil,
-				ExpectedErr:   testErr,
-			},
+			// TODO Revert when specs are fetched via subresolvers
+			//{
+			//	Name:            "Returns error when Spec retrieval failed",
+			//	TransactionerFn: txGen.ThatDoesntExpectCommit,
+			//	ServiceFn: func() *automock.EventService {
+			//		svc := &automock.EventService{}
+			//		svc.On("GetForBundle", txtest.CtxWithDBMatcher(), "foo", "foo").Return(modelEvent, nil).Once()
+			//
+			//		return svc
+			//	},
+			//	SpecServiceFn: func() *automock.SpecService {
+			//		svc := &automock.SpecService{}
+			//		svc.On("GetByReferenceObjectID", txtest.CtxWithDBMatcher(), model.EventSpecReference, modelEvent.ID).Return(nil, testErr).Once()
+			//		return svc
+			//	},
+			//	BundleRefServiceFn: func() *automock.BundleReferenceService {
+			//		return &automock.BundleReferenceService{}
+			//	},
+			//	ConverterFn: func() *automock.EventConverter {
+			//		return &automock.EventConverter{}
+			//	},
+			//	InputID:       "foo",
+			//	Bundle:        app,
+			//	ExpectedEvent: nil,
+			//	ExpectedErr:   testErr,
+			//},
 			{
 				Name:            "Returns error when BundleReference retrieval failed",
 				TransactionerFn: txGen.ThatDoesntExpectCommit,
@@ -760,7 +782,8 @@ func TestResolver_Event(t *testing.T) {
 				},
 				SpecServiceFn: func() *automock.SpecService {
 					svc := &automock.SpecService{}
-					svc.On("GetByReferenceObjectID", txtest.CtxWithDBMatcher(), model.EventSpecReference, modelEvent.ID).Return(modelSpec, nil).Once()
+					// TODO Revert when specs are fetched via subresolvers
+					//svc.On("GetByReferenceObjectID", txtest.CtxWithDBMatcher(), model.EventSpecReference, modelEvent.ID).Return(modelSpec, nil).Once()
 					return svc
 				},
 				BundleRefServiceFn: func() *automock.BundleReferenceService {
@@ -787,7 +810,8 @@ func TestResolver_Event(t *testing.T) {
 				},
 				SpecServiceFn: func() *automock.SpecService {
 					svc := &automock.SpecService{}
-					svc.On("GetByReferenceObjectID", txtest.CtxWithDBMatcher(), model.EventSpecReference, modelEvent.ID).Return(modelSpec, nil).Once()
+					// TODO Revert when specs are fetched via subresolvers
+					//svc.On("GetByReferenceObjectID", txtest.CtxWithDBMatcher(), model.EventSpecReference, modelEvent.ID).Return(modelSpec, nil).Once()
 					return svc
 				},
 				BundleRefServiceFn: func() *automock.BundleReferenceService {
@@ -836,7 +860,8 @@ func TestResolver_Event(t *testing.T) {
 				},
 				SpecServiceFn: func() *automock.SpecService {
 					svc := &automock.SpecService{}
-					svc.On("GetByReferenceObjectID", txtest.CtxWithDBMatcher(), model.EventSpecReference, modelEvent.ID).Return(modelSpec, nil).Once()
+					// TODO Revert when specs are fetched via subresolvers
+					//svc.On("GetByReferenceObjectID", txtest.CtxWithDBMatcher(), model.EventSpecReference, modelEvent.ID).Return(modelSpec, nil).Once()
 					return svc
 				},
 				BundleRefServiceFn: func() *automock.BundleReferenceService {
@@ -901,9 +926,10 @@ func TestResolver_Events(t *testing.T) {
 	bundleIDs := []string{firstBundleID, secondBundleID}
 	firstEventID := "eventID"
 	secondEventID := "eventID2"
-	eventIDs := []string{firstEventID, secondEventID}
-	firstSpecID := "specID"
-	secondSpecID := "specID2"
+	// TODO Revert when specs are fetched via subresolvers
+	//eventIDs := []string{firstEventID, secondEventID}
+	//firstSpecID := "specID"
+	//secondSpecID := "specID2"
 
 	// model Events
 	eventFirstBundle := fixModelEventAPIDefinition(firstEventID, "Foo", "Lorem Ipsum", group)
@@ -938,12 +964,14 @@ func TestResolver_Events(t *testing.T) {
 	totalCounts := map[string]int{firstBundleID: numberOfEventsInFirstBundle, secondBundleID: numberOfEventsInSecondBundle}
 
 	// Event Specs
-	eventFirstSpec := &model.Spec{ID: firstSpecID, ObjectType: model.EventSpecReference, ObjectID: firstEventID}
-	eventSecondSpec := &model.Spec{ID: secondSpecID, ObjectType: model.EventSpecReference, ObjectID: secondEventID}
-	specsFirstEvent := []*model.Spec{eventFirstSpec}
-	specsSecondEvent := []*model.Spec{eventSecondSpec}
-	specs := []*model.Spec{eventFirstSpec, eventSecondSpec}
-
+	// TODO Revert when specs are fetched via subresolvers
+	//eventFirstSpec := &model.Spec{ID: firstSpecID, ObjectType: model.EventSpecReference, ObjectID: firstEventID}
+	//eventSecondSpec := &model.Spec{ID: secondSpecID, ObjectType: model.EventSpecReference, ObjectID: secondEventID}
+	//specsFirstEvent := []*model.Spec{eventFirstSpec}
+	//specsSecondEvent := []*model.Spec{eventSecondSpec}
+	//specs := []*model.Spec{eventFirstSpec, eventSecondSpec}
+	specsFirstEvent := []*model.Spec{nil}
+	specsSecondEvent := []*model.Spec{nil}
 	txGen := txtest.NewTransactionContextGenerator(testErr)
 
 	first := 2
@@ -970,7 +998,8 @@ func TestResolver_Events(t *testing.T) {
 			},
 			SpecServiceFn: func() *automock.SpecService {
 				svc := &automock.SpecService{}
-				svc.On("ListByReferenceObjectIDs", txtest.CtxWithDBMatcher(), model.EventSpecReference, eventIDs).Return(specs, nil).Once()
+				// TODO Revert when specs are fetched via subresolvers
+				//svc.On("ListByReferenceObjectIDs", txtest.CtxWithDBMatcher(), model.EventSpecReference, eventIDs).Return(specs, nil).Once()
 				return svc
 			},
 			BundleReferenceFn: func() *automock.BundleReferenceService {
@@ -1025,28 +1054,29 @@ func TestResolver_Events(t *testing.T) {
 			ExpectedResult: nil,
 			ExpectedErr:    []error{testErr},
 		},
-		{
-			Name:            "Returns error when Specs retrieval failed",
-			TransactionerFn: txGen.ThatDoesntExpectCommit,
-			ServiceFn: func() *automock.EventService {
-				svc := &automock.EventService{}
-				svc.On("ListByBundleIDs", txtest.CtxWithDBMatcher(), bundleIDs, first, after).Return(eventPages, nil).Once()
-				return svc
-			},
-			SpecServiceFn: func() *automock.SpecService {
-				svc := &automock.SpecService{}
-				svc.On("ListByReferenceObjectIDs", txtest.CtxWithDBMatcher(), model.EventSpecReference, eventIDs).Return(nil, testErr).Once()
-				return svc
-			},
-			BundleReferenceFn: func() *automock.BundleReferenceService {
-				return &automock.BundleReferenceService{}
-			},
-			ConverterFn: func() *automock.EventConverter {
-				return &automock.EventConverter{}
-			},
-			ExpectedResult: nil,
-			ExpectedErr:    []error{testErr},
-		},
+		// TODO Revert when specs are fetched via subresolvers
+		//{
+		//	Name:            "Returns error when Specs retrieval failed",
+		//	TransactionerFn: txGen.ThatDoesntExpectCommit,
+		//	ServiceFn: func() *automock.EventService {
+		//		svc := &automock.EventService{}
+		//		svc.On("ListByBundleIDs", txtest.CtxWithDBMatcher(), bundleIDs, first, after).Return(eventPages, nil).Once()
+		//		return svc
+		//	},
+		//	SpecServiceFn: func() *automock.SpecService {
+		//		svc := &automock.SpecService{}
+		//		svc.On("ListByReferenceObjectIDs", txtest.CtxWithDBMatcher(), model.EventSpecReference, eventIDs).Return(nil, testErr).Once()
+		//		return svc
+		//	},
+		//	BundleReferenceFn: func() *automock.BundleReferenceService {
+		//		return &automock.BundleReferenceService{}
+		//	},
+		//	ConverterFn: func() *automock.EventConverter {
+		//		return &automock.EventConverter{}
+		//	},
+		//	ExpectedResult: nil,
+		//	ExpectedErr:    []error{testErr},
+		//},
 		{
 			Name:            "Returns error when BundleReferences retrieval failed",
 			TransactionerFn: txGen.ThatDoesntExpectCommit,
@@ -1057,7 +1087,8 @@ func TestResolver_Events(t *testing.T) {
 			},
 			SpecServiceFn: func() *automock.SpecService {
 				svc := &automock.SpecService{}
-				svc.On("ListByReferenceObjectIDs", txtest.CtxWithDBMatcher(), model.EventSpecReference, eventIDs).Return(specs, nil).Once()
+				// TODO Revert when specs are fetched via subresolvers
+				//svc.On("ListByReferenceObjectIDs", txtest.CtxWithDBMatcher(), model.EventSpecReference, eventIDs).Return(specs, nil).Once()
 				return svc
 			},
 			BundleReferenceFn: func() *automock.BundleReferenceService {
@@ -1081,7 +1112,8 @@ func TestResolver_Events(t *testing.T) {
 			},
 			SpecServiceFn: func() *automock.SpecService {
 				svc := &automock.SpecService{}
-				svc.On("ListByReferenceObjectIDs", txtest.CtxWithDBMatcher(), model.EventSpecReference, eventIDs).Return(specs, nil).Once()
+				// TODO Revert when specs are fetched via subresolvers
+				//svc.On("ListByReferenceObjectIDs", txtest.CtxWithDBMatcher(), model.EventSpecReference, eventIDs).Return(specs, nil).Once()
 				return svc
 			},
 			BundleReferenceFn: func() *automock.BundleReferenceService {
@@ -1107,7 +1139,8 @@ func TestResolver_Events(t *testing.T) {
 			},
 			SpecServiceFn: func() *automock.SpecService {
 				svc := &automock.SpecService{}
-				svc.On("ListByReferenceObjectIDs", txtest.CtxWithDBMatcher(), model.EventSpecReference, eventIDs).Return(specs, nil).Once()
+				// TODO Revert when specs are fetched via subresolvers
+				//svc.On("ListByReferenceObjectIDs", txtest.CtxWithDBMatcher(), model.EventSpecReference, eventIDs).Return(specs, nil).Once()
 				return svc
 			},
 			BundleReferenceFn: func() *automock.BundleReferenceService {

--- a/components/director/internal/domain/bundle/resolver_test.go
+++ b/components/director/internal/domain/bundle/resolver_test.go
@@ -32,11 +32,11 @@ func TestResolver_API(t *testing.T) {
 		modelAPI := fixModelAPIDefinition(id, "name", "bar", "test")
 
 		// TODO Revert when specs are fetched via subresolvers
-		//modelSpec := &model.Spec{
+		// modelSpec := &model.Spec{
 		//	ID:         id,
 		//	ObjectType: model.APISpecReference,
 		//	ObjectID:   id,
-		//}
+		// }
 		var modelSpec *model.Spec
 
 		modelBundleRef := &model.BundleReference{
@@ -74,7 +74,7 @@ func TestResolver_API(t *testing.T) {
 				SpecServiceFn: func() *automock.SpecService {
 					svc := &automock.SpecService{}
 					// TODO Revert when specs are fetched via subresolvers
-					//svc.On("GetByReferenceObjectID", txtest.CtxWithDBMatcher(), model.APISpecReference, modelAPI.ID).Return(modelSpec, nil).Once()
+					// svc.On("GetByReferenceObjectID", txtest.CtxWithDBMatcher(), model.APISpecReference, modelAPI.ID).Return(modelSpec, nil).Once()
 					return svc
 				},
 				BundleReferenceServiceFn: func() *automock.BundleReferenceService {
@@ -138,7 +138,7 @@ func TestResolver_API(t *testing.T) {
 				ExpectedErr: nil,
 			},
 			// TODO Revert when specs are fetched via subresolvers
-			//{
+			// {
 			//	Name:            "Returns error when Spec retrieval failed",
 			//	TransactionerFn: txGen.ThatDoesntExpectCommit,
 			//	ServiceFn: func() *automock.APIService {
@@ -162,7 +162,7 @@ func TestResolver_API(t *testing.T) {
 			//	Bundle:      app,
 			//	ExpectedAPI: nil,
 			//	ExpectedErr: testErr,
-			//},
+			// },
 			{
 				Name:            "Returns error when BundleReference retrieval failed",
 				TransactionerFn: txGen.ThatDoesntExpectCommit,
@@ -175,7 +175,7 @@ func TestResolver_API(t *testing.T) {
 				SpecServiceFn: func() *automock.SpecService {
 					svc := &automock.SpecService{}
 					// TODO Revert when specs are fetched via subresolvers
-					//svc.On("GetByReferenceObjectID", txtest.CtxWithDBMatcher(), model.APISpecReference, modelAPI.ID).Return(modelSpec, nil).Once()
+					// svc.On("GetByReferenceObjectID", txtest.CtxWithDBMatcher(), model.APISpecReference, modelAPI.ID).Return(modelSpec, nil).Once()
 					return svc
 				},
 				BundleReferenceServiceFn: func() *automock.BundleReferenceService {
@@ -203,7 +203,7 @@ func TestResolver_API(t *testing.T) {
 				SpecServiceFn: func() *automock.SpecService {
 					svc := &automock.SpecService{}
 					// TODO Revert when specs are fetched via subresolvers
-					//svc.On("GetByReferenceObjectID", txtest.CtxWithDBMatcher(), model.APISpecReference, modelAPI.ID).Return(modelSpec, nil).Once()
+					// svc.On("GetByReferenceObjectID", txtest.CtxWithDBMatcher(), model.APISpecReference, modelAPI.ID).Return(modelSpec, nil).Once()
 					return svc
 				},
 				BundleReferenceServiceFn: func() *automock.BundleReferenceService {
@@ -253,7 +253,7 @@ func TestResolver_API(t *testing.T) {
 				SpecServiceFn: func() *automock.SpecService {
 					svc := &automock.SpecService{}
 					// TODO Revert when specs are fetched via subresolvers
-					//svc.On("GetByReferenceObjectID", txtest.CtxWithDBMatcher(), model.APISpecReference, modelAPI.ID).Return(modelSpec, nil).Once()
+					// svc.On("GetByReferenceObjectID", txtest.CtxWithDBMatcher(), model.APISpecReference, modelAPI.ID).Return(modelSpec, nil).Once()
 					return svc
 				},
 				BundleReferenceServiceFn: func() *automock.BundleReferenceService {
@@ -319,9 +319,9 @@ func TestResolver_APIs(t *testing.T) {
 	firstAPIID := "apiID"
 	secondAPIID := "apiID2"
 	// TODO Revert when specs are fetched via subresolvers
-	//apiIDs := []string{firstAPIID, secondAPIID}
-	//firstSpecID := "specID"
-	//secondSpecID := "specID2"
+	// apiIDs := []string{firstAPIID, secondAPIID}
+	// firstSpecID := "specID"
+	// secondSpecID := "specID2"
 
 	// model APIDefs
 	apiDefFirstBundle := fixModelAPIDefinition(firstAPIID, "Foo", "Lorem Ipsum", group)
@@ -357,9 +357,9 @@ func TestResolver_APIs(t *testing.T) {
 
 	// API Specs
 	// TODO Revert when specs are fetched via subresolvers
-	//apiDefFirstSpec := &model.Spec{ID: firstSpecID, ObjectType: model.APISpecReference, ObjectID: firstAPIID}
-	//apiDefSecondSpec := &model.Spec{ID: secondSpecID, ObjectType: model.APISpecReference, ObjectID: secondAPIID}
-	//specs := []*model.Spec{nil}
+	// apiDefFirstSpec := &model.Spec{ID: firstSpecID, ObjectType: model.APISpecReference, ObjectID: firstAPIID}
+	// apiDefSecondSpec := &model.Spec{ID: secondSpecID, ObjectType: model.APISpecReference, ObjectID: secondAPIID}
+	// specs := []*model.Spec{nil}
 	specsFirstAPI := []*model.Spec{nil}
 	specsSecondAPI := []*model.Spec{nil}
 
@@ -390,7 +390,7 @@ func TestResolver_APIs(t *testing.T) {
 			SpecServiceFn: func() *automock.SpecService {
 				svc := &automock.SpecService{}
 				// TODO Revert when specs are fetched via subresolvers
-				//svc.On("ListByReferenceObjectIDs", txtest.CtxWithDBMatcher(), model.APISpecReference, apiIDs).Return(specs, nil).Once()
+				// svc.On("ListByReferenceObjectIDs", txtest.CtxWithDBMatcher(), model.APISpecReference, apiIDs).Return(specs, nil).Once()
 				return svc
 			},
 			BundleReferenceFn: func() *automock.BundleReferenceService {
@@ -446,7 +446,7 @@ func TestResolver_APIs(t *testing.T) {
 			ExpectedErr:    []error{testErr},
 		},
 		// TODO Revert when specs are fetched via subresolvers
-		//{
+		// {
 		//	Name:            "Returns error when Specs retrieval failed",
 		//	TransactionerFn: txGen.ThatDoesntExpectCommit,
 		//	ServiceFn: func() *automock.APIService {
@@ -467,7 +467,7 @@ func TestResolver_APIs(t *testing.T) {
 		//	},
 		//	ExpectedResult: nil,
 		//	ExpectedErr:    []error{testErr},
-		//},
+		// },
 		{
 			Name:            "Returns error when BundleReferences retrieval failed",
 			TransactionerFn: txGen.ThatDoesntExpectCommit,
@@ -479,7 +479,7 @@ func TestResolver_APIs(t *testing.T) {
 			SpecServiceFn: func() *automock.SpecService {
 				svc := &automock.SpecService{}
 				// TODO Revert when specs are fetched via subresolvers
-				//svc.On("ListByReferenceObjectIDs", txtest.CtxWithDBMatcher(), model.APISpecReference, apiIDs).Return(specs, nil).Once()
+				// svc.On("ListByReferenceObjectIDs", txtest.CtxWithDBMatcher(), model.APISpecReference, apiIDs).Return(specs, nil).Once()
 				return svc
 			},
 			BundleReferenceFn: func() *automock.BundleReferenceService {
@@ -504,7 +504,7 @@ func TestResolver_APIs(t *testing.T) {
 			SpecServiceFn: func() *automock.SpecService {
 				svc := &automock.SpecService{}
 				// TODO Revert when specs are fetched via subresolvers
-				//svc.On("ListByReferenceObjectIDs", txtest.CtxWithDBMatcher(), model.APISpecReference, apiIDs).Return(specs, nil).Once()
+				// svc.On("ListByReferenceObjectIDs", txtest.CtxWithDBMatcher(), model.APISpecReference, apiIDs).Return(specs, nil).Once()
 				return svc
 			},
 			BundleReferenceFn: func() *automock.BundleReferenceService {
@@ -531,7 +531,7 @@ func TestResolver_APIs(t *testing.T) {
 			SpecServiceFn: func() *automock.SpecService {
 				svc := &automock.SpecService{}
 				// TODO Revert when specs are fetched via subresolvers
-				//svc.On("ListByReferenceObjectIDs", txtest.CtxWithDBMatcher(), model.APISpecReference, apiIDs).Return(specs, nil).Once()
+				// svc.On("ListByReferenceObjectIDs", txtest.CtxWithDBMatcher(), model.APISpecReference, apiIDs).Return(specs, nil).Once()
 				return svc
 			},
 			BundleReferenceFn: func() *automock.BundleReferenceService {
@@ -558,7 +558,7 @@ func TestResolver_APIs(t *testing.T) {
 			SpecServiceFn: func() *automock.SpecService {
 				svc := &automock.SpecService{}
 				// TODO Revert when specs are fetched via subresolvers
-				//svc.On("ListByReferenceObjectIDs", txtest.CtxWithDBMatcher(), model.APISpecReference, apiIDs).Return(specs, nil).Once()
+				// svc.On("ListByReferenceObjectIDs", txtest.CtxWithDBMatcher(), model.APISpecReference, apiIDs).Return(specs, nil).Once()
 				return svc
 			},
 			BundleReferenceFn: func() *automock.BundleReferenceService {
@@ -641,11 +641,11 @@ func TestResolver_Event(t *testing.T) {
 		var nilBundleID *string
 		modelEvent := fixModelEventAPIDefinition(id, "name", "bar", "test")
 		// TODO Revert when specs are fetched via subresolvers
-		//modelSpec := &model.Spec{
+		// modelSpec := &model.Spec{
 		//	ID:         id,
 		//	ObjectType: model.EventSpecReference,
 		//	ObjectID:   id,
-		//}
+		// }
 		var modelSpec *model.Spec
 
 		modelBundleRef := &model.BundleReference{
@@ -682,7 +682,7 @@ func TestResolver_Event(t *testing.T) {
 				SpecServiceFn: func() *automock.SpecService {
 					svc := &automock.SpecService{}
 					// TODO Revert when specs are fetched via subresolvers
-					//svc.On("GetByReferenceObjectID", txtest.CtxWithDBMatcher(), model.EventSpecReference, modelEvent.ID).Return(modelSpec, nil).Once()
+					// svc.On("GetByReferenceObjectID", txtest.CtxWithDBMatcher(), model.EventSpecReference, modelEvent.ID).Return(modelSpec, nil).Once()
 					return svc
 				},
 				BundleRefServiceFn: func() *automock.BundleReferenceService {
@@ -746,7 +746,7 @@ func TestResolver_Event(t *testing.T) {
 				ExpectedErr:   nil,
 			},
 			// TODO Revert when specs are fetched via subresolvers
-			//{
+			// {
 			//	Name:            "Returns error when Spec retrieval failed",
 			//	TransactionerFn: txGen.ThatDoesntExpectCommit,
 			//	ServiceFn: func() *automock.EventService {
@@ -770,7 +770,7 @@ func TestResolver_Event(t *testing.T) {
 			//	Bundle:        app,
 			//	ExpectedEvent: nil,
 			//	ExpectedErr:   testErr,
-			//},
+			// },
 			{
 				Name:            "Returns error when BundleReference retrieval failed",
 				TransactionerFn: txGen.ThatDoesntExpectCommit,
@@ -783,7 +783,7 @@ func TestResolver_Event(t *testing.T) {
 				SpecServiceFn: func() *automock.SpecService {
 					svc := &automock.SpecService{}
 					// TODO Revert when specs are fetched via subresolvers
-					//svc.On("GetByReferenceObjectID", txtest.CtxWithDBMatcher(), model.EventSpecReference, modelEvent.ID).Return(modelSpec, nil).Once()
+					// svc.On("GetByReferenceObjectID", txtest.CtxWithDBMatcher(), model.EventSpecReference, modelEvent.ID).Return(modelSpec, nil).Once()
 					return svc
 				},
 				BundleRefServiceFn: func() *automock.BundleReferenceService {
@@ -811,7 +811,7 @@ func TestResolver_Event(t *testing.T) {
 				SpecServiceFn: func() *automock.SpecService {
 					svc := &automock.SpecService{}
 					// TODO Revert when specs are fetched via subresolvers
-					//svc.On("GetByReferenceObjectID", txtest.CtxWithDBMatcher(), model.EventSpecReference, modelEvent.ID).Return(modelSpec, nil).Once()
+					// svc.On("GetByReferenceObjectID", txtest.CtxWithDBMatcher(), model.EventSpecReference, modelEvent.ID).Return(modelSpec, nil).Once()
 					return svc
 				},
 				BundleRefServiceFn: func() *automock.BundleReferenceService {
@@ -861,7 +861,7 @@ func TestResolver_Event(t *testing.T) {
 				SpecServiceFn: func() *automock.SpecService {
 					svc := &automock.SpecService{}
 					// TODO Revert when specs are fetched via subresolvers
-					//svc.On("GetByReferenceObjectID", txtest.CtxWithDBMatcher(), model.EventSpecReference, modelEvent.ID).Return(modelSpec, nil).Once()
+					// svc.On("GetByReferenceObjectID", txtest.CtxWithDBMatcher(), model.EventSpecReference, modelEvent.ID).Return(modelSpec, nil).Once()
 					return svc
 				},
 				BundleRefServiceFn: func() *automock.BundleReferenceService {
@@ -927,9 +927,9 @@ func TestResolver_Events(t *testing.T) {
 	firstEventID := "eventID"
 	secondEventID := "eventID2"
 	// TODO Revert when specs are fetched via subresolvers
-	//eventIDs := []string{firstEventID, secondEventID}
-	//firstSpecID := "specID"
-	//secondSpecID := "specID2"
+	// eventIDs := []string{firstEventID, secondEventID}
+	// firstSpecID := "specID"
+	// secondSpecID := "specID2"
 
 	// model Events
 	eventFirstBundle := fixModelEventAPIDefinition(firstEventID, "Foo", "Lorem Ipsum", group)
@@ -965,11 +965,11 @@ func TestResolver_Events(t *testing.T) {
 
 	// Event Specs
 	// TODO Revert when specs are fetched via subresolvers
-	//eventFirstSpec := &model.Spec{ID: firstSpecID, ObjectType: model.EventSpecReference, ObjectID: firstEventID}
-	//eventSecondSpec := &model.Spec{ID: secondSpecID, ObjectType: model.EventSpecReference, ObjectID: secondEventID}
-	//specsFirstEvent := []*model.Spec{eventFirstSpec}
-	//specsSecondEvent := []*model.Spec{eventSecondSpec}
-	//specs := []*model.Spec{eventFirstSpec, eventSecondSpec}
+	// eventFirstSpec := &model.Spec{ID: firstSpecID, ObjectType: model.EventSpecReference, ObjectID: firstEventID}
+	// eventSecondSpec := &model.Spec{ID: secondSpecID, ObjectType: model.EventSpecReference, ObjectID: secondEventID}
+	// specsFirstEvent := []*model.Spec{eventFirstSpec}
+	// specsSecondEvent := []*model.Spec{eventSecondSpec}
+	// specs := []*model.Spec{eventFirstSpec, eventSecondSpec}
 	specsFirstEvent := []*model.Spec{nil}
 	specsSecondEvent := []*model.Spec{nil}
 	txGen := txtest.NewTransactionContextGenerator(testErr)
@@ -999,7 +999,7 @@ func TestResolver_Events(t *testing.T) {
 			SpecServiceFn: func() *automock.SpecService {
 				svc := &automock.SpecService{}
 				// TODO Revert when specs are fetched via subresolvers
-				//svc.On("ListByReferenceObjectIDs", txtest.CtxWithDBMatcher(), model.EventSpecReference, eventIDs).Return(specs, nil).Once()
+				// svc.On("ListByReferenceObjectIDs", txtest.CtxWithDBMatcher(), model.EventSpecReference, eventIDs).Return(specs, nil).Once()
 				return svc
 			},
 			BundleReferenceFn: func() *automock.BundleReferenceService {
@@ -1055,7 +1055,7 @@ func TestResolver_Events(t *testing.T) {
 			ExpectedErr:    []error{testErr},
 		},
 		// TODO Revert when specs are fetched via subresolvers
-		//{
+		// {
 		//	Name:            "Returns error when Specs retrieval failed",
 		//	TransactionerFn: txGen.ThatDoesntExpectCommit,
 		//	ServiceFn: func() *automock.EventService {
@@ -1076,7 +1076,7 @@ func TestResolver_Events(t *testing.T) {
 		//	},
 		//	ExpectedResult: nil,
 		//	ExpectedErr:    []error{testErr},
-		//},
+		// },
 		{
 			Name:            "Returns error when BundleReferences retrieval failed",
 			TransactionerFn: txGen.ThatDoesntExpectCommit,
@@ -1088,7 +1088,7 @@ func TestResolver_Events(t *testing.T) {
 			SpecServiceFn: func() *automock.SpecService {
 				svc := &automock.SpecService{}
 				// TODO Revert when specs are fetched via subresolvers
-				//svc.On("ListByReferenceObjectIDs", txtest.CtxWithDBMatcher(), model.EventSpecReference, eventIDs).Return(specs, nil).Once()
+				// svc.On("ListByReferenceObjectIDs", txtest.CtxWithDBMatcher(), model.EventSpecReference, eventIDs).Return(specs, nil).Once()
 				return svc
 			},
 			BundleReferenceFn: func() *automock.BundleReferenceService {
@@ -1113,7 +1113,7 @@ func TestResolver_Events(t *testing.T) {
 			SpecServiceFn: func() *automock.SpecService {
 				svc := &automock.SpecService{}
 				// TODO Revert when specs are fetched via subresolvers
-				//svc.On("ListByReferenceObjectIDs", txtest.CtxWithDBMatcher(), model.EventSpecReference, eventIDs).Return(specs, nil).Once()
+				// svc.On("ListByReferenceObjectIDs", txtest.CtxWithDBMatcher(), model.EventSpecReference, eventIDs).Return(specs, nil).Once()
 				return svc
 			},
 			BundleReferenceFn: func() *automock.BundleReferenceService {
@@ -1140,7 +1140,7 @@ func TestResolver_Events(t *testing.T) {
 			SpecServiceFn: func() *automock.SpecService {
 				svc := &automock.SpecService{}
 				// TODO Revert when specs are fetched via subresolvers
-				//svc.On("ListByReferenceObjectIDs", txtest.CtxWithDBMatcher(), model.EventSpecReference, eventIDs).Return(specs, nil).Once()
+				// svc.On("ListByReferenceObjectIDs", txtest.CtxWithDBMatcher(), model.EventSpecReference, eventIDs).Return(specs, nil).Once()
 				return svc
 			},
 			BundleReferenceFn: func() *automock.BundleReferenceService {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Due to high CPU usage in our production database, we need to seek workaround logic to ease the DB load.
The real solution is to extract the spec retrieval in separate subresolver, and the Kyma runtime agent to stop retrieving specs

Changes proposed in this pull request:
- Temporary return empty specs 


**Pull Request status**
<!-- Feel free to construct the checklist with whatever items seem most reasonable for your change. You could disassemble the Implementation part to even smaller separate checklist items if you're working on something big for example. But do make the effort to provide a checklist of some sort so that the core team as well as the community can have an idea about the progress of your Pull Request.
-->

- [x] Implementation
- [x] Unit tests
- [ ] Integration tests
- [x] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [ ] Mocks are regenerated, using the automated script
