### PR TITLE
Adjust istio metrics

### DIFF
--- a/chart/compass/templates/general-dashboard-configmap.yaml
+++ b/chart/compass/templates/general-dashboard-configmap.yaml
@@ -564,7 +564,9 @@ data:
       "refresh": "",
       "schemaVersion": 27,
       "style": "dark",
-      "tags": [],
+      "tags": [
+        "compass"
+      ],
       "templating": {
         "list": []
       },

--- a/chart/compass/templates/general-dashboard-configmap.yaml
+++ b/chart/compass/templates/general-dashboard-configmap.yaml
@@ -145,13 +145,14 @@ data:
           "hiddenSeries": false,
           "id": 48,
           "legend": {
-            "avg": false,
-            "current": false,
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
             "max": false,
             "min": false,
             "show": true,
             "total": false,
-            "values": false
+            "values": true
           },
           "lines": true,
           "linewidth": 1,
@@ -171,7 +172,7 @@ data:
           "targets": [
             {
               "exemplar": true,
-              "expr": "sum(istio_requests_total{reporter=\"source\",source_app=\"istio-ingressgateway\",response_code=\"200\"})",
+              "expr": "sum(rate(istio_requests_total{reporter=\"source\",source_app=\"istio-ingressgateway\",response_code=\"200\"}[1m]) * 60)",
               "interval": "",
               "legendFormat": "",
               "refId": "A"
@@ -181,7 +182,7 @@ data:
           "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
-          "title": "Total istio ingresgateway successful requests",
+          "title": "Istio ingresgateway successful requests [req/min]",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -198,7 +199,7 @@ data:
           "yaxes": [
             {
               "$$hashKey": "object:334",
-              "format": "short",
+              "format": "req/min",
               "label": null,
               "logBase": 1,
               "max": null,
@@ -241,13 +242,14 @@ data:
           "hiddenSeries": false,
           "id": 46,
           "legend": {
-            "avg": false,
-            "current": false,
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
             "max": false,
             "min": false,
             "show": true,
             "total": false,
-            "values": false
+            "values": true
           },
           "lines": true,
           "linewidth": 1,
@@ -267,7 +269,7 @@ data:
           "targets": [
             {
               "exemplar": true,
-              "expr": "sum(istio_requests_total{reporter=\"source\",source_app=\"istio-ingressgateway\",response_code=\"500\"})",
+              "expr": "sum(rate(istio_requests_total{reporter=\"source\",source_app=\"istio-ingressgateway\",response_code=\"500\"}[1m]) * 60)",
               "interval": "",
               "legendFormat": "",
               "refId": "A"
@@ -277,7 +279,7 @@ data:
           "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
-          "title": "Total istio ingresgateway failed requests",
+          "title": "Istio ingresgateway failed requests [req/min]",
           "tooltip": {
             "shared": true,
             "sort": 0,
@@ -294,7 +296,7 @@ data:
           "yaxes": [
             {
               "$$hashKey": "object:251",
-              "format": "short",
+              "format": "req/min",
               "label": null,
               "logBase": 1,
               "max": null,


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Currently, we have metrics showing the total count of successful and failed istio requests but we want their rate.

Changes proposed in this pull request:
- Adjust the PromQL of the istio metrics to visualize the requests rate rather than the total number

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- https://github.com/kyma-incubator/compass/pull/2969

**Pull Request status**
<!-- Feel free to construct the checklist with whatever items seem most reasonable for your change. You could disassemble the Implementation part to even smaller separate checklist items if you're working on something big for example. But do make the effort to provide a checklist of some sort so that the core team as well as the community can have an idea about the progress of your Pull Request.
-->

- [x] Implementation
- [x] [N/A] Unit tests
- [x] [N/A] Integration tests
- [x] [N/A] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [x] [N/A] Mocks are regenerated, using the automated script
