### PR TITLE
Adjust app name and rune limits

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -127,7 +127,7 @@ global:
       name: compass-pairing-adapter
     director:
       dir:
-      version: "PR-2775"
+      version: "PR-2804"
       name: compass-director
     hydrator:
       dir:

--- a/components/director/pkg/graphql/api_validation.go
+++ b/components/director/pkg/graphql/api_validation.go
@@ -10,7 +10,7 @@ import (
 // Validate missing godoc
 func (i APIDefinitionInput) Validate() error {
 	return validation.ValidateStruct(&i,
-		validation.Field(&i.Name, validation.Required, is.PrintableASCII, validation.Length(1, 100)),
+		validation.Field(&i.Name, validation.Required, is.PrintableASCII, validation.Length(1, appNameLengthLimit)),
 		validation.Field(&i.Description, validation.RuneLength(0, descriptionStringLengthLimit)),
 		validation.Field(&i.TargetURL, validation.Required, inputvalidation.IsURL, validation.RuneLength(1, longStringLengthLimit)),
 		validation.Field(&i.Group, validation.RuneLength(0, groupLengthLimit)),

--- a/components/director/pkg/graphql/api_validation_test.go
+++ b/components/director/pkg/graphql/api_validation_test.go
@@ -172,8 +172,8 @@ func TestAPIDefinitionInput_Validate_Group(t *testing.T) {
 			ExpectedValid: true,
 		},
 		{
-			Name:          "String longer than 36 chars",
-			Value:         str.Ptr(inputvalidationtest.String37Long),
+			Name:          "String longer than 100 chars",
+			Value:         str.Ptr(inputvalidationtest.String101Long),
 			ExpectedValid: false,
 		},
 	}

--- a/components/director/pkg/graphql/app_validation_test.go
+++ b/components/director/pkg/graphql/app_validation_test.go
@@ -27,8 +27,8 @@ func TestApplicationRegisterInput_Validate_Name(t *testing.T) {
 			ExpectedValid: false,
 		},
 		{
-			Name:          "String longer than 37 chars",
-			Value:         inputvalidationtest.String37Long,
+			Name:          "String longer than 100 chars",
+			Value:         inputvalidationtest.String101Long,
 			ExpectedValid: false,
 		},
 	}

--- a/components/director/pkg/graphql/event_api_validation_test.go
+++ b/components/director/pkg/graphql/event_api_validation_test.go
@@ -169,8 +169,8 @@ func TestEventAPIDefinitionInput_Validate_Group(t *testing.T) {
 			ExpectedValid: true,
 		},
 		{
-			Name:          "String longer than 36 chars",
-			Value:         str.Ptr(inputvalidationtest.String37Long),
+			Name:          "String longer than 100 chars",
+			Value:         str.Ptr(inputvalidationtest.String101Long),
 			ExpectedValid: false,
 		},
 	}

--- a/components/director/pkg/graphql/schema.graphql
+++ b/components/director/pkg/graphql/schema.graphql
@@ -247,7 +247,7 @@ input APIDefinitionInput {
 	"""
 	targetURL: String!
 	"""
-	**Validation:** max=36
+	**Validation:** max=100
 	"""
 	group: String
 	spec: APISpecInput

--- a/components/director/pkg/graphql/validation.go
+++ b/components/director/pkg/graphql/validation.go
@@ -10,8 +10,8 @@ const (
 	longLongStringLengthLimit          = 512
 	descriptionStringLengthLimit       = 2000
 	jsonPathStringLengthLimit          = 2000
-	appNameLengthLimit                 = 36
-	groupLengthLimit                   = 36
+	appNameLengthLimit                 = 100
+	groupLengthLimit                   = 100
 	alphanumericUnderscoreRegexpString = "^[a-zA-Z0-9_]*$"
 )
 

--- a/components/director/pkg/inputvalidation/inputvalidationtest/validator_fixtures.go
+++ b/components/director/pkg/inputvalidation/inputvalidationtest/validator_fixtures.go
@@ -5,6 +5,8 @@ import "strings"
 var (
 	// String37Long missing godoc
 	String37Long = strings.Repeat("a", 37)
+	// String101Long missing godoc
+	String101Long = strings.Repeat("a", 101)
 	// String129Long missing godoc
 	String129Long = strings.Repeat("a", 129)
 	// String257Long missing godoc


### PR DESCRIPTION
**Description**
The validation rules for App name and Rune (API group) were set to 36, and in DB limit is 256. With this PR the allowed size is now 100 for those properties (to avoid ASCII to UTF overflow).
 
Changes proposed in this pull request:
- Adjust app name and rune limits

**Pull Request status**

- [x] Implementation
- [x] Unit tests
- [ ] Integration tests
- [x] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [ ] Mocks are regenerated, using the automated script
