### PR TITLE
Fix formation assignments stuck in initial state when object is without any webhooks

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -139,7 +139,7 @@ global:
       name: compass-pairing-adapter
     director:
       dir: dev/incubator/
-      version: "PR-3111"
+      version: "PR-3114"
       name: compass-director
     hydrator:
       dir: dev/incubator/

--- a/components/director/internal/domain/formation/service.go
+++ b/components/director/internal/domain/formation/service.go
@@ -1013,9 +1013,6 @@ func (s *service) resynchronizeFormationAssignmentNotifications(ctx context.Cont
 		if err != nil {
 			return nil, err
 		}
-		if notificationForFA == nil {
-			continue
-		}
 
 		reverseFA, err := s.formationAssignmentService.GetReverseBySourceAndTarget(ctx, fa.FormationID, fa.Source, fa.Target)
 		if err != nil && !apperrors.IsNotFoundError(err) {


### PR DESCRIPTION
**Description**
When there are formation lifecycle notifications all formation assignments are created in `INITIAL` state and when the formation is ready they get resynchronized. After #3097 the formation assignments that do not have webhooks get stuck in `INITIAL` state because they are skipped.

Changes proposed in this pull request:
- in `resynchronizeFormationAssignments` remove nil check for no notifications, as this is handled in formation assignment service `ProcessFormationAssignmentPair`

**Related issue(s)**
- #3097
- #3112

**Pull Request status**
<!-- Feel free to construct the checklist with whatever items seem most reasonable for your change. You could disassemble the Implementation part to even smaller separate checklist items if you're working on something big for example. But do make the effort to provide a checklist of some sort so that the core team as well as the community can have an idea about the progress of your Pull Request.
-->

- [x] Implementation
- [x] Unit tests
- [x] [N/A] Integration tests
- [x] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [x] Mocks are regenerated, using the automated script
