### PR TITLE
Add policyLevel 'none' to ORD policyLevel enum values

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -127,7 +127,7 @@ global:
       name: compass-pairing-adapter
     director:
       dir:
-      version: "PR-2820"
+      version: "PR-2822"
       name: compass-director
     hydrator:
       dir:

--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -147,7 +147,7 @@ global:
       name: compass-ord-service
     schema_migrator:
       dir:
-      version: "PR-2798"
+      version: "PR-2822"
       name: compass-schema-migrator
     system_broker:
       dir:

--- a/components/director/internal/open_resource_discovery/validation_test.go
+++ b/components/director/internal/open_resource_discovery/validation_test.go
@@ -1325,7 +1325,8 @@ func TestDocuments_ValidatePackage(t *testing.T) {
 				return []*ord.Document{doc}
 			},
 		}, {
-			Name: "Invalid `lineOfBusiness` field when `policyLevel` is `sap partner`",
+			Name:              "Valid `lineOfBusiness` field when `policyLevel` is `sap partner`",
+			ExpectedToBeValid: true,
 			DocumentProvider: func() []*ord.Document {
 				doc := fixORDDocument()
 				doc.Packages[0].LineOfBusiness = json.RawMessage(`["LoB"]`)
@@ -1341,6 +1342,16 @@ func TestDocuments_ValidatePackage(t *testing.T) {
 				doc := fixORDDocument()
 				doc.Packages[0].LineOfBusiness = json.RawMessage(`["LoB"]`)
 				doc.Packages[0].PolicyLevel = ord.PolicyLevelCustom
+
+				return []*ord.Document{doc}
+			},
+		}, {
+			Name:              "Valid `lineOfBusiness` field when `policyLevel` is `none`",
+			ExpectedToBeValid: true,
+			DocumentProvider: func() []*ord.Document {
+				doc := fixORDDocument()
+				doc.Packages[0].LineOfBusiness = json.RawMessage(`["LoB"]`)
+				doc.Packages[0].PolicyLevel = ord.PolicyLevelNone
 
 				return []*ord.Document{doc}
 			},
@@ -1395,7 +1406,8 @@ func TestDocuments_ValidatePackage(t *testing.T) {
 				return []*ord.Document{doc}
 			},
 		}, {
-			Name: "Invalid `industry` field when `policyLevel` is `sap partner`",
+			Name:              "Valid `industry` field when `policyLevel` is `sap partner`",
+			ExpectedToBeValid: true,
 			DocumentProvider: func() []*ord.Document {
 				doc := fixORDDocument()
 				doc.Packages[0].Industry = json.RawMessage(`["SomeIndustry"]`)
@@ -1411,6 +1423,16 @@ func TestDocuments_ValidatePackage(t *testing.T) {
 				doc := fixORDDocument()
 				doc.Packages[0].Industry = json.RawMessage(`["SomeIndustry"]`)
 				doc.Packages[0].PolicyLevel = ord.PolicyLevelCustom
+
+				return []*ord.Document{doc}
+			},
+		}, {
+			Name:              "Valid `industry` field when `policyLevel` is `none`",
+			ExpectedToBeValid: true,
+			DocumentProvider: func() []*ord.Document {
+				doc := fixORDDocument()
+				doc.Packages[0].Industry = json.RawMessage(`["SomeIndustry"]`)
+				doc.Packages[0].PolicyLevel = ord.PolicyLevelNone
 
 				return []*ord.Document{doc}
 			},
@@ -2300,7 +2322,8 @@ func TestDocuments_ValidateAPI(t *testing.T) {
 				return []*ord.Document{doc}
 			},
 		}, {
-			Name: "Invalid `lineOfBusiness` field when `policyLevel` is `sap partner` for API",
+			Name:              "Valid `lineOfBusiness` field when `policyLevel` is `sap partner` for API",
+			ExpectedToBeValid: true,
 			DocumentProvider: func() []*ord.Document {
 				doc := fixORDDocument()
 				doc.APIResources[0].LineOfBusiness = json.RawMessage(`["LoB"]`)
@@ -2316,6 +2339,16 @@ func TestDocuments_ValidateAPI(t *testing.T) {
 				doc := fixORDDocument()
 				doc.APIResources[0].LineOfBusiness = json.RawMessage(`["LoB"]`)
 				doc.Packages[0].PolicyLevel = ord.PolicyLevelCustom
+
+				return []*ord.Document{doc}
+			},
+		}, {
+			Name:              "Valid `lineOfBusiness` field when `policyLevel` is `none` for API",
+			ExpectedToBeValid: true,
+			DocumentProvider: func() []*ord.Document {
+				doc := fixORDDocument()
+				doc.APIResources[0].LineOfBusiness = json.RawMessage(`["LoB"]`)
+				doc.Packages[0].PolicyLevel = ord.PolicyLevelNone
 
 				return []*ord.Document{doc}
 			},
@@ -2370,7 +2403,8 @@ func TestDocuments_ValidateAPI(t *testing.T) {
 				return []*ord.Document{doc}
 			},
 		}, {
-			Name: "Invalid `industry` field when `policyLevel` is `sap partner` for API",
+			Name:              "Valid `industry` field when `policyLevel` is `sap partner` for API",
+			ExpectedToBeValid: true,
 			DocumentProvider: func() []*ord.Document {
 				doc := fixORDDocument()
 				doc.APIResources[0].Industry = json.RawMessage(`["SomeIndustry"]`)
@@ -2386,6 +2420,16 @@ func TestDocuments_ValidateAPI(t *testing.T) {
 				doc := fixORDDocument()
 				doc.APIResources[0].Industry = json.RawMessage(`["SomeIndustry"]`)
 				doc.Packages[0].PolicyLevel = ord.PolicyLevelCustom
+
+				return []*ord.Document{doc}
+			},
+		}, {
+			Name:              "Valid `industry` field when `policyLevel` is `none`",
+			ExpectedToBeValid: true,
+			DocumentProvider: func() []*ord.Document {
+				doc := fixORDDocument()
+				doc.APIResources[0].Industry = json.RawMessage(`["SomeIndustry"]`)
+				doc.Packages[0].PolicyLevel = ord.PolicyLevelNone
 
 				return []*ord.Document{doc}
 			},
@@ -4363,7 +4407,8 @@ func TestDocuments_ValidateEvent(t *testing.T) {
 				return []*ord.Document{doc}
 			},
 		}, {
-			Name: "Invalid `lineOfBusiness` field when `policyLevel` is `sap partner` for Event",
+			Name:              "Valid `lineOfBusiness` field when `policyLevel` is `sap partner` for Event",
+			ExpectedToBeValid: true,
 			DocumentProvider: func() []*ord.Document {
 				doc := fixORDDocument()
 				doc.EventResources[0].LineOfBusiness = json.RawMessage(`["LoB"]`)
@@ -4379,6 +4424,16 @@ func TestDocuments_ValidateEvent(t *testing.T) {
 				doc := fixORDDocument()
 				doc.EventResources[0].LineOfBusiness = json.RawMessage(`["LoB"]`)
 				doc.Packages[0].PolicyLevel = ord.PolicyLevelCustom
+
+				return []*ord.Document{doc}
+			},
+		}, {
+			Name:              "Valid `lineOfBusiness` field when `policyLevel` is `none`",
+			ExpectedToBeValid: true,
+			DocumentProvider: func() []*ord.Document {
+				doc := fixORDDocument()
+				doc.EventResources[0].LineOfBusiness = json.RawMessage(`["LoB"]`)
+				doc.Packages[0].PolicyLevel = ord.PolicyLevelNone
 
 				return []*ord.Document{doc}
 			},
@@ -4433,7 +4488,8 @@ func TestDocuments_ValidateEvent(t *testing.T) {
 				return []*ord.Document{doc}
 			},
 		}, {
-			Name: "Invalid `industry` field when `policyLevel` is `sap partner` for Event",
+			Name:              "Valid `industry` field when `policyLevel` is `sap partner` for Event",
+			ExpectedToBeValid: true,
 			DocumentProvider: func() []*ord.Document {
 				doc := fixORDDocument()
 				doc.EventResources[0].Industry = json.RawMessage(`["SomeIndustry"]`)
@@ -4449,6 +4505,16 @@ func TestDocuments_ValidateEvent(t *testing.T) {
 				doc := fixORDDocument()
 				doc.EventResources[0].Industry = json.RawMessage(`["SomeIndustry"]`)
 				doc.Packages[0].PolicyLevel = ord.PolicyLevelCustom
+
+				return []*ord.Document{doc}
+			},
+		}, {
+			Name:              "Valid `industry` field when `policyLevel` is `none`",
+			ExpectedToBeValid: true,
+			DocumentProvider: func() []*ord.Document {
+				doc := fixORDDocument()
+				doc.EventResources[0].Industry = json.RawMessage(`["SomeIndustry"]`)
+				doc.Packages[0].PolicyLevel = ord.PolicyLevelNone
 
 				return []*ord.Document{doc}
 			},

--- a/components/schema-migrator/migrations/director/20230112121009_add-ord-none-policy-level.down.sql
+++ b/components/schema-migrator/migrations/director/20230112121009_add-ord-none-policy-level.down.sql
@@ -1,0 +1,90 @@
+BEGIN;
+
+-- We need to drop these views because they references the 'policy_level' type. After we modify the `policy_level` type we can recreate the views as is done eventually in this script.
+DROP VIEW IF EXISTS tenants_packages;
+DROP VIEW IF EXISTS packages_tenants;
+
+---
+
+ALTER TYPE policy_level RENAME TO policy_level_old;
+
+CREATE TYPE policy_level AS ENUM ('custom', 'sap:core:v1','sap:partner:v1');
+
+ALTER TABLE packages
+    ALTER COLUMN policy_level TYPE policy_level
+        USING policy_level::text::policy_level;
+
+DROP TYPE policy_level_old;
+
+---
+
+CREATE OR REPLACE VIEW tenants_packages
+            (tenant_id, id, ord_id, title, short_description, description, version, package_links,
+             links, licence_type, tags, countries, labels, policy_level, app_id, custom_policy_level, vendor,
+             part_of_products, line_of_business, industry, resource_hash, support_info)
+AS
+SELECT DISTINCT t_apps.tenant_id,
+                p.id,
+                p.ord_id,
+                p.title,
+                p.short_description,
+                p.description,
+                p.version,
+                p.package_links,
+                p.links,
+                p.licence_type,
+                p.tags,
+                p.countries,
+                p.labels,
+                p.policy_level,
+                p.app_id,
+                p.custom_policy_level,
+                p.vendor,
+                p.part_of_products,
+                p.line_of_business,
+                p.industry,
+                p.resource_hash,
+                p.support_info
+FROM packages p
+         JOIN (SELECT a1.id,
+                      a1.tenant_id AS tenant_id
+               FROM tenant_applications a1
+               UNION ALL
+               SELECT apps_subaccounts.id,
+                      apps_subaccounts.tenant_id
+               FROM apps_subaccounts) t_apps
+              ON p.app_id = t_apps.id;
+
+CREATE OR REPLACE VIEW packages_tenants
+            (id, ord_id, title, short_description, description, version, package_links, links, licence_type, tags,
+             countries, labels, policy_level, app_id, custom_policy_level, vendor, part_of_products, line_of_business,
+             industry, resource_hash, documentation_labels, support_info, tenant_id, owner)
+AS
+SELECT p.id,
+       p.ord_id,
+       p.title,
+       p.short_description,
+       p.description,
+       p.version,
+       p.package_links,
+       p.links,
+       p.licence_type,
+       p.tags,
+       p.countries,
+       p.labels,
+       p.policy_level,
+       p.app_id,
+       p.custom_policy_level,
+       p.vendor,
+       p.part_of_products,
+       p.line_of_business,
+       p.industry,
+       p.resource_hash,
+       p.documentation_labels,
+       p.support_info,
+       ta.tenant_id,
+       ta.owner
+FROM packages p
+         JOIN tenant_applications ta ON ta.id = p.app_id;
+
+COMMIT;

--- a/components/schema-migrator/migrations/director/20230112121009_add-ord-none-policy-level.up.sql
+++ b/components/schema-migrator/migrations/director/20230112121009_add-ord-none-policy-level.up.sql
@@ -1,5 +1,90 @@
 BEGIN;
 
-ALTER TYPE policy_level ADD VALUE 'none';
+-- We need to drop these views because they references the 'policy_level' type. After we modify the `policy_level` type we can recreate the views as is done eventually in this script.
+DROP VIEW IF EXISTS tenants_packages;
+DROP VIEW IF EXISTS packages_tenants;
+
+---
+
+ALTER TYPE policy_level RENAME TO policy_level_old;
+
+CREATE TYPE policy_level AS ENUM ('custom', 'sap:core:v1','sap:partner:v1', 'none');
+
+ALTER TABLE packages
+    ALTER COLUMN policy_level TYPE policy_level
+        USING policy_level::text::policy_level;
+
+DROP TYPE policy_level_old;
+
+---
+
+CREATE OR REPLACE VIEW tenants_packages
+            (tenant_id, id, ord_id, title, short_description, description, version, package_links,
+             links, licence_type, tags, countries, labels, policy_level, app_id, custom_policy_level, vendor,
+             part_of_products, line_of_business, industry, resource_hash, support_info)
+AS
+SELECT DISTINCT t_apps.tenant_id,
+                p.id,
+                p.ord_id,
+                p.title,
+                p.short_description,
+                p.description,
+                p.version,
+                p.package_links,
+                p.links,
+                p.licence_type,
+                p.tags,
+                p.countries,
+                p.labels,
+                p.policy_level,
+                p.app_id,
+                p.custom_policy_level,
+                p.vendor,
+                p.part_of_products,
+                p.line_of_business,
+                p.industry,
+                p.resource_hash,
+                p.support_info
+FROM packages p
+         JOIN (SELECT a1.id,
+                      a1.tenant_id AS tenant_id
+               FROM tenant_applications a1
+               UNION ALL
+               SELECT apps_subaccounts.id,
+                      apps_subaccounts.tenant_id
+               FROM apps_subaccounts) t_apps
+              ON p.app_id = t_apps.id;
+
+CREATE OR REPLACE VIEW packages_tenants
+            (id, ord_id, title, short_description, description, version, package_links, links, licence_type, tags,
+             countries, labels, policy_level, app_id, custom_policy_level, vendor, part_of_products, line_of_business,
+             industry, resource_hash, documentation_labels, support_info, tenant_id, owner)
+AS
+SELECT p.id,
+       p.ord_id,
+       p.title,
+       p.short_description,
+       p.description,
+       p.version,
+       p.package_links,
+       p.links,
+       p.licence_type,
+       p.tags,
+       p.countries,
+       p.labels,
+       p.policy_level,
+       p.app_id,
+       p.custom_policy_level,
+       p.vendor,
+       p.part_of_products,
+       p.line_of_business,
+       p.industry,
+       p.resource_hash,
+       p.documentation_labels,
+       p.support_info,
+       ta.tenant_id,
+       ta.owner
+FROM packages p
+         JOIN tenant_applications ta ON ta.id = p.app_id;
 
 COMMIT;

--- a/components/schema-migrator/migrations/director/20230112121009_add-ord-none-policy-level.up.sql
+++ b/components/schema-migrator/migrations/director/20230112121009_add-ord-none-policy-level.up.sql
@@ -1,0 +1,5 @@
+BEGIN;
+
+ALTER TYPE policy_level ADD VALUE 'none';
+
+COMMIT;


### PR DESCRIPTION
# Add policyLevel 'none' to ORD policyLevel enum values

**Description**

Changes proposed in this pull request:
- Add additional policyLevel called `none` - this can be used to explicitly state that no policy level is applied

**Pull Request status**
<!-- Feel free to construct the checklist with whatever items seem most reasonable for your change. You could disassemble the Implementation part to even smaller separate checklist items if you're working on something big for example. But do make the effort to provide a checklist of some sort so that the core team as well as the community can have an idea about the progress of your Pull Request.
-->

- [x] Implementation
- [x] Unit tests
- [x] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
