### PR TITLE
Forbid deletion of application templates if there are existing associated applications

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -163,7 +163,7 @@ global:
       name: compass-ord-service
     schema_migrator:
       dir:
-      version: "PR-2978"
+      version: "PR-2980"
       name: compass-schema-migrator
     system_broker:
       dir:

--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -184,7 +184,7 @@ global:
       name: compass-console
     e2e_tests:
       dir:
-      version: "PR-2970"
+      version: "PR-2980"
       name: compass-e2e-tests
   isLocalEnv: false
   isForTesting: false

--- a/components/schema-migrator/migrations/director/20230328144000_forbid_deleting_app_template_if_it_has_associated_application.down.sql
+++ b/components/schema-migrator/migrations/director/20230328144000_forbid_deleting_app_template_if_it_has_associated_application.down.sql
@@ -4,4 +4,3 @@ ALTER TABLE applications
     DROP CONSTRAINT IF EXISTS applications_app_template_id_fkey;
 
 COMMIT;
-

--- a/components/schema-migrator/migrations/director/20230328144000_forbid_deleting_app_template_if_it_has_associated_application.down.sql
+++ b/components/schema-migrator/migrations/director/20230328144000_forbid_deleting_app_template_if_it_has_associated_application.down.sql
@@ -2,5 +2,8 @@ BEGIN;
 
 ALTER TABLE applications
     DROP CONSTRAINT IF EXISTS applications_app_template_id_fkey;
+ALTER TABLE applications
+    ADD CONSTRAINT applications_app_template_id_fkey
+        FOREIGN KEY (app_template_id) REFERENCES app_templates(id) ON DELETE SET NULL;
 
 COMMIT;

--- a/components/schema-migrator/migrations/director/20230328144000_forbid_deleting_app_template_if_it_has_associated_application.down.sql
+++ b/components/schema-migrator/migrations/director/20230328144000_forbid_deleting_app_template_if_it_has_associated_application.down.sql
@@ -1,0 +1,7 @@
+BEGIN;
+
+ALTER TABLE applications
+    DROP CONSTRAINT IF EXISTS applications_app_template_id_fkey;
+
+COMMIT;
+

--- a/components/schema-migrator/migrations/director/20230328144000_forbid_deleting_app_template_if_it_has_associated_application.up.sql
+++ b/components/schema-migrator/migrations/director/20230328144000_forbid_deleting_app_template_if_it_has_associated_application.up.sql
@@ -1,0 +1,8 @@
+BEGIN;
+
+ALTER TABLE applications DROP CONSTRAINT applications_app_template_id_fkey;
+ALTER TABLE applications
+    ADD CONSTRAINT applications_app_template_id_fkey
+        FOREIGN KEY (app_template_id) REFERENCES app_templates(id) ON DELETE RESTRICT;
+
+COMMIT;


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Currently application templates can be deleted even if there are existing applications created from it. With this PR we forbid this action.

Changes proposed in this pull request:
- introduce schema migrations for the new constraint
- add e2e test


**Pull Request status**
<!-- Feel free to construct the checklist with whatever items seem most reasonable for your change. You could disassemble the Implementation part to even smaller separate checklist items if you're working on something big for example. But do make the effort to provide a checklist of some sort so that the core team as well as the community can have an idea about the progress of your Pull Request.
-->

- [x] Implementation
- [ ] Unit tests
- [x] Integration tests
- [x] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [ ] Mocks are regenerated, using the automated script
