### PR TITLE
System fetcher does not update app templates

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -127,7 +127,7 @@ global:
       name: compass-pairing-adapter
     director:
       dir:
-      version: "PR-2815"
+      version: "PR-2819"
       name: compass-director
     hydrator:
       dir:

--- a/components/director/internal/model/app_template.go
+++ b/components/director/internal/model/app_template.go
@@ -18,6 +18,7 @@ type ApplicationTemplate struct {
 	Placeholders         []ApplicationTemplatePlaceholder
 	AccessLevel          ApplicationTemplateAccessLevel
 	Webhooks             []Webhook
+	Labels               map[string]interface{}
 }
 
 // ApplicationTemplatePage missing godoc
@@ -114,6 +115,7 @@ type ApplicationTemplateUpdateInput struct {
 	ApplicationInputJSON string
 	Placeholders         []ApplicationTemplatePlaceholder
 	AccessLevel          ApplicationTemplateAccessLevel
+	Labels               map[string]interface{}
 }
 
 // ToApplicationTemplate missing godoc
@@ -130,5 +132,6 @@ func (a *ApplicationTemplateUpdateInput) ToApplicationTemplate(id string) Applic
 		ApplicationInputJSON: a.ApplicationInputJSON,
 		Placeholders:         a.Placeholders,
 		AccessLevel:          a.AccessLevel,
+		Labels:               a.Labels,
 	}
 }

--- a/components/director/internal/systemfetcher/loader.go
+++ b/components/director/internal/systemfetcher/loader.go
@@ -341,10 +341,9 @@ func areAppTemplatesEqual(appTemplate *model.ApplicationTemplate, appTemplateInp
 
 	isAppInputJSONEqual := appTemplate.ApplicationInputJSON == appTemplateInput.ApplicationInputJSON
 	isLabelEqual := reflect.DeepEqual(appTemplate.Labels, appTemplateInput.Labels)
-	isWebhookEqual := (appTemplate.Webhooks == nil && appTemplateInput.Webhooks == nil) || reflect.DeepEqual(appTemplate.Webhooks, appTemplateInput.Webhooks)
 	isPlaceholderEqual := reflect.DeepEqual(appTemplate.Placeholders, appTemplateInput.Placeholders)
 
-	if isAppInputJSONEqual && isLabelEqual && isWebhookEqual && isPlaceholderEqual {
+	if isAppInputJSONEqual && isLabelEqual && isPlaceholderEqual {
 		return true
 	}
 

--- a/components/director/internal/systemfetcher/loader.go
+++ b/components/director/internal/systemfetcher/loader.go
@@ -221,15 +221,6 @@ func (d *DataLoader) upsertAppTemplates(ctx context.Context, appTemplateInputs [
 			continue
 		}
 
-		var appInput1 map[string]interface{}
-		if err := json.Unmarshal([]byte(appTmplInput.ApplicationInputJSON), &appInput1); err != nil {
-			return errors.Wrapf(err, "while unmarshaling application input json")
-		}
-		var appInput2 map[string]interface{}
-		if err := json.Unmarshal([]byte(appTemplate.ApplicationInputJSON), &appInput2); err != nil {
-			return errors.Wrapf(err, "while unmarshaling application input json")
-		}
-
 		if !areAppTemplatesEqual(appTemplate, appTmplInput) {
 			log.C(ctx).Infof("Updating application template with id %q", appTemplate.ID)
 			appTemplateUpdateInput := model.ApplicationTemplateUpdateInput{
@@ -348,7 +339,7 @@ func areAppTemplatesEqual(appTemplate *model.ApplicationTemplate, appTemplateInp
 		return false
 	}
 
-	isAppInputJSONEqual := reflect.DeepEqual(appTemplate.ApplicationInputJSON, appTemplateInput.ApplicationInputJSON)
+	isAppInputJSONEqual := appTemplate.ApplicationInputJSON == appTemplateInput.ApplicationInputJSON
 	isLabelEqual := reflect.DeepEqual(appTemplate.Labels, appTemplateInput.Labels)
 	isWebhookEqual := (appTemplate.Webhooks == nil && appTemplateInput.Webhooks == nil) || reflect.DeepEqual(appTemplate.Webhooks, appTemplateInput.Webhooks)
 	isPlaceholderEqual := reflect.DeepEqual(appTemplate.Placeholders, appTemplateInput.Placeholders)

--- a/components/director/internal/systemfetcher/loader_test.go
+++ b/components/director/internal/systemfetcher/loader_test.go
@@ -449,7 +449,7 @@ func TestLoadData(t *testing.T) {
 						},
 					},
 					Labels: map[string]interface{}{
-						"managed_app_provisioning": false,
+						"managed_app_provisioning": true,
 					},
 				}
 				appTmplSvc := &automock.AppTmplService{}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:
- Historically, SF took into consideration only the ApplicationInputJSON object when it compares the two templates. However, when there are differences in the labels, placeholders, etc, but not in the ApplicationInputJSON, it does not update the template. This PR fixes that.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- ...

**Pull Request status**
<!-- Feel free to construct the checklist with whatever items seem most reasonable for your change. You could disassemble the Implementation part to even smaller separate checklist items if you're working on something big for example. But do make the effort to provide a checklist of some sort so that the core team as well as the community can have an idea about the progress of your Pull Request.
-->

- [x] Implementation
- [x] Unit tests
- [ ] Integration tests
- [x] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [ ] Mocks are regenerated, using the automated script
