### PR TITLE
Adjust app name and rune limits

### DIFF
--- a/components/director/pkg/graphql/api_validation.go
+++ b/components/director/pkg/graphql/api_validation.go
@@ -10,7 +10,7 @@ import (
 // Validate missing godoc
 func (i APIDefinitionInput) Validate() error {
 	return validation.ValidateStruct(&i,
-		validation.Field(&i.Name, validation.Required, is.PrintableASCII, validation.Length(1, 100)),
+		validation.Field(&i.Name, validation.Required, is.PrintableASCII, validation.Length(1, appNameLengthLimit)),
 		validation.Field(&i.Description, validation.RuneLength(0, descriptionStringLengthLimit)),
 		validation.Field(&i.TargetURL, validation.Required, inputvalidation.IsURL, validation.RuneLength(1, longStringLengthLimit)),
 		validation.Field(&i.Group, validation.RuneLength(0, groupLengthLimit)),

--- a/components/director/pkg/graphql/schema.graphql
+++ b/components/director/pkg/graphql/schema.graphql
@@ -247,7 +247,7 @@ input APIDefinitionInput {
 	"""
 	targetURL: String!
 	"""
-	**Validation:** max=36
+	**Validation:** max=100
 	"""
 	group: String
 	spec: APISpecInput

--- a/components/director/pkg/graphql/validation.go
+++ b/components/director/pkg/graphql/validation.go
@@ -10,8 +10,8 @@ const (
 	longLongStringLengthLimit          = 512
 	descriptionStringLengthLimit       = 2000
 	jsonPathStringLengthLimit          = 2000
-	appNameLengthLimit                 = 36
-	groupLengthLimit                   = 36
+	appNameLengthLimit                 = 100
+	groupLengthLimit                   = 100
 	alphanumericUnderscoreRegexpString = "^[a-zA-Z0-9_]*$"
 )
 


### PR DESCRIPTION
**Description**
The validation rules for App name and Rune (API group) were set to 36, and in DB limit is 256. With this PR the allowed size is now 100 for those properties (to avoid ASCII to UTF overflow).
 
Changes proposed in this pull request:
- Adjust app name and rune limits

**Pull Request status**

- [x] Implementation
- [ ] Unit tests
- [ ] Integration tests
- [ ] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [ ] Mocks are regenerated, using the automated script
