### PR TITLE
Remove leftover ASA GraphQL model

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -180,7 +180,7 @@ global:
       name: compass-console
     e2e_tests:
       dir:
-      version: "PR-2922"
+      version: "PR-2925"
       name: compass-e2e-tests
   isLocalEnv: false
   isForTesting: false

--- a/tests/director/tests/automatic_scenario_assignment_test.go
+++ b/tests/director/tests/automatic_scenario_assignment_test.go
@@ -21,8 +21,12 @@ func TestAutomaticScenarioAssignmentQueries(t *testing.T) {
 
 	testScenarioA := "ASA1"
 	testScenarioB := "ASA2"
-	testSelectorA := graphql.LabelSelectorInput{
+	testSelectorA := graphql.Label{
 		Key:   "global_subaccount_id",
+		Value: subaccount,
+	}
+	testSelectorAInput := graphql.LabelSelectorInput{
+		Key:   testSelectorA.Key,
 		Value: subaccount,
 	}
 
@@ -34,7 +38,7 @@ func TestAutomaticScenarioAssignmentQueries(t *testing.T) {
 		Name: testScenarioB,
 	}
 
-	testSelectorAGQL, err := testctx.Tc.Graphqlizer.LabelSelectorInputToGQL(testSelectorA)
+	testSelectorAGQL, err := testctx.Tc.Graphqlizer.LabelSelectorInputToGQL(testSelectorAInput)
 	require.NoError(t, err)
 
 	// setup available scenarios
@@ -70,15 +74,13 @@ func TestAutomaticScenarioAssignmentQueries(t *testing.T) {
 	saveExample(t, listAssignmentsRequest.Query(), "query automatic scenario assignments")
 	saveExample(t, getAssignmentForScenarioRequest.Query(), "query automatic scenario assignment for scenario")
 	saveExample(t, listAssignmentsForSelectorRequest.Query(), "query automatic scenario assignments for selector")
-	inputAssignment1 := graphql.AutomaticScenarioAssignmentSetInput{ScenarioName: testScenarioA, Selector: &testSelectorA}
-	inputAssignment2 := graphql.AutomaticScenarioAssignmentSetInput{ScenarioName: testScenarioB, Selector: &testSelectorA}
 
 	assertions.AssertAutomaticScenarioAssignments(t,
-		[]graphql.AutomaticScenarioAssignmentSetInput{inputAssignment1, inputAssignment2},
+		map[string]*graphql.Label{testScenarioA: &testSelectorA, testScenarioB: &testSelectorA},
 		actualAssignmentsPage.Data)
-	assertions.AssertAutomaticScenarioAssignment(t, inputAssignment1, actualAssignmentForScenario)
+	assertions.AssertAutomaticScenarioAssignment(t, testScenarioA, &testSelectorA, actualAssignmentForScenario)
 	assertions.AssertAutomaticScenarioAssignments(t,
-		[]graphql.AutomaticScenarioAssignmentSetInput{inputAssignment1, inputAssignment2},
+		map[string]*graphql.Label{testScenarioA: &testSelectorA, testScenarioB: &testSelectorA},
 		actualAssignmentsForSelector)
 }
 

--- a/tests/director/tests/automatic_scenario_assignment_test.go
+++ b/tests/director/tests/automatic_scenario_assignment_test.go
@@ -21,10 +21,7 @@ func TestAutomaticScenarioAssignmentQueries(t *testing.T) {
 
 	testScenarioA := "ASA1"
 	testScenarioB := "ASA2"
-	testSelectorA := graphql.Label{
-		Key:   "global_subaccount_id",
-		Value: subaccount,
-	}
+	testSelectorA := fixtures.FixLabelSelector("global_subaccount_id", subaccount)
 	testSelectorAInput := graphql.LabelSelectorInput{
 		Key:   testSelectorA.Key,
 		Value: subaccount,

--- a/tests/director/tests/formation_api_test.go
+++ b/tests/director/tests/formation_api_test.go
@@ -486,10 +486,7 @@ func TestTenantFormationFlow(t *testing.T) {
 	subaccountID := tenant.TestTenants.GetIDByName(t, tenant.TestProviderSubaccount)
 
 	ctx := context.Background()
-	scenarioSelector := &graphql.Label{
-		Key:   "global_subaccount_id",
-		Value: subaccountID,
-	}
+	scenarioSelector := fixtures.FixLabelSelector("global_subaccount_id", subaccountID)
 
 	t.Logf("Should create formation: %s", firstFormation)
 	var formation graphql.Formation
@@ -517,7 +514,7 @@ func TestTenantFormationFlow(t *testing.T) {
 	t.Log("Should match expected ASA")
 	asaPage := fixtures.ListAutomaticScenarioAssignmentsWithinTenant(t, ctx, certSecuredGraphQLClient, tenantId)
 	require.Equal(t, 1, len(asaPage.Data))
-	assertions.AssertAutomaticScenarioAssignment(t, firstFormation, scenarioSelector, *asaPage.Data[0])
+	assertions.AssertAutomaticScenarioAssignment(t, firstFormation, &scenarioSelector, *asaPage.Data[0])
 
 	t.Logf("Unassign tenant %s from formation %s", subaccountID, firstFormation)
 	unassignReq := fixtures.FixUnassignFormationRequest(subaccountID, string(graphql.FormationObjectTypeTenant), firstFormation)
@@ -632,11 +629,8 @@ func TestSubaccountInAtMostOneFormationOfType(t *testing.T) {
 	asaPage := fixtures.ListAutomaticScenarioAssignmentsWithinTenant(t, ctx, certSecuredGraphQLClient, tenantId)
 	require.Equal(t, 1, len(asaPage.Data))
 
-	scenarioSelector := &graphql.Label{
-		Key:   "global_subaccount_id",
-		Value: subaccountID,
-	}
-	assertions.AssertAutomaticScenarioAssignment(t, firstFormation, scenarioSelector, *asaPage.Data[0])
+	scenarioSelector := fixtures.FixLabelSelector("global_subaccount_id", subaccountID)
+	assertions.AssertAutomaticScenarioAssignment(t, firstFormation, &scenarioSelector, *asaPage.Data[0])
 
 	t.Logf("Should fail to assign tenant %s to second formation of type %s", subaccountID, formationTemplateName)
 	assignReq = fixtures.FixAssignFormationRequest(subaccountID, string(graphql.FormationObjectTypeTenant), secondFormation)
@@ -664,7 +658,7 @@ func TestSubaccountInAtMostOneFormationOfType(t *testing.T) {
 	asaPage = fixtures.ListAutomaticScenarioAssignmentsWithinTenant(t, ctx, certSecuredGraphQLClient, tenantId)
 	require.Equal(t, 2, len(asaPage.Data))
 
-	assertions.AssertAutomaticScenarioAssignments(t, map[string]*graphql.Label{firstFormation: scenarioSelector, secondFormation: scenarioSelector}, asaPage.Data)
+	assertions.AssertAutomaticScenarioAssignments(t, map[string]*graphql.Label{firstFormation: &scenarioSelector, secondFormation: &scenarioSelector}, asaPage.Data)
 
 	t.Logf("Unassign tenant %s from formation %s", subaccountID, firstFormation)
 	var unassignFormation graphql.Formation

--- a/tests/pkg/assertions/assertions.go
+++ b/tests/pkg/assertions/assertions.go
@@ -429,17 +429,10 @@ func AssertAutomaticScenarioAssignment(t *testing.T, expectedScenario string, ex
 
 func AssertAutomaticScenarioAssignments(t *testing.T, expected map[string]*graphql.Label, actual []*graphql.AutomaticScenarioAssignment) {
 	assert.Equal(t, len(expected), len(actual))
-	for scenario := range expected {
-		found := false
-		for _, actualAssignment := range actual {
-			require.NotNil(t, actualAssignment)
-			if scenario == actualAssignment.ScenarioName {
-				found = true
-				AssertAutomaticScenarioAssignment(t, scenario, expected[scenario], *actualAssignment)
-				break
-			}
-		}
-		assert.True(t, found, "Assignment for scenario: '%s' not found", scenario)
+	for _, actualAssignment := range actual {
+		expectedAssignment, ok := expected[actualAssignment.ScenarioName]
+		require.True(t, ok, "Assignment for scenario: '%s' not found", actualAssignment.ScenarioName)
+		AssertAutomaticScenarioAssignment(t, actualAssignment.ScenarioName, expectedAssignment, *actualAssignment)
 	}
 }
 

--- a/tests/pkg/assertions/assertions.go
+++ b/tests/pkg/assertions/assertions.go
@@ -419,27 +419,27 @@ func AssertGraphQLJSONSchema(t *testing.T, inExpected *graphql.JSONSchema, inAct
 	assert.Equal(t, expected, actual)
 }
 
-func AssertAutomaticScenarioAssignment(t *testing.T, expected graphql.AutomaticScenarioAssignmentSetInput, actual graphql.AutomaticScenarioAssignment) {
-	assert.Equal(t, expected.ScenarioName, actual.ScenarioName)
+func AssertAutomaticScenarioAssignment(t *testing.T, expectedScenario string, expectedSelector *graphql.Label, actual graphql.AutomaticScenarioAssignment) {
+	assert.Equal(t, expectedScenario, actual.ScenarioName)
 	require.NotNil(t, actual.Selector)
-	require.NotNil(t, expected.Selector)
-	assert.Equal(t, expected.Selector.Value, actual.Selector.Value)
-	assert.Equal(t, expected.Selector.Key, actual.Selector.Key)
+	require.NotNil(t, expectedSelector)
+	assert.Equal(t, expectedSelector.Value, actual.Selector.Value)
+	assert.Equal(t, expectedSelector.Key, actual.Selector.Key)
 }
 
-func AssertAutomaticScenarioAssignments(t *testing.T, expected []graphql.AutomaticScenarioAssignmentSetInput, actual []*graphql.AutomaticScenarioAssignment) {
+func AssertAutomaticScenarioAssignments(t *testing.T, expected map[string]*graphql.Label, actual []*graphql.AutomaticScenarioAssignment) {
 	assert.Equal(t, len(expected), len(actual))
-	for _, expectedAssignment := range expected {
+	for scenario := range expected {
 		found := false
 		for _, actualAssignment := range actual {
 			require.NotNil(t, actualAssignment)
-			if expectedAssignment.ScenarioName == actualAssignment.ScenarioName {
+			if scenario == actualAssignment.ScenarioName {
 				found = true
-				AssertAutomaticScenarioAssignment(t, expectedAssignment, *actualAssignment)
+				AssertAutomaticScenarioAssignment(t, scenario, expected[scenario], *actualAssignment)
 				break
 			}
 		}
-		assert.True(t, found, "Assignment for scenario: '%s' not found", expectedAssignment.ScenarioName)
+		assert.True(t, found, "Assignment for scenario: '%s' not found", scenario)
 	}
 }
 

--- a/tests/pkg/fixtures/label_selector_fixtures.go
+++ b/tests/pkg/fixtures/label_selector_fixtures.go
@@ -1,0 +1,10 @@
+package fixtures
+
+import "github.com/kyma-incubator/compass/components/director/pkg/graphql"
+
+func FixLabelSelector(key, value string) graphql.Label {
+	return graphql.Label{
+		Key:   key,
+		Value: value,
+	}
+}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
The struct `graphql.AutomaticScenarioAssignmentSetInput` was removed, but the director dependency version still has it, so bumping it will leave the tests in an uncompilable state. This PR removes the last references to that struct.

Changes proposed in this pull request:
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- ...

**Pull Request status**
<!-- Feel free to construct the checklist with whatever items seem most reasonable for your change. You could disassemble the Implementation part to even smaller separate checklist items if you're working on something big for example. But do make the effort to provide a checklist of some sort so that the core team as well as the community can have an idea about the progress of your Pull Request.
-->

- [x] [N/A] Implementation
- [x] [N/A] Unit tests
- [x] Integration tests
- [x] [N/A] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [x] [N/A] Mocks are regenerated, using the automated script
