### PR TITLE
Defer application unassignment in benchmark tests

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -180,7 +180,7 @@ global:
       name: compass-console
     e2e_tests:
       dir:
-      version: "PR-2882"
+      version: "PR-2910"
       name: compass-e2e-tests
   isLocalEnv: false
   isForTesting: false

--- a/tests/director/bench/application_api_test.go
+++ b/tests/director/bench/application_api_test.go
@@ -46,6 +46,7 @@ func BenchmarkApplicationsForRuntime(b *testing.B) {
 		}
 		appResp, err := fixtures.RegisterApplicationFromInput(b, ctx, certSecuredGraphQLClient, tenantID, appInput)
 		defer fixtures.CleanupApplication(b, ctx, certSecuredGraphQLClient, tenantID, &appResp)
+		defer fixtures.UnassignFormationWithApplicationObjectType(b, ctx, certSecuredGraphQLClient, graphql.FormationInput{Name: testScenario}, appResp.ID, tenantID)
 		require.NoError(b, err)
 		require.NotEmpty(b, appResp.ID)
 	}


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:
- add defer statement to unassign application from formation in benchmark tests
