### PR TITLE
[HOTFIX] Fix matching certificate subjects

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -139,11 +139,11 @@ global:
       name: compass-pairing-adapter
     director:
       dir: dev/incubator/
-      version: "PR-3033"
+      version: "PR-3109"
       name: compass-director
     hydrator:
       dir: dev/incubator/
-      version: "PR-3084"
+      version: "PR-3109"
       name: compass-hydrator
     ias_adapter:
       dir: dev/incubator/

--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -481,7 +481,7 @@ global:
     port: 3000
     prefix: /hydrators
     certSubjectMappingResyncInterval: "10s"
-    subjectConsumerMappingConfig: '[{"consumer_type": "Super Admin", "tenant_access_levels": ["customer", "account","subaccount", "global", "organization", "folder", "resource-group"], "subject": "C=DE, L=local, O=SAP SE, OU=Region, OU=SAP Cloud Platform Clients, OU=f8075207-1478-4a80-bd26-24a4785a2bfd, CN=compass"}, {"consumer_type": "Integration System", "tenant_access_levels": ["account","subaccount"], "subject": "C=DE, L=local, O=SAP SE, OU=Region, OU=SAP Cloud Platform Clients, OU=f8075207-1478-4a80-bd26-24a4785a2bfd, CN=integration-system-test"}, {"consumer_type": "Technical Client", "tenant_access_levels": ["global"], "subject": "C=DE, L=local, O=SAP SE, OU=SAP Cloud Platform Clients, OU=1f538f34-30bf-4d3d-aeaa-02e69eef84ae, CN=technical-client-test"}]'
+    subjectConsumerMappingConfig: '[{"consumer_type": "Super Admin", "tenant_access_levels": ["customer", "account","subaccount", "global", "organization", "folder", "resource-group"], "subject": "C=DE, L=local, O=SAP SE, OU=Region, OU=SAP Cloud Platform Clients, OU=f8075207-1478-4a80-bd26-24a4785a2bfd, CN=compass"}, {"consumer_type": "Integration System", "tenant_access_levels": ["account","subaccount"], "subject": "C=DE, L=local, O=SAP SE, OU=Region, OU=SAP Cloud Platform Clients, OU=f8075207-1478-4a80-bd26-24a4785a2bfd, CN=integration-system-test"}, {"consumer_type": "Technical Client", "tenant_access_levels": ["global"], "subject": "C=DE, L=local, O=SAP SE, OU=SAP Cloud Platform Clients, OU=Region, OU=1f538f34-30bf-4d3d-aeaa-02e69eef84ae, CN=technical-client-test"}]'
     certificateDataHeader: "Certificate-Data"
     consumerClaimsKeys:
       clientIDKey: "client_id"
@@ -794,7 +794,7 @@ global:
   externalCertConfiguration:
     issuerLocality: "local,local2" # In local setup we have manually created connector CA certificate with 'local' Locality property
     subjectPattern: "/C=DE/O=SAP SE/OU=SAP Cloud Platform Clients/OU=Region/OU=%s/L=%s/CN=%s"
-    technicalClientSubjectPattern: "/C=DE/O=SAP SE/OU=SAP Cloud Platform Clients/OU=%s/L=%s/CN=%s"
+    technicalClientSubjectPattern: "/C=DE/O=SAP SE/OU=SAP Cloud Platform Clients/OU=Region/OU=%s/L=%s/CN=%s"
     ouCertSubaccountID: "f8075207-1478-4a80-bd26-24a4785a2bfd"
     commonName: "compass"
     locality: "local"

--- a/components/director/pkg/cert/certutils_test.go
+++ b/components/director/pkg/cert/certutils_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestSubjectExtraction(t *testing.T) {
-	for _, testCase := range []struct {
+	testCases := []struct {
 		subject          string
 		orgUnitPattern   string
 		orgRegionPattern string
@@ -114,8 +114,10 @@ func TestSubjectExtraction(t *testing.T) {
 			orgUnits:   []string{},
 			commonName: "",
 		},
-	} {
-		t.Run("should extract subject values", func(t *testing.T) {
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.subject, func(t *testing.T) {
 			assert.Equal(t, testCase.country, cert.GetCountry(testCase.subject))
 			assert.Equal(t, testCase.locality, cert.GetLocality(testCase.subject))
 			assert.Equal(t, testCase.province, cert.GetProvince(testCase.subject))

--- a/components/director/pkg/cert/certutils_test.go
+++ b/components/director/pkg/cert/certutils_test.go
@@ -117,7 +117,7 @@ func TestSubjectExtraction(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		t.Run(testCase.subject, func(t *testing.T) {
+		t.Run("should extract subject values from subject: "+testCase.subject, func(t *testing.T) {
 			assert.Equal(t, testCase.country, cert.GetCountry(testCase.subject))
 			assert.Equal(t, testCase.locality, cert.GetLocality(testCase.subject))
 			assert.Equal(t, testCase.province, cert.GetProvince(testCase.subject))

--- a/components/hydrator/internal/subject/cert_subject.go
+++ b/components/hydrator/internal/subject/cert_subject.go
@@ -128,10 +128,25 @@ func (p *processor) authIDFromMappings() func(subject string) string {
 }
 
 func subjectsMatch(actualSubject, expectedSubject string) bool {
-	expectedSubjectComponents := strings.Split(expectedSubject, ",")
+	return cert.GetCommonName(expectedSubject) == cert.GetCommonName(actualSubject) &&
+		cert.GetCountry(expectedSubject) == cert.GetCountry(actualSubject) &&
+		cert.GetLocality(expectedSubject) == cert.GetLocality(actualSubject) &&
+		cert.GetOrganization(expectedSubject) == cert.GetOrganization(actualSubject) &&
+		matchOrganizationalUnits(cert.GetAllOrganizationalUnits(actualSubject), cert.GetAllOrganizationalUnits(expectedSubject))
+}
 
-	for _, expectedSubjectComponent := range expectedSubjectComponents {
-		if !strings.Contains(actualSubject, strings.TrimSpace(expectedSubjectComponent)) {
+func matchOrganizationalUnits(actualOrgUnits, expectedOrgUnits []string) bool {
+	if len(expectedOrgUnits) != len(actualOrgUnits) {
+		return false
+	}
+
+	expectedOrgUnitsMap := make(map[string]struct{}, len(expectedOrgUnits))
+	for _, expectedOrgUnit := range expectedOrgUnits {
+		expectedOrgUnitsMap[strings.TrimSpace(expectedOrgUnit)] = struct{}{}
+	}
+
+	for _, actualOrgUnit := range actualOrgUnits {
+		if _, exist := expectedOrgUnitsMap[strings.TrimSpace(actualOrgUnit)]; !exist {
 			return false
 		}
 	}


### PR DESCRIPTION
**Description**
When CMP is called with certificate as part of the request processing the hydarator component is matching the certificate subject against whitelisted certificate subject mappings. The OU parts of the subject can be separated by `,` or by `+`. If the subject from the request uses `,` for separator and the whitelisted subject uses `+` as separator the hydrator fails to match them.

Changes proposed in this pull request:
- Use cert utils methods to compare the subject parts

**Pull Request status**
<!-- Feel free to construct the checklist with whatever items seem most reasonable for your change. You could disassemble the Implementation part to even smaller separate checklist items if you're working on something big for example. But do make the effort to provide a checklist of some sort so that the core team as well as the community can have an idea about the progress of your Pull Request.
-->

- [X] Implementation
- [X] Unit tests
- [X] Integration tests
- [X] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->