### PR TITLE
On AppTemplate Update also update webhooks

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -139,7 +139,7 @@ global:
       name: compass-pairing-adapter
     director:
       dir: dev/incubator/
-      version: "PR-3129"
+      version: "PR-3130"
       name: compass-director
     hydrator:
       dir: dev/incubator/
@@ -188,7 +188,7 @@ global:
       name: compass-console
     e2e_tests:
       dir: dev/incubator/
-      version: "PR-3103"
+      version: "PR-3130"
       name: compass-e2e-tests
   isLocalEnv: false
   isForTesting: false

--- a/components/director/internal/domain/apptemplate/automock/webhook_repository.go
+++ b/components/director/internal/domain/apptemplate/automock/webhook_repository.go
@@ -28,6 +28,20 @@ func (_m *WebhookRepository) CreateMany(ctx context.Context, tenant string, item
 	return r0
 }
 
+// DeleteAllByApplicationTemplateID provides a mock function with given fields: ctx, applicationTemplateID
+func (_m *WebhookRepository) DeleteAllByApplicationTemplateID(ctx context.Context, applicationTemplateID string) error {
+	ret := _m.Called(ctx, applicationTemplateID)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, string) error); ok {
+		r0 = rf(ctx, applicationTemplateID)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 type mockConstructorTestingTNewWebhookRepository interface {
 	mock.TestingT
 	Cleanup(func())

--- a/components/director/internal/domain/apptemplate/converter.go
+++ b/components/director/internal/domain/apptemplate/converter.go
@@ -128,6 +128,11 @@ func (c *converter) UpdateInputFromGraphQL(in graphql.ApplicationTemplateUpdateI
 		}
 	}
 
+	webhooks, err := c.webhookConverter.MultipleInputFromGraphQL(in.Webhooks)
+	if err != nil {
+		return model.ApplicationTemplateUpdateInput{}, errors.Wrapf(err, "error occurred while converting webhooks og GraphQL input to Application Template model with name %s", in.Name)
+	}
+
 	return model.ApplicationTemplateUpdateInput{
 		Name:                 in.Name,
 		Description:          in.Description,
@@ -136,6 +141,7 @@ func (c *converter) UpdateInputFromGraphQL(in graphql.ApplicationTemplateUpdateI
 		Placeholders:         c.placeholdersFromGraphql(in.Placeholders),
 		AccessLevel:          model.ApplicationTemplateAccessLevel(in.AccessLevel),
 		Labels:               in.Labels,
+		Webhooks:             webhooks,
 	}, nil
 }
 

--- a/components/director/internal/domain/apptemplate/converter_test.go
+++ b/components/director/internal/domain/apptemplate/converter_test.go
@@ -309,11 +309,12 @@ func TestConverter_UpdateInputFromGraphQL(t *testing.T) {
 	appTemplateInputModel := fixModelAppTemplateUpdateInputWithLabels(testName, "{\"name\":\"foo\",\"description\":\"Lorem ipsum\"}", newTestLabels)
 
 	testCases := []struct {
-		Name           string
-		AppConverterFn func() *automock.AppConverter
-		Input          graphql.ApplicationTemplateUpdateInput
-		Expected       model.ApplicationTemplateUpdateInput
-		ExpectedError  error
+		Name               string
+		AppConverterFn     func() *automock.AppConverter
+		WebhookConverterFn func() *automock.WebhookConverter
+		Input              graphql.ApplicationTemplateUpdateInput
+		Expected           model.ApplicationTemplateUpdateInput
+		ExpectedError      error
 	}{
 		{
 			Name: "All properties given",
@@ -322,15 +323,40 @@ func TestConverter_UpdateInputFromGraphQL(t *testing.T) {
 				appConverter.On("CreateJSONInputGQLToJSON", appTemplateInputGQL.ApplicationInput).Return(appTemplateInputModel.ApplicationInputJSON, nil).Once()
 				return &appConverter
 			},
+			WebhookConverterFn: func() *automock.WebhookConverter {
+				conv := &automock.WebhookConverter{}
+				conv.On("MultipleInputFromGraphQL", []*graphql.WebhookInput(nil)).Return([]*model.WebhookInput(nil), nil)
+				return conv
+			},
 			Input:         *appTemplateInputGQL,
 			Expected:      *appTemplateInputModel,
 			ExpectedError: nil,
+		},
+		{
+			Name: "Error when converting Webhook",
+			AppConverterFn: func() *automock.AppConverter {
+				appConverter := automock.AppConverter{}
+				appConverter.On("CreateJSONInputGQLToJSON", appTemplateInputGQL.ApplicationInput).Return(appTemplateInputModel.ApplicationInputJSON, nil).Once()
+				return &appConverter
+			},
+			WebhookConverterFn: func() *automock.WebhookConverter {
+				conv := &automock.WebhookConverter{}
+				conv.On("MultipleInputFromGraphQL", []*graphql.WebhookInput(nil)).Return(nil, mockedError)
+				return conv
+			},
+			Input:         *appTemplateInputGQL,
+			ExpectedError: mockedError,
 		},
 		{
 			Name: "Empty",
 			AppConverterFn: func() *automock.AppConverter {
 				appConverter := automock.AppConverter{}
 				return &appConverter
+			},
+			WebhookConverterFn: func() *automock.WebhookConverter {
+				conv := &automock.WebhookConverter{}
+				conv.On("MultipleInputFromGraphQL", []*graphql.WebhookInput(nil)).Return([]*model.WebhookInput(nil), nil)
+				return conv
 			},
 			Input: graphql.ApplicationTemplateUpdateInput{},
 			Expected: model.ApplicationTemplateUpdateInput{
@@ -345,6 +371,11 @@ func TestConverter_UpdateInputFromGraphQL(t *testing.T) {
 				appConverter.On("CreateJSONInputGQLToJSON", appTemplateInputGQL.ApplicationInput).Return("", testError).Once()
 				return &appConverter
 			},
+			WebhookConverterFn: func() *automock.WebhookConverter {
+				conv := &automock.WebhookConverter{}
+				conv.On("MultipleInputFromGraphQL", []*graphql.WebhookInput(nil)).Return([]*model.WebhookInput(nil), nil)
+				return conv
+			},
 			Input:         *appTemplateInputGQL,
 			ExpectedError: testError,
 		},
@@ -353,7 +384,8 @@ func TestConverter_UpdateInputFromGraphQL(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run(testCase.Name, func(t *testing.T) {
 			appConv := testCase.AppConverterFn()
-			converter := apptemplate.NewConverter(appConv, nil)
+			webhookConv := testCase.WebhookConverterFn()
+			converter := apptemplate.NewConverter(appConv, webhookConv)
 			// WHEN
 			res, err := converter.UpdateInputFromGraphQL(testCase.Input)
 

--- a/components/director/internal/domain/apptemplate/resolver.go
+++ b/components/director/internal/domain/apptemplate/resolver.go
@@ -468,6 +468,15 @@ func (r *Resolver) UpdateApplicationTemplate(ctx context.Context, id string, in 
 		return nil, err
 	}
 
+	webhooks, err := r.webhookSvc.EnrichWebhooksWithTenantMappingWebhooks(in.Webhooks)
+	if err != nil {
+		return nil, err
+	}
+
+	if in.Webhooks != nil {
+		in.Webhooks = webhooks
+	}
+
 	convertedIn, err := r.appTemplateConverter.UpdateInputFromGraphQL(in)
 	if err != nil {
 		return nil, err

--- a/components/director/internal/domain/apptemplate/resolver_test.go
+++ b/components/director/internal/domain/apptemplate/resolver_test.go
@@ -1691,7 +1691,7 @@ func TestResolver_UpdateApplicationTemplate(t *testing.T) {
 				return srm
 			},
 			WebhookConvFn:  UnusedWebhookConv,
-			WebhookSvcFn:   UnusedWebhookSvc,
+			WebhookSvcFn:   SuccessfulWebhookSvc(gqlAppTemplateUpdateInputWithProvider.Webhooks, gqlAppTemplateUpdateInputWithProvider.Webhooks),
 			Input:          gqlAppTemplateUpdateInput,
 			ExpectedOutput: gqlAppTemplate,
 		},
@@ -1747,7 +1747,7 @@ func TestResolver_UpdateApplicationTemplate(t *testing.T) {
 				return srm
 			},
 			WebhookConvFn:  UnusedWebhookConv,
-			WebhookSvcFn:   UnusedWebhookSvc,
+			WebhookSvcFn:   SuccessfulWebhookSvc(gqlAppTemplateUpdateInputWithProvider.Webhooks, gqlAppTemplateUpdateInputWithProvider.Webhooks),
 			Input:          gqlAppTemplateUpdateInput,
 			ExpectedOutput: gqlAppTemplate,
 		},
@@ -1762,7 +1762,7 @@ func TestResolver_UpdateApplicationTemplate(t *testing.T) {
 			},
 			SelfRegManagerFn: UnusedSelfRegManager,
 			WebhookConvFn:    UnusedWebhookConv,
-			WebhookSvcFn:     UnusedWebhookSvc,
+			WebhookSvcFn:     SuccessfulWebhookSvc(gqlAppTemplateUpdateInputWithProvider.Webhooks, gqlAppTemplateUpdateInputWithProvider.Webhooks),
 			Input:            gqlAppTemplateUpdateInput,
 			ExpectedError:    testError,
 		},
@@ -1786,7 +1786,7 @@ func TestResolver_UpdateApplicationTemplate(t *testing.T) {
 				return srm
 			},
 			WebhookConvFn: UnusedWebhookConv,
-			WebhookSvcFn:  UnusedWebhookSvc,
+			WebhookSvcFn:  SuccessfulWebhookSvc(gqlAppTemplateUpdateInputWithProvider.Webhooks, gqlAppTemplateUpdateInputWithProvider.Webhooks),
 			Input:         gqlAppTemplateUpdateInput,
 			ExpectedError: testError,
 		},
@@ -1811,7 +1811,7 @@ func TestResolver_UpdateApplicationTemplate(t *testing.T) {
 				return srm
 			},
 			WebhookConvFn: UnusedWebhookConv,
-			WebhookSvcFn:  UnusedWebhookSvc,
+			WebhookSvcFn:  SuccessfulWebhookSvc(gqlAppTemplateUpdateInputWithProvider.Webhooks, gqlAppTemplateUpdateInputWithProvider.Webhooks),
 			Input:         gqlAppTemplateUpdateInput,
 			ExpectedError: testError,
 		},
@@ -1830,7 +1830,7 @@ func TestResolver_UpdateApplicationTemplate(t *testing.T) {
 			},
 			SelfRegManagerFn: UnusedSelfRegManager,
 			WebhookConvFn:    UnusedWebhookConv,
-			WebhookSvcFn:     UnusedWebhookSvc,
+			WebhookSvcFn:     SuccessfulWebhookSvc(gqlAppTemplateUpdateInputWithProvider.Webhooks, gqlAppTemplateUpdateInputWithProvider.Webhooks),
 			Input:            gqlAppTemplateUpdateInput,
 			ExpectedError:    testError,
 		},
@@ -1853,7 +1853,7 @@ func TestResolver_UpdateApplicationTemplate(t *testing.T) {
 				return srm
 			},
 			WebhookConvFn: UnusedWebhookConv,
-			WebhookSvcFn:  UnusedWebhookSvc,
+			WebhookSvcFn:  SuccessfulWebhookSvc(gqlAppTemplateUpdateInputWithProvider.Webhooks, gqlAppTemplateUpdateInputWithProvider.Webhooks),
 			Input:         gqlAppTemplateUpdateInput,
 			ExpectedError: testError,
 		},
@@ -1873,7 +1873,7 @@ func TestResolver_UpdateApplicationTemplate(t *testing.T) {
 				return srm
 			},
 			WebhookConvFn: UnusedWebhookConv,
-			WebhookSvcFn:  UnusedWebhookSvc,
+			WebhookSvcFn:  SuccessfulWebhookSvc(gqlAppTemplateUpdateInputWithProvider.Webhooks, gqlAppTemplateUpdateInputWithProvider.Webhooks),
 			Input:         gqlAppTemplateUpdateInputWithoutNameProperty,
 			ExpectedError: errors.New("appInput: (name: cannot be blank.)"),
 		},
