### PR TITLE
Add log for existing app template subscription

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -127,7 +127,7 @@ global:
       name: compass-pairing-adapter
     director:
       dir:
-      version: "PR-2777"
+      version: "PR-2794"
       name: compass-director
     hydrator:
       dir:

--- a/components/director/internal/domain/subscription/service.go
+++ b/components/director/internal/domain/subscription/service.go
@@ -310,6 +310,7 @@ func (s *service) SubscribeTenantToApplication(ctx context.Context, providerID, 
 	for _, app := range applications {
 		if str.PtrStrToStr(app.ApplicationTemplateID) == appTemplate.ID {
 			// Already subscribed
+			log.C(ctx).Infof("Consumer %q is already subscribed", consumerTenantID)
 			return true, nil
 		}
 	}


### PR DESCRIPTION
# Add log for existing app subscription

**Description**

Improve traceability in case an existing tenant subscription related to an app template exists.