### PR TITLE
Relax input validation of tenant mapping status API

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -139,7 +139,7 @@ global:
       name: compass-pairing-adapter
     director:
       dir:
-      version: "PR-2836"
+      version: "PR-2842"
       name: compass-director
     hydrator:
       dir:
@@ -172,7 +172,7 @@ global:
       version: "0a651695"
     external_services_mock:
       dir:
-      version: "PR-2825"
+      version: "PR-2842"
       name: compass-external-services-mock
     console:
       dir:
@@ -180,7 +180,7 @@ global:
       name: compass-console
     e2e_tests:
       dir:
-      version: "PR-2838"
+      version: "PR-2842"
       name: compass-e2e-tests
   isLocalEnv: false
   isForTesting: false

--- a/components/director/internal/domain/apptemplate/config.go
+++ b/components/director/internal/domain/apptemplate/config.go
@@ -2,8 +2,9 @@ package apptemplate
 
 import (
 	"encoding/json"
-	"github.com/pkg/errors"
 	"os"
+
+	"github.com/pkg/errors"
 )
 
 // UnmarshalTenantMappingConfig unmarshalls a string into map[string]interface{}

--- a/components/director/internal/formationmapping/handler.go
+++ b/components/director/internal/formationmapping/handler.go
@@ -295,9 +295,9 @@ func (b RequestBody) Validate() error {
 		fieldRules = append(fieldRules, validation.Field(&b.State, validation.In(model.ReadyAssignmentState, model.ConfigPendingAssignmentState)))
 		fieldRules = append(fieldRules, validation.Field(&b.Error, validation.Empty))
 		return validation.ValidateStruct(&b, fieldRules...)
-	} else {
-		return errors.New("The request body cannot contains only state")
 	}
+
+	return nil
 }
 
 // processFormationAssignmentAsynchronousUnassign handles the async unassign formation assignment status update

--- a/components/director/internal/formationmapping/handler_test.go
+++ b/components/director/internal/formationmapping/handler_test.go
@@ -141,15 +141,6 @@ func Test_StatusUpdate(t *testing.T) {
 			expectedStatusCode: http.StatusBadRequest,
 			expectedErrOutput:  "Request Body contains invalid input:",
 		},
-		{
-			name: "Validate Error: error when request body contains only state",
-			reqBody: fm.RequestBody{
-				State: model.ReadyAssignmentState,
-			},
-			hasURLVars:         true,
-			expectedStatusCode: http.StatusBadRequest,
-			expectedErrOutput:  "Request Body contains invalid input:",
-		},
 		// Business logic unit tests for assign operation
 		{
 			name:       "Success when operation is assign",

--- a/tests/director/tests/formation_api_test.go
+++ b/tests/director/tests/formation_api_test.go
@@ -2481,7 +2481,7 @@ func TestFormationAssignments(stdT *testing.T) {
 
 		})
 
-		t.Run("Consecutive unassigns before formation assignments are processed unassigns both participants", func(t *testing.T) {
+		t.Run("Consecutive participants unassignment are still in formation before the formation assignments are processed by the async API call and removed afterwards", func(t *testing.T) {
 			var assignedFormation graphql.Formation
 
 			t.Logf("Assign tenant %s to formation %s", subscriptionConsumerSubaccountID, providerFormationName)
@@ -2491,7 +2491,7 @@ func TestFormationAssignments(stdT *testing.T) {
 			require.Equal(t, providerFormationName, assignedFormation.Name)
 			defer fixtures.CleanupFormationWithTenantObjectType(t, ctx, certSecuredGraphQLClient, assignedFormation.Name, subscriptionConsumerSubaccountID, subscriptionConsumerAccountID)
 
-			t.Logf("Assign application to formation %s", formation.Name)
+			t.Logf("Assign application with ID: %s to formation %s", actualApp.ID, formation.Name)
 			defer fixtures.CleanupFormation(t, ctx, certSecuredGraphQLClient, graphql.FormationInput{Name: providerFormationName}, actualApp.ID, graphql.FormationObjectTypeApplication, subscriptionConsumerTenantID)
 			assignReq = fixtures.FixAssignFormationRequest(actualApp.ID, string(graphql.FormationObjectTypeApplication), providerFormationName)
 			err = testctx.Tc.RunOperationWithCustomTenant(ctx, certSecuredGraphQLClient, subscriptionConsumerAccountID, assignReq, &assignedFormation)
@@ -2500,14 +2500,14 @@ func TestFormationAssignments(stdT *testing.T) {
 
 			assertFormationAssignmentsAsynchronously(t, ctx, subscriptionConsumerAccountID, formation.ID, 4, expectedAssignmentsBySourceID)
 
-			t.Logf("Check that %s is assigned from formation %s", subscriptionConsumerAccountID, providerFormationName)
+			t.Logf("Check that the runtime context with ID: %s is assigned to formation: %s", rtCtx.ID, providerFormationName)
 			actualRtmCtx := fixtures.GetRuntimeContext(t, ctx, certSecuredGraphQLClient, subscriptionConsumerAccountID, consumerSubaccountRuntime.ID, rtCtx.ID)
 			scenarios, hasScenarios := actualRtmCtx.Labels["scenarios"]
 			assert.True(t, hasScenarios)
 			assert.Len(t, scenarios, 1)
 			assert.Contains(t, scenarios, providerFormationName)
 
-			t.Logf("Check that %s is assigned from formation %s", actualApp.ID, providerFormationName)
+			t.Logf("Check that the application with ID: %s is assigned to formation: %s", actualApp.ID, providerFormationName)
 			app := fixtures.GetApplication(t, ctx, certSecuredGraphQLClient, subscriptionConsumerAccountID, actualApp.ID)
 			scenarios, hasScenarios = app.Labels["scenarios"]
 			assert.True(t, hasScenarios)
@@ -2522,20 +2522,20 @@ func TestFormationAssignments(stdT *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, providerFormationName, unassignFormation.Name)
 
-			t.Logf("Unassign application from formation %s", formation.Name)
+			t.Logf("Unassign application with ID: %s from formation %s", actualApp.ID, formation.Name)
 			unassignReq = fixtures.FixUnassignFormationRequest(actualApp.ID, string(graphql.FormationObjectTypeApplication), providerFormationName)
 			err = testctx.Tc.RunOperationWithCustomTenant(ctx, certSecuredGraphQLClient, subscriptionConsumerAccountID, unassignReq, &unassignFormation)
 			require.NoError(t, err)
 			require.Equal(t, formation.Name, assignedFormation.Name)
 
-			t.Logf("Check that %s is still assigned from formation %s", subscriptionConsumerSubaccountID, providerFormationName)
+			t.Logf("Check that the runtime context with ID: %s is still assigned to formation: %s", rtCtx.ID, providerFormationName)
 			actualRtmCtx = fixtures.GetRuntimeContext(t, ctx, certSecuredGraphQLClient, subscriptionConsumerAccountID, consumerSubaccountRuntime.ID, rtCtx.ID)
 			scenarios, hasScenarios = actualRtmCtx.Labels["scenarios"]
 			assert.True(t, hasScenarios)
 			assert.Len(t, scenarios, 1)
 			assert.Contains(t, scenarios, providerFormationName)
 
-			t.Logf("Check that %s is still assigned from formation %s", actualApp.ID, providerFormationName)
+			t.Logf("Check that the application with ID: %s is still assigned to formation: %s", actualApp.ID, providerFormationName)
 			app = fixtures.GetApplication(t, ctx, certSecuredGraphQLClient, subscriptionConsumerAccountID, actualApp.ID)
 			scenarios, hasScenarios = app.Labels["scenarios"]
 			assert.True(t, hasScenarios)


### PR DESCRIPTION
**Description**
Relax the input validation in such a way that we allow only a `state` to be reported on the async status API

**Related issue(s)**
- https://github.com/kyma-incubator/compass/pull/2712
- https://github.com/kyma-incubator/compass/pull/2722

**Pull Request status**
- [x] Implementation
- [x] Unit tests
- [x] Integration tests
- [x] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [x] [N/A] Mocks are regenerated, using the automated script
