### PR TITLE
Return not found error when deleting Tenant Access that does not exist

### DIFF
--- a/components/director/internal/domain/tenant/resolver.go
+++ b/components/director/internal/domain/tenant/resolver.go
@@ -401,6 +401,10 @@ func (r *Resolver) RemoveTenantAccess(ctx context.Context, tenantID, resourceID 
 
 	tenantAccess, err := r.srv.GetTenantAccessForResource(ctx, internalTenantID, resourceID, resourceTypeModel)
 	if err != nil {
+		if apperrors.IsNotFoundError(err) {
+			return nil, apperrors.NewNotFoundErrorWithType(resource.TenantAccess)
+		}
+
 		return nil, errors.Wrapf(err, "while fetching stored tenant access for tenant %q about resource %q of type %q", internalTenantID, resourceID, resourceTypeModel)
 	}
 	tenantAccess.ExternalTenantID = tenantID

--- a/components/director/internal/domain/tenant/resolver_test.go
+++ b/components/director/internal/domain/tenant/resolver_test.go
@@ -1478,6 +1478,18 @@ func TestResolver_RemoveTenantAccess(t *testing.T) {
 			ExpectedErrorMsg: "while fetching stored tenant access for tenant",
 		},
 		{
+			Name: "Error not found when getting tenant access record",
+			TxFn: txGen.ThatDoesntExpectCommit,
+			TenantSvcFn: func() *automock.BusinessTenantMappingService {
+				TenantSvc := &automock.BusinessTenantMappingService{}
+				TenantSvc.On("GetInternalTenant", txtest.CtxWithDBMatcher(), testExternal).Return(testInternal, nil).Once()
+				TenantSvc.On("GetTenantAccessForResource", txtest.CtxWithDBMatcher(), testInternal, testID, resource.Application).Return(nil, apperrors.NewNotFoundErrorWithType(resource.TenantAccess)).Once()
+				return TenantSvc
+			},
+			Input:            tenantAccessInput,
+			ExpectedErrorMsg: "Object not found [object=tenantAccess]",
+		},
+		{
 			Name: "Error when resource type is invalid",
 			TxFn: txGen.ThatDoesntExpectCommit,
 			TenantSvcFn: func() *automock.BusinessTenantMappingService {

--- a/components/director/internal/repo/tenant_access_m2m.go
+++ b/components/director/internal/repo/tenant_access_m2m.go
@@ -75,7 +75,8 @@ func GetSingleTenantAccess(ctx context.Context, m2mTable string, tenantID, resou
 	tenantAccess := &TenantAccess{}
 	err := getter.GetGlobal(ctx, Conditions{NewEqualCondition(M2MTenantIDColumn, tenantID), NewEqualCondition(M2MResourceIDColumn, resourceID)}, NoOrderBy, tenantAccess)
 	if err != nil {
-		return nil, persistence.MapSQLError(ctx, err, resource.TenantAccess, resource.Get, "while fetching tenant access record from '%s' table", m2mTable)
+		log.C(ctx).Error(persistence.MapSQLError(ctx, err, resource.TenantAccess, resource.Get, "while fetching tenant access record from '%s' table", m2mTable))
+		return nil, err
 	}
 
 	return tenantAccess, nil


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:
- return not found error during delete if Tenant Access record does not exist

**Pull Request status**
<!-- Feel free to construct the checklist with whatever items seem most reasonable for your change. You could disassemble the Implementation part to even smaller separate checklist items if you're working on something big for example. But do make the effort to provide a checklist of some sort so that the core team as well as the community can have an idea about the progress of your Pull Request.
-->

- [X] Implementation
- [X] Unit tests
- [X] Integration tests
- [ ] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
