### PR TITLE
Fix Runtime e2e test

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -184,7 +184,7 @@ global:
       name: compass-console
     e2e_tests:
       dir:
-      version: "PR-3003"
+      version: "PR-3025"
       name: compass-e2e-tests
   isLocalEnv: false
   isForTesting: false

--- a/tests/director/tests/runtime_api_test.go
+++ b/tests/director/tests/runtime_api_test.go
@@ -713,6 +713,7 @@ func TestQuerySpecificRuntimeWithCertificate(t *testing.T) {
 func TestRuntimeTypeAndRegionLabels(t *testing.T) {
 	ctx := context.Background()
 	runtimeName := "runtime-with-int-sys-creds"
+	runtimeNameCert := "runtime-with-cert-creds"
 
 	t.Run(fmt.Sprintf("Validate %q, %q labels and application namespace - they are added when runtime is registered with integration system credentials", conf.RuntimeTypeLabelKey, tenantfetcher.RegionKey), func(t *testing.T) {
 		runtimeInput := fixRuntimeInput(runtimeName)
@@ -766,7 +767,7 @@ func TestRuntimeTypeAndRegionLabels(t *testing.T) {
 		providerClientKey, providerRawCertChain := certprovider.NewExternalCertFromConfig(t, ctx, conf.ExternalCertProviderConfig, true)
 		directorCertSecuredClient := gql.NewCertAuthorizedGraphQLClientWithCustomURL(conf.DirectorExternalCertSecuredURL, providerClientKey, providerRawCertChain, conf.SkipSSLValidation)
 
-		rtInput := fixRuntimeInput(runtimeName)
+		rtInput := fixRuntimeInput(runtimeNameCert)
 		runtimeInGQL, err := testctx.Tc.Graphqlizer.RuntimeRegisterInputToGQL(rtInput)
 		require.NoError(t, err)
 		actualRuntime := graphql.RuntimeExt{}

--- a/tests/director/tests/runtime_api_test.go
+++ b/tests/director/tests/runtime_api_test.go
@@ -713,9 +713,9 @@ func TestQuerySpecificRuntimeWithCertificate(t *testing.T) {
 func TestRuntimeTypeAndRegionLabels(t *testing.T) {
 	ctx := context.Background()
 	runtimeName := "runtime-with-int-sys-creds"
-	runtimeInput := fixRuntimeInput(runtimeName)
 
 	t.Run(fmt.Sprintf("Validate %q, %q labels and application namespace - they are added when runtime is registered with integration system credentials", conf.RuntimeTypeLabelKey, tenantfetcher.RegionKey), func(t *testing.T) {
+		runtimeInput := fixRuntimeInput(runtimeName)
 		subaccountID := tenant.TestTenants.GetIDByName(t, tenant.TestProviderSubaccount) // randomly selected subaccount the parent of which is the default tenant used below
 		tenantID := tenant.TestTenants.GetDefaultTenantID()
 		intSysName := "runtime-integration-system"
@@ -766,7 +766,8 @@ func TestRuntimeTypeAndRegionLabels(t *testing.T) {
 		providerClientKey, providerRawCertChain := certprovider.NewExternalCertFromConfig(t, ctx, conf.ExternalCertProviderConfig, true)
 		directorCertSecuredClient := gql.NewCertAuthorizedGraphQLClientWithCustomURL(conf.DirectorExternalCertSecuredURL, providerClientKey, providerRawCertChain, conf.SkipSSLValidation)
 
-		runtimeInGQL, err := testctx.Tc.Graphqlizer.RuntimeRegisterInputToGQL(runtimeInput)
+		rtInput := fixRuntimeInput(runtimeName)
+		runtimeInGQL, err := testctx.Tc.Graphqlizer.RuntimeRegisterInputToGQL(rtInput)
 		require.NoError(t, err)
 		actualRuntime := graphql.RuntimeExt{}
 
@@ -778,7 +779,7 @@ func TestRuntimeTypeAndRegionLabels(t *testing.T) {
 		//THEN
 		require.NoError(t, err)
 		require.NotEmpty(t, actualRuntime.ID)
-		assertions.AssertRuntime(t, runtimeInput, actualRuntime)
+		assertions.AssertRuntime(t, rtInput, actualRuntime)
 
 		t.Logf("Validate %q label is not added when runtime is registered without integration system credentials...", conf.RuntimeTypeLabelKey)
 		runtimeTypeLabelValue, ok := actualRuntime.Labels[conf.RuntimeTypeLabelKey].(string)


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
This PR adapts misconfigured e2e introduced by the PR below. 

Changes proposed in this pull request:
- Use two separate runtime inputs for two separate tests

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- https://github.com/kyma-incubator/compass/pull/3003

**Pull Request status**
<!-- Feel free to construct the checklist with whatever items seem most reasonable for your change. You could disassemble the Implementation part to even smaller separate checklist items if you're working on something big for example. But do make the effort to provide a checklist of some sort so that the core team as well as the community can have an idea about the progress of your Pull Request.
-->

- [ ] Implementation
- [ ] Unit tests
- [x] Integration tests
- [x] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [ ] Mocks are regenerated, using the automated script
