### PR TITLE
Switch helm driver to sql on local env

### DIFF
--- a/docs/compass/04-01-installation.md
+++ b/docs/compass/04-01-installation.md
@@ -124,12 +124,12 @@ global:
 Start the Database installation by using the following command:
 
 ```bash
-<script from ../../installation/scripts/install-db.sh> --overrides-file <file from ../../installation/resources/compass-overrides-local.yaml> --overrides-file <file from above step - e.g. additionalCompassOverrides.yaml> --timeout <e.g: 30m0s> --sql-helm-backend
+<script from ../../installation/scripts/install-db.sh> --overrides-file <file from ../../installation/resources/compass-overrides-local.yaml> --overrides-file <file from above step - e.g. additionalCompassOverrides.yaml> --timeout <e.g: 30m0s>
 ```
 Once the Database is provisioned procced and start the Compass installation by using the following command:
 
 ```bash
-<script from ../../installation/scripts/install-compass.sh> --overrides-file <file from ../../installation/resources/compass-overrides-local.yaml> --overrides-file <file from above step - e.g. additionalCompassOverrides.yaml> --timeout <e.g: 30m0s>
+<script from ../../installation/scripts/install-compass.sh> --overrides-file <file from ../../installation/resources/compass-overrides-local.yaml> --overrides-file <file from above step - e.g. additionalCompassOverrides.yaml> --timeout <e.g: 30m0s> --sql-helm-backend
 ```
 
 ### Certificate Management

--- a/docs/compass/04-01-installation.md
+++ b/docs/compass/04-01-installation.md
@@ -124,7 +124,7 @@ global:
 Start the Database installation by using the following command:
 
 ```bash
-<script from ../../installation/scripts/install-db.sh> --overrides-file <file from ../../installation/resources/compass-overrides-local.yaml> --overrides-file <file from above step - e.g. additionalCompassOverrides.yaml> --timeout <e.g: 30m0s>
+<script from ../../installation/scripts/install-db.sh> --overrides-file <file from ../../installation/resources/compass-overrides-local.yaml> --overrides-file <file from above step - e.g. additionalCompassOverrides.yaml> --timeout <e.g: 30m0s> --sql-helm-backend
 ```
 Once the Database is provisioned procced and start the Compass installation by using the following command:
 
@@ -390,7 +390,7 @@ Start Database installation:
 ```
 Then, install compass component:
 ```bash
