### PR TITLE
[HOTFIX] Fix get Application template Webhook for Formation Notifications

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -139,7 +139,7 @@ global:
       name: compass-pairing-adapter
     director:
       dir: dev/incubator/
-      version: "PR-3064"
+      version: "PR-3101"
       name: compass-director
     hydrator:
       dir: dev/incubator/
@@ -184,7 +184,7 @@ global:
       name: compass-console
     e2e_tests:
       dir: dev/incubator/
-      version: "PR-3077"
+      version: "PR-3101"
       name: compass-e2e-tests
   isLocalEnv: false
   isForTesting: false

--- a/components/director/internal/domain/webhook/repository.go
+++ b/components/director/internal/domain/webhook/repository.go
@@ -203,9 +203,12 @@ func (r *repository) ListByReferenceObjectTypesAndWebhookType(ctx context.Contex
 		if err != nil {
 			return nil, err
 		}
-		conditionsForAppTemplate := repo.NewNotNullCondition(refColumn)
+		conditionsForAppTemplate := repo.Conditions{
+			repo.NewNotNullCondition(refColumn),
+			repo.NewEqualCondition("type", whType),
+		}
 
-		if err := r.listerGlobal.ListGlobal(ctx, &appTemplateWebhooks, conditionsForAppTemplate); err != nil {
+		if err := r.listerGlobal.ListGlobal(ctx, &appTemplateWebhooks, conditionsForAppTemplate...); err != nil {
 			return nil, err
 		}
 

--- a/components/director/internal/domain/webhook/repository_test.go
+++ b/components/director/internal/domain/webhook/repository_test.go
@@ -759,8 +759,8 @@ func Test_ListByReferenceObjectTypesAndWebhookType(t *testing.T) {
 				},
 			},
 			{
-				Query:    regexp.QuoteMeta(`SELECT id, app_id, app_template_id, type, url, auth, runtime_id, integration_system_id, mode, correlation_id_key, retry_interval, timeout, url_template, input_template, header_template, output_template, status_template, created_at, formation_template_id FROM public.webhooks WHERE app_template_id IS NOT NULL`),
-				Args:     []driver.Value{},
+				Query:    regexp.QuoteMeta(`SELECT id, app_id, app_template_id, type, url, auth, runtime_id, integration_system_id, mode, correlation_id_key, retry_interval, timeout, url_template, input_template, header_template, output_template, status_template, created_at, formation_template_id FROM public.webhooks WHERE app_template_id IS NOT NULL AND type = $1`),
+				Args:     []driver.Value{whModel2.Type},
 				IsSelect: true,
 				ValidRowsProvider: func() []*sqlmock.Rows {
 					return []*sqlmock.Rows{sqlmock.NewRows(fixColumns).

--- a/tests/director/tests/formation_api_test.go
+++ b/tests/director/tests/formation_api_test.go
@@ -1701,8 +1701,17 @@ func TestFormationNotificationsWithApplicationOnlyParticipants(t *testing.T) {
 		defer fixtures.CleanupWebhook(t, ctx, certSecuredGraphQLClient, tnt, actualApplicationWebhook.ID)
 
 		t.Logf("Add webhook with type %q and mode: %q to application template with ID %q", webhookType, webhookMode, appTmpl2.ID)
+
 		actualApplicationTemplateWebhook := fixtures.AddWebhookToApplicationTemplate(t, ctx, oauthGraphQLClient, applicationWebhookInput, "", appTmpl2.ID)
 		defer fixtures.CleanupWebhook(t, ctx, oauthGraphQLClient, "", actualApplicationTemplateWebhook.ID)
+
+		// register a few more webhooks for the application template to verify that only the correct type of webhook is used when generation formation notifications
+		actualUnregisterApplicationWebhook := fixtures.AddWebhookToApplicationTemplate(t, ctx, oauthGraphQLClient, fixtures.FixNonFormationNotificationWebhookInput(graphql.WebhookTypeUnregisterApplication), "", appTmpl2.ID)
+		defer fixtures.CleanupWebhook(t, ctx, oauthGraphQLClient, "", actualUnregisterApplicationWebhook.ID)
+		actualRegisterApplicationWebhook := fixtures.AddWebhookToApplicationTemplate(t, ctx, oauthGraphQLClient, fixtures.FixNonFormationNotificationWebhookInput(graphql.WebhookTypeRegisterApplication), "", appTmpl2.ID)
+		defer fixtures.CleanupWebhook(t, ctx, oauthGraphQLClient, "", actualRegisterApplicationWebhook.ID)
+		actualORDWebhook := fixtures.AddWebhookToApplicationTemplate(t, ctx, oauthGraphQLClient, fixtures.FixNonFormationNotificationWebhookInput(graphql.WebhookTypeOpenResourceDiscovery), "", appTmpl2.ID)
+		defer fixtures.CleanupWebhook(t, ctx, oauthGraphQLClient, "", actualORDWebhook.ID)
 
 		formationName := "app-to-app-formation-name"
 		t.Logf("Creating formation with name: %q from template with name: %q", formationName, formationTmplName)

--- a/tests/pkg/fixtures/webhook_fixtures.go
+++ b/tests/pkg/fixtures/webhook_fixtures.go
@@ -17,3 +17,11 @@ func FixFormationNotificationWebhookInput(webhookType graphql.WebhookType, mode 
 		OutputTemplate: &outputTemplate,
 	}
 }
+
+func FixNonFormationNotificationWebhookInput(webhookType graphql.WebhookType) *graphql.WebhookInput {
+	return &graphql.WebhookInput{
+		URL:            str.Ptr("http://new-webhook.url"),
+		Type:           webhookType,
+		OutputTemplate: str.Ptr("{\\\"location\\\":\\\"{{.Headers.Location}}\\\",\\\"success_status_code\\\": 202,\\\"error\\\": \\\"{{.Body.error}}\\\"}"),
+	}
+}


### PR DESCRIPTION
**Description**

When selecting Application templates Webhooks for Formation Notifications the webhook type is not specified. It is not deterministic which webhook will be returned if the template has more than one webhook.

Changes proposed in this pull request:

- select only webhooks of specific type