### PR TITLE
Handle null error value in Formation Status API

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -127,7 +127,7 @@ global:
       name: compass-pairing-adapter
     director:
       dir:
-      version: "PR-2809"
+      version: "PR-2810"
       name: compass-director
     hydrator:
       dir:

--- a/components/director/internal/domain/formation/resolver.go
+++ b/components/director/internal/domain/formation/resolver.go
@@ -394,6 +394,10 @@ func (r *Resolver) StatusDataLoader(keys []dataloader.ParamFormationStatus) ([]*
 			if isInErrorState(fa.State) {
 				condition = graphql.FormationStatusConditionError
 
+				if fa.Value == nil {
+					formationStatusErrors = append(formationStatusErrors, &graphql.FormationStatusError{AssignmentID: fa.ID})
+					continue
+				}
 				var assignmentError formationassignment.AssignmentErrorWrapper
 				if err = json.Unmarshal(fa.Value, &assignmentError); err != nil {
 					return nil, []error{errors.Wrapf(err, "while unmarshalling formation assignment error with assignment ID %q", fa.ID)}


### PR DESCRIPTION
**Description**
Currently when there is a formation assignment in an either `CREATE_ERROR` or `DELETE_ERROR` state with `null` Value, and the querying for formations with their status fails.

Changes proposed in this pull request:
- check for `nil` and still add an error field for the formation assignment in the status API, but with no error message or error code.

**Related issue(s)**
- #2809 
- #2798 

**Pull Request status**

- [x] Implementation
- [x] Unit tests
- [x] [N/A] Integration tests
- [x] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [x] [N/A] Mocks are regenerated, using the automated script
