### PR TITLE
Allow application template consumers to report status for formation notifications to their applications

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -27,6 +27,7 @@
 /components/director/internal/domain/formation @kyma-incubator/team-raptor
 /components/director/internal/domain/formationassignment @kyma-incubator/team-raptor
 /components/director/internal/domain/formationtemplate @kyma-incubator/team-raptor
+/components/director/internal/formationmapping @kyma-incubator/team-raptor
 /components/director/internal/info @kyma-incubator/team-raptor
 /components/director/internal/nsadapter @kyma-incubator/team-falcon
 /components/director/internal/open_resource_discovery @kyma-incubator/team-falcon

--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -127,7 +127,7 @@ global:
       name: compass-pairing-adapter
     director:
       dir:
-      version: "PR-2824"
+      version: "PR-2835"
       name: compass-director
     hydrator:
       dir:

--- a/components/director/internal/formationmapping/OWNERS
+++ b/components/director/internal/formationmapping/OWNERS
@@ -1,0 +1,8 @@
+reviewers:
+  - team-raptor
+approvers:
+  - team-raptor
+labels:
+  - ":t-rex: team-raptor"
+options:
+  no_parent_owners: true

--- a/components/director/internal/formationmapping/auth_middleware.go
+++ b/components/director/internal/formationmapping/auth_middleware.go
@@ -214,7 +214,16 @@ func (a *Authenticator) isAuthorized(ctx context.Context, formationAssignmentID,
 				return false, http.StatusInternalServerError, errors.Wrap(err, "while closing database transaction")
 			}
 
-			log.C(ctx).Infof("The caller with ID: %q and type: %q has owner access to the target of the formation assignment with ID: %q and type: %q that is being updated", consumerID, consumerType, fa.Target, fa.TargetType)
+			log.C(ctx).Infof("The caller with ID: %q and type: %q manages the target of the formation assignment with ID: %q and type: %q that is being updated", consumerID, consumerType, fa.Target, fa.TargetType)
+			return true, http.StatusOK, nil
+		}
+
+		if app.ApplicationTemplateID != nil && *app.ApplicationTemplateID == consumerID {
+			if err := tx.Commit(); err != nil {
+				return false, http.StatusInternalServerError, errors.Wrap(err, "while closing database transaction")
+			}
+
+			log.C(ctx).Infof("The caller with ID: %q and type: %q is the parent of the target of the formation assignment with ID: %q and type: %q that is being updated", consumerID, consumerType, fa.Target, fa.TargetType)
 			return true, http.StatusOK, nil
 		}
 

