### PR TITLE
UCL managed app templates have invalid jsonPaths

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -139,7 +139,7 @@ global:
       name: compass-pairing-adapter
     director:
       dir: dev/incubator/
-      version: "PR-3052"
+      version: "PR-3062"
       name: compass-director
     hydrator:
       dir: dev/incubator/

--- a/components/director/internal/systemfetcher/loader.go
+++ b/components/director/internal/systemfetcher/loader.go
@@ -260,13 +260,11 @@ func enrichApplicationTemplateInput(appTemplateInputs []model.ApplicationTemplat
 			appTemplateInput.Placeholders = []model.ApplicationTemplatePlaceholder{
 				{
 					Name:        "name",
-					Description: str.Ptr("Application’s technical name"),
-					JSONPath:    str.Ptr("$.metadata.name"),
+					Description: str.Ptr("Application’s technical name")
 				},
 				{
 					Name:        "display-name",
-					Description: str.Ptr("Application’s display name"),
-					JSONPath:    str.Ptr("$.spec.displayName"),
+					Description: str.Ptr("Application’s display name")
 				},
 			}
 		}

--- a/components/director/internal/systemfetcher/loader.go
+++ b/components/director/internal/systemfetcher/loader.go
@@ -261,10 +261,12 @@ func enrichApplicationTemplateInput(appTemplateInputs []model.ApplicationTemplat
 				{
 					Name:        "name",
 					Description: str.Ptr("Application’s technical name"),
+					JSONPath: str.Ptr("$.displayName"),
 				},
 				{
 					Name:        "display-name",
 					Description: str.Ptr("Application’s display name"),
+					JSONPath: str.Ptr("$.displayName"),
 				},
 			}
 		}

--- a/components/director/internal/systemfetcher/loader.go
+++ b/components/director/internal/systemfetcher/loader.go
@@ -261,12 +261,12 @@ func enrichApplicationTemplateInput(appTemplateInputs []model.ApplicationTemplat
 				{
 					Name:        "name",
 					Description: str.Ptr("Application’s technical name"),
-					JSONPath:    str.Ptr("Path to technical name in system information"),
+					JSONPath:    str.Ptr("$.metadata.name"),
 				},
 				{
 					Name:        "display-name",
 					Description: str.Ptr("Application’s display name"),
-					JSONPath:    str.Ptr("Path to display name in system information"),
+					JSONPath:    str.Ptr("$.spec.displayName"),
 				},
 			}
 		}

--- a/components/director/internal/systemfetcher/loader.go
+++ b/components/director/internal/systemfetcher/loader.go
@@ -260,11 +260,11 @@ func enrichApplicationTemplateInput(appTemplateInputs []model.ApplicationTemplat
 			appTemplateInput.Placeholders = []model.ApplicationTemplatePlaceholder{
 				{
 					Name:        "name",
-					Description: str.Ptr("Application’s technical name")
+					Description: str.Ptr("Application’s technical name"),
 				},
 				{
 					Name:        "display-name",
-					Description: str.Ptr("Application’s display name")
+					Description: str.Ptr("Application’s display name"),
 				},
 			}
 		}


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:
- Default values for app templates JSON Path set to more meaningful values.

**Pull Request status**
- [x] Implementation
- [x] Unit tests
- [x] Integration tests
- [x] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [x] Mocks are regenerated, using the automated script
