### PR TITLE
Add delay 10s between retries when fetch tenants

### DIFF
--- a/components/director/internal/tenantfetchersvc/resync/synchronizer.go
+++ b/components/director/internal/tenantfetchersvc/resync/synchronizer.go
@@ -14,12 +14,13 @@ import (
 )
 
 const (
-	retryDelayMilliseconds = 100
+	retryDelaySeconds = 10
 	// TenantOnDemandProvider is the name of the business tenant mapping provider used when the tenant is not found in the events service
 	TenantOnDemandProvider = "lazily-tenant-fetcher"
 )
 
 // TenantStorageService missing godoc
+//
 //go:generate mockery --name=TenantStorageService --output=automock --outpkg=automock --case=underscore --disable-version-string
 type TenantStorageService interface {
 	List(ctx context.Context) ([]*model.BusinessTenantMapping, error)
@@ -28,6 +29,7 @@ type TenantStorageService interface {
 }
 
 // TenantCreator takes care of retrieving tenants from external tenant registry and storing them in Director
+//
 //go:generate mockery --name=TenantCreator --output=automock --outpkg=automock --case=underscore --disable-version-string
 type TenantCreator interface {
 	FetchTenant(ctx context.Context, externalTenantID string) (*model.BusinessTenantMappingInput, error)
@@ -36,6 +38,7 @@ type TenantCreator interface {
 }
 
 // TenantDeleter takes care of retrieving no longer used tenants from external tenant registry and delete them from Director
+//
 //go:generate mockery --name=TenantDeleter --output=automock --outpkg=automock --case=underscore --disable-version-string
 type TenantDeleter interface {
 	TenantsToDelete(ctx context.Context, region, fromTimestamp string) ([]model.BusinessTenantMappingInput, error)
@@ -43,6 +46,7 @@ type TenantDeleter interface {
 }
 
 // TenantMover takes care of moving tenants from one parent tenant to another.
+//
 //go:generate mockery --name=TenantMover --output=automock --outpkg=automock --case=underscore --disable-version-string
 type TenantMover interface {
 	TenantsToMove(ctx context.Context, region, fromTimestamp string) ([]model.MovedSubaccountMappingInput, error)
@@ -50,6 +54,7 @@ type TenantMover interface {
 }
 
 // AggregationFailurePusher takes care of pushing aggregation failures to Prometheus.
+//
 //go:generate mockery --name=AggregationFailurePusher --output=automock --outpkg=automock --case=underscore --disable-version-string
 type AggregationFailurePusher interface {
 	ReportAggregationFailure(ctx context.Context, err error)

--- a/components/director/internal/tenantfetchersvc/resync/tenant_manager.go
+++ b/components/director/internal/tenantfetchersvc/resync/tenant_manager.go
@@ -311,7 +311,7 @@ func fetchTenants(ctx context.Context, eventAPIClient EventAPIClient, eventsType
 }
 
 func fetchWithRetries(retryAttempts uint, applyFunc func() error) error {
-	return retry.Do(applyFunc, retry.Attempts(retryAttempts), retry.Delay(retryDelayMilliseconds*time.Millisecond))
+	return retry.Do(applyFunc, retry.Attempts(retryAttempts), retry.Delay(retryDelaySeconds*time.Second))
 }
 
 func walkThroughPages(ctx context.Context, eventAPIClient EventAPIClient, eventsType EventsType, configProvider func() (QueryParams, PageConfig), applyFunc func(*EventsPage) error) error {

--- a/components/director/internal/tenantfetchersvc/resync/tenant_mover.go
+++ b/components/director/internal/tenantfetchersvc/resync/tenant_mover.go
@@ -247,7 +247,7 @@ func fetchMovedSubaccountsWithRetries(ctx context.Context, eventAPIClient EventA
 		}
 		tenants = fetchedTenants
 		return nil
-	}, retry.Attempts(retryAttempts), retry.Delay(retryDelayMilliseconds*time.Millisecond))
+	}, retry.Attempts(retryAttempts), retry.Delay(retryDelaySeconds*time.Second))
 	if err != nil {
 		return nil, errors.Wrapf(err, "while fetching moved tenants after %d retries", retryAttempts)
 	}


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:
- Add delay 10 sec between retries to ensure no cached results are returned.

**Pull Request status**
- [x] Implementation
- [x] Unit tests
- [x] Integration tests
- [ ] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [x] Mocks are regenerated, using the automated script
