### PR TITLE
Fix cert subject mappings cleanup in e2e tests

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -139,7 +139,7 @@ global:
       name: compass-pairing-adapter
     director:
       dir:
-      version: "PR-2965"
+      version: "PR-2955"
       name: compass-director
     hydrator:
       dir:
@@ -180,7 +180,7 @@ global:
       name: compass-console
     e2e_tests:
       dir:
-      version: "PR-2955"
+      version: "PR-2965"
       name: compass-e2e-tests
   isLocalEnv: false
   isForTesting: false

--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -139,7 +139,7 @@ global:
       name: compass-pairing-adapter
     director:
       dir:
-      version: "PR-2955"
+      version: "PR-2965"
       name: compass-director
     hydrator:
       dir:

--- a/tests/director/tests/cert_subject_mapping_test.go
+++ b/tests/director/tests/cert_subject_mapping_test.go
@@ -40,7 +40,7 @@ func TestCreateCertSubjectMapping(t *testing.T) {
 
 	t.Logf("Creating certificate subject mapping with subject: %s, consumer type: %s and tenant access levels: %s", subject, consumerType, tenantAccessLevels)
 	err = testctx.Tc.RunOperationWithoutTenant(ctx, certSecuredGraphQLClient, certSubjectMappingReq, &csm)
-	defer fixtures.CleanupCertificateSubjectMapping(t, ctx, certSecuredGraphQLClient, csm.ID)
+	defer fixtures.CleanupCertificateSubjectMapping(t, ctx, certSecuredGraphQLClient, &csm)
 
 	require.NoError(t, err)
 	require.NotEmpty(t, csm.ID)
@@ -50,8 +50,10 @@ func TestCreateCertSubjectMapping(t *testing.T) {
 func TestDeleteCertSubjectMapping(t *testing.T) {
 	csmInput := fixtures.FixCertificateSubjectMappingInput(subject, consumerType, &internalConsumerID, tenantAccessLevels)
 	t.Logf("Create certificate subject mapping with subject: %s, consumer type: %s and tenant access levels: %s", subject, consumerType, tenantAccessLevels)
-	csmCreate := fixtures.CreateCertificateSubjectMapping(t, ctx, certSecuredGraphQLClient, csmInput)
-	defer fixtures.CleanupCertificateSubjectMapping(t, ctx, certSecuredGraphQLClient, csmCreate.ID)
+
+	var csmCreate graphql.CertificateSubjectMapping // needed so the 'defer' can be above the cert subject mapping creation
+	defer fixtures.CleanupCertificateSubjectMapping(t, ctx, certSecuredGraphQLClient, &csmCreate)
+	csmCreate = fixtures.CreateCertificateSubjectMapping(t, ctx, certSecuredGraphQLClient, csmInput)
 
 	deleteCertSubjectMappingReq := fixtures.FixDeleteCertificateSubjectMappingRequest(csmCreate.ID)
 	saveExample(t, deleteCertSubjectMappingReq.Query(), "delete certificate subject mapping")
@@ -68,8 +70,10 @@ func TestDeleteCertSubjectMapping(t *testing.T) {
 func TestUpdateCertSubjectMapping(t *testing.T) {
 	csmCreateInput := fixtures.FixCertificateSubjectMappingInput(subject, consumerType, &internalConsumerID, tenantAccessLevels)
 	t.Logf("Create certificate subject mapping with subject: %s, consumer type: %s and tenant access levels: %s", subject, consumerType, tenantAccessLevels)
-	csmCreate := fixtures.CreateCertificateSubjectMapping(t, ctx, certSecuredGraphQLClient, csmCreateInput)
-	defer fixtures.CleanupCertificateSubjectMapping(t, ctx, certSecuredGraphQLClient, csmCreate.ID)
+
+	var csmCreate graphql.CertificateSubjectMapping // needed so the 'defer' can be above the cert subject mapping creation
+	defer fixtures.CleanupCertificateSubjectMapping(t, ctx, certSecuredGraphQLClient, &csmCreate)
+	csmCreate = fixtures.CreateCertificateSubjectMapping(t, ctx, certSecuredGraphQLClient, csmCreateInput)
 
 	updatedCertSubjectMappingInput := fixtures.FixCertificateSubjectMappingInput(updatedSubject, updatedConsumerType, &updatedInternalConsumerID, updatedTntAccessLevels)
 	csmUpdatedGQLInput, err := testctx.Tc.Graphqlizer.CertificateSubjectMappingInputToGQL(updatedCertSubjectMappingInput)
@@ -90,8 +94,10 @@ func TestUpdateCertSubjectMapping(t *testing.T) {
 func TestQuerySingleCertSubjectMapping(t *testing.T) {
 	csmInput := fixtures.FixCertificateSubjectMappingInput(subject, consumerType, &internalConsumerID, tenantAccessLevels)
 	t.Logf("Create certificate subject mapping with subject: %s, consumer type: %s and tenant access levels: %s", subject, consumerType, tenantAccessLevels)
-	csmCreate := fixtures.CreateCertificateSubjectMapping(t, ctx, certSecuredGraphQLClient, csmInput)
-	defer fixtures.CleanupCertificateSubjectMapping(t, ctx, certSecuredGraphQLClient, csmCreate.ID)
+
+	var csmCreate graphql.CertificateSubjectMapping // needed so the 'defer' can be above the cert subject mapping creation
+	defer fixtures.CleanupCertificateSubjectMapping(t, ctx, certSecuredGraphQLClient, &csmCreate)
+	csmCreate = fixtures.CreateCertificateSubjectMapping(t, ctx, certSecuredGraphQLClient, csmInput)
 
 	queryCertSubjectMappingReq := fixtures.FixQueryCertificateSubjectMappingRequest(csmCreate.ID)
 	saveExample(t, queryCertSubjectMappingReq.Query(), "query certificate subject mapping")
@@ -119,14 +125,18 @@ func TestQueryCertSubjectMappings(t *testing.T) {
 	// Create first certificate subject mapping
 	csmInput := fixtures.FixCertificateSubjectMappingInput(subject, consumerType, &internalConsumerID, tenantAccessLevels)
 	t.Logf("Create certificate subject mapping with subject: %s, consumer type: %s and tenant access levels: %s", subject, consumerType, tenantAccessLevels)
-	csmCreate := fixtures.CreateCertificateSubjectMapping(t, ctx, certSecuredGraphQLClient, csmInput)
-	defer fixtures.CleanupCertificateSubjectMapping(t, ctx, certSecuredGraphQLClient, csmCreate.ID)
+
+	var csmCreate graphql.CertificateSubjectMapping // needed so the 'defer' can be above the cert subject mapping creation
+	defer fixtures.CleanupCertificateSubjectMapping(t, ctx, certSecuredGraphQLClient, &csmCreate)
+	csmCreate = fixtures.CreateCertificateSubjectMapping(t, ctx, certSecuredGraphQLClient, csmInput)
 
 	// Create second certificate subject mapping
 	csmInput2 := fixtures.FixCertificateSubjectMappingInput(updatedSubject, updatedConsumerType, &updatedInternalConsumerID, updatedTntAccessLevels)
 	t.Logf("Create certificate subject mapping with subject: %s, consumer type: %s and tenant access levels: %s", updatedSubject, updatedConsumerType, updatedTntAccessLevels)
-	csmCreate2 := fixtures.CreateCertificateSubjectMapping(t, ctx, certSecuredGraphQLClient, csmInput2)
-	defer fixtures.CleanupCertificateSubjectMapping(t, ctx, certSecuredGraphQLClient, csmCreate2.ID)
+
+	var csmCreate2 graphql.CertificateSubjectMapping // needed so the 'defer' can be above the cert subject mapping creation
+	defer fixtures.CleanupCertificateSubjectMapping(t, ctx, certSecuredGraphQLClient, &csmCreate2)
+	csmCreate2 = fixtures.CreateCertificateSubjectMapping(t, ctx, certSecuredGraphQLClient, csmInput2)
 
 	certSubjectMappings := graphql.CertificateSubjectMappingPage{}
 	t.Log("Query certificate subject mappings...")
@@ -171,8 +181,10 @@ func TestQueryCertSubjectMappingWithNewlyCreatedSubjectMapping(t *testing.T) {
 	certSubjectMappingCustomSubjectWithCommaSeparator := strings.ReplaceAll(strings.TrimLeft(certSubjectMappingCustomSubject, "/"), "/", ",")
 	csmInput := fixtures.FixCertificateSubjectMappingInput(certSubjectMappingCustomSubjectWithCommaSeparator, consumerType, &internalConsumerID, tenantAccessLevels)
 	t.Logf("Create certificate subject mapping with subject: %s, consumer type: %s and tenant access levels: %s", certSubjectMappingCustomSubjectWithCommaSeparator, consumerType, tenantAccessLevels)
-	csmCreate := fixtures.CreateCertificateSubjectMapping(t, ctx, certSecuredGraphQLClient, csmInput)
-	defer fixtures.CleanupCertificateSubjectMapping(t, ctx, certSecuredGraphQLClient, csmCreate.ID)
+
+	var csmCreate graphql.CertificateSubjectMapping // needed so the 'defer' can be above the cert subject mapping creation
+	defer fixtures.CleanupCertificateSubjectMapping(t, ctx, certSecuredGraphQLClient, &csmCreate)
+	csmCreate = fixtures.CreateCertificateSubjectMapping(t, ctx, certSecuredGraphQLClient, csmInput)
 
 	t.Logf("Sleeping for %s, so the hydrator component could update the certificate subject mapping cache with the new data", conf.CertSubjectMappingResyncInterval.String())
 	time.Sleep(conf.CertSubjectMappingResyncInterval)

--- a/tests/director/tests/formation_api_test.go
+++ b/tests/director/tests/formation_api_test.go
@@ -1234,8 +1234,10 @@ func TestFormationNotificationsWithApplicationOnlyParticipants(t *testing.T) {
 	certSubjectMappingCustomSubjectWithCommaSeparator := strings.ReplaceAll(strings.TrimLeft(certSubjectMappingCustomSubject, "/"), "/", ",")
 	csmInput := fixtures.FixCertificateSubjectMappingInput(certSubjectMappingCustomSubjectWithCommaSeparator, consumerType, &internalConsumerID, tenantAccessLevels)
 	t.Logf("Create certificate subject mapping with subject: %s, consumer type: %s and tenant access levels: %s", certSubjectMappingCustomSubjectWithCommaSeparator, consumerType, tenantAccessLevels)
-	csmCreate := fixtures.CreateCertificateSubjectMapping(t, ctx, certSecuredGraphQLClient, csmInput)
-	defer fixtures.CleanupCertificateSubjectMapping(t, ctx, certSecuredGraphQLClient, csmCreate.ID)
+
+	var csmCreate graphql.CertificateSubjectMapping // needed so the 'defer' can be above the cert subject mapping creation
+	defer fixtures.CleanupCertificateSubjectMapping(t, ctx, certSecuredGraphQLClient, &csmCreate)
+	csmCreate = fixtures.CreateCertificateSubjectMapping(t, ctx, certSecuredGraphQLClient, csmInput)
 
 	t.Logf("Sleeping for %s, so the hydrator component could update the certificate subject mapping cache with the new data", conf.CertSubjectMappingResyncInterval.String())
 	time.Sleep(conf.CertSubjectMappingResyncInterval)

--- a/tests/pkg/fixtures/cert_subject_mapping_queries.go
+++ b/tests/pkg/fixtures/cert_subject_mapping_queries.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func CreateCertificateSubjectMapping(t require.TestingT, ctx context.Context, gqlClient *gcli.Client, in graphql.CertificateSubjectMappingInput) *graphql.CertificateSubjectMapping {
+func CreateCertificateSubjectMapping(t require.TestingT, ctx context.Context, gqlClient *gcli.Client, in graphql.CertificateSubjectMappingInput) graphql.CertificateSubjectMapping {
 	csmGQLInput, err := testctx.Tc.Graphqlizer.CertificateSubjectMappingInputToGQL(in)
 	require.NoError(t, err)
 
@@ -21,7 +21,7 @@ func CreateCertificateSubjectMapping(t require.TestingT, ctx context.Context, gq
 	require.NoError(t, err)
 	require.NotEmpty(t, csm.ID)
 
-	return &csm
+	return csm
 }
 
 func FixCertificateSubjectMappingInput(subject, consumerType string, internalConsumerID *string, tenantAccessLevels []string) graphql.CertificateSubjectMappingInput {
@@ -33,13 +33,13 @@ func FixCertificateSubjectMappingInput(subject, consumerType string, internalCon
 	}
 }
 
-func CleanupCertificateSubjectMapping(t require.TestingT, ctx context.Context, gqlClient *gcli.Client, id string) *graphql.CertificateSubjectMapping {
-	deleteRequest := FixDeleteCertificateSubjectMappingRequest(id)
+func CleanupCertificateSubjectMapping(t require.TestingT, ctx context.Context, gqlClient *gcli.Client, csm *graphql.CertificateSubjectMapping) *graphql.CertificateSubjectMapping {
+	deleteRequest := FixDeleteCertificateSubjectMappingRequest(csm.ID)
 
-	csm := graphql.CertificateSubjectMapping{}
-	err := testctx.Tc.RunOperationWithoutTenant(ctx, gqlClient, deleteRequest, &csm)
+	result := graphql.CertificateSubjectMapping{}
+	err := testctx.Tc.RunOperationWithoutTenant(ctx, gqlClient, deleteRequest, &result)
 
 	assertions.AssertNoErrorForOtherThanNotFound(t, err)
 
-	return &csm
+	return &result
 }


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Currently, in the e2e tests, there are assertions between the creation of a cert subject mapping and the 'defer' that cleans it up. This way, there is a chance that the 'defer' will not be scheduled if one of the assertions fails.

Changes proposed in this pull request:
- Fix cert subject mappings cleanup in e2e tests

**Pull Request status**
<!-- Feel free to construct the checklist with whatever items seem most reasonable for your change. You could disassemble the Implementation part to even smaller separate checklist items if you're working on something big for example. But do make the effort to provide a checklist of some sort so that the core team as well as the community can have an idea about the progress of your Pull Request.
-->

- [x] Implementation
- [ ] Unit tests
- [x] Integration tests
- [x] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [ ] Mocks are regenerated, using the automated script