-<script from ../../installation/scripts/install-compass.sh> --overrides-file <file from ../../installation/resources/compass-overrides-local.yaml> --overrides-file <file from above step - e.g. additionalCompassOverrides.yaml> --timeout <e.g: 30m0s>
+<script from ../../installation/scripts/install-compass.sh> --overrides-file <file from ../../installation/resources/compass-overrides-local.yaml> --overrides-file <file from above step - e.g. additionalCompassOverrides.yaml> --timeout <e.g: 30m0s> --sql-helm-backend
 ```
 
 Once Compass is installed, the Runtime Agent will be configured to fetch the Runtime configuration from the Compass installation within the same cluster.

--- a/installation/cmd/run.sh
+++ b/installation/cmd/run.sh
@@ -276,22 +276,11 @@ if [[ ! ${SKIP_DB_INSTALL} ]]; then
   echo "DB installation status ${STATUS}"
 fi
 
-DB_USER=$(base64 -d <<< $(kubectl get secret -n compass-system compass-postgresql -o=jsonpath="{.data['postgresql-director-username']}"))
-DB_PWD=$(base64 -d <<< $(kubectl get secret -n compass-system compass-postgresql -o=jsonpath="{.data['postgresql-director-password']}"))
-DB_NAME=$(base64 -d <<< $(kubectl get secret -n compass-system compass-postgresql -o=jsonpath="{.data['postgresql-directorDatabaseName']}"))
-DB_PORT=$(base64 -d <<< $(kubectl get secret -n compass-system compass-postgresql -o=jsonpath="{.data['postgresql-servicePort']}"))
-
-kubectl port-forward --namespace compass-system svc/compass-postgresql 5432:5432 &
-export HELM_DRIVER=sql
-export HELM_DRIVER_SQL_CONNECTION_STRING=postgres://${DB_USER}:${DB_PWD}@localhost:${DB_PORT}/${DB_NAME}?sslmode=disable
-
 echo 'Installing Compass'
 COMPASS_OVERRIDES="${CURRENT_DIR}/../resources/compass-overrides-local.yaml"
-bash "${ROOT_PATH}"/installation/scripts/install-compass.sh --overrides-file "${COMPASS_OVERRIDES}" --timeout 30m0s
+bash "${ROOT_PATH}"/installation/scripts/install-compass.sh --overrides-file "${COMPASS_OVERRIDES}" --timeout 30m0s --sql-helm-backend
 STATUS=$(helm status compass -n compass-system -o json | jq .info.status)
 echo "Compass installation status ${STATUS}"
-
-pkill kubectl
 
 prometheusMTLSPatch
 

--- a/installation/cmd/run.sh
+++ b/installation/cmd/run.sh
@@ -276,11 +276,22 @@ if [[ ! ${SKIP_DB_INSTALL} ]]; then
   echo "DB installation status ${STATUS}"
 fi
 
+DB_USER=$(base64 -d <<< $(kubectl get secret -n compass-system compass-postgresql -o=jsonpath="{.data['postgresql-director-username']}"))
+DB_PWD=$(base64 -d <<< $(kubectl get secret -n compass-system compass-postgresql -o=jsonpath="{.data['postgresql-director-password']}"))
+DB_NAME=$(base64 -d <<< $(kubectl get secret -n compass-system compass-postgresql -o=jsonpath="{.data['postgresql-directorDatabaseName']}"))
+DB_PORT=$(base64 -d <<< $(kubectl get secret -n compass-system compass-postgresql -o=jsonpath="{.data['postgresql-servicePort']}"))
+
+kubectl port-forward --namespace compass-system svc/compass-postgresql 5432:5432 &
+export HELM_DRIVER=sql
+export HELM_DRIVER_SQL_CONNECTION_STRING=postgres://${DB_USER}:${DB_PWD}@localhost:${DB_PORT}/${DB_NAME}?sslmode=disable
+
 echo 'Installing Compass'
 COMPASS_OVERRIDES="${CURRENT_DIR}/../resources/compass-overrides-local.yaml"
 bash "${ROOT_PATH}"/installation/scripts/install-compass.sh --overrides-file "${COMPASS_OVERRIDES}" --timeout 30m0s
 STATUS=$(helm status compass -n compass-system -o json | jq .info.status)
 echo "Compass installation status ${STATUS}"
+
+pkill kubectl
 
 prometheusMTLSPatch
 

--- a/installation/scripts/install-compass.sh
+++ b/installation/scripts/install-compass.sh
@@ -2,6 +2,9 @@
 
 set -o errexit
 
+GREEN='\033[0;32m'
+NC='\033[0m' # No Color
+
 CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 SCRIPTS_DIR="${CURRENT_DIR}/../scripts"
 source $SCRIPTS_DIR/utils.sh
@@ -43,6 +46,10 @@ do
             shift # past argument
             shift
         ;;
+        --sql-helm-backend)
+            SQL_HELM_BACKEND=true
+            shift # past argument
+        ;;
         --*)
             echo "Unknown flag ${1}"
             exit 1
@@ -55,6 +62,21 @@ do
 done
 set -- "${POSITIONAL[@]}" # restore positional parameters
 
+if [[ ${SQL_HELM_BACKEND} ]]; then
+    echo -e "${GREEN}Helm SQL storage backend will be used${NC}"
+
+    DB_USER=$(base64 -d <<< $(kubectl get secret -n compass-system compass-postgresql -o=jsonpath="{.data['postgresql-director-username']}"))
+    DB_PWD=$(base64 -d <<< $(kubectl get secret -n compass-system compass-postgresql -o=jsonpath="{.data['postgresql-director-password']}"))
+    DB_NAME=$(base64 -d <<< $(kubectl get secret -n compass-system compass-postgresql -o=jsonpath="{.data['postgresql-directorDatabaseName']}"))
+    DB_PORT=$(base64 -d <<< $(kubectl get secret -n compass-system compass-postgresql -o=jsonpath="{.data['postgresql-servicePort']}"))
+
+    kubectl port-forward --namespace compass-system svc/compass-postgresql ${DB_PORT}:${DB_PORT} &
+    export HELM_DRIVER=sql
+    export HELM_DRIVER_SQL_CONNECTION_STRING=postgres://${DB_USER}:${DB_PWD}@localhost:${DB_PORT}/${DB_NAME}?sslmode=disable
+fi
+
+sleep 5 #wait port-forwarding to be completed
+
 echo "Wait for helm stable status"
 wait_for_helm_stable_state "compass" "compass-system" 
 
@@ -62,3 +84,5 @@ echo "Install Compass"
 echo "Path to compass charts: " ${COMPASS_CHARTS}
 helm upgrade --install --wait --timeout "${TIMEOUT}" -f ./mergedOverrides.yaml --create-namespace --namespace compass-system compass "${COMPASS_CHARTS}"
 trap "cleanup_trap" RETURN EXIT INT TERM
+
+pkill kubectl


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

For every helm chart, helm 3 generates a new secret.
The purpose of this auto generated secret is for recording release information and its size is correlated with the size of the helm chart.
The default release information storage for Helm 3 is Secret (in the namespace of the release).
In k8s the individual secrets are limited to 1MiB in size. Which means that if our chart become bigger than 1MB we will hit that limit.

In order to avoid hitting this limit we have to change the default helm storage backend.
The supported storage backends for helm are - secret, configmap, sql
The secrets and configmaps are limited to 1 MiB in size. So the only available option for us is to use SQL as a storage backend.

Changes proposed in this pull request:
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- ...

**Pull Request status**
<!-- Feel free to construct the checklist with whatever items seem most reasonable for your change. You could disassemble the Implementation part to even smaller separate checklist items if you're working on something big for example. But do make the effort to provide a checklist of some sort so that the core team as well as the community can have an idea about the progress of your Pull Request.
-->

- [ ] Implementation
- [ ] Unit tests
- [ ] Integration tests
- [ ] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [ ] Mocks are regenerated, using the automated script
