### PR TITLE
Remove a negative test

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -169,7 +169,7 @@ global:
       name: compass-console
     e2e_tests:
       dir:
-      version: "PR-2791"
+      version: "PR-2806"
       name: compass-e2e-tests
   isLocalEnv: false
   isForTesting: false


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:
- Remove a negative test, because of the following 2 reasons. The functionality it checks was covered with Unit test from one side and the external service mock executes the subscription requests synchronously instead asynchronously and this is different form expected productive behaviour.

**Pull Request status**
- [x] Implementation
- [ ] Unit tests
- [ ] Integration tests
- [x] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [ ] Mocks are regenerated, using the automated script
