### PR TITLE
Fix incomplete e2e tests logs

### DIFF
--- a/installation/scripts/kyma-scripts/testing-common.sh
+++ b/installation/scripts/kyma-scripts/testing-common.sh
@@ -86,10 +86,9 @@ function getContainerFromPod() {
 
 function printLogsFromPod() {
     local namespace=$1 pod=$2
-    local tailLimit=4000 bytesLimit=500000
-    log "Fetching logs from '${pod}' with options tailLimit=${tailLimit} and bytesLimit=${bytesLimit}" nc bold
+    log "Fetching logs from '${pod}'" nc bold
     testPod=$(getContainerFromPod ${namespace} ${pod})
-    result=$(kubectl $(context_arg)  logs --tail=${tailLimit} --limit-bytes=${bytesLimit} -n ${namespace} -c ${testPod} ${pod})
+    result=$(kubectl $(context_arg)  logs -n ${namespace} -c ${testPod} ${pod})
     if [ "${#result}" -eq 0 ]; then
         log "FAILED" red
         return 1


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
It seems that when we're fetching the logs from the e2e tests we are passing two parameters - "-tail" and "-limit-bytes" and the current values don't seem enough to print all of the logs hence part of them are cut off.

This PR removes the two parameters to reduce the risk of incomplete logs in the future.

**Pull Request status**
<!-- Feel free to construct the checklist with whatever items seem most reasonable for your change. You could disassemble the Implementation part to even smaller separate checklist items if you're working on something big for example. But do make the effort to provide a checklist of some sort so that the core team as well as the community can have an idea about the progress of your Pull Request.
-->

- [ ] Implementation
- [ ] Unit tests
- [ ] Integration tests
- [ ] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [ ] Mocks are regenerated, using the automated script