@@ -1896,7 +1896,7 @@ func TestResolver_UpdateApplicationTemplate(t *testing.T) {
 				return srm
 			},
 			WebhookConvFn: UnusedWebhookConv,
-			WebhookSvcFn:  UnusedWebhookSvc,
+			WebhookSvcFn:  SuccessfulWebhookSvc(gqlAppTemplateUpdateInputWithProvider.Webhooks, gqlAppTemplateUpdateInputWithProvider.Webhooks),
 			Input:         gqlAppTemplateUpdateInputWithoutDisplayNameLabel,
 			ExpectedError: errors.New("applicationInputJSON name property or applicationInputJSON displayName label is missing. They must be present in order to proceed."),
 		},
@@ -1919,7 +1919,7 @@ func TestResolver_UpdateApplicationTemplate(t *testing.T) {
 				return srm
 			},
 			WebhookConvFn: UnusedWebhookConv,
-			WebhookSvcFn:  UnusedWebhookSvc,
+			WebhookSvcFn:  SuccessfulWebhookSvc(gqlAppTemplateUpdateInputWithProvider.Webhooks, gqlAppTemplateUpdateInputWithProvider.Webhooks),
 			Input:         gqlAppTemplateUpdateInputWithNonStringDisplayLabel,
 			ExpectedError: errors.New("\"displayName\" label value must be string"),
 		},
