### PR TITLE
Use correlation ID as client user if not provided in pairing flow

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -127,7 +127,7 @@ global:
       name: compass-pairing-adapter
     director:
       dir:
-      version: "PR-2824"
+      version: "PR-2834"
       name: compass-director
     hydrator:
       dir:

--- a/components/director/internal/domain/onetimetoken/service.go
+++ b/components/director/internal/domain/onetimetoken/service.go
@@ -8,6 +8,8 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/kyma-incubator/compass/components/director/pkg/correlation"
+
 	"github.com/kyma-incubator/compass/components/director/internal/domain/scenariogroups"
 
 	pkgadapters "github.com/kyma-incubator/compass/components/director/pkg/adapters"
@@ -259,8 +261,9 @@ func (s *service) getTokenFromAdapter(ctx context.Context, adapterURL string, ap
 	}
 
 	clientUser, err := client.LoadFromContext(ctx)
-	if err != nil {
-		log.C(ctx).Infof("unable to provide client_user for internal tenant [%s] with corresponding external tenant [%s]", tntCtx.InternalID, extTenant)
+	if err != nil || clientUser == "" {
+		log.C(ctx).Warnf("unable to provide client_user for internal tenant [%s] with corresponding external tenant [%s]. Using correlation ID as client_user header...", tntCtx.InternalID, extTenant)
+		clientUser = correlation.CorrelationIDFromContext(ctx)
 	}
 
 	scenarioGroups := scenariogroups.LoadFromContext(ctx)


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:
- Use correlation ID as client user if not provided in pairing flow

**Pull Request status**

- [x] Implementation
- N/A Unit tests
- N/A Integration tests
- [x] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- N/A Mocks are regenerated, using the automated script