--- a/components/director/internal/formationmapping/auth_middleware_test.go
+++ b/components/director/internal/formationmapping/auth_middleware_test.go
@@ -29,6 +29,7 @@ func TestAuthenticator_Handler(t *testing.T) {
 	testFormationAssignmentID := "testFormationAssignmentID"
 	consumerUUID := uuid.New().String()
 	appTemplateID := "testAppTemplateID"
+	intSystemID := "intSystemID"
 	runtimeID := "testRuntimeID"
 
 	testErr := errors.New("test error")
@@ -44,7 +45,7 @@ func TestAuthenticator_Handler(t *testing.T) {
 	faWithSourceAppAndTargetRuntimeContext := fixFormationAssignmentModel(testFormationID, internalTntID, faSourceID, faTargetID, model.FormationAssignmentTypeApplication, model.FormationAssignmentTypeRuntimeContext)
 
 	intSysApp := &model.Application{
-		IntegrationSystemID: &faTargetID,
+		IntegrationSystemID: &intSystemID,
 	}
 
 	appWithAppTemplate := &model.Application{
@@ -114,7 +115,7 @@ func TestAuthenticator_Handler(t *testing.T) {
 				return faSvc
 			},
 			contextFn: func() context.Context {
-				c := fixGetConsumer(consumerUUID, consumer.Runtime)
+				c := fixGetConsumer(consumerUUID, consumer.ExternalCertificate)
 				return fixContextWithTenantAndConsumer(c, internalTntID, externalTntID)
 			},
 			hasURLVars:         true,
@@ -134,7 +135,7 @@ func TestAuthenticator_Handler(t *testing.T) {
 			name:       "Authorization fail: error when transaction begin fails",
 			transactFn: txGen.ThatFailsOnBegin,
 			contextFn: func() context.Context {
-				c := fixGetConsumer(consumerUUID, consumer.Runtime)
+				c := fixGetConsumer(consumerUUID, consumer.ExternalCertificate)
 				return fixContextWithTenantAndConsumer(c, internalTntID, externalTntID)
 			},
 			hasURLVars:         true,
@@ -150,7 +151,7 @@ func TestAuthenticator_Handler(t *testing.T) {
 				return faSvc
 			},
 			contextFn: func() context.Context {
-				c := fixGetConsumer(consumerUUID, consumer.Runtime)
+				c := fixGetConsumer(consumerUUID, consumer.ExternalCertificate)
 				return fixContextWithTenantAndConsumer(c, internalTntID, externalTntID)
 			},
 			hasURLVars:         true,
@@ -166,7 +167,7 @@ func TestAuthenticator_Handler(t *testing.T) {
 				return faSvc
 			},
 			contextFn: func() context.Context {
-				c := fixGetConsumer(consumerUUID, consumer.Runtime)
+				c := fixGetConsumer(consumerUUID, consumer.ExternalCertificate)
 				ctxOnlyWithConsumer := consumer.SaveToContext(emptyCtx, c)
 				return ctxOnlyWithConsumer
 			},
@@ -183,7 +184,7 @@ func TestAuthenticator_Handler(t *testing.T) {
 				return faSvc
 			},
 			contextFn: func() context.Context {
-				c := fixGetConsumer(consumerUUID, consumer.Runtime)
+				c := fixGetConsumer(consumerUUID, consumer.ExternalCertificate)
 				return fixContextWithTenantAndConsumer(c, internalTntID, externalTntID)
 			},
 			hasURLVars:         true,
@@ -205,7 +206,7 @@ func TestAuthenticator_Handler(t *testing.T) {
 				return appRepo
 			},
 			contextFn: func() context.Context {
-				c := fixGetConsumer(consumerUUID, consumer.Application)
+				c := fixGetConsumer(consumerUUID, consumer.ExternalCertificate)
 				return fixContextWithTenantAndConsumer(c, internalTntID, externalTntID)
 			},
 			hasURLVars:         true,
@@ -227,7 +228,7 @@ func TestAuthenticator_Handler(t *testing.T) {
 				return appRepo
 			},
 			contextFn: func() context.Context {
-				c := fixGetConsumer(consumerUUID, consumer.IntegrationSystem)
+				c := fixGetConsumer(consumerUUID, consumer.ExternalCertificate)
 				return fixContextWithTenantAndConsumer(c, internalTntID, externalTntID)
 			},
 			hasURLVars:         true,
@@ -249,7 +250,7 @@ func TestAuthenticator_Handler(t *testing.T) {
 				return appRepo
 			},
 			contextFn: func() context.Context {
-				c := fixGetConsumer(consumerUUID, consumer.IntegrationSystem)
+				c := fixGetConsumer(consumerUUID, consumer.ExternalCertificate)
 				return fixContextWithTenantAndConsumer(c, internalTntID, externalTntID)
 			},
 			hasURLVars:         true,
@@ -276,7 +277,7 @@ func TestAuthenticator_Handler(t *testing.T) {
 				return appTemplateRepo
 			},
 			contextFn: func() context.Context {
-				c := fixGetConsumer(consumerUUID, consumer.IntegrationSystem)
+				c := fixGetConsumer(consumerUUID, consumer.ExternalCertificate)
 				return fixContextWithTenantAndConsumer(c, internalTntID, externalTntID)
 			},
 			hasURLVars:         true,
@@ -303,7 +304,7 @@ func TestAuthenticator_Handler(t *testing.T) {
 				return appTemplateRepo
 			},
 			contextFn: func() context.Context {
-				c := fixGetConsumer(consumerUUID, consumer.IntegrationSystem)
+				c := fixGetConsumer(consumerUUID, consumer.ExternalCertificate)
 				return fixContextWithTenantAndConsumer(c, internalTntID, externalTntID)
 			},
 			hasURLVars:         true,
@@ -335,7 +336,7 @@ func TestAuthenticator_Handler(t *testing.T) {
 				return lblRepo
 			},
 			contextFn: func() context.Context {
-				c := fixGetConsumer(consumerUUID, consumer.IntegrationSystem)
+				c := fixGetConsumer(consumerUUID, consumer.ExternalCertificate)
 				return fixContextWithTenantAndConsumer(c, internalTntID, externalTntID)
 			},
 			hasURLVars:         true,
@@ -368,7 +369,7 @@ func TestAuthenticator_Handler(t *testing.T) {
 			},
 			consumerSubaccountLabelKey: consumerSubaccountLabelKey,
 			contextFn: func() context.Context {
-				c := fixGetConsumer(consumerUUID, consumer.IntegrationSystem)
+				c := fixGetConsumer(consumerUUID, consumer.ExternalCertificate)
 				return fixContextWithTenantAndConsumer(c, internalTntID, externalTntID)
 			},
 			hasURLVars:         true,
@@ -401,7 +402,7 @@ func TestAuthenticator_Handler(t *testing.T) {
 			},
 			consumerSubaccountLabelKey: consumerSubaccountLabelKey,
 			contextFn: func() context.Context {
-				c := fixGetConsumer(consumerUUID, consumer.IntegrationSystem)
+				c := fixGetConsumer(consumerUUID, consumer.ExternalCertificate)
 				return fixContextWithTenantAndConsumer(c, internalTntID, externalTntID)
 			},
 			hasURLVars:         true,
@@ -422,7 +423,7 @@ func TestAuthenticator_Handler(t *testing.T) {
 				return appRepo
 			},
 			contextFn: func() context.Context {
-				c := fixGetConsumer(faTargetID, consumer.IntegrationSystem)
+				c := fixGetConsumer(intSystemID, consumer.IntegrationSystem)
 				return fixContextWithTenantAndConsumer(c, internalTntID, externalTntID)
 			},
 			hasURLVars:         true,
@@ -430,7 +431,7 @@ func TestAuthenticator_Handler(t *testing.T) {
 			expectedErrOutput:  "",
 		},
 		{
-			name:       "Authorization fail: when the int system caller has owner access to the target FA with type application but the transaction fail",
+			name:       "Authorization fail: when the int system caller manages the target FA with type application but the transaction fail",
 			transactFn: txGen.ThatFailsOnCommit,
 			faServiceFn: func() *automock.FormationAssignmentService {
 				faSvc := &automock.FormationAssignmentService{}
@@ -443,7 +444,7 @@ func TestAuthenticator_Handler(t *testing.T) {
 				return appRepo
 			},
 			contextFn: func() context.Context {
-				c := fixGetConsumer(faTargetID, consumer.IntegrationSystem)
+				c := fixGetConsumer(intSystemID, consumer.IntegrationSystem)
 				return fixContextWithTenantAndConsumer(c, internalTntID, externalTntID)
 			},
 			hasURLVars:         true,
@@ -451,7 +452,7 @@ func TestAuthenticator_Handler(t *testing.T) {
 			expectedErrOutput:  "An unexpected error occurred while processing the request",
 		},
 		{
-			name:       "Authorization success: when the caller has owner access to the formation assignment target with type application",
+			name:       "Authorization success: when the int system caller manages the formation assignment target with type application",
 			transactFn: txGen.ThatSucceeds,
 			faServiceFn: func() *automock.FormationAssignmentService {
 				faSvc := &automock.FormationAssignmentService{}
@@ -461,11 +462,52 @@ func TestAuthenticator_Handler(t *testing.T) {
 			appRepoFn: func() *automock.ApplicationRepository {
 				appRepo := &automock.ApplicationRepository{}
 				appRepo.On("GetByID", contextThatHasTenant(internalTntID), internalTntID, faTargetID).Return(intSysApp, nil)
-				appRepo.On("OwnerExists", contextThatHasTenant(internalTntID), internalTntID, faTargetID).Return(true, nil)
 				return appRepo
 			},
 			contextFn: func() context.Context {
-				c := fixGetConsumer(consumerUUID, consumer.IntegrationSystem)
+				c := fixGetConsumer(intSystemID, consumer.IntegrationSystem)
+				return fixContextWithTenantAndConsumer(c, internalTntID, externalTntID)
+			},
+			hasURLVars:         true,
+			expectedStatusCode: http.StatusOK,
+			expectedErrOutput:  "",
+		},
+		{
+			name:       "Authorization fail: when the caller is the parent of the formation assignment target with type application but the transaction fail",
+			transactFn: txGen.ThatFailsOnCommit,
+			faServiceFn: func() *automock.FormationAssignmentService {
+				faSvc := &automock.FormationAssignmentService{}
+				faSvc.On("GetGlobalByIDAndFormationID", contextThatHasTenant(internalTntID), testFormationAssignmentID, testFormationID).Return(faWithSourceRuntimeAndTargetApp, nil)
+				return faSvc
+			},
+			appRepoFn: func() *automock.ApplicationRepository {
+				appRepo := &automock.ApplicationRepository{}
+				appRepo.On("GetByID", contextThatHasTenant(internalTntID), internalTntID, faTargetID).Return(appWithAppTemplate, nil)
+				return appRepo
+			},
+			contextFn: func() context.Context {
+				c := fixGetConsumer(appTemplateID, consumer.ExternalCertificate)
+				return fixContextWithTenantAndConsumer(c, internalTntID, externalTntID)
+			},
+			hasURLVars:         true,
+			expectedStatusCode: http.StatusInternalServerError,
+			expectedErrOutput:  "An unexpected error occurred while processing the request",
+		},
+		{
+			name:       "Authorization success: when the caller is the parent of the formation assignment target with type application",
+			transactFn: txGen.ThatSucceeds,
+			faServiceFn: func() *automock.FormationAssignmentService {
+				faSvc := &automock.FormationAssignmentService{}
+				faSvc.On("GetGlobalByIDAndFormationID", contextThatHasTenant(internalTntID), testFormationAssignmentID, testFormationID).Return(faWithSourceRuntimeAndTargetApp, nil)
+				return faSvc
+			},
+			appRepoFn: func() *automock.ApplicationRepository {
+				appRepo := &automock.ApplicationRepository{}
+				appRepo.On("GetByID", contextThatHasTenant(internalTntID), internalTntID, faTargetID).Return(appWithAppTemplate, nil)
+				return appRepo
+			},
+			contextFn: func() context.Context {
+				c := fixGetConsumer(appTemplateID, consumer.ExternalCertificate)
 				return fixContextWithTenantAndConsumer(c, internalTntID, externalTntID)
 			},
 			hasURLVars:         true,
@@ -487,7 +529,7 @@ func TestAuthenticator_Handler(t *testing.T) {
 				return appRepo
 			},
 			contextFn: func() context.Context {
-				c := fixGetConsumer(consumerUUID, consumer.IntegrationSystem)
+				c := fixGetConsumer(consumerUUID, consumer.ExternalCertificate)
 				return fixContextWithTenantAndConsumer(c, internalTntID, externalTntID)
 			},
 			hasURLVars:         true,
@@ -520,7 +562,7 @@ func TestAuthenticator_Handler(t *testing.T) {
 			},
 			consumerSubaccountLabelKey: consumerSubaccountLabelKey,
 			contextFn: func() context.Context {
-				c := fixGetConsumer(consumerUUID, consumer.IntegrationSystem)
+				c := fixGetConsumer(consumerUUID, consumer.ExternalCertificate)
 				return fixContextWithTenantAndConsumer(c, internalTntID, externalTntID)
 			},
 			hasURLVars:         true,
@@ -553,7 +595,7 @@ func TestAuthenticator_Handler(t *testing.T) {
 			},
 			consumerSubaccountLabelKey: consumerSubaccountLabelKey,
 			contextFn: func() context.Context {
-				c := fixGetConsumer(consumerUUID, consumer.IntegrationSystem)
+				c := fixGetConsumer(consumerUUID, consumer.ExternalCertificate)
 				return fixContextWithTenantAndConsumer(c, internalTntID, externalTntID)
 			},
 			hasURLVars:         true,
@@ -575,7 +617,7 @@ func TestAuthenticator_Handler(t *testing.T) {
 				return rtmRepo
 			},
 			contextFn: func() context.Context {
-				c := fixGetConsumer(consumerUUID, consumer.Runtime)
+				c := fixGetConsumer(consumerUUID, consumer.ExternalCertificate)
 				return fixContextWithTenantAndConsumer(c, internalTntID, externalTntID)
 			},
 			hasURLVars:         true,
@@ -596,7 +638,7 @@ func TestAuthenticator_Handler(t *testing.T) {
 				return rtmRepo
 			},
 			contextFn: func() context.Context {
-				c := fixGetConsumer(consumerUUID, consumer.Runtime)
+				c := fixGetConsumer(consumerUUID, consumer.ExternalCertificate)
 				return fixContextWithTenantAndConsumer(c, internalTntID, externalTntID)
 			},
 			hasURLVars:         true,
@@ -617,7 +659,7 @@ func TestAuthenticator_Handler(t *testing.T) {
 				return rtmRepo
 			},
 			contextFn: func() context.Context {
-				c := fixGetConsumer(consumerUUID, consumer.Runtime)
+				c := fixGetConsumer(consumerUUID, consumer.ExternalCertificate)
 				return fixContextWithTenantAndConsumer(c, internalTntID, externalTntID)
 			},
 			hasURLVars:         true,
@@ -638,7 +680,7 @@ func TestAuthenticator_Handler(t *testing.T) {
 				return rtmRepo
 			},
 			contextFn: func() context.Context {
-				c := fixGetConsumer(consumerUUID, consumer.Runtime)
+				c := fixGetConsumer(consumerUUID, consumer.ExternalCertificate)
 				return fixContextWithTenantAndConsumer(c, internalTntID, externalTntID)
 			},
 			hasURLVars:         true,
@@ -660,7 +702,7 @@ func TestAuthenticator_Handler(t *testing.T) {
 				return rtmCtxRepo
 			},
 			contextFn: func() context.Context {
-				c := fixGetConsumer(consumerUUID, consumer.Runtime)
+				c := fixGetConsumer(consumerUUID, consumer.ExternalCertificate)
 				return fixContextWithTenantAndConsumer(c, internalTntID, externalTntID)
 			},
 			hasURLVars:         true,
@@ -686,7 +728,7 @@ func TestAuthenticator_Handler(t *testing.T) {
 				return rtmCtxRepo
 			},
 			contextFn: func() context.Context {
-				c := fixGetConsumer(consumerUUID, consumer.Runtime)
+				c := fixGetConsumer(consumerUUID, consumer.ExternalCertificate)
 				return fixContextWithTenantAndConsumer(c, internalTntID, externalTntID)
 			},
 			hasURLVars:         true,
@@ -712,7 +754,7 @@ func TestAuthenticator_Handler(t *testing.T) {
 				return rtmCtxRepo
 			},
 			contextFn: func() context.Context {
-				c := fixGetConsumer(consumerUUID, consumer.Runtime)
+				c := fixGetConsumer(consumerUUID, consumer.ExternalCertificate)
 				return fixContextWithTenantAndConsumer(c, internalTntID, externalTntID)
 			},
 			hasURLVars:         true,
@@ -738,7 +780,7 @@ func TestAuthenticator_Handler(t *testing.T) {
 				return rtmCtxRepo
 			},
 			contextFn: func() context.Context {
-				c := fixGetConsumer(consumerUUID, consumer.Runtime)
+				c := fixGetConsumer(consumerUUID, consumer.ExternalCertificate)
 				return fixContextWithTenantAndConsumer(c, internalTntID, externalTntID)
 			},
 			hasURLVars:         true,
@@ -764,7 +806,7 @@ func TestAuthenticator_Handler(t *testing.T) {
 				return rtmCtxRepo
 			},
 			contextFn: func() context.Context {
-				c := fixGetConsumer(consumerUUID, consumer.Runtime)
+				c := fixGetConsumer(consumerUUID, consumer.ExternalCertificate)
 				return fixContextWithTenantAndConsumer(c, internalTntID, externalTntID)
 			},
 			hasURLVars:         true,

--- a/installation/scripts/install-db.sh
+++ b/installation/scripts/install-db.sh
@@ -8,7 +8,8 @@ source $SCRIPTS_DIR/utils.sh
 
 TIMEOUT=30m0s
 
-DATA_DIR="$( cd ${SCRIPTS_DIR}/../data && pwd )"
+DATA_DIR="${SCRIPTS_DIR}/../data"
+mkdir -p "${DATA_DIR}"
 DB_CHARTS="$( cd ${CURRENT_DIR}/../../chart/localdb && pwd )"
 
 function cleanup_trap() {


### PR DESCRIPTION
**Description**

When we allow dynamic registration of subject mappings, we will support onboarded application templates to have their certificates registered in the subject mapping as well. The subject mapping will map their id as the `internal_consumer_id`. Then we would like to allow them to use their certificate to authenticate to compass and report status for their own applications.

This is similar to how we allow self registered application templates to report status for their applications with their self registered certificate, but for app templates that are not self register but onboarded to compass from different sources.

Changes proposed in this pull request:
- Allow application template consumers to report status for formation notifications to their applications

**Pull Request status**

- [x] Implementation
- [x] Unit tests
- N/A Integration tests
- [ ] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- N/A Mocks are regenerated, using the automated script