@@ -1966,7 +1966,7 @@ func TestResolver_UpdateApplicationTemplate(t *testing.T) {
 				return srm
 			},
 			WebhookConvFn: UnusedWebhookConv,
-			WebhookSvcFn:  UnusedWebhookSvc,
+			WebhookSvcFn:   SuccessfulWebhookSvc(gqlAppTemplateUpdateInputWithProvider.Webhooks, gqlAppTemplateUpdateInputWithProvider.Webhooks),
 			Input:         gqlAppTemplateUpdateInput,
 			ExpectedError: testError,
 		},
@@ -1992,7 +1992,7 @@ func TestResolver_UpdateApplicationTemplate(t *testing.T) {
 				return srm
 			},
 			WebhookConvFn: UnusedWebhookConv,
-			WebhookSvcFn:  UnusedWebhookSvc,
+			WebhookSvcFn:   SuccessfulWebhookSvc(gqlAppTemplateUpdateInputWithProvider.Webhooks, gqlAppTemplateUpdateInputWithProvider.Webhooks),
 			Input:         gqlAppTemplateUpdateInput,
 			ExpectedError: testError,
 		},

--- a/components/director/internal/domain/apptemplate/service.go
+++ b/components/director/internal/domain/apptemplate/service.go
@@ -55,6 +55,7 @@ type UIDService interface {
 //go:generate mockery --name=WebhookRepository --output=automock --outpkg=automock --case=underscore --disable-version-string
 type WebhookRepository interface {
 	CreateMany(ctx context.Context, tenant string, items []*model.Webhook) error
+	DeleteAllByApplicationTemplateID(ctx context.Context, applicationTemplateID string) error
 }
 
 // LabelUpsertService missing godoc
@@ -313,6 +314,18 @@ func (s *service) Update(ctx context.Context, id string, in model.ApplicationTem
 	err = s.appTemplateRepo.Update(ctx, appTemplate)
 	if err != nil {
 		return errors.Wrapf(err, "while updating Application Template with ID %s", id)
+	}
+
+	if err = s.webhookRepo.DeleteAllByApplicationTemplateID(ctx, appTemplate.ID); err != nil {
+		return errors.Wrapf(err, "while deleting Webhooks for applicationTemplate")
+	}
+
+	webhooks := make([]*model.Webhook, 0, len(in.Webhooks))
+	for _, item := range in.Webhooks {
+		webhooks = append(webhooks, item.ToWebhook(s.uidService.Generate(), appTemplate.ID, model.ApplicationTemplateWebhookReference))
+	}
+	if err = s.webhookRepo.CreateMany(ctx, "", webhooks); err != nil {
+		return errors.Wrapf(err, "while creating Webhooks for applicationTemplate")
 	}
 
 	err = s.labelUpsertService.UpsertMultipleLabels(ctx, "", model.AppTemplateLabelableObject, id, in.Labels)

--- a/components/director/internal/domain/apptemplate/service_test.go
+++ b/components/director/internal/domain/apptemplate/service_test.go
@@ -1099,9 +1099,9 @@ func TestService_Update(t *testing.T) {
 	appInputJSONWithNewAppType := fmt.Sprintf(appInputJSONWithAppTypeLabelString, updatedAppTemplateTestName)
 
 	modelAppTemplate := fixModelAppTemplateWithAppInputJSON(testID, testName, appInputJSON, nil)
-	modelAppTemplateWithNewName := fixModelAppTemplateWithAppInputJSON(testID, updatedAppTemplateTestName, appInputJSONWithNewAppType, nil)
+	modelAppTemplateWithNewName := fixModelAppTemplateWithAppInputJSON(testID, updatedAppTemplateTestName, appInputJSONWithNewAppType, []*model.Webhook{})
 	modelAppTemplateOtherSystemType := fixModelAppTemplateWithAppInputJSON(testID, testNameOtherSystemType, appInputJSON, nil)
-	modelAppTemplateWithLabels := fixModelAppTemplateWithAppInputJSONAndLabels(testID, testName, appInputJSON, nil, newTestLabels)
+	modelAppTemplateWithLabels := fixModelAppTemplateWithAppInputJSONAndLabels(testID, testName, appInputJSON, []*model.Webhook{}, newTestLabels)
 	modelAppTemplateUpdateInput := fixModelAppTemplateUpdateInputWithLabels(testName, appInputJSON, newTestLabels)
 
 	modelApplicationFromTemplate := fixModelApplication(testAppID, testAppName)
@@ -1128,7 +1128,12 @@ func TestService_Update(t *testing.T) {
 				appTemplateRepo.On("Update", ctx, *modelAppTemplateWithLabels).Return(nil).Once()
 				return appTemplateRepo
 			},
-			WebhookRepoFn: UnusedWebhookRepo,
+			WebhookRepoFn: func() *automock.WebhookRepository {
+				webhookRepo := &automock.WebhookRepository{}
+				webhookRepo.On("DeleteAllByApplicationTemplateID", ctx, modelAppTemplateWithLabels.ID).Return(nil).Once()
+				webhookRepo.On("CreateMany", ctx, "", []*model.Webhook{}).Return(nil).Once()
+				return webhookRepo
+			},
 			LabelUpsertSvcFn: func() *automock.LabelUpsertService {
 				labelUpsertService := &automock.LabelUpsertService{}
 				labelUpsertService.On("UpsertMultipleLabels", ctx, "", model.AppTemplateLabelableObject, testID, modelAppTemplateUpdateInput.Labels).Return(nil).Once()
@@ -1153,7 +1158,12 @@ func TestService_Update(t *testing.T) {
 				appTemplateRepo.On("Update", ctx, mock.AnythingOfType("model.ApplicationTemplate")).Return(nil).Once()
 				return appTemplateRepo
 			},
-			WebhookRepoFn: UnusedWebhookRepo,
+			WebhookRepoFn: func() *automock.WebhookRepository {
+				webhookRepo := &automock.WebhookRepository{}
+				webhookRepo.On("DeleteAllByApplicationTemplateID", ctx, modelAppTemplateWithLabels.ID).Return(nil).Once()
+				webhookRepo.On("CreateMany", ctx, "", []*model.Webhook{}).Return(nil).Once()
+				return webhookRepo
+			},
 			LabelUpsertSvcFn: func() *automock.LabelUpsertService {
 				labelUpsertService := &automock.LabelUpsertService{}
 				labelUpsertService.On("UpsertMultipleLabels", ctx, "", model.AppTemplateLabelableObject, testID, mock.Anything).Return(nil).Once()
@@ -1178,7 +1188,12 @@ func TestService_Update(t *testing.T) {
 				appTemplateRepo.On("Update", ctx, *modelAppTemplateWithNewName).Return(nil).Once()
 				return appTemplateRepo
 			},
-			WebhookRepoFn: UnusedWebhookRepo,
+			WebhookRepoFn: func() *automock.WebhookRepository {
+				webhookRepo := &automock.WebhookRepository{}
+				webhookRepo.On("DeleteAllByApplicationTemplateID", ctx, modelAppTemplateWithLabels.ID).Return(nil).Once()
+				webhookRepo.On("CreateMany", ctx, "", []*model.Webhook{}).Return(nil).Once()
+				return webhookRepo
+			},
 			LabelRepoFn: func() *automock.LabelRepository {
 				labelRepo := &automock.LabelRepository{}
 				labelRepo.On("GetByKey", ctx, "", model.AppTemplateLabelableObject, modelAppTemplate.ID, "region").Return(nil, apperrors.NewNotFoundError(resource.Label, "id")).Once()
@@ -1207,7 +1222,12 @@ func TestService_Update(t *testing.T) {
 				appTemplateRepo.On("Update", ctx, *modelAppTemplateWithNewName).Return(nil).Once()
 				return appTemplateRepo
 			},
-			WebhookRepoFn: UnusedWebhookRepo,
+			WebhookRepoFn: func() *automock.WebhookRepository {
+				webhookRepo := &automock.WebhookRepository{}
+				webhookRepo.On("DeleteAllByApplicationTemplateID", ctx, modelAppTemplateWithLabels.ID).Return(nil).Once()
+				webhookRepo.On("CreateMany", ctx, "", []*model.Webhook{}).Return(nil).Once()
+				return webhookRepo
+			},
 			LabelRepoFn: func() *automock.LabelRepository {
 				labelRepo := &automock.LabelRepository{}
 				labelRepo.On("GetByKey", ctx, "", model.AppTemplateLabelableObject, modelAppTemplate.ID, "region").Return(nil, apperrors.NewNotFoundError(resource.Label, "id")).Once()
@@ -1237,7 +1257,12 @@ func TestService_Update(t *testing.T) {
 				appTemplateRepo.On("Update", ctx, *modelAppTemplateWithNewName).Return(nil).Once()
 				return appTemplateRepo
 			},
-			WebhookRepoFn: UnusedWebhookRepo,
+			WebhookRepoFn: func() *automock.WebhookRepository {
+				webhookRepo := &automock.WebhookRepository{}
+				webhookRepo.On("DeleteAllByApplicationTemplateID", ctx, modelAppTemplateWithLabels.ID).Return(nil).Once()
+				webhookRepo.On("CreateMany", ctx, "", []*model.Webhook{}).Return(nil).Once()
+				return webhookRepo
+			},
 			LabelRepoFn: func() *automock.LabelRepository {
 				labelRepo := &automock.LabelRepository{}
 				labelRepo.On("GetByKey", ctx, "", model.AppTemplateLabelableObject, modelAppTemplate.ID, "region").Return(nil, apperrors.NewNotFoundError(resource.Label, "id")).Once()
@@ -1267,7 +1292,12 @@ func TestService_Update(t *testing.T) {
 				appTemplateRepo.On("Update", ctx, *modelAppTemplateWithNewName).Return(nil).Once()
 				return appTemplateRepo
 			},
-			WebhookRepoFn: UnusedWebhookRepo,
+			WebhookRepoFn: func() *automock.WebhookRepository {
+				webhookRepo := &automock.WebhookRepository{}
+				webhookRepo.On("DeleteAllByApplicationTemplateID", ctx, modelAppTemplateWithLabels.ID).Return(nil).Once()
+				webhookRepo.On("CreateMany", ctx, "", []*model.Webhook{}).Return(nil).Once()
+				return webhookRepo
+			},
 			LabelRepoFn: func() *automock.LabelRepository {
 				labelRepo := &automock.LabelRepository{}
 				labelRepo.On("GetByKey", ctx, "", model.AppTemplateLabelableObject, modelAppTemplate.ID, "region").Return(nil, apperrors.NewNotFoundError(resource.Label, "id")).Once()
@@ -1375,12 +1405,17 @@ func TestService_Update(t *testing.T) {
 				appTemplateRepo := &automock.ApplicationTemplateRepository{}
 				appInputJSON := `{"name":"foo","providerName":"compass","description":"Lorem ipsum","labels":{"applicationType":"random-text","test":["val","val2"]},"healthCheckURL":"https://foo.bar","webhooks":[{"type":"","url":"webhook1.foo.bar","auth":null},{"type":"","url":"webhook2.foo.bar","auth":null}],"integrationSystemID":"iiiiiiiii-iiii-iiii-iiii-iiiiiiiiiiii"}`
 
-				modelOtherSystemTypeUpdate := fixModelAppTemplateWithAppInputJSONAndLabels(testID, testNameOtherSystemType, appInputJSON, nil, newTestLabels)
+				modelOtherSystemTypeUpdate := fixModelAppTemplateWithAppInputJSONAndLabels(testID, testNameOtherSystemType, appInputJSON, []*model.Webhook{}, newTestLabels)
 				appTemplateRepo.On("Get", ctx, modelAppTemplateOtherSystemType.ID).Return(modelAppTemplateOtherSystemType, nil).Once()
 				appTemplateRepo.On("Update", ctx, *modelOtherSystemTypeUpdate).Return(nil).Once()
 				return appTemplateRepo
 			},
-			WebhookRepoFn: UnusedWebhookRepo,
+			WebhookRepoFn: func() *automock.WebhookRepository {
+				webhookRepo := &automock.WebhookRepository{}
+				webhookRepo.On("DeleteAllByApplicationTemplateID", ctx, modelAppTemplateWithLabels.ID).Return(nil).Once()
+				webhookRepo.On("CreateMany", ctx, "", []*model.Webhook{}).Return(nil).Once()
+				return webhookRepo
+			},
 			LabelUpsertSvcFn: func() *automock.LabelUpsertService {
 				labelUpsertService := &automock.LabelUpsertService{}
 				labelUpsertService.On("UpsertMultipleLabels", ctx, "", model.AppTemplateLabelableObject, testID, mock.Anything).Return(nil).Once()
@@ -1491,7 +1526,12 @@ func TestService_Update(t *testing.T) {
 				appTemplateRepo.On("Update", ctx, *modelAppTemplateWithLabels).Return(nil).Once()
 				return appTemplateRepo
 			},
-			WebhookRepoFn: UnusedWebhookRepo,
+			WebhookRepoFn: func() *automock.WebhookRepository {
+				webhookRepo := &automock.WebhookRepository{}
+				webhookRepo.On("DeleteAllByApplicationTemplateID", ctx, modelAppTemplateWithLabels.ID).Return(nil).Once()
+				webhookRepo.On("CreateMany", ctx, "", []*model.Webhook{}).Return(nil).Once()
+				return webhookRepo
+			},
 			LabelUpsertSvcFn: func() *automock.LabelUpsertService {
 				labelUpsertService := &automock.LabelUpsertService{}
 				labelUpsertService.On("UpsertMultipleLabels", ctx, "", model.AppTemplateLabelableObject, testID, modelAppTemplateUpdateInput.Labels).Return(testError).Once()

--- a/components/director/internal/domain/webhook/repository.go
+++ b/components/director/internal/domain/webhook/repository.go
@@ -356,6 +356,11 @@ func (r *repository) DeleteAllByApplicationID(ctx context.Context, tenant, appli
 	return r.deleter.DeleteMany(ctx, resource.AppWebhook, tenant, repo.Conditions{repo.NewEqualCondition("app_id", applicationID)})
 }
 
+// DeleteAllByApplicationTemplateID missing godoc
+func (r *repository) DeleteAllByApplicationTemplateID(ctx context.Context, applicationTemplateID string) error {
+	return r.deleterGlobal.DeleteManyGlobal(ctx, repo.Conditions{repo.NewEqualCondition("app_template_id", applicationTemplateID)})
+}
+
 func convertToWebhooks(entities Collection, r *repository) ([]*model.Webhook, error) {
 	out := make([]*model.Webhook, 0, len(entities))
 	for _, ent := range entities {

--- a/components/director/internal/domain/webhook/repository_test.go
+++ b/components/director/internal/domain/webhook/repository_test.go
@@ -363,6 +363,29 @@ func TestRepositoryListByApplicationID(t *testing.T) {
 	testListByObjectID(t, "ListByReferenceObjectID", repo.NoLock, []interface{}{givenTenant(), givenApplicationID(), model.ApplicationWebhookReference})
 }
 
+func TestRepositoryDeleteAllByApplicatioTemplateID(t *testing.T) {
+	suite := testdb.RepoDeleteTestSuite{
+		Name: "Webhook Delete by ApplicationTemplateID",
+		SQLQueryDetails: []testdb.SQLQueryDetails{
+			{
+				Query:         regexp.QuoteMeta(`DELETE FROM public.webhooks WHERE app_template_id = $1`),
+				Args:          []driver.Value{givenApplicationID()},
+				ValidResult:   sqlmock.NewResult(-1, 1),
+				InvalidResult: sqlmock.NewResult(-1, 2),
+			},
+		},
+		ConverterMockProvider: func() testdb.Mock {
+			return &automock.EntityConverter{}
+		},
+		RepoConstructorFunc: webhook.NewRepository,
+		MethodArgs:          []interface{}{givenApplicationID()},
+		MethodName:          "DeleteAllByApplicationTemplateID",
+		IsDeleteMany:        true,
+	}
+
+	suite.Run(t)
+}
+
 func TestRepositoryListByApplicationIDWithSelectForUpdate(t *testing.T) {
 	testListByObjectID(t, "ListByApplicationIDWithSelectForUpdate", " "+repo.ForUpdateLock, []interface{}{givenTenant(), givenApplicationID()})
 }

--- a/components/director/internal/model/app_template.go
+++ b/components/director/internal/model/app_template.go
@@ -118,12 +118,20 @@ type ApplicationTemplateUpdateInput struct {
 	Placeholders         []ApplicationTemplatePlaceholder
 	AccessLevel          ApplicationTemplateAccessLevel
 	Labels               map[string]interface{}
+	Webhooks             []*WebhookInput
 }
 
 // ToApplicationTemplate missing godoc
 func (a *ApplicationTemplateUpdateInput) ToApplicationTemplate(id string) ApplicationTemplate {
 	if a == nil {
 		return ApplicationTemplate{}
+	}
+
+	uidService := uid.NewService()
+	webhooks := make([]Webhook, 0)
+	for _, webhookInput := range a.Webhooks {
+		webhook := webhookInput.ToWebhook(uidService.Generate(), id, ApplicationTemplateWebhookReference)
+		webhooks = append(webhooks, *webhook)
 	}
 
 	return ApplicationTemplate{
@@ -135,5 +143,6 @@ func (a *ApplicationTemplateUpdateInput) ToApplicationTemplate(id string) Applic
 		Placeholders:         a.Placeholders,
 		AccessLevel:          a.AccessLevel,
 		Labels:               a.Labels,
+		Webhooks:             webhooks,
 	}
 }

--- a/components/director/internal/systemfetcher/loader.go
+++ b/components/director/internal/systemfetcher/loader.go
@@ -363,20 +363,14 @@ func areWebhooksEqual(webhooksModel []model.Webhook, webhooksInput []*model.Webh
 	if len(webhooksModel) != len(webhooksInput) {
 		return false
 	}
-
+	foundWebhooksCounter := 0
 	for _, whModel := range webhooksModel {
-		isEqual := false
-
 		for _, whInput := range webhooksInput {
-			if whModel.ID == whInput.ID {
-				isEqual = reflect.DeepEqual(whModel, *whInput.ToWebhook(whModel.ID, whModel.ObjectID, whModel.ObjectType))
+			if reflect.DeepEqual(whModel, *whInput.ToWebhook(whModel.ID, whModel.ObjectID, whModel.ObjectType)) {
+				foundWebhooksCounter++
+				break
 			}
 		}
-
-		if !isEqual {
-			return false
-		}
 	}
-
-	return true
+	return foundWebhooksCounter == len(webhooksModel)
 }

--- a/components/director/internal/systemfetcher/loader.go
+++ b/components/director/internal/systemfetcher/loader.go
@@ -238,6 +238,7 @@ func (d *DataLoader) upsertAppTemplates(ctx context.Context, appTemplateInputs [
 				Placeholders:         appTmplInput.Placeholders,
 				AccessLevel:          appTmplInput.AccessLevel,
 				Labels:               appTmplInput.Labels,
+				Webhooks:             appTmplInput.Webhooks,
 			}
 			if err := d.appTmplSvc.Update(ctx, appTemplate.ID, appTemplateUpdateInput); err != nil {
 				return errors.Wrapf(err, "while updating application template with id %q", appTemplate.ID)

--- a/components/director/pkg/auth-middleware/automock/claims_validator.go
+++ b/components/director/pkg/auth-middleware/automock/claims_validator.go
@@ -5,7 +5,7 @@ package automock
 import (
 	context "context"
 
-	token_claims "github.com/kyma-incubator/compass/components/director/pkg/idtokenclaims"
+	idtokenclaims "github.com/kyma-incubator/compass/components/director/pkg/idtokenclaims"
 	mock "github.com/stretchr/testify/mock"
 )
 
@@ -15,11 +15,11 @@ type ClaimsValidator struct {
 }
 
 // Validate provides a mock function with given fields: _a0, _a1
-func (_m *ClaimsValidator) Validate(_a0 context.Context, _a1 token_claims.Claims) error {
+func (_m *ClaimsValidator) Validate(_a0 context.Context, _a1 idtokenclaims.Claims) error {
 	ret := _m.Called(_a0, _a1)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, token_claims.Claims) error); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, idtokenclaims.Claims) error); ok {
 		r0 = rf(_a0, _a1)
 	} else {
 		r0 = ret.Error(0)

--- a/components/director/pkg/graphql/app_template_validation.go
+++ b/components/director/pkg/graphql/app_template_validation.go
@@ -35,6 +35,7 @@ func (i ApplicationTemplateUpdateInput) Validate() error {
 		"description":            validation.Validate(i.Description, validation.RuneLength(0, descriptionStringLengthLimit)),
 		"placeholders":           validation.Validate(i.Placeholders, validation.Each(validation.Required)),
 		"accessLevel":            validation.Validate(i.AccessLevel, validation.Required, validation.In(ApplicationTemplateAccessLevelGlobal)),
+		"webhooks":               validation.Validate(i.Webhooks, validation.By(webhooksRuleFunc)),
 		"applicationNamespace":   validation.Validate(i.ApplicationNamespace, validation.Length(1, longStringLengthLimit)),
 	}.Filter()
 }

--- a/components/director/pkg/graphql/app_template_validation_test.go
+++ b/components/director/pkg/graphql/app_template_validation_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// ApplicationTemaplteInput
+// ApplicationTemplateInput
 
 func TestApplicationTemplateInput_Validate_Rule_ValidPlaceholders(t *testing.T) {
 	testPlaceholderName := "test"
@@ -362,7 +362,7 @@ func TestApplicationTemplateInput_Validate_Webhooks(t *testing.T) {
 	}
 }
 
-// ApplicationTemaplteInput
+// ApplicationTemplateUpdateInput
 
 func TestApplicationTemplateUpdateInput_Validate_Rule_ValidPlaceholders(t *testing.T) {
 	testPlaceholderName := "test"

--- a/components/director/pkg/graphql/graphqlizer/graphqlizer.go
+++ b/components/director/pkg/graphql/graphqlizer/graphqlizer.go
@@ -184,10 +184,16 @@ func (g *Graphqlizer) ApplicationTemplateUpdateInputToGQL(in graphql.Application
 				{{- if $i}}, {{- end}} {{ PlaceholderDefinitionInputToGQL $e }}
 			{{- end }} ],
 		{{- end }}
+		accessLevel: {{.AccessLevel}},
 		{{- if .Labels }}
 		labels: {{ LabelsToGQL .Labels}},
 		{{- end }}
-		accessLevel: {{.AccessLevel}},
+		{{- if .Webhooks }}
+		webhooks: [
+			{{- range $i, $e := .Webhooks }}
+				{{- if $i}}, {{- end}} {{ WebhookInputToGQL $e }}
+			{{- end }} ],
+		{{- end}}
 	}`)
 }
 

--- a/components/director/pkg/graphql/models_gen.go
+++ b/components/director/pkg/graphql/models_gen.go
@@ -166,6 +166,7 @@ type ApplicationTemplateUpdateInput struct {
 	// **Validation:** ASCII printable characters, max=100
 	Name string `json:"name"`
 	// **Validation:** max=2000
+	Webhooks             []*WebhookInput                `json:"webhooks"`
 	Description          *string                        `json:"description"`
 	ApplicationInput     *ApplicationJSONInput          `json:"applicationInput"`
 	Placeholders         []*PlaceholderDefinitionInput  `json:"placeholders"`

--- a/components/director/pkg/graphql/schema.graphql
+++ b/components/director/pkg/graphql/schema.graphql
@@ -431,6 +431,7 @@ input ApplicationTemplateUpdateInput {
 	"""
 	**Validation:** max=2000
 	"""
+	webhooks: [WebhookInput!]
 	description: String
 	applicationInput: ApplicationJSONInput!
 	placeholders: [PlaceholderDefinitionInput!]

--- a/components/director/pkg/graphql/schema_gen.go
+++ b/components/director/pkg/graphql/schema_gen.go
@@ -5416,6 +5416,7 @@ input ApplicationTemplateUpdateInput {
 	"""
 	**Validation:** max=2000
 	"""
+	webhooks: [WebhookInput!]
 	description: String
 	applicationInput: ApplicationJSONInput!
 	placeholders: [PlaceholderDefinitionInput!]
@@ -31372,6 +31373,12 @@ func (ec *executionContext) unmarshalInputApplicationTemplateUpdateInput(ctx con
 		case "name":
 			var err error
 			it.Name, err = ec.unmarshalNString2string(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		case "webhooks":
+			var err error
+			it.Webhooks, err = ec.unmarshalOWebhookInput2ᚕᚖgithubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋdirectorᚋpkgᚋgraphqlᚐWebhookInputᚄ(ctx, v)
 			if err != nil {
 				return it, err
 			}

--- a/tests/director/tests/application_templates_api_test.go
+++ b/tests/director/tests/application_templates_api_test.go
@@ -416,10 +416,18 @@ func TestUpdateApplicationTemplate(t *testing.T) {
 
 	t.Log("Create application template")
 	appTmplInput := fixAppTemplateInputWithDefaultDistinguishLabel(appTemplateName)
+	appTmplInput.Webhooks = []*graphql.WebhookInput{{
+		Type: graphql.WebhookTypeConfigurationChanged,
+		URL:  ptr.String("http://url.com"),
+	}}
 	appTemplate, err := fixtures.CreateApplicationTemplateFromInput(t, ctx, certSecuredGraphQLClient, tenantId, appTmplInput)
 	defer fixtures.CleanupApplicationTemplate(t, ctx, certSecuredGraphQLClient, tenantId, appTemplate)
 	require.NoError(t, err)
 	require.NotEmpty(t, appTemplate.ID)
+	require.NotEmpty(t, appTemplate.Webhooks)
+	oldWebhokCount := len(appTemplate.Webhooks)
+	oldWebhokID := appTemplate.Webhooks[0].ID
+	oldWebhokUrl := appTemplate.Webhooks[0].URL
 
 	newAppCreateInput.Labels = map[string]interface{}{"displayName": "{{display-name}}"}
 	appTemplateInput := graphql.ApplicationTemplateUpdateInput{Name: newName, ApplicationInput: newAppCreateInput, Description: &newDescription, AccessLevel: graphql.ApplicationTemplateAccessLevelGlobal}
@@ -431,7 +439,13 @@ func TestUpdateApplicationTemplate(t *testing.T) {
 			Name: "display-name",
 		},
 	}
+	appTemplateInput.Webhooks = []*graphql.WebhookInput{{
+		Type: graphql.WebhookTypeConfigurationChanged,
+		URL:  ptr.String("http://url2.com"),
+	}}
+
 	appTemplateGQL, err := testctx.Tc.Graphqlizer.ApplicationTemplateUpdateInputToGQL(appTemplateInput)
+	require.NoError(t, err)
 
 	updateAppTemplateRequest := fixtures.FixUpdateApplicationTemplateRequest(appTemplate.ID, appTemplateGQL)
 	updateOutput := graphql.ApplicationTemplate{}
@@ -443,6 +457,15 @@ func TestUpdateApplicationTemplate(t *testing.T) {
 
 	require.NoError(t, err)
 	require.NotEmpty(t, updateOutput.ID)
+
+	require.NotEmpty(t, updateOutput.Webhooks)
+	newWebhokCount := len(updateOutput.Webhooks)
+	newWebhokID := updateOutput.Webhooks[0].ID
+	newWebhokUrl := updateOutput.Webhooks[0].URL
+
+	require.Equal(t, oldWebhokCount, newWebhokCount)
+	require.NotEqual(t, oldWebhokID, newWebhokID)
+	require.NotEqual(t, oldWebhokUrl, newWebhokUrl)
 
 	//THEN
 	t.Log("Check if application template was updated")
@@ -483,6 +506,7 @@ func TestUpdateLabelsOfApplicationTemplateFailsWithInsufficientScopes(t *testing
 		},
 	}
 	appTemplateGQL, err := testctx.Tc.Graphqlizer.ApplicationTemplateUpdateInputToGQL(appTemplateInput)
+	require.NoError(t, err)
 
 	updateAppTemplateRequest := fixtures.FixUpdateApplicationTemplateRequest(appTemplate.ID, appTemplateGQL)
 	updateOutput := graphql.ApplicationTemplate{}

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/kyma-incubator/compass/components/connectivity-adapter v0.0.0-20230607082115-977757624f7e
 	github.com/kyma-incubator/compass/components/connector v0.0.0-20230607082115-977757624f7e
-	github.com/kyma-incubator/compass/components/director v0.0.0-20230619093445-88247e2c2d11
+	github.com/kyma-incubator/compass/components/director v0.0.0-20230621073022-b86ba01cda62
 	github.com/kyma-incubator/compass/components/external-services-mock v0.0.0-20230607082115-977757624f7e
 	github.com/kyma-incubator/compass/components/gateway v0.0.0-20230607082115-977757624f7e
 	github.com/kyma-incubator/compass/components/operations-controller v0.0.0-20230607082115-977757624f7e

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -127,10 +127,8 @@ github.com/kyma-incubator/compass/components/connectivity-adapter v0.0.0-2023060
 github.com/kyma-incubator/compass/components/connectivity-adapter v0.0.0-20230607082115-977757624f7e/go.mod h1:wu4vtgHm698Rf6A52QI0+EkO8rlS7kAOSsoHtzKraD8=
 github.com/kyma-incubator/compass/components/connector v0.0.0-20230607082115-977757624f7e h1:gcJyTTwZyUvEDhSQ/VcfVWWaLam6Ht/HH1Npv03G520=
 github.com/kyma-incubator/compass/components/connector v0.0.0-20230607082115-977757624f7e/go.mod h1:K740+tPkGSt9EDSesTwrtHPfRHAiFnj/wJyYaLvuDYU=
-github.com/kyma-incubator/compass/components/director v0.0.0-20230607082115-977757624f7e h1:YOi7R2EBIfYmp+7645bFxE0f0sEJzL/q8HDuPhw/Yik=
-github.com/kyma-incubator/compass/components/director v0.0.0-20230607082115-977757624f7e/go.mod h1:gbMcV8XF0oQOtlACKrF4B9OFAAFEkUBd8yEYKJUtP7M=
-github.com/kyma-incubator/compass/components/director v0.0.0-20230619093445-88247e2c2d11 h1:4EEfGvoBuo8w8wN5uC1Qh72wzK6O2hRKfnvdyycaFLU=
-github.com/kyma-incubator/compass/components/director v0.0.0-20230619093445-88247e2c2d11/go.mod h1:sr7AoPj8TO1IALpEp6nx/MYRoYcNGPttJTVKKwZj18Y=
+github.com/kyma-incubator/compass/components/director v0.0.0-20230621073022-b86ba01cda62 h1:99BVUtFUuo9Rqvpl2GXC3woE++tAnQhnaiuJ+ZyohyY=
+github.com/kyma-incubator/compass/components/director v0.0.0-20230621073022-b86ba01cda62/go.mod h1:sr7AoPj8TO1IALpEp6nx/MYRoYcNGPttJTVKKwZj18Y=
 github.com/kyma-incubator/compass/components/external-services-mock v0.0.0-20230607082115-977757624f7e h1:9iWqUgbVTFyX94Eeg6Sl/CraWScoq22+1xo3Vw+kR4g=
 github.com/kyma-incubator/compass/components/external-services-mock v0.0.0-20230607082115-977757624f7e/go.mod h1:FZ3omoYpzcGNWatm1rQavxzZmUN3Z4UyhCSXjT+4ZNM=
 github.com/kyma-incubator/compass/components/gateway v0.0.0-20230607082115-977757624f7e h1:anb5oeC6tjN8gjiyDAaekGh1XWLfPx1HnmY5NIRrdA4=


### PR DESCRIPTION
**Description**

Application Template updates through GraphQL API so far do not update the template's web hooks. With this change, the web hooks are also updated. During the update the web hooks are recreated by removing old web hooks and creating the new one - the web hooks IDs are not preserved as there are no other objects that depend on them and IDs are not relevant for any associations.

Replaces https://github.com/kyma-incubator/compass/pull/3126

Changes proposed in this pull request:
- Handle Webhook update
- Adapt e2e tests

**Pull Request status**
- [x] Implementation
- [x] Unit tests
- [x] Integration tests
- [x] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [x] Mocks are regenerated, using the automated script
