### PR TITLE
Fix assign to formation from ASA

### DIFF
--- a/components/director/internal/domain/formation/assign_formation_test.go
+++ b/components/director/internal/domain/formation/assign_formation_test.go
@@ -636,7 +636,7 @@ func TestServiceAssignFormation(t *testing.T) {
 			RuntimeRepoFN: func() *automock.RuntimeRepository {
 				runtimeRepo := &automock.RuntimeRepository{}
 				runtimeRepo.On("ListOwnedRuntimes", ctx, TargetTenant, runtimeLblFilters).Return(make([]*model.Runtime, 0), nil).Once()
-				runtimeRepo.On("ListAll", ctx, TargetTenant, runtimeLblFilters).Return(make([]*model.Runtime, 0), nil).Once()
+				runtimeRepo.On("ListAllWithUnionSetCombination", ctx, TargetTenant, runtimeLblFilters).Return(make([]*model.Runtime, 0), nil).Once()
 				return runtimeRepo
 			},
 			FormationRepositoryFn: func() *automock.FormationRepository {

--- a/components/director/internal/domain/formation/automock/automatic_formation_assignment_repository.go
+++ b/components/director/internal/domain/formation/automock/automatic_formation_assignment_repository.go
@@ -80,13 +80,13 @@ func (_m *AutomaticFormationAssignmentRepository) ListAll(ctx context.Context, t
 	return r0, r1
 }
 
-type mockConstructorTestingTNewAutomaticFormationAssignmentRepository interface {
+type NewAutomaticFormationAssignmentRepositoryT interface {
 	mock.TestingT
 	Cleanup(func())
 }
 
 // NewAutomaticFormationAssignmentRepository creates a new instance of AutomaticFormationAssignmentRepository. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
-func NewAutomaticFormationAssignmentRepository(t mockConstructorTestingTNewAutomaticFormationAssignmentRepository) *AutomaticFormationAssignmentRepository {
+func NewAutomaticFormationAssignmentRepository(t NewAutomaticFormationAssignmentRepositoryT) *AutomaticFormationAssignmentRepository {
 	mock := &AutomaticFormationAssignmentRepository{}
 	mock.Mock.Test(t)
 

--- a/components/director/internal/domain/formation/automock/automatic_formation_assignment_service.go
+++ b/components/director/internal/domain/formation/automock/automatic_formation_assignment_service.go
@@ -36,13 +36,13 @@ func (_m *AutomaticFormationAssignmentService) GetForScenarioName(ctx context.Co
 	return r0, r1
 }
 
-type mockConstructorTestingTNewAutomaticFormationAssignmentService interface {
+type NewAutomaticFormationAssignmentServiceT interface {
 	mock.TestingT
 	Cleanup(func())
 }
 
 // NewAutomaticFormationAssignmentService creates a new instance of AutomaticFormationAssignmentService. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
-func NewAutomaticFormationAssignmentService(t mockConstructorTestingTNewAutomaticFormationAssignmentService) *AutomaticFormationAssignmentService {
+func NewAutomaticFormationAssignmentService(t NewAutomaticFormationAssignmentServiceT) *AutomaticFormationAssignmentService {
 	mock := &AutomaticFormationAssignmentService{}
 	mock.Mock.Test(t)
 

--- a/components/director/internal/domain/formation/automock/formation_repository.go
+++ b/components/director/internal/domain/formation/automock/formation_repository.go
@@ -112,13 +112,13 @@ func (_m *FormationRepository) List(ctx context.Context, tenant string, pageSize
 	return r0, r1
 }
 
-type mockConstructorTestingTNewFormationRepository interface {
+type NewFormationRepositoryT interface {
 	mock.TestingT
 	Cleanup(func())
 }
 
 // NewFormationRepository creates a new instance of FormationRepository. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
-func NewFormationRepository(t mockConstructorTestingTNewFormationRepository) *FormationRepository {
+func NewFormationRepository(t NewFormationRepositoryT) *FormationRepository {
 	mock := &FormationRepository{}
 	mock.Mock.Test(t)
 

--- a/components/director/internal/domain/formation/automock/formation_template_repository.go
+++ b/components/director/internal/domain/formation/automock/formation_template_repository.go
@@ -61,13 +61,13 @@ func (_m *FormationTemplateRepository) GetByName(ctx context.Context, templateNa
 	return r0, r1
 }
 
-type mockConstructorTestingTNewFormationTemplateRepository interface {
+type NewFormationTemplateRepositoryT interface {
 	mock.TestingT
 	Cleanup(func())
 }
 
 // NewFormationTemplateRepository creates a new instance of FormationTemplateRepository. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
-func NewFormationTemplateRepository(t mockConstructorTestingTNewFormationTemplateRepository) *FormationTemplateRepository {
+func NewFormationTemplateRepository(t NewFormationTemplateRepositoryT) *FormationTemplateRepository {
 	mock := &FormationTemplateRepository{}
 	mock.Mock.Test(t)
 

--- a/components/director/internal/domain/formation/automock/label_def_repository.go
+++ b/components/director/internal/domain/formation/automock/label_def_repository.go
@@ -52,13 +52,13 @@ func (_m *LabelDefRepository) UpdateWithVersion(ctx context.Context, def model.L
 	return r0
 }
 
-type mockConstructorTestingTNewLabelDefRepository interface {
+type NewLabelDefRepositoryT interface {
 	mock.TestingT
 	Cleanup(func())
 }
 
 // NewLabelDefRepository creates a new instance of LabelDefRepository. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
-func NewLabelDefRepository(t mockConstructorTestingTNewLabelDefRepository) *LabelDefRepository {
+func NewLabelDefRepository(t NewLabelDefRepositoryT) *LabelDefRepository {
 	mock := &LabelDefRepository{}
 	mock.Mock.Test(t)
 

--- a/components/director/internal/domain/formation/automock/label_def_service.go
+++ b/components/director/internal/domain/formation/automock/label_def_service.go
@@ -78,13 +78,13 @@ func (_m *LabelDefService) ValidateExistingLabelsAgainstSchema(ctx context.Conte
 	return r0
 }
 
-type mockConstructorTestingTNewLabelDefService interface {
+type NewLabelDefServiceT interface {
 	mock.TestingT
 	Cleanup(func())
 }
 
 // NewLabelDefService creates a new instance of LabelDefService. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
-func NewLabelDefService(t mockConstructorTestingTNewLabelDefService) *LabelDefService {
+func NewLabelDefService(t NewLabelDefServiceT) *LabelDefService {
 	mock := &LabelDefService{}
 	mock.Mock.Test(t)
 

--- a/components/director/internal/domain/formation/automock/label_repository.go
+++ b/components/director/internal/domain/formation/automock/label_repository.go
@@ -75,13 +75,13 @@ func (_m *LabelRepository) ListForObjectIDs(ctx context.Context, tenant string, 
 	return r0, r1
 }
 
-type mockConstructorTestingTNewLabelRepository interface {
+type NewLabelRepositoryT interface {
 	mock.TestingT
 	Cleanup(func())
 }
 
 // NewLabelRepository creates a new instance of LabelRepository. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
-func NewLabelRepository(t mockConstructorTestingTNewLabelRepository) *LabelRepository {
+func NewLabelRepository(t NewLabelRepositoryT) *LabelRepository {
 	mock := &LabelRepository{}
 	mock.Mock.Test(t)
 

--- a/components/director/internal/domain/formation/automock/label_service.go
+++ b/components/director/internal/domain/formation/automock/label_service.go
@@ -66,13 +66,13 @@ func (_m *LabelService) UpdateLabel(ctx context.Context, tenant string, id strin
 	return r0
 }
 
-type mockConstructorTestingTNewLabelService interface {
+type NewLabelServiceT interface {
 	mock.TestingT
 	Cleanup(func())
 }
 
 // NewLabelService creates a new instance of LabelService. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
-func NewLabelService(t mockConstructorTestingTNewLabelService) *LabelService {
+func NewLabelService(t NewLabelServiceT) *LabelService {
 	mock := &LabelService{}
 	mock.Mock.Test(t)
 

--- a/components/director/internal/domain/formation/automock/notifications_service.go
+++ b/components/director/internal/domain/formation/automock/notifications_service.go
@@ -42,13 +42,13 @@ func (_m *NotificationsService) GenerateNotifications(ctx context.Context, tenan
 	return r0, r1
 }
 
-type mockConstructorTestingTNewNotificationsService interface {
+type NewNotificationsServiceT interface {
 	mock.TestingT
 	Cleanup(func())
 }
 
 // NewNotificationsService creates a new instance of NotificationsService. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
-func NewNotificationsService(t mockConstructorTestingTNewNotificationsService) *NotificationsService {
+func NewNotificationsService(t NewNotificationsServiceT) *NotificationsService {
 	mock := &NotificationsService{}
 	mock.Mock.Test(t)
 

--- a/components/director/internal/domain/formation/automock/runtime_context_repository.go
+++ b/components/director/internal/domain/formation/automock/runtime_context_repository.go
@@ -151,13 +151,13 @@ func (_m *RuntimeContextRepository) ListByScenariosAndRuntimeIDs(ctx context.Con
 	return r0, r1
 }
 
-type mockConstructorTestingTNewRuntimeContextRepository interface {
+type NewRuntimeContextRepositoryT interface {
 	mock.TestingT
 	Cleanup(func())
 }
 
 // NewRuntimeContextRepository creates a new instance of RuntimeContextRepository. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
-func NewRuntimeContextRepository(t mockConstructorTestingTNewRuntimeContextRepository) *RuntimeContextRepository {
+func NewRuntimeContextRepository(t NewRuntimeContextRepositoryT) *RuntimeContextRepository {
 	mock := &RuntimeContextRepository{}
 	mock.Mock.Test(t)
 

--- a/components/director/internal/domain/formation/automock/runtime_repository.go
+++ b/components/director/internal/domain/formation/automock/runtime_repository.go
@@ -17,8 +17,8 @@ type RuntimeRepository struct {
 	mock.Mock
 }
 
-// GetByFiltersAndID provides a mock function with given fields: ctx, tenant, id, filter
-func (_m *RuntimeRepository) GetByFiltersAndID(ctx context.Context, tenant string, id string, filter []*labelfilter.LabelFilter) (*model.Runtime, error) {
+// GetByFiltersAndIDUsingUnion provides a mock function with given fields: ctx, tenant, id, filter
+func (_m *RuntimeRepository) GetByFiltersAndIDUsingUnion(ctx context.Context, tenant string, id string, filter []*labelfilter.LabelFilter) (*model.Runtime, error) {
 	ret := _m.Called(ctx, tenant, id, filter)
 
 	var r0 *model.Runtime
@@ -65,6 +65,29 @@ func (_m *RuntimeRepository) GetByID(ctx context.Context, tenant string, id stri
 
 // ListAll provides a mock function with given fields: ctx, tenant, filter
 func (_m *RuntimeRepository) ListAll(ctx context.Context, tenant string, filter []*labelfilter.LabelFilter) ([]*model.Runtime, error) {
+	ret := _m.Called(ctx, tenant, filter)
+
+	var r0 []*model.Runtime
+	if rf, ok := ret.Get(0).(func(context.Context, string, []*labelfilter.LabelFilter) []*model.Runtime); ok {
+		r0 = rf(ctx, tenant, filter)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*model.Runtime)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, string, []*labelfilter.LabelFilter) error); ok {
+		r1 = rf(ctx, tenant, filter)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// ListAllWithUnionSetCombination provides a mock function with given fields: ctx, tenant, filter
+func (_m *RuntimeRepository) ListAllWithUnionSetCombination(ctx context.Context, tenant string, filter []*labelfilter.LabelFilter) ([]*model.Runtime, error) {
 	ret := _m.Called(ctx, tenant, filter)
 
 	var r0 []*model.Runtime
@@ -199,13 +222,13 @@ func (_m *RuntimeRepository) OwnerExistsByFiltersAndID(ctx context.Context, tena
 	return r0, r1
 }
 
-type mockConstructorTestingTNewRuntimeRepository interface {
+type NewRuntimeRepositoryT interface {
 	mock.TestingT
 	Cleanup(func())
 }
 
 // NewRuntimeRepository creates a new instance of RuntimeRepository. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
-func NewRuntimeRepository(t mockConstructorTestingTNewRuntimeRepository) *RuntimeRepository {
+func NewRuntimeRepository(t NewRuntimeRepositoryT) *RuntimeRepository {
 	mock := &RuntimeRepository{}
 	mock.Mock.Test(t)
 

--- a/components/director/internal/domain/formation/automock/tenant_service.go
+++ b/components/director/internal/domain/formation/automock/tenant_service.go
@@ -34,13 +34,13 @@ func (_m *TenantService) GetInternalTenant(ctx context.Context, externalTenant s
 	return r0, r1
 }
 
-type mockConstructorTestingTNewTenantService interface {
+type NewTenantServiceT interface {
 	mock.TestingT
 	Cleanup(func())
 }
 
 // NewTenantService creates a new instance of TenantService. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
-func NewTenantService(t mockConstructorTestingTNewTenantService) *TenantService {
+func NewTenantService(t NewTenantServiceT) *TenantService {
 	mock := &TenantService{}
 	mock.Mock.Test(t)
 

--- a/components/director/internal/domain/formation/automock/uuid_service.go
+++ b/components/director/internal/domain/formation/automock/uuid_service.go
@@ -23,13 +23,13 @@ func (_m *UuidService) Generate() string {
 	return r0
 }
 
-type mockConstructorTestingTNewUuidService interface {
+type NewUuidServiceT interface {
 	mock.TestingT
 	Cleanup(func())
 }
 
 // NewUuidService creates a new instance of UuidService. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
-func NewUuidService(t mockConstructorTestingTNewUuidService) *UuidService {
+func NewUuidService(t NewUuidServiceT) *UuidService {
 	mock := &UuidService{}
 	mock.Mock.Test(t)
 

--- a/components/director/internal/domain/formation/service_test.go
+++ b/components/director/internal/domain/formation/service_test.go
@@ -883,7 +883,7 @@ func TestService_CreateAutomaticScenarioAssignment(t *testing.T) {
 			RuntimeRepoFN: func() *automock.RuntimeRepository {
 				runtimeRepo := &automock.RuntimeRepository{}
 				runtimeRepo.On("ListOwnedRuntimes", ctx, TargetTenantID, runtimeLblFilters).Return(ownedRuntimes, nil).Once()
-				runtimeRepo.On("ListAll", ctx, TargetTenantID, runtimeLblFilters).Return(runtimes, nil).Once()
+				runtimeRepo.On("ListAllWithUnionSetCombination", ctx, TargetTenantID, runtimeLblFilters).Return(runtimes, nil).Once()
 				return runtimeRepo
 			},
 			RuntimeContextRepoFn: func() *automock.RuntimeContextRepository {
@@ -966,7 +966,7 @@ func TestService_CreateAutomaticScenarioAssignment(t *testing.T) {
 			RuntimeRepoFN: func() *automock.RuntimeRepository {
 				runtimeRepo := &automock.RuntimeRepository{}
 				runtimeRepo.On("ListOwnedRuntimes", ctx, TargetTenantID, runtimeLblFilters).Return(ownedRuntimes, nil).Once()
-				runtimeRepo.On("ListAll", ctx, TargetTenantID, runtimeLblFilters).Return(runtimes, nil).Once()
+				runtimeRepo.On("ListAllWithUnionSetCombination", ctx, TargetTenantID, runtimeLblFilters).Return(runtimes, nil).Once()
 				return runtimeRepo
 			},
 			RuntimeContextRepoFn: func() *automock.RuntimeContextRepository {
@@ -1046,7 +1046,7 @@ func TestService_CreateAutomaticScenarioAssignment(t *testing.T) {
 			RuntimeRepoFN: func() *automock.RuntimeRepository {
 				runtimeRepo := &automock.RuntimeRepository{}
 				runtimeRepo.On("ListOwnedRuntimes", ctx, TargetTenantID, runtimeLblFilters).Return(ownedRuntimes, nil).Once()
-				runtimeRepo.On("ListAll", ctx, TargetTenantID, runtimeLblFilters).Return(runtimes, nil).Once()
+				runtimeRepo.On("ListAllWithUnionSetCombination", ctx, TargetTenantID, runtimeLblFilters).Return(runtimes, nil).Once()
 				return runtimeRepo
 			},
 			RuntimeContextRepoFn: func() *automock.RuntimeContextRepository {
@@ -1105,7 +1105,7 @@ func TestService_CreateAutomaticScenarioAssignment(t *testing.T) {
 			RuntimeRepoFN: func() *automock.RuntimeRepository {
 				runtimeRepo := &automock.RuntimeRepository{}
 				runtimeRepo.On("ListOwnedRuntimes", ctx, TargetTenantID, runtimeLblFilters).Return(ownedRuntimes, nil).Once()
-				runtimeRepo.On("ListAll", ctx, TargetTenantID, runtimeLblFilters).Return(nil, testErr).Once()
+				runtimeRepo.On("ListAllWithUnionSetCombination", ctx, TargetTenantID, runtimeLblFilters).Return(nil, testErr).Once()
 				return runtimeRepo
 			},
 			RuntimeContextRepoFn: func() *automock.RuntimeContextRepository {
@@ -1477,7 +1477,7 @@ func TestService_DeleteManyASAForSameTargetTenant(t *testing.T) {
 		runtimeRepo := &automock.RuntimeRepository{}
 		runtimeRepo.On("ListOwnedRuntimes", ctx, TargetTenantID, runtimeLblFilters).Return(make([]*model.Runtime, 0), nil).Twice()
 
-		runtimeRepo.On("ListAll", ctx, TargetTenantID, runtimeLblFilters).Return(make([]*model.Runtime, 0), nil).Twice()
+		runtimeRepo.On("ListAllWithUnionSetCombination", ctx, TargetTenantID, runtimeLblFilters).Return(make([]*model.Runtime, 0), nil).Twice()
 
 		formationRepo := &automock.FormationRepository{}
 		formationRepo.On("GetByName", ctx, scenarioNameA, "").Return(formations[0], nil).Once()
@@ -1751,7 +1751,7 @@ func TestService_DeleteAutomaticScenarioAssignment(t *testing.T) {
 			RuntimeRepoFN: func() *automock.RuntimeRepository {
 				runtimeRepo := &automock.RuntimeRepository{}
 				runtimeRepo.On("ListOwnedRuntimes", ctx, TargetTenantID, runtimeLblFilters).Return(ownedRuntimes, nil).Once()
-				runtimeRepo.On("ListAll", ctx, TargetTenantID, runtimeLblFilters).Return(runtimes, nil).Once()
+				runtimeRepo.On("ListAllWithUnionSetCombination", ctx, TargetTenantID, runtimeLblFilters).Return(runtimes, nil).Once()
 
 				return runtimeRepo
 			},
@@ -1837,7 +1837,7 @@ func TestService_DeleteAutomaticScenarioAssignment(t *testing.T) {
 			RuntimeRepoFN: func() *automock.RuntimeRepository {
 				runtimeRepo := &automock.RuntimeRepository{}
 				runtimeRepo.On("ListOwnedRuntimes", ctx, TargetTenantID, runtimeLblFilters).Return(ownedRuntimes, nil).Once()
-				runtimeRepo.On("ListAll", ctx, TargetTenantID, runtimeLblFilters).Return(runtimes, nil).Once()
+				runtimeRepo.On("ListAllWithUnionSetCombination", ctx, TargetTenantID, runtimeLblFilters).Return(runtimes, nil).Once()
 				return runtimeRepo
 			},
 			RuntimeContextRepoFn: func() *automock.RuntimeContextRepository {
@@ -1916,7 +1916,7 @@ func TestService_DeleteAutomaticScenarioAssignment(t *testing.T) {
 			RuntimeRepoFN: func() *automock.RuntimeRepository {
 				runtimeRepo := &automock.RuntimeRepository{}
 				runtimeRepo.On("ListOwnedRuntimes", ctx, TargetTenantID, runtimeLblFilters).Return(ownedRuntimes, nil).Once()
-				runtimeRepo.On("ListAll", ctx, TargetTenantID, runtimeLblFilters).Return(runtimes, nil).Once()
+				runtimeRepo.On("ListAllWithUnionSetCombination", ctx, TargetTenantID, runtimeLblFilters).Return(runtimes, nil).Once()
 				return runtimeRepo
 			},
 			RuntimeContextRepoFn: func() *automock.RuntimeContextRepository {
@@ -1982,7 +1982,7 @@ func TestService_DeleteAutomaticScenarioAssignment(t *testing.T) {
 			RuntimeRepoFN: func() *automock.RuntimeRepository {
 				runtimeRepo := &automock.RuntimeRepository{}
 				runtimeRepo.On("ListOwnedRuntimes", ctx, TargetTenantID, runtimeLblFilters).Return(ownedRuntimes, nil).Once()
-				runtimeRepo.On("ListAll", ctx, TargetTenantID, runtimeLblFilters).Return(nil, testErr).Once()
+				runtimeRepo.On("ListAllWithUnionSetCombination", ctx, TargetTenantID, runtimeLblFilters).Return(nil, testErr).Once()
 				return runtimeRepo
 			},
 			RuntimeContextRepoFn: func() *automock.RuntimeContextRepository {
@@ -2458,7 +2458,7 @@ func TestService_EnsureScenarioAssigned(t *testing.T) {
 			RuntimeRepoFN: func() *automock.RuntimeRepository {
 				runtimeRepo := &automock.RuntimeRepository{}
 				runtimeRepo.On("ListOwnedRuntimes", ctx, TargetTenantID, runtimeLblFilters).Return(ownedRuntimes, nil).Once()
-				runtimeRepo.On("ListAll", ctx, TargetTenantID, runtimeLblFilters).Return(runtimes, nil).Once()
+				runtimeRepo.On("ListAllWithUnionSetCombination", ctx, TargetTenantID, runtimeLblFilters).Return(runtimes, nil).Once()
 				return runtimeRepo
 			},
 			RuntimeContextRepoFn: func() *automock.RuntimeContextRepository {
@@ -2533,7 +2533,7 @@ func TestService_EnsureScenarioAssigned(t *testing.T) {
 			RuntimeRepoFN: func() *automock.RuntimeRepository {
 				runtimeRepo := &automock.RuntimeRepository{}
 				runtimeRepo.On("ListOwnedRuntimes", ctx, TargetTenantID, runtimeLblFilters).Return(ownedRuntimes, nil).Once()
-				runtimeRepo.On("ListAll", ctx, TargetTenantID, runtimeLblFilters).Return(runtimes, nil).Once()
+				runtimeRepo.On("ListAllWithUnionSetCombination", ctx, TargetTenantID, runtimeLblFilters).Return(runtimes, nil).Once()
 				return runtimeRepo
 			},
 			RuntimeContextRepoFn: func() *automock.RuntimeContextRepository {
@@ -2606,7 +2606,7 @@ func TestService_EnsureScenarioAssigned(t *testing.T) {
 			RuntimeRepoFN: func() *automock.RuntimeRepository {
 				runtimeRepo := &automock.RuntimeRepository{}
 				runtimeRepo.On("ListOwnedRuntimes", ctx, TargetTenantID, runtimeLblFilters).Return(ownedRuntimes, nil).Once()
-				runtimeRepo.On("ListAll", ctx, TargetTenantID, runtimeLblFilters).Return(runtimes, nil).Once()
+				runtimeRepo.On("ListAllWithUnionSetCombination", ctx, TargetTenantID, runtimeLblFilters).Return(runtimes, nil).Once()
 				return runtimeRepo
 			},
 			RuntimeContextRepoFn: func() *automock.RuntimeContextRepository {
@@ -2657,7 +2657,7 @@ func TestService_EnsureScenarioAssigned(t *testing.T) {
 			RuntimeRepoFN: func() *automock.RuntimeRepository {
 				runtimeRepo := &automock.RuntimeRepository{}
 				runtimeRepo.On("ListOwnedRuntimes", ctx, TargetTenantID, runtimeLblFilters).Return(ownedRuntimes, nil).Once()
-				runtimeRepo.On("ListAll", ctx, TargetTenantID, runtimeLblFilters).Return(nil, testErr).Once()
+				runtimeRepo.On("ListAllWithUnionSetCombination", ctx, TargetTenantID, runtimeLblFilters).Return(nil, testErr).Once()
 				return runtimeRepo
 			},
 			RuntimeContextRepoFn: func() *automock.RuntimeContextRepository {
@@ -3023,7 +3023,7 @@ func TestService_RemoveAssignedScenario(t *testing.T) {
 			RuntimeRepoFN: func() *automock.RuntimeRepository {
 				runtimeRepo := &automock.RuntimeRepository{}
 				runtimeRepo.On("ListOwnedRuntimes", ctx, TargetTenantID, runtimeLblFilters).Return(ownedRuntimes, nil).Once()
-				runtimeRepo.On("ListAll", ctx, TargetTenantID, runtimeLblFilters).Return(runtimes, nil).Once()
+				runtimeRepo.On("ListAllWithUnionSetCombination", ctx, TargetTenantID, runtimeLblFilters).Return(runtimes, nil).Once()
 				return runtimeRepo
 			},
 			RuntimeContextRepoFn: func() *automock.RuntimeContextRepository {
@@ -3105,7 +3105,7 @@ func TestService_RemoveAssignedScenario(t *testing.T) {
 			RuntimeRepoFN: func() *automock.RuntimeRepository {
 				runtimeRepo := &automock.RuntimeRepository{}
 				runtimeRepo.On("ListOwnedRuntimes", ctx, TargetTenantID, runtimeLblFilters).Return(ownedRuntimes, nil).Once()
-				runtimeRepo.On("ListAll", ctx, TargetTenantID, runtimeLblFilters).Return(runtimes, nil).Once()
+				runtimeRepo.On("ListAllWithUnionSetCombination", ctx, TargetTenantID, runtimeLblFilters).Return(runtimes, nil).Once()
 
 				return runtimeRepo
 			},
@@ -3182,7 +3182,7 @@ func TestService_RemoveAssignedScenario(t *testing.T) {
 			RuntimeRepoFN: func() *automock.RuntimeRepository {
 				runtimeRepo := &automock.RuntimeRepository{}
 				runtimeRepo.On("ListOwnedRuntimes", ctx, TargetTenantID, runtimeLblFilters).Return(ownedRuntimes, nil).Once()
-				runtimeRepo.On("ListAll", ctx, TargetTenantID, runtimeLblFilters).Return(runtimes, nil).Once()
+				runtimeRepo.On("ListAllWithUnionSetCombination", ctx, TargetTenantID, runtimeLblFilters).Return(runtimes, nil).Once()
 				return runtimeRepo
 			},
 			RuntimeContextRepoFn: func() *automock.RuntimeContextRepository {
@@ -3245,7 +3245,7 @@ func TestService_RemoveAssignedScenario(t *testing.T) {
 			RuntimeRepoFN: func() *automock.RuntimeRepository {
 				runtimeRepo := &automock.RuntimeRepository{}
 				runtimeRepo.On("ListOwnedRuntimes", ctx, TargetTenantID, runtimeLblFilters).Return(ownedRuntimes, nil).Once()
-				runtimeRepo.On("ListAll", ctx, TargetTenantID, runtimeLblFilters).Return(nil, testErr).Once()
+				runtimeRepo.On("ListAllWithUnionSetCombination", ctx, TargetTenantID, runtimeLblFilters).Return(nil, testErr).Once()
 				return runtimeRepo
 			},
 			RuntimeContextRepoFn: func() *automock.RuntimeContextRepository {
@@ -3801,8 +3801,8 @@ func TestService_GetScenariosFromMatchingASAs(t *testing.T) {
 			},
 			RuntimeRepoFn: func() *automock.RuntimeRepository {
 				runtimeRepo := &automock.RuntimeRepository{}
-				runtimeRepo.On("GetByFiltersAndID", ctx, testScenarios[0].TargetTenantID, rtmCtx.RuntimeID, runtimeLblFilters).Return(&model.Runtime{}, nil).Once()
-				runtimeRepo.On("GetByFiltersAndID", ctx, testScenarios[1].TargetTenantID, rtmCtx2.RuntimeID, runtimeLblFilters).Return(nil, notFoudErr).Once()
+				runtimeRepo.On("GetByFiltersAndIDUsingUnion", ctx, testScenarios[0].TargetTenantID, rtmCtx.RuntimeID, runtimeLblFilters).Return(&model.Runtime{}, nil).Once()
+				runtimeRepo.On("GetByFiltersAndIDUsingUnion", ctx, testScenarios[1].TargetTenantID, rtmCtx2.RuntimeID, runtimeLblFilters).Return(nil, notFoudErr).Once()
 				return runtimeRepo
 			},
 			FormationRepoFn: func() *automock.FormationRepository {
@@ -3895,7 +3895,7 @@ func TestService_GetScenariosFromMatchingASAs(t *testing.T) {
 			},
 			RuntimeRepoFn: func() *automock.RuntimeRepository {
 				runtimeRepo := &automock.RuntimeRepository{}
-				runtimeRepo.On("GetByFiltersAndID", ctx, testScenarios[0].TargetTenantID, rtmCtx.RuntimeID, runtimeLblFilters).Return(nil, testErr).Once()
+				runtimeRepo.On("GetByFiltersAndIDUsingUnion", ctx, testScenarios[0].TargetTenantID, rtmCtx.RuntimeID, runtimeLblFilters).Return(nil, testErr).Once()
 				return runtimeRepo
 			},
 			FormationRepoFn: func() *automock.FormationRepository {

--- a/components/director/internal/domain/formation/unassign_formation_test.go
+++ b/components/director/internal/domain/formation/unassign_formation_test.go
@@ -645,7 +645,7 @@ func TestServiceUnassignFormation(t *testing.T) {
 			RuntimeRepoFN: func() *automock.RuntimeRepository {
 				runtimeRepo := &automock.RuntimeRepository{}
 				runtimeRepo.On("ListOwnedRuntimes", ctx, asa.TargetTenantID, runtimeLblFilters).Return(make([]*model.Runtime, 0), nil).Once()
-				runtimeRepo.On("ListAll", ctx, asa.TargetTenantID, runtimeLblFilters).Return(make([]*model.Runtime, 0), nil).Once()
+				runtimeRepo.On("ListAllWithUnionSetCombination", ctx, asa.TargetTenantID, runtimeLblFilters).Return(make([]*model.Runtime, 0), nil).Once()
 				return runtimeRepo
 			},
 			FormationRepositoryFn: func() *automock.FormationRepository {

--- a/components/director/pkg/graphql/app_template_validation_test.go
+++ b/components/director/pkg/graphql/app_template_validation_test.go
@@ -126,7 +126,7 @@ func TestApplicationTemplateInput_Validate_Description(t *testing.T) {
 		Valid bool
 	}{
 		{
-			Name:  "Valid",
+			Name: "Valid",
 			Value: str.Ptr("valid	valid"),
 			Valid: true,
 		},
@@ -476,7 +476,7 @@ func TestApplicationTemplateUpdateInput_Validate_Description(t *testing.T) {
 		Valid bool
 	}{
 		{
-			Name:  "Valid",
+			Name: "Valid",
 			Value: str.Ptr("valid	valid"),
 			Valid: true,
 		},
@@ -716,7 +716,7 @@ func TestPlaceholderDefinitionInput_Validate_Description(t *testing.T) {
 		Valid bool
 	}{
 		{
-			Name:  "Valid",
+			Name: "Valid",
 			Value: str.Ptr("valid	valid"),
 			Valid: true,
 		},

--- a/tests/director/tests/formation_api_test.go
+++ b/tests/director/tests/formation_api_test.go
@@ -581,7 +581,8 @@ func TestRuntimeContextsFormationProcessingFromASA(stdT *testing.T) {
 		// Create provider formation template
 		providerFormationTmplName := "provider-formation-template-name"
 		providerAppTypes := []string{"provider-app-type-1", "provider-app-type-2"}
-		providerFT := createFormationTemplate(t, ctx, providerFormationTmplName, conf.SubscriptionProviderAppNameValue, providerAppTypes, graphql.ArtifactTypeSubscription)
+		runtimeTypes := []string{conf.SubscriptionProviderAppNameValue, "runtime-type-2"}
+		providerFT := createFormationTemplateWithMultipleRuntimeTypes(t, ctx, providerFormationTmplName, runtimeTypes, providerAppTypes, graphql.ArtifactTypeSubscription)
 		defer fixtures.CleanupFormationTemplate(t, ctx, certSecuredGraphQLClient, providerFT.ID)
 
 		// Create kyma formation
@@ -2948,6 +2949,26 @@ func createFormationTemplate(t *testing.T, ctx context.Context, formationTemplat
 		Name:                   formationTemplateName,
 		ApplicationTypes:       applicationTypes,
 		RuntimeTypes:           []string{runtimeType},
+		RuntimeTypeDisplayName: formationTemplateName,
+		RuntimeArtifactKind:    runtimeArtifactKind,
+	}
+
+	formationTmplGQLInput, err := testctx.Tc.Graphqlizer.FormationTemplateInputToGQL(formationTmplInput)
+	require.NoError(t, err)
+	formationTmplRequest := fixtures.FixCreateFormationTemplateRequest(formationTmplGQLInput)
+
+	ft := graphql.FormationTemplate{}
+	t.Logf("Creating formation template with name: %q", formationTemplateName)
+	err = testctx.Tc.RunOperationWithoutTenant(ctx, certSecuredGraphQLClient, formationTmplRequest, &ft)
+	require.NoError(t, err)
+	return ft
+}
+
+func createFormationTemplateWithMultipleRuntimeTypes(t *testing.T, ctx context.Context, formationTemplateName string, runtimeTypes []string, applicationTypes []string, runtimeArtifactKind graphql.ArtifactType) graphql.FormationTemplate {
+	formationTmplInput := graphql.FormationTemplateInput{
+		Name:                   formationTemplateName,
+		ApplicationTypes:       applicationTypes,
+		RuntimeTypes:           runtimeTypes,
 		RuntimeTypeDisplayName: formationTemplateName,
 		RuntimeArtifactKind:    runtimeArtifactKind,
 	}


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:
- Use Union SetCombination when listing runtimes matching formationTemplate. For formationTemplates that supports more than one runtimeType list runtimes of any of the runtimeTypes
- Use Union SetCombination when checking for OwnedRuntime existence
- Use formationTemplate with two runtimeTypes in e2e tests

**Pull Request status**

- [ x] Implementation
- [ x] Unit tests
- [ x] Integration tests
- [ ] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [ x] Mocks are regenerated, using the automated script
