### PR TITLE
fix verifiers cache usage

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -143,7 +143,7 @@ global:
       name: compass-director
     hydrator:
       dir:
-      version: "PR-2880"
+      version: "PR-2896"
       name: compass-hydrator
     gateway:
       dir:

--- a/components/hydrator/internal/authnmappinghandler/handler_test.go
+++ b/components/hydrator/internal/authnmappinghandler/handler_test.go
@@ -275,7 +275,7 @@ func TestHandler(t *testing.T) {
 
 		verifierMock := &automock.TokenVerifier{}
 		verifierMock.On("Verify", mock.Anything, mockedToken1).Return(tokenDataMock, nil).Once()
-		verifierMock.On("Verify", mock.Anything, mockedToken2).Return(nil, mockErr).Once()
+		verifierMock.On("Verify", mock.Anything, mockedToken2).Return(nil, mockErr).Twice()
 
 		handler := authnmappinghandler.NewHandler(reqDataParserMock, mockedWellKnownConfigClient, func(_ context.Context, _ authnmappinghandler.OpenIDMetadata) authnmappinghandler.TokenVerifier {
 			return verifierMock


### PR DESCRIPTION
**Description**

A race condition occures in the Hydrator component when verifying token. Requests A and B with tokens from issuer X are sent to UCL. Request A is being processed. No verifier is found in the cache for the token issuer and the Hydrator preceeds with determining the correct verifier. Then the Hydrator receives request B . Once again it does not find verifier in the cache and proceeds with determining the verifier. Then while processing request A a verifier is found and stored in the cache. During the processing of request B the Hydrator loops through the trusted issuers and reaches the issuer of the token. The issuer is now present in the cache and the Hydrators does not verify the token using the verifier as it expects that the token was already veryfied because the verifier is present in the cahce. This results in the request proceeding with empty scopes.

Changes proposed in this pull request:
- remove the second lookup in the cache, this way the cache will be used correctly and will optimise the performance in most of the cases.  Only when such race condition occurs it will do the same thing twice.

**Pull Request status**
<!-- Feel free to construct the checklist with whatever items seem most reasonable for your change. You could disassemble the Implementation part to even smaller separate checklist items if you're working on something big for example. But do make the effort to provide a checklist of some sort so that the core team as well as the community can have an idea about the progress of your Pull Request.
-->

- [x] Implementation
- [x] Unit tests
- [x] Integration tests
- [x] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
