### PR TITLE
[HOTFIX] Fix processing composite labels in webhook input template parsing

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -139,7 +139,7 @@ global:
       name: compass-pairing-adapter
     director:
       dir:
-      version: "PR-3020"
+      version: "PR-3023"
       name: compass-director
     hydrator:
       dir:
@@ -184,7 +184,7 @@ global:
       name: compass-console
     e2e_tests:
       dir:
-      version: "PR-3011"
+      version: "PR-3023"
       name: compass-e2e-tests
   isLocalEnv: false
   isForTesting: false

--- a/components/director/internal/domain/formation/fixtures_test.go
+++ b/components/director/internal/domain/formation/fixtures_test.go
@@ -1065,26 +1065,26 @@ func fixModelBusinessTenantMappingWithType(t tnt.Type) *model.BusinessTenantMapp
 	}
 }
 
-func fixApplicationLabelsMap() map[string]interface{} {
-	return map[string]interface{}{
+func fixApplicationLabelsMap() map[string]string {
+	return map[string]string{
 		"app-label-key": "app-label-value",
 	}
 }
 
-func fixApplicationTemplateLabelsMap() map[string]interface{} {
-	return map[string]interface{}{
+func fixApplicationTemplateLabelsMap() map[string]string {
+	return map[string]string{
 		"apptemplate-label-key": "apptemplate-label-value",
 	}
 }
 
-func fixRuntimeLabelsMap() map[string]interface{} {
-	return map[string]interface{}{
+func fixRuntimeLabelsMap() map[string]string {
+	return map[string]string{
 		"runtime-label-key": "runtime-label-value",
 	}
 }
 
-func fixRuntimeContextLabelsMap() map[string]interface{} {
-	return map[string]interface{}{
+func fixRuntimeContextLabelsMap() map[string]string {
+	return map[string]string{
 		"runtime-context-label-key": "runtime-context-label-value",
 	}
 }

--- a/components/director/internal/domain/formation/notificationbuilder.go
+++ b/components/director/internal/domain/formation/notificationbuilder.go
@@ -263,16 +263,11 @@ func buildFormationLifecycleInput(details *formationconstraintpkg.GenerateFormat
 	}
 }
 
-func determineResourceSubtype(labels map[string]interface{}, labelKey string) (string, error) {
+func determineResourceSubtype(labels map[string]string, labelKey string) (string, error) {
 	labelValue, ok := labels[labelKey]
 	if !ok {
 		return "", errors.Errorf("Missing %q label", labelKey)
 	}
 
-	subtype, ok := labelValue.(string)
-	if !ok {
-		return "", errors.Errorf("Failed to convert %q label to string", labelKey)
-	}
-
-	return subtype, nil
+	return labelValue, nil
 }

--- a/components/director/internal/domain/formation/notificationbuilder_test.go
+++ b/components/director/internal/domain/formation/notificationbuilder_test.go
@@ -281,26 +281,26 @@ func TestNotificationBuilder_PrepareDetailsForConfigurationChangeNotificationGen
 
 	application := &webhookdir.ApplicationWithLabels{
 		Application: fixApplicationModel(ApplicationID),
-		Labels: map[string]interface{}{
+		Labels: map[string]string{
 			applicationType: applicationType,
 		},
 	}
 
 	runtime := &webhookdir.RuntimeWithLabels{
 		Runtime: fixRuntimeModel(RuntimeContextRuntimeID),
-		Labels: map[string]interface{}{
+		Labels: map[string]string{
 			runtimeType: runtimeType,
 		},
 	}
 
 	applicationWithoutType := &webhookdir.ApplicationWithLabels{
 		Application: fixApplicationModel(ApplicationID),
-		Labels:      map[string]interface{}{},
+		Labels:      map[string]string{},
 	}
 
 	runtimeWithoutType := &webhookdir.RuntimeWithLabels{
 		Runtime: fixRuntimeModel(RuntimeContextRuntimeID),
-		Labels:  map[string]interface{}{},
+		Labels:  map[string]string{},
 	}
 
 	runtimeContext := &webhookdir.RuntimeContextWithLabels{
@@ -483,14 +483,14 @@ func TestNotificationBuilder_PrepareDetailsForApplicationTenantMappingNotificati
 
 	application := &webhookdir.ApplicationWithLabels{
 		Application: fixApplicationModel(ApplicationID),
-		Labels: map[string]interface{}{
+		Labels: map[string]string{
 			applicationType: applicationType,
 		},
 	}
 
 	applicationWithoutType := &webhookdir.ApplicationWithLabels{
 		Application: fixApplicationModel(ApplicationID),
-		Labels:      map[string]interface{}{},
+		Labels:      map[string]string{},
 	}
 
 	testCases := []struct {

--- a/components/director/internal/domain/formationassignment/notifications_test.go
+++ b/components/director/internal/domain/formationassignment/notifications_test.go
@@ -63,7 +63,7 @@ func Test_GenerateFormationAssignmentNotification(t *testing.T) {
 		ObjectType: model.RuntimeWebhookReference,
 	}
 
-	testLabels := map[string]interface{}{"testLabelKey": "testLabelValue"}
+	testLabels := map[string]string{"testLabelKey": "testLabelValue"}
 	testAppWithLabels := &webhook.ApplicationWithLabels{
 		Application: &model.Application{
 			Name:                  "testAppName",

--- a/components/director/internal/domain/webhook/datainputbuilder/builder.go
+++ b/components/director/internal/domain/webhook/datainputbuilder/builder.go
@@ -208,7 +208,6 @@ func (b *WebhookDataInputBuilder) PrepareRuntimesAndRuntimeContextsMappingsInFor
 	}
 
 	runtimesLabels, err := b.getLabelsForObjects(ctx, tenant, runtimesIDs, model.RuntimeLabelableObject)
-	//b.labelRepository.ListForObjectIDs(ctx, tenant, model.RuntimeLabelableObject, runtimesIDs)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "while listing runtime labels")
 	}
@@ -222,7 +221,6 @@ func (b *WebhookDataInputBuilder) PrepareRuntimesAndRuntimeContextsMappingsInFor
 	}
 
 	runtimeContextsLabels, err := b.getLabelsForObjects(ctx, tenant, runtimeContextsIDs, model.RuntimeContextLabelableObject)
-	//b.labelRepository.ListForObjectIDs(ctx, tenant, model.RuntimeContextLabelableObject, runtimeContextsIDs)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "while listing labels for runtime contexts")
 	}
@@ -262,7 +260,6 @@ func (b *WebhookDataInputBuilder) PrepareApplicationMappingsInFormation(ctx cont
 	}
 
 	applicationsToBeNotifiedForLabels, err := b.getLabelsForObjects(ctx, tenant, applicationsToBeNotifiedForIDs, model.ApplicationLabelableObject)
-	//b.labelRepository.ListForObjectIDs(ctx, tenant, model.ApplicationLabelableObject, applicationsToBeNotifiedForIDs)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "while listing labels for applications")
 	}
@@ -281,7 +278,6 @@ func (b *WebhookDataInputBuilder) PrepareApplicationMappingsInFormation(ctx cont
 	}
 
 	applicationTemplatesLabels, err := b.getLabelsForObjects(ctx, tenant, applicationsTemplateIDs, model.AppTemplateLabelableObject)
-	//b.labelRepository.ListForObjectIDs(ctx, tenant, model.AppTemplateLabelableObject, applicationsTemplateIDs)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "while listing labels for application templates")
 	}

--- a/components/director/internal/domain/webhook/datainputbuilder/builder.go
+++ b/components/director/internal/domain/webhook/datainputbuilder/builder.go
@@ -312,7 +312,6 @@ func (b *WebhookDataInputBuilder) getLabelsForObject(ctx context.Context, tenant
 		} else {
 			labelsMap[l.Key] = unquotedLabel
 		}
-
 	}
 	return labelsMap, nil
 }
@@ -323,23 +322,23 @@ func (b *WebhookDataInputBuilder) getLabelsForObjects(ctx context.Context, tenan
 		return nil, errors.Wrapf(err, "while listing labels for %q with IDs: %q", objectType, objectIDs)
 	}
 	labelsForResourcesMap := make(map[string]map[string]string, len(labelsForResources))
-	for resourceId, labels := range labelsForResources {
+	for resourceID, labels := range labelsForResources {
 		for key, value := range labels {
 			labelBytes, err := json.Marshal(value)
 			if err != nil {
 				return nil, errors.Wrap(err, "while marshaling label value")
 			}
 
-			if _, ok := labelsForResourcesMap[resourceId]; !ok {
-				labelsForResourcesMap[resourceId] = make(map[string]string)
+			if _, ok := labelsForResourcesMap[resourceID]; !ok {
+				labelsForResourcesMap[resourceID] = make(map[string]string)
 			}
 
 			stringLabel := string(labelBytes)
 			unquotedLabel, err := strconv.Unquote(stringLabel)
 			if err != nil {
-				labelsForResourcesMap[resourceId][key] = stringLabel
+				labelsForResourcesMap[resourceID][key] = stringLabel
 			} else {
-				labelsForResourcesMap[resourceId][key] = unquotedLabel
+				labelsForResourcesMap[resourceID][key] = unquotedLabel
 			}
 		}
 	}

--- a/components/director/internal/domain/webhook/datainputbuilder/builder.go
+++ b/components/director/internal/domain/webhook/datainputbuilder/builder.go
@@ -3,9 +3,9 @@ package datainputbuilder
 import (
 	"context"
 	"encoding/json"
-	"github.com/davecgh/go-spew/spew"
-	"github.com/kyma-incubator/compass/components/director/pkg/log"
 	"strconv"
+
+	"github.com/kyma-incubator/compass/components/director/pkg/log"
 
 	"github.com/kyma-incubator/compass/components/director/pkg/webhook"
 
@@ -339,9 +339,7 @@ func (b *WebhookDataInputBuilder) getLabelsForObjects(ctx context.Context, tenan
 			}
 
 			stringLabel := string(labelBytes)
-			spew.Dump("STRING LABEL", stringLabel)
 			unquotedLabel, err := strconv.Unquote(stringLabel)
-			spew.Dump("UNQUOTED LABEL", unquotedLabel)
 			if err != nil {
 				labelsForResourcesMap[resourceId][key] = stringLabel
 			} else {

--- a/components/director/internal/domain/webhook/datainputbuilder/builder_test.go
+++ b/components/director/internal/domain/webhook/datainputbuilder/builder_test.go
@@ -937,11 +937,11 @@ func convertLabels(labels map[string]*model.Label) map[string]string {
 	for _, l := range labels {
 		stringLabel, ok := l.Value.(string)
 		if !ok {
-			marshaled, err := json.Marshal(l.Value)
+			marshalled, err := json.Marshal(l.Value)
 			if err != nil {
 				return nil
 			}
-			stringLabel = string(marshaled)
+			stringLabel = string(marshalled)
 		}
 
 		convertedLabels[l.Key] = stringLabel

--- a/components/director/internal/domain/webhook/datainputbuilder/fixtures_test.go
+++ b/components/director/internal/domain/webhook/datainputbuilder/fixtures_test.go
@@ -26,40 +26,51 @@ var (
 	applicationMappings = map[string]*webhook.ApplicationWithLabels{
 		ApplicationID: {
 			Application: fixApplicationModel(ApplicationID),
-			Labels:      fixApplicationLabelsMap(),
+			Labels:      fixLabelsMapForApplicationWithLabels(),
 		},
 		Application2ID: {
 			Application: fixApplicationModelWithoutTemplate(Application2ID),
-			Labels:      fixApplicationLabelsMap(),
+			Labels:      fixLabelsMapForApplicationWithLabels(),
+		},
+	}
+
+	applicationMappingsWithCompositeLabel = map[string]*webhook.ApplicationWithLabels{
+		ApplicationID: {
+			Application: fixApplicationModel(ApplicationID),
+			Labels:      fixLabelsMapForApplicationWithCompositeLabels(),
+		},
+		Application2ID: {
+			Application: fixApplicationModelWithoutTemplate(Application2ID),
+			Labels:      fixLabelsMapForApplicationWithLabels(),
 		},
 	}
 
 	applicationTemplateMappings = map[string]*webhook.ApplicationTemplateWithLabels{
 		ApplicationTemplateID: {
 			ApplicationTemplate: fixApplicationTemplateModel(),
-			Labels:              fixApplicationTemplateLabelsMap(),
+			Labels:              fixLabelsMapForApplicationTemplateWithLabels(),
 		},
 	}
 
 	runtimeMappings = map[string]*webhook.RuntimeWithLabels{
 		RuntimeContextRuntimeID: {
 			Runtime: fixRuntimeModel(RuntimeContextRuntimeID),
-			Labels:  fixRuntimeLabelsMap(),
+			Labels:  fixLabelsMapForRuntimeWithLabels(),
 		},
 		RuntimeID: {
 			Runtime: fixRuntimeModel(RuntimeID),
-			Labels:  fixRuntimeLabelsMap(),
+			Labels:  fixLabelsMapForRuntimeWithLabels(),
 		},
 	}
 
 	runtimeContextMappings = map[string]*webhook.RuntimeContextWithLabels{
 		RuntimeContextRuntimeID: {
 			RuntimeContext: fixRuntimeContextModel(),
-			Labels:         fixRuntimeContextLabelsMap(),
+			Labels:         fixLabelsMapForRuntimeContextWithLabels(),
 		},
 		RuntimeID: {
 			RuntimeContext: fixRuntimeContextModelWithRuntimeID(RuntimeID),
-			Labels:         fixRuntimeContextLabelsMap(),
+			Labels:         fixLabelsMapForRuntimeContextWithLabels(),
 		},
 	}
 )
@@ -70,8 +81,32 @@ func fixApplicationLabelsMap() map[string]interface{} {
 	}
 }
 
+func fixApplicationLabelsMapWithUnquotableLabels() map[string]interface{} {
+	return map[string]interface{}{
+		"app-label-key": []string{"app-label-value"},
+	}
+}
+
+func fixLabelsMapForApplicationWithLabels() map[string]string {
+	return map[string]string{
+		"app-label-key": "app-label-value",
+	}
+}
+
+func fixLabelsMapForApplicationWithCompositeLabels() map[string]string {
+	return map[string]string{
+		"app-label-key": "[\"app-label-value\"]",
+	}
+}
+
 func fixApplicationTemplateLabelsMap() map[string]interface{} {
 	return map[string]interface{}{
+		"apptemplate-label-key": "apptemplate-label-value",
+	}
+}
+
+func fixLabelsMapForApplicationTemplateWithLabels() map[string]string {
+	return map[string]string{
 		"apptemplate-label-key": "apptemplate-label-value",
 	}
 }
@@ -109,8 +144,20 @@ func fixRuntimeLabelsMap() map[string]interface{} {
 	}
 }
 
+func fixLabelsMapForRuntimeWithLabels() map[string]string {
+	return map[string]string{
+		"runtime-label-key": "runtime-label-value",
+	}
+}
+
 func fixRuntimeContextLabelsMap() map[string]interface{} {
 	return map[string]interface{}{
+		"runtime-context-label-key": "runtime-context-label-value",
+	}
+}
+
+func fixLabelsMapForRuntimeContextWithLabels() map[string]string {
+	return map[string]string{
 		"runtime-context-label-key": "runtime-context-label-value",
 	}
 }

--- a/components/director/pkg/graphql/webhook_validation.go
+++ b/components/director/pkg/graphql/webhook_validation.go
@@ -25,21 +25,21 @@ var emptyFormationConfigurationChangeInput = &webhook.FormationConfigurationChan
 	},
 	ApplicationTemplate: &webhook.ApplicationTemplateWithLabels{
 		ApplicationTemplate: &model.ApplicationTemplate{},
-		Labels:              map[string]interface{}{},
+		Labels:              map[string]string{},
 	},
 	Application: &webhook.ApplicationWithLabels{
 		Application: &model.Application{
 			BaseEntity: &model.BaseEntity{},
 		},
-		Labels: map[string]interface{}{},
+		Labels: map[string]string{},
 	},
 	Runtime: &webhook.RuntimeWithLabels{
 		Runtime: &model.Runtime{},
-		Labels:  map[string]interface{}{},
+		Labels:  map[string]string{},
 	},
 	RuntimeContext: &webhook.RuntimeContextWithLabels{
 		RuntimeContext: &model.RuntimeContext{},
-		Labels:         map[string]interface{}{},
+		Labels:         map[string]string{},
 	},
 	CustomerTenantContext: &webhook.CustomerTenantContext{},
 }
@@ -53,23 +53,23 @@ var emptyApplicationTenantMappingInput = &webhook.ApplicationTenantMappingInput{
 	},
 	SourceApplicationTemplate: &webhook.ApplicationTemplateWithLabels{
 		ApplicationTemplate: &model.ApplicationTemplate{},
-		Labels:              map[string]interface{}{},
+		Labels:              map[string]string{},
 	},
 	SourceApplication: &webhook.ApplicationWithLabels{
 		Application: &model.Application{
 			BaseEntity: &model.BaseEntity{},
 		},
-		Labels: map[string]interface{}{},
+		Labels: map[string]string{},
 	},
 	TargetApplicationTemplate: &webhook.ApplicationTemplateWithLabels{
 		ApplicationTemplate: &model.ApplicationTemplate{},
-		Labels:              map[string]interface{}{},
+		Labels:              map[string]string{},
 	},
 	TargetApplication: &webhook.ApplicationWithLabels{
 		Application: &model.Application{
 			BaseEntity: &model.BaseEntity{},
 		},
-		Labels: map[string]interface{}{},
+		Labels: map[string]string{},
 	},
 	CustomerTenantContext: &webhook.CustomerTenantContext{},
 }

--- a/components/director/pkg/webhook/formation_configuration_change.go
+++ b/components/director/pkg/webhook/formation_configuration_change.go
@@ -11,25 +11,25 @@ import (
 // ApplicationWithLabels represents an application with its corresponding labels
 type ApplicationWithLabels struct {
 	*model.Application
-	Labels map[string]interface{}
+	Labels map[string]string
 }
 
 // ApplicationTemplateWithLabels represents an application template with its corresponding labels
 type ApplicationTemplateWithLabels struct {
 	*model.ApplicationTemplate
-	Labels map[string]interface{}
+	Labels map[string]string
 }
 
 // RuntimeWithLabels represents a runtime with its corresponding labels
 type RuntimeWithLabels struct {
 	*model.Runtime
-	Labels map[string]interface{}
+	Labels map[string]string
 }
 
 // RuntimeContextWithLabels represents runtime context with its corresponding labels
 type RuntimeContextWithLabels struct {
 	*model.RuntimeContext
-	Labels map[string]interface{}
+	Labels map[string]string
 }
 
 // CustomerTenantContext represents the tenant hierarchy of the customer creating the formation. Both IDs are the external ones

--- a/tests/director/tests/formation_api_test.go
+++ b/tests/director/tests/formation_api_test.go
@@ -1299,7 +1299,7 @@ func TestFormationNotificationsWithApplicationOnlyParticipants(t *testing.T) {
 
 	applicationType1 := "app-type-1"
 	t.Logf("Create application template for type: %q", applicationType1)
-	appTemplateInput := fixtures.FixApplicationTemplateWithoutWebhook(applicationType1, localTenantID, appRegion, appNamespace, namePlaceholder, displayNamePlaceholder)
+	appTemplateInput := fixtures.FixApplicationTemplateWithCompositeLabelWithoutWebhook(applicationType1, localTenantID, appRegion, appNamespace, namePlaceholder, displayNamePlaceholder)
 	appTmpl, err := fixtures.CreateApplicationTemplateFromInput(t, ctx, oauthGraphQLClient, "", appTemplateInput)
 	defer fixtures.CleanupApplicationTemplate(t, ctx, oauthGraphQLClient, "", appTmpl)
 	require.NoError(t, err)
@@ -1320,7 +1320,7 @@ func TestFormationNotificationsWithApplicationOnlyParticipants(t *testing.T) {
 	localTenantID2 := "local-tenant-id2"
 	applicationType2 := "app-type-2"
 	t.Logf("Create application template for type %q", applicationType2)
-	appTemplateInput = fixtures.FixApplicationTemplateWithoutWebhook(applicationType2, localTenantID2, appRegion, appNamespace, namePlaceholder, displayNamePlaceholder)
+	appTemplateInput = fixtures.FixApplicationTemplateWithCompositeLabelWithoutWebhook(applicationType2, localTenantID2, appRegion, appNamespace, namePlaceholder, displayNamePlaceholder)
 	appTmpl2, err := fixtures.CreateApplicationTemplateFromInput(t, ctx, oauthGraphQLClient, "", appTemplateInput)
 
 	defer fixtures.CleanupApplicationTemplate(t, ctx, oauthGraphQLClient, "", appTmpl2)
@@ -1364,7 +1364,7 @@ func TestFormationNotificationsWithApplicationOnlyParticipants(t *testing.T) {
 		webhookType := graphql.WebhookTypeApplicationTenantMapping
 		webhookMode := graphql.WebhookModeSync
 		urlTemplate := "{\\\"path\\\":\\\"" + conf.ExternalServicesMockMtlsSecuredURL + "/formation-callback/{{.TargetApplication.ID}}{{if eq .Operation \\\"unassign\\\"}}/{{.SourceApplication.ID}}{{end}}\\\",\\\"method\\\":\\\"{{if eq .Operation \\\"assign\\\"}}PATCH{{else}}DELETE{{end}}\\\"}"
-		inputTemplate := "{\\\"ucl-formation-id\\\":\\\"{{.FormationID}}\\\",\\\"globalAccountId\\\":\\\"{{.CustomerTenantContext.AccountID}}\\\",\\\"crmId\\\":\\\"{{.CustomerTenantContext.CustomerID}}\\\",\\\"items\\\":[{\\\"region\\\":\\\"{{ if .SourceApplication.Labels.region }}{{.SourceApplication.Labels.region}}{{ else }}{{.SourceApplicationTemplate.Labels.region}}{{ end }}\\\",\\\"application-namespace\\\":\\\"{{.SourceApplicationTemplate.ApplicationNamespace}}\\\",\\\"tenant-id\\\":\\\"{{.SourceApplication.LocalTenantID}}\\\",\\\"ucl-system-tenant-id\\\":\\\"{{.SourceApplication.ID}}\\\"}]}"
+		inputTemplate := "{\\\"ucl-formation-id\\\":\\\"{{.FormationID}}\\\",\\\"globalAccountId\\\":\\\"{{.CustomerTenantContext.AccountID}}\\\",\\\"crmId\\\":\\\"{{.CustomerTenantContext.CustomerID}}\\\",\\\"items\\\":[{\\\"region\\\":\\\"{{ if .SourceApplication.Labels.region }}{{.SourceApplication.Labels.region}}{{ else }}{{.SourceApplicationTemplate.Labels.region}}{{ end }}\\\",\\\"application-namespace\\\":\\\"{{.SourceApplicationTemplate.ApplicationNamespace}}\\\"{{ if .SourceApplicationTemplate.Labels.composite }},\\\"composite-label\\\":{{.SourceApplicationTemplate.Labels.composite}}{{end}},\\\"tenant-id\\\":\\\"{{.SourceApplication.LocalTenantID}}\\\",\\\"ucl-system-tenant-id\\\":\\\"{{.SourceApplication.ID}}\\\"}]}"
 		outputTemplate := "{\\\"config\\\":\\\"{{.Body.Config}}\\\", \\\"location\\\":\\\"{{.Headers.Location}}\\\",\\\"error\\\": \\\"{{.Body.error}}\\\",\\\"success_status_code\\\": 200, \\\"incomplete_status_code\\\": 204}"
 
 		applicationWebhookInput := fixtures.FixFormationNotificationWebhookInput(webhookType, webhookMode, urlTemplate, inputTemplate, outputTemplate)

--- a/tests/pkg/fixtures/application_fixtures.go
+++ b/tests/pkg/fixtures/application_fixtures.go
@@ -26,6 +26,17 @@ func FixApplicationTemplateWithoutWebhook(applicationType, localTenantID, region
 	return FixApplicationTemplateWithWebhookInput(applicationType, localTenantID, region, namespace, namePlaceholder, displayNamePlaceholder, nil)
 }
 
+func FixApplicationTemplateWithCompositeLabelWithoutWebhook(applicationType, localTenantID, region, namespace, namePlaceholder, displayNamePlaceholder string) graphql.ApplicationTemplateInput {
+	appTemplateInput := FixApplicationTemplateWithWebhookInput(applicationType, localTenantID, region, namespace, namePlaceholder, displayNamePlaceholder, nil)
+	appTemplateInput.Labels = map[string]interface{}{
+		"composite": map[string]interface{}{
+			"key":  "value",
+			"key2": "value2",
+		},
+	}
+	return appTemplateInput
+}
+
 func FixApplicationTemplateWithWebhookInput(applicationType, localTenantID, region, namespace, namePlaceholder, displayNamePlaceholder string, webhookInput *graphql.WebhookInput) graphql.ApplicationTemplateInput {
 	var webhooks []*graphql.WebhookInput = nil
 	if webhookInput != nil {


### PR DESCRIPTION
**Description**
Parsing webhook input template that refers to composite label values failed due to resulting in malformed JSON object.

Changes proposed in this pull request:
- Support referencing composite label values in webhook input template

**Pull Request status**

- [X] Implementation
- [X] Unit tests
- [X] Integration tests
- [x] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
