### PR TITLE
Change the log level to info on update/delete app template mutations

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -139,7 +139,7 @@ global:
       name: compass-pairing-adapter
     director:
       dir: dev/incubator/
-      version: "PR-3049"
+      version: "PR-3051"
       name: compass-director
     hydrator:
       dir: dev/incubator/

--- a/components/director/internal/domain/apptemplate/resolver.go
+++ b/components/director/internal/domain/apptemplate/resolver.go
@@ -496,7 +496,7 @@ func (r *Resolver) UpdateApplicationTemplate(ctx context.Context, id string, in 
 		}
 	}
 
-	log.C(ctx).Debugf("Updating an Application Template with id %q", id)
+	log.C(ctx).Infof("Updating an Application Template with id %q", id)
 	err = r.appTemplateSvc.Update(ctx, id, convertedIn)
 	if err != nil {
 		return nil, err
@@ -568,7 +568,7 @@ func (r *Resolver) DeleteApplicationTemplate(ctx context.Context, id string) (*g
 		ctx = persistence.SaveToContext(ctx, tx)
 	}
 
-	log.C(ctx).Debugf("Deleting an Application Template with id %q", id)
+	log.C(ctx).Infof("Deleting an Application Template with id %q", id)
 	err = r.appTemplateSvc.Delete(ctx, id)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
# Change the log level to info on update/delete app template mutations

For better traceability when investigating issues. These flows don't happen often so our flows won't be additionally flooded if we add them in our info logs.