### PR TITLE
Fix label api_id in ord aggregation notifications

### DIFF
--- a/chart/compass/templates/additional-prometheus-rules.yaml
+++ b/chart/compass/templates/additional-prometheus-rules.yaml
@@ -133,7 +133,7 @@ spec:
       {{- end }}
         - alert: ORDAggregationValidationErrors
           annotations:
-            description: Aggregation for api_id = {{`{{`}} $labels.api_id {{`}}`}}, x-request-id = {{`{{`}} $labels.x_request_id {{`}}`}} failed with error = {{`{{`}} $labels.error {{`}}`}}
+            description: Aggregation for app_id = {{`{{`}} $labels.app_id {{`}}`}}, x-request-id = {{`{{`}} $labels.x_request_id {{`}}`}} failed with error = {{`{{`}} $labels.error {{`}}`}}
           expr: delta(compass_ordaggregator_compass_ord_aggregator_job_sync_failure_number[1m]) >= 0
           for: 0m
           labels:

--- a/components/director/internal/metrics/const.go
+++ b/components/director/internal/metrics/const.go
@@ -15,8 +15,8 @@ const (
 	OrdAggregatorSubsystem = "ordaggregator"
 	// ErrorMetricLabel is the error label used by metrics config for creating CounterVec for Prometheus
 	ErrorMetricLabel = "error"
-	// APIIDMetricLabel is an additional label used by ord aggregator for creating CounterVec for Prometheus
-	APIIDMetricLabel = "api_id"
+	// APPIDMetricLabel is an additional label used by ord aggregator for creating CounterVec for Prometheus
+	APPIDMetricLabel = "app_id"
 	// CorrelationIDMetricLabel is an additional label used by ord aggregator for creating CounterVec for Prometheus
 	CorrelationIDMetricLabel = "x_request_id"
 )

--- a/components/director/internal/open_resource_discovery/service.go
+++ b/components/director/internal/open_resource_discovery/service.go
@@ -1132,7 +1132,7 @@ func (s *Service) processWebhookAndDocuments(ctx context.Context, cfg MetricsCon
 		MetricName: strings.ReplaceAll(strings.ToLower(cfg.JobName), "-", "_") + "_job_sync_failure_number",
 		Timeout:    cfg.ClientTimeout,
 		Subsystem:  metrics.OrdAggregatorSubsystem,
-		Labels:     []string{metrics.ErrorMetricLabel, metrics.APIIDMetricLabel, metrics.CorrelationIDMetricLabel},
+		Labels:     []string{metrics.ErrorMetricLabel, metrics.APPIDMetricLabel, metrics.CorrelationIDMetricLabel},
 	}
 
 	if webhook.Type == model.WebhookTypeOpenResourceDiscovery && webhook.URL != nil {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Replace api_id with app_id in ord notifications.

Changes proposed in this pull request:
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- ...

**Pull Request status**
<!-- Feel free to construct the checklist with whatever items seem most reasonable for your change. You could disassemble the Implementation part to even smaller separate checklist items if you're working on something big for example. But do make the effort to provide a checklist of some sort so that the core team as well as the community can have an idea about the progress of your Pull Request.
-->

- [ ] Implementation
- [ ] Unit tests
- [ ] Integration tests
- [ ] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [ ] Mocks are regenerated, using the automated script
