### PR TITLE
Fix Formation Assignment creation

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -127,7 +127,7 @@ global:
       name: compass-pairing-adapter
     director:
       dir:
-      version: "PR-2778"
+      version: "PR-2809"
       name: compass-director
     hydrator:
       dir:

--- a/components/director/internal/domain/formationassignment/automock/formation_assignment_repository.go
+++ b/components/director/internal/domain/formationassignment/automock/formation_assignment_repository.go
@@ -87,13 +87,13 @@ func (_m *FormationAssignmentRepository) Get(ctx context.Context, id string, ten
 	return r0, r1
 }
 
-// GetByTargetAndSource provides a mock function with given fields: ctx, target, source, tenantID
-func (_m *FormationAssignmentRepository) GetByTargetAndSource(ctx context.Context, target string, source string, tenantID string) (*model.FormationAssignment, error) {
-	ret := _m.Called(ctx, target, source, tenantID)
+// GetByTargetAndSource provides a mock function with given fields: ctx, target, source, tenantID, formationID
+func (_m *FormationAssignmentRepository) GetByTargetAndSource(ctx context.Context, target string, source string, tenantID string, formationID string) (*model.FormationAssignment, error) {
+	ret := _m.Called(ctx, target, source, tenantID, formationID)
 
 	var r0 *model.FormationAssignment
-	if rf, ok := ret.Get(0).(func(context.Context, string, string, string) *model.FormationAssignment); ok {
-		r0 = rf(ctx, target, source, tenantID)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, string) *model.FormationAssignment); ok {
+		r0 = rf(ctx, target, source, tenantID, formationID)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*model.FormationAssignment)
@@ -101,8 +101,8 @@ func (_m *FormationAssignmentRepository) GetByTargetAndSource(ctx context.Contex
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, string, string, string) error); ok {
-		r1 = rf(ctx, target, source, tenantID)
+	if rf, ok := ret.Get(1).(func(context.Context, string, string, string, string) error); ok {
+		r1 = rf(ctx, target, source, tenantID, formationID)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -354,13 +354,13 @@ func (_m *FormationAssignmentRepository) Update(ctx context.Context, _a1 *model.
 	return r0
 }
 
-type mockConstructorTestingTNewFormationAssignmentRepository interface {
+type NewFormationAssignmentRepositoryT interface {
 	mock.TestingT
 	Cleanup(func())
 }
 
 // NewFormationAssignmentRepository creates a new instance of FormationAssignmentRepository. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
-func NewFormationAssignmentRepository(t mockConstructorTestingTNewFormationAssignmentRepository) *FormationAssignmentRepository {
+func NewFormationAssignmentRepository(t NewFormationAssignmentRepositoryT) *FormationAssignmentRepository {
 	mock := &FormationAssignmentRepository{}
 	mock.Mock.Test(t)
 

--- a/components/director/internal/domain/formationassignment/repository.go
+++ b/components/director/internal/domain/formationassignment/repository.go
@@ -71,10 +71,10 @@ func (r *repository) Create(ctx context.Context, item *model.FormationAssignment
 	return r.creator.Create(ctx, r.conv.ToEntity(item))
 }
 
-// GetByTargetAndSource queries for a single Formation Assignment matching by a given Target and Source
-func (r *repository) GetByTargetAndSource(ctx context.Context, target, source, tenantID string) (*model.FormationAssignment, error) {
+// GetByTargetAndSource queries for a single Formation Assignment matching by a given Target, Source for the given Formation
+func (r *repository) GetByTargetAndSource(ctx context.Context, target, source, tenantID, formationID string) (*model.FormationAssignment, error) {
 	var entity Entity
-	if err := r.getter.Get(ctx, resource.FormationAssignment, tenantID, repo.Conditions{repo.NewEqualCondition("target", target), repo.NewEqualCondition("source", source)}, repo.NoOrderBy, &entity); err != nil {
+	if err := r.getter.Get(ctx, resource.FormationAssignment, tenantID, repo.Conditions{repo.NewEqualCondition("formation_id", formationID), repo.NewEqualCondition("target", target), repo.NewEqualCondition("source", source)}, repo.NoOrderBy, &entity); err != nil {
 		return nil, err
 	}
 

--- a/components/director/internal/domain/formationassignment/repository_test.go
+++ b/components/director/internal/domain/formationassignment/repository_test.go
@@ -525,8 +525,8 @@ func TestRepository_GetByTargetAndSource(t *testing.T) {
 		MethodName: "GetByTargetAndSource",
 		SQLQueryDetails: []testdb.SQLQueryDetails{
 			{
-				Query:    regexp.QuoteMeta(`SELECT id, formation_id, tenant_id, source, source_type, target, target_type, state, value FROM public.formation_assignments WHERE tenant_id = $1 AND target = $2 AND source = $3`),
-				Args:     []driver.Value{TestTenantID, TestTarget, TestSource},
+				Query:    regexp.QuoteMeta(`SELECT id, formation_id, tenant_id, source, source_type, target, target_type, state, value FROM public.formation_assignments WHERE tenant_id = $1 AND formation_id = $2 AND target = $3 AND source = $4`),
+				Args:     []driver.Value{TestTenantID, TestFormationID, TestTarget, TestSource},
 				IsSelect: true,
 				ValidRowsProvider: func() []*sqlmock.Rows {
 					return []*sqlmock.Rows{sqlmock.NewRows(fixColumns).AddRow(TestID, TestFormationID, TestTenantID, TestSource, TestSourceType, TestTarget, TestTargetType, TestState, TestConfigValueStr)}
@@ -542,7 +542,7 @@ func TestRepository_GetByTargetAndSource(t *testing.T) {
 		RepoConstructorFunc:       formationassignment.NewRepository,
 		ExpectedModelEntity:       fixFormationAssignmentModel(TestConfigValueRawJSON),
 		ExpectedDBEntity:          fixFormationAssignmentEntity(TestConfigValueStr),
-		MethodArgs:                []interface{}{TestTarget, TestSource, TestTenantID},
+		MethodArgs:                []interface{}{TestTarget, TestSource, TestTenantID, TestFormationID},
 		DisableConverterErrorTest: true,
 	}
 

--- a/components/director/internal/domain/formationassignment/service.go
+++ b/components/director/internal/domain/formationassignment/service.go
@@ -22,7 +22,7 @@ import (
 //go:generate mockery --name=FormationAssignmentRepository --output=automock --outpkg=automock --case=underscore --disable-version-string
 type FormationAssignmentRepository interface {
 	Create(ctx context.Context, item *model.FormationAssignment) error
-	GetByTargetAndSource(ctx context.Context, target, source, tenantID string) (*model.FormationAssignment, error)
+	GetByTargetAndSource(ctx context.Context, target, source, tenantID, formationID string) (*model.FormationAssignment, error)
 	Get(ctx context.Context, id, tenantID string) (*model.FormationAssignment, error)
 	GetGlobalByID(ctx context.Context, id string) (*model.FormationAssignment, error)
 	GetGlobalByIDAndFormationID(ctx context.Context, id, formationID string) (*model.FormationAssignment, error)
@@ -141,7 +141,7 @@ func (s *service) CreateIfNotExists(ctx context.Context, in *model.FormationAssi
 		return "", errors.Wrapf(err, "while loading tenant from context")
 	}
 
-	existingEntity, err := s.repo.GetByTargetAndSource(ctx, in.Target, in.Source, tenantID)
+	existingEntity, err := s.repo.GetByTargetAndSource(ctx, in.Target, in.Source, tenantID, in.FormationID)
 	if err != nil && !apperrors.IsNotFoundError(err) {
 		return "", errors.Wrapf(err, "while getting formation assignment by target %q and source %q", in.Target, in.Source)
 	}

--- a/components/director/internal/domain/formationassignment/service_test.go
+++ b/components/director/internal/domain/formationassignment/service_test.go
@@ -124,7 +124,7 @@ func TestService_CreateIfNotExists(t *testing.T) {
 			FormationAssignmentInput: faInput,
 			FormationAssignmentRepo: func() *automock.FormationAssignmentRepository {
 				repo := &automock.FormationAssignmentRepository{}
-				repo.On("GetByTargetAndSource", ctxWithTenant, faModel.Target, faModel.Source, TestTenantID).Return(nil, apperrors.NewNotFoundError(resource.FormationAssignment, faModel.Source)).Once()
+				repo.On("GetByTargetAndSource", ctxWithTenant, faModel.Target, faModel.Source, TestTenantID, faModel.FormationID).Return(nil, apperrors.NewNotFoundError(resource.FormationAssignment, faModel.Source)).Once()
 				repo.On("Create", ctxWithTenant, faModel).Return(nil).Once()
 				return repo
 			},
@@ -138,7 +138,7 @@ func TestService_CreateIfNotExists(t *testing.T) {
 			UUIDService:              unusedUIDService,
 			FormationAssignmentRepo: func() *automock.FormationAssignmentRepository {
 				repo := &automock.FormationAssignmentRepository{}
-				repo.On("GetByTargetAndSource", ctxWithTenant, faModel.Target, faModel.Source, TestTenantID).Return(nil, testErr).Once()
+				repo.On("GetByTargetAndSource", ctxWithTenant, faModel.Target, faModel.Source, TestTenantID, faModel.FormationID).Return(nil, testErr).Once()
 				return repo
 			},
 			ExpectedErrorMsg: testErr.Error(),
@@ -150,7 +150,7 @@ func TestService_CreateIfNotExists(t *testing.T) {
 			UUIDService:              unusedUIDService,
 			FormationAssignmentRepo: func() *automock.FormationAssignmentRepository {
 				repo := &automock.FormationAssignmentRepository{}
-				repo.On("GetByTargetAndSource", ctxWithTenant, faModel.Target, faModel.Source, TestTenantID).Return(faModel, nil).Once()
+				repo.On("GetByTargetAndSource", ctxWithTenant, faModel.Target, faModel.Source, TestTenantID, faModel.FormationID).Return(faModel, nil).Once()
 				return repo
 			},
 			ExpectedOutput:   TestID,
@@ -1154,7 +1154,7 @@ func TestService_GenerateAssignments(t *testing.T) {
 				repo := &automock.FormationAssignmentRepository{}
 				repo.On("ListAllForObjectIDs", ctxWithTenant, TestTenantID, formation.ID, formationParticipantsIDs).Return(allAssignments, nil).Once()
 				for i := range formationAssignmentsForApplication {
-					repo.On("GetByTargetAndSource", ctxWithTenant, formationAssignmentsForApplication[i].Target, formationAssignmentsForApplication[i].Source, TestTenantID).Return(nil, apperrors.NewNotFoundErrorWithType(resource.FormationAssignment)).Once()
+					repo.On("GetByTargetAndSource", ctxWithTenant, formationAssignmentsForApplication[i].Target, formationAssignmentsForApplication[i].Source, TestTenantID, formationAssignmentsForApplication[i].FormationID).Return(nil, apperrors.NewNotFoundErrorWithType(resource.FormationAssignment)).Once()
 					repo.On("Create", ctxWithTenant, formationAssignmentsForApplication[i]).Return(nil).Once()
 				}
 				repo.On("ListForIDs", ctxWithTenant, TestTenantID, formationAssignmentIDs).Return(formationAssignmentsForApplication, nil).Once()
@@ -1195,7 +1195,7 @@ func TestService_GenerateAssignments(t *testing.T) {
 				unassignAppFormationAssignments := fixFormationAssignmentsWithObjectTypeAndID(model.FormationAssignmentTypeApplication, objectID, applications[0].ID, runtimes[0].ID, runtimeContexts[0].ID)
 				repo.On("ListAllForObjectIDs", ctxWithTenant, TestTenantID, formation.ID, []string{applications[0].ID, objectID, runtimes[0].ID, runtimeContexts[0].ID}).Return(append(allAssignments, unassignAppFormationAssignments...), nil).Once()
 				for i := range formationAssignmentsForApplication {
-					repo.On("GetByTargetAndSource", ctxWithTenant, formationAssignmentsForApplication[i].Target, formationAssignmentsForApplication[i].Source, TestTenantID).Return(nil, apperrors.NewNotFoundErrorWithType(resource.FormationAssignment)).Once()
+					repo.On("GetByTargetAndSource", ctxWithTenant, formationAssignmentsForApplication[i].Target, formationAssignmentsForApplication[i].Source, TestTenantID, formationAssignmentsForApplication[i].FormationID).Return(nil, apperrors.NewNotFoundErrorWithType(resource.FormationAssignment)).Once()
 					repo.On("Create", ctxWithTenant, formationAssignmentsForApplication[i]).Return(nil).Once()
 				}
 				repo.On("ListForIDs", ctxWithTenant, TestTenantID, formationAssignmentIDs).Return(formationAssignmentsForApplication, nil).Once()
@@ -1235,7 +1235,7 @@ func TestService_GenerateAssignments(t *testing.T) {
 				repo := &automock.FormationAssignmentRepository{}
 				repo.On("ListAllForObjectIDs", ctxWithTenant, TestTenantID, formation.ID, []string{applications[0].ID, objectID, runtimes[0].ID, runtimeContexts[0].ID}).Return(allAssignments, nil).Once()
 				for i := range formationAssignmentsForApplication {
-					repo.On("GetByTargetAndSource", ctxWithTenant, formationAssignmentsForApplication[i].Target, formationAssignmentsForApplication[i].Source, TestTenantID).Return(nil, apperrors.NewNotFoundErrorWithType(resource.FormationAssignment)).Once()
+					repo.On("GetByTargetAndSource", ctxWithTenant, formationAssignmentsForApplication[i].Target, formationAssignmentsForApplication[i].Source, TestTenantID, formationAssignmentsForApplication[i].FormationID).Return(nil, apperrors.NewNotFoundErrorWithType(resource.FormationAssignment)).Once()
 					repo.On("Create", ctxWithTenant, formationAssignmentsForApplication[i]).Return(nil).Once()
 				}
 				repo.On("ListForIDs", ctxWithTenant, TestTenantID, formationAssignmentIDs).Return(formationAssignmentsForApplication, nil).Once()
@@ -1275,7 +1275,7 @@ func TestService_GenerateAssignments(t *testing.T) {
 				repo := &automock.FormationAssignmentRepository{}
 				repo.On("ListAllForObjectIDs", ctxWithTenant, TestTenantID, formation.ID, []string{applications[0].ID, runtimes[0].ID, objectID, runtimeContexts[0].ID}).Return(allAssignments, nil).Once()
 				for i := range formationAssignmentsForRuntime {
-					repo.On("GetByTargetAndSource", ctxWithTenant, formationAssignmentsForRuntime[i].Target, formationAssignmentsForRuntime[i].Source, TestTenantID).Return(nil, apperrors.NewNotFoundErrorWithType(resource.FormationAssignment)).Once()
+					repo.On("GetByTargetAndSource", ctxWithTenant, formationAssignmentsForRuntime[i].Target, formationAssignmentsForRuntime[i].Source, TestTenantID, formationAssignmentsForApplication[i].FormationID).Return(nil, apperrors.NewNotFoundErrorWithType(resource.FormationAssignment)).Once()
 					repo.On("Create", ctxWithTenant, formationAssignmentsForRuntime[i]).Return(nil).Once()
 				}
 				repo.On("ListForIDs", ctxWithTenant, TestTenantID, formationAssignmentIDs).Return(formationAssignmentsForRuntime, nil).Once()
@@ -1315,7 +1315,7 @@ func TestService_GenerateAssignments(t *testing.T) {
 				repo := &automock.FormationAssignmentRepository{}
 				repo.On("ListAllForObjectIDs", ctxWithTenant, TestTenantID, formation.ID, append(formationParticipantsIDs, objectID)).Return(allAssignments, nil).Once()
 				for i := range formationAssignmentsForRuntimeContext {
-					repo.On("GetByTargetAndSource", ctxWithTenant, formationAssignmentsForRuntimeContext[i].Target, formationAssignmentsForRuntimeContext[i].Source, TestTenantID).Return(nil, apperrors.NewNotFoundErrorWithType(resource.FormationAssignment)).Once()
+					repo.On("GetByTargetAndSource", ctxWithTenant, formationAssignmentsForRuntimeContext[i].Target, formationAssignmentsForRuntimeContext[i].Source, TestTenantID, formationAssignmentsForApplication[i].FormationID).Return(nil, apperrors.NewNotFoundErrorWithType(resource.FormationAssignment)).Once()
 					repo.On("Create", ctxWithTenant, formationAssignmentsForRuntimeContext[i]).Return(nil).Once()
 				}
 				repo.On("ListForIDs", ctxWithTenant, TestTenantID, formationAssignmentIDs).Return(formationAssignmentsForRuntimeContext, nil).Once()
@@ -1356,7 +1356,7 @@ func TestService_GenerateAssignments(t *testing.T) {
 				repo := &automock.FormationAssignmentRepository{}
 				repo.On("ListAllForObjectIDs", ctxWithTenant, TestTenantID, formation.ID, append(formationParticipantsIDs, objectID)).Return(allAssignments, nil).Once()
 				for i := range formationAssignmentsForRuntimeContextWithParentInTheFormation {
-					repo.On("GetByTargetAndSource", ctxWithTenant, formationAssignmentsForRuntimeContextWithParentInTheFormation[i].Target, formationAssignmentsForRuntimeContextWithParentInTheFormation[i].Source, TestTenantID).Return(nil, apperrors.NewNotFoundErrorWithType(resource.FormationAssignment)).Once()
+					repo.On("GetByTargetAndSource", ctxWithTenant, formationAssignmentsForRuntimeContextWithParentInTheFormation[i].Target, formationAssignmentsForRuntimeContextWithParentInTheFormation[i].Source, TestTenantID, formationAssignmentsForApplication[i].FormationID).Return(nil, apperrors.NewNotFoundErrorWithType(resource.FormationAssignment)).Once()
 					repo.On("Create", ctxWithTenant, formationAssignmentsForRuntimeContextWithParentInTheFormation[i]).Return(nil).Once()
 				}
 				repo.On("ListForIDs", ctxWithTenant, TestTenantID, formationAssignmentIDsRtmCtxParentInFormation).Return(formationAssignmentsForRuntimeContextWithParentInTheFormation, nil).Once()
@@ -1514,7 +1514,7 @@ func TestService_GenerateAssignments(t *testing.T) {
 			FormationAssignmentRepo: func() *automock.FormationAssignmentRepository {
 				repo := &automock.FormationAssignmentRepository{}
 				repo.On("ListAllForObjectIDs", ctxWithTenant, TestTenantID, formation.ID, append(formationParticipantsIDs, objectID)).Return(allAssignments, nil).Once()
-				repo.On("GetByTargetAndSource", ctxWithTenant, formationAssignmentsForRuntimeContext[0].Target, formationAssignmentsForRuntimeContext[0].Source, TestTenantID).Return(nil, testErr).Once()
+				repo.On("GetByTargetAndSource", ctxWithTenant, formationAssignmentsForRuntimeContext[0].Target, formationAssignmentsForRuntimeContext[0].Source, TestTenantID, formationAssignmentsForRuntimeContext[0].FormationID).Return(nil, testErr).Once()
 				return repo
 			},
 			UIDService: func() *automock.UIDService {
@@ -1549,7 +1549,7 @@ func TestService_GenerateAssignments(t *testing.T) {
 				repo := &automock.FormationAssignmentRepository{}
 				repo.On("ListAllForObjectIDs", ctxWithTenant, TestTenantID, formation.ID, formationParticipantsIDs).Return(allAssignments, nil).Once()
 				for i := range formationAssignmentsForApplication {
-					repo.On("GetByTargetAndSource", ctxWithTenant, formationAssignmentsForApplication[i].Target, formationAssignmentsForApplication[i].Source, TestTenantID).Return(nil, apperrors.NewNotFoundErrorWithType(resource.FormationAssignment)).Once()
+					repo.On("GetByTargetAndSource", ctxWithTenant, formationAssignmentsForApplication[i].Target, formationAssignmentsForApplication[i].Source, TestTenantID, formationAssignmentsForApplication[i].FormationID).Return(nil, apperrors.NewNotFoundErrorWithType(resource.FormationAssignment)).Once()
 					repo.On("Create", ctxWithTenant, formationAssignmentsForApplication[i]).Return(nil).Once()
 				}
 				repo.On("ListForIDs", ctxWithTenant, TestTenantID, formationAssignmentIDs).Return(nil, testErr).Once()


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:
- `GetBySourceAndTarget` was not checking for `FormationID`, so in the case that there are multiple formations with the same participants it could end up returning the wrong formation assignments. This function was used in `CreateIfNotExists`, which is was used to create missing formation assignments when assigning to formation.

**Related issue(s)**
- #2702
- #2798 

**Pull Request status**
<!-- Feel free to construct the checklist with whatever items seem most reasonable for your change. You could disassemble the Implementation part to even smaller separate checklist items if you're working on something big for example. But do make the effort to provide a checklist of some sort so that the core team as well as the community can have an idea about the progress of your Pull Request.
-->

- [x] Implementation
- [x] Unit tests
- [x] [N/A] Integration tests
- [x] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [x] Mocks are regenerated, using the automated script
