### PR TITLE
Fix formation resynchronization after unassign

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -139,7 +139,7 @@ global:
       name: compass-pairing-adapter
     director:
       dir: dev/incubator/
-      version: "PR-3088"
+      version: "PR-3133"
       name: compass-director
     hydrator:
       dir: dev/incubator/

--- a/components/director/internal/domain/formation/automock/formation_assignment_notifications_service.go
+++ b/components/director/internal/domain/formation/automock/formation_assignment_notifications_service.go
@@ -17,13 +17,13 @@ type FormationAssignmentNotificationsService struct {
 	mock.Mock
 }
 
-// GenerateFormationAssignmentNotification provides a mock function with given fields: ctx, formationAssignment
-func (_m *FormationAssignmentNotificationsService) GenerateFormationAssignmentNotification(ctx context.Context, formationAssignment *model.FormationAssignment) (*webhookclient.FormationAssignmentNotificationRequest, error) {
-	ret := _m.Called(ctx, formationAssignment)
+// GenerateFormationAssignmentNotification provides a mock function with given fields: ctx, formationAssignment, operation
+func (_m *FormationAssignmentNotificationsService) GenerateFormationAssignmentNotification(ctx context.Context, formationAssignment *model.FormationAssignment, operation model.FormationOperation) (*webhookclient.FormationAssignmentNotificationRequest, error) {
+	ret := _m.Called(ctx, formationAssignment, operation)
 
 	var r0 *webhookclient.FormationAssignmentNotificationRequest
-	if rf, ok := ret.Get(0).(func(context.Context, *model.FormationAssignment) *webhookclient.FormationAssignmentNotificationRequest); ok {
-		r0 = rf(ctx, formationAssignment)
+	if rf, ok := ret.Get(0).(func(context.Context, *model.FormationAssignment, model.FormationOperation) *webhookclient.FormationAssignmentNotificationRequest); ok {
+		r0 = rf(ctx, formationAssignment, operation)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*webhookclient.FormationAssignmentNotificationRequest)
@@ -31,8 +31,8 @@ func (_m *FormationAssignmentNotificationsService) GenerateFormationAssignmentNo
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, *model.FormationAssignment) error); ok {
-		r1 = rf(ctx, formationAssignment)
+	if rf, ok := ret.Get(1).(func(context.Context, *model.FormationAssignment, model.FormationOperation) error); ok {
+		r1 = rf(ctx, formationAssignment, operation)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/components/director/internal/domain/formation/service_test.go
+++ b/components/director/internal/domain/formation/service_test.go
@@ -2688,10 +2688,10 @@ func TestServiceResynchronizeFormationNotifications(t *testing.T) {
 			},
 			FormationAssignmentNotificationServiceFN: func() *automock.FormationAssignmentNotificationsService {
 				svc := &automock.FormationAssignmentNotificationsService{}
-				svc.On("GenerateFormationAssignmentNotification", ctx, formationAssignments[0]).Return(notificationsForAssignments[0], nil).Once()
-				svc.On("GenerateFormationAssignmentNotification", ctx, formationAssignments[1]).Return(notificationsForAssignments[1], nil).Once()
-				svc.On("GenerateFormationAssignmentNotification", ctx, formationAssignments[2]).Return(notificationsForAssignments[2], nil).Once()
-				svc.On("GenerateFormationAssignmentNotification", ctx, formationAssignments[3]).Return(notificationsForAssignments[3], nil).Once()
+				svc.On("GenerateFormationAssignmentNotification", ctx, formationAssignments[0], model.AssignFormation).Return(notificationsForAssignments[0], nil).Once()
+				svc.On("GenerateFormationAssignmentNotification", ctx, formationAssignments[1], model.AssignFormation).Return(notificationsForAssignments[1], nil).Once()
+				svc.On("GenerateFormationAssignmentNotification", ctx, formationAssignments[2], model.UnassignFormation).Return(notificationsForAssignments[2], nil).Once()
+				svc.On("GenerateFormationAssignmentNotification", ctx, formationAssignments[3], model.UnassignFormation).Return(notificationsForAssignments[3], nil).Once()
 				return svc
 			},
 			FormationRepositoryFn: func() *automock.FormationRepository {
@@ -2720,10 +2720,10 @@ func TestServiceResynchronizeFormationNotifications(t *testing.T) {
 			},
 			FormationAssignmentNotificationServiceFN: func() *automock.FormationAssignmentNotificationsService {
 				svc := &automock.FormationAssignmentNotificationsService{}
-				svc.On("GenerateFormationAssignmentNotification", ctx, formationAssignments[0]).Return(notificationsForAssignments[0], nil).Once()
-				svc.On("GenerateFormationAssignmentNotification", ctx, formationAssignments[1]).Return(notificationsForAssignments[1], nil).Once()
-				svc.On("GenerateFormationAssignmentNotification", ctx, formationAssignments[2]).Return(notificationsForAssignments[2], nil).Once()
-				svc.On("GenerateFormationAssignmentNotification", ctx, formationAssignments[3]).Return(notificationsForAssignments[3], nil).Once()
+				svc.On("GenerateFormationAssignmentNotification", ctx, formationAssignments[0], model.AssignFormation).Return(notificationsForAssignments[0], nil).Once()
+				svc.On("GenerateFormationAssignmentNotification", ctx, formationAssignments[1], model.AssignFormation).Return(notificationsForAssignments[1], nil).Once()
+				svc.On("GenerateFormationAssignmentNotification", ctx, formationAssignments[2], model.UnassignFormation).Return(notificationsForAssignments[2], nil).Once()
+				svc.On("GenerateFormationAssignmentNotification", ctx, formationAssignments[3], model.UnassignFormation).Return(notificationsForAssignments[3], nil).Once()
 				return svc
 			},
 			FormationRepositoryFn: func() *automock.FormationRepository {
@@ -2753,10 +2753,10 @@ func TestServiceResynchronizeFormationNotifications(t *testing.T) {
 			},
 			FormationAssignmentNotificationServiceFN: func() *automock.FormationAssignmentNotificationsService {
 				svc := &automock.FormationAssignmentNotificationsService{}
-				svc.On("GenerateFormationAssignmentNotification", ctx, formationAssignments[0]).Return(notificationsForAssignments[0], nil).Once()
-				svc.On("GenerateFormationAssignmentNotification", ctx, formationAssignments[1]).Return(notificationsForAssignments[1], nil).Once()
-				svc.On("GenerateFormationAssignmentNotification", ctx, formationAssignments[2]).Return(notificationsForAssignments[2], nil).Once()
-				svc.On("GenerateFormationAssignmentNotification", ctx, formationAssignments[3]).Return(notificationsForAssignments[3], nil).Once()
+				svc.On("GenerateFormationAssignmentNotification", ctx, formationAssignments[0], model.AssignFormation).Return(notificationsForAssignments[0], nil).Once()
+				svc.On("GenerateFormationAssignmentNotification", ctx, formationAssignments[1], model.AssignFormation).Return(notificationsForAssignments[1], nil).Once()
+				svc.On("GenerateFormationAssignmentNotification", ctx, formationAssignments[2], model.UnassignFormation).Return(notificationsForAssignments[2], nil).Once()
+				svc.On("GenerateFormationAssignmentNotification", ctx, formationAssignments[3], model.UnassignFormation).Return(notificationsForAssignments[3], nil).Once()
 				return svc
 			},
 			FormationRepositoryFn: func() *automock.FormationRepository {
@@ -2791,10 +2791,10 @@ func TestServiceResynchronizeFormationNotifications(t *testing.T) {
 			},
 			FormationAssignmentNotificationServiceFN: func() *automock.FormationAssignmentNotificationsService {
 				svc := &automock.FormationAssignmentNotificationsService{}
-				svc.On("GenerateFormationAssignmentNotification", ctx, formationAssignments[0]).Return(notificationsForAssignments[0], nil).Once()
-				svc.On("GenerateFormationAssignmentNotification", ctx, formationAssignments[1]).Return(notificationsForAssignments[1], nil).Once()
-				svc.On("GenerateFormationAssignmentNotification", ctx, formationAssignments[2]).Return(notificationsForAssignments[2], nil).Once()
-				svc.On("GenerateFormationAssignmentNotification", ctx, formationAssignments[3]).Return(notificationsForAssignments[3], nil).Once()
+				svc.On("GenerateFormationAssignmentNotification", ctx, formationAssignments[0], model.AssignFormation).Return(notificationsForAssignments[0], nil).Once()
+				svc.On("GenerateFormationAssignmentNotification", ctx, formationAssignments[1], model.AssignFormation).Return(notificationsForAssignments[1], nil).Once()
+				svc.On("GenerateFormationAssignmentNotification", ctx, formationAssignments[2], model.UnassignFormation).Return(notificationsForAssignments[2], nil).Once()
+				svc.On("GenerateFormationAssignmentNotification", ctx, formationAssignments[3], model.UnassignFormation).Return(notificationsForAssignments[3], nil).Once()
 				return svc
 			},
 			FormationRepositoryFn: func() *automock.FormationRepository {
@@ -2833,10 +2833,10 @@ func TestServiceResynchronizeFormationNotifications(t *testing.T) {
 			},
 			FormationAssignmentNotificationServiceFN: func() *automock.FormationAssignmentNotificationsService {
 				svc := &automock.FormationAssignmentNotificationsService{}
-				svc.On("GenerateFormationAssignmentNotification", ctx, formationAssignments[0]).Return(notificationsForAssignments[0], nil).Once()
-				svc.On("GenerateFormationAssignmentNotification", ctx, formationAssignments[1]).Return(notificationsForAssignments[1], nil).Once()
-				svc.On("GenerateFormationAssignmentNotification", ctx, formationAssignments[2]).Return(notificationsForAssignments[2], nil).Once()
-				svc.On("GenerateFormationAssignmentNotification", ctx, formationAssignments[3]).Return(notificationsForAssignments[3], nil).Once()
+				svc.On("GenerateFormationAssignmentNotification", ctx, formationAssignments[0], model.AssignFormation).Return(notificationsForAssignments[0], nil).Once()
+				svc.On("GenerateFormationAssignmentNotification", ctx, formationAssignments[1], model.AssignFormation).Return(notificationsForAssignments[1], nil).Once()
+				svc.On("GenerateFormationAssignmentNotification", ctx, formationAssignments[2], model.UnassignFormation).Return(notificationsForAssignments[2], nil).Once()
+				svc.On("GenerateFormationAssignmentNotification", ctx, formationAssignments[3], model.UnassignFormation).Return(notificationsForAssignments[3], nil).Once()
 				return svc
 			},
 			FormationRepositoryFn: func() *automock.FormationRepository {
@@ -2858,7 +2858,7 @@ func TestServiceResynchronizeFormationNotifications(t *testing.T) {
 			},
 			FormationAssignmentNotificationServiceFN: func() *automock.FormationAssignmentNotificationsService {
 				svc := &automock.FormationAssignmentNotificationsService{}
-				svc.On("GenerateFormationAssignmentNotification", ctx, formationAssignments[0]).Return(notificationsForAssignments[0], nil).Once()
+				svc.On("GenerateFormationAssignmentNotification", ctx, formationAssignments[0], model.AssignFormation).Return(notificationsForAssignments[0], nil).Once()
 				return svc
 			},
 			FormationRepositoryFn: func() *automock.FormationRepository {
@@ -2880,8 +2880,8 @@ func TestServiceResynchronizeFormationNotifications(t *testing.T) {
 			},
 			FormationAssignmentNotificationServiceFN: func() *automock.FormationAssignmentNotificationsService {
 				svc := &automock.FormationAssignmentNotificationsService{}
-				svc.On("GenerateFormationAssignmentNotification", ctx, formationAssignments[0]).Return(notificationsForAssignments[0], nil)
-				svc.On("GenerateFormationAssignmentNotification", ctx, reverseAssignment).Return(nil, testErr)
+				svc.On("GenerateFormationAssignmentNotification", ctx, formationAssignments[0], model.AssignFormation).Return(notificationsForAssignments[0], nil)
+				svc.On("GenerateFormationAssignmentNotification", ctx, reverseAssignment, model.AssignFormation).Return(nil, testErr)
 				return svc
 			},
 			FormationRepositoryFn: func() *automock.FormationRepository {
@@ -2901,7 +2901,7 @@ func TestServiceResynchronizeFormationNotifications(t *testing.T) {
 			},
 			FormationAssignmentNotificationServiceFN: func() *automock.FormationAssignmentNotificationsService {
 				svc := &automock.FormationAssignmentNotificationsService{}
-				svc.On("GenerateFormationAssignmentNotification", ctx, formationAssignments[0]).Return(nil, testErr).Once()
+				svc.On("GenerateFormationAssignmentNotification", ctx, formationAssignments[0], model.AssignFormation).Return(nil, testErr).Once()
 				return svc
 			},
 			FormationRepositoryFn: func() *automock.FormationRepository {
@@ -2959,10 +2959,10 @@ func TestServiceResynchronizeFormationNotifications(t *testing.T) {
 			FormationAssignmentNotificationServiceFN: func() *automock.FormationAssignmentNotificationsService {
 				svc := &automock.FormationAssignmentNotificationsService{}
 
-				svc.On("GenerateFormationAssignmentNotification", ctx, formationAssignments[0]).Return(notificationsForAssignments[0], nil).Once()
-				svc.On("GenerateFormationAssignmentNotification", ctx, formationAssignments[1]).Return(notificationsForAssignments[1], nil).Once()
-				svc.On("GenerateFormationAssignmentNotification", ctx, formationAssignments[2]).Return(notificationsForAssignments[2], nil).Once()
-				svc.On("GenerateFormationAssignmentNotification", ctx, formationAssignments[3]).Return(notificationsForAssignments[3], nil).Once()
+				svc.On("GenerateFormationAssignmentNotification", ctx, formationAssignments[0], model.AssignFormation).Return(notificationsForAssignments[0], nil).Once()
+				svc.On("GenerateFormationAssignmentNotification", ctx, formationAssignments[1], model.AssignFormation).Return(notificationsForAssignments[1], nil).Once()
+				svc.On("GenerateFormationAssignmentNotification", ctx, formationAssignments[2], model.UnassignFormation).Return(notificationsForAssignments[2], nil).Once()
+				svc.On("GenerateFormationAssignmentNotification", ctx, formationAssignments[3], model.UnassignFormation).Return(notificationsForAssignments[3], nil).Once()
 				return svc
 			},
 			WebhookRepoFn: func() *automock.WebhookRepository {

--- a/components/director/internal/domain/formationassignment/notifications.go
+++ b/components/director/internal/domain/formationassignment/notifications.go
@@ -66,7 +66,7 @@ func NewFormationAssignmentNotificationService(formationAssignmentRepo Formation
 }
 
 // GenerateFormationAssignmentNotification generates formation assignment notification by provided model.FormationAssignment
-func (fan *formationAssignmentNotificationService) GenerateFormationAssignmentNotification(ctx context.Context, fa *model.FormationAssignment) (*webhookclient.FormationAssignmentNotificationRequest, error) {
+func (fan *formationAssignmentNotificationService) GenerateFormationAssignmentNotification(ctx context.Context, fa *model.FormationAssignment, operation model.FormationOperation) (*webhookclient.FormationAssignmentNotificationRequest, error) {
 	log.C(ctx).Infof("Generating notification for formation assignment with ID: %q and target type: %q and target ID: %q", fa.ID, fa.TargetType, fa.Target)
 
 	customerTenantContext, err := fan.extractCustomerTenantContext(ctx, fa.TenantID)
@@ -81,11 +81,11 @@ func (fan *formationAssignmentNotificationService) GenerateFormationAssignmentNo
 
 	switch fa.TargetType {
 	case model.FormationAssignmentTypeApplication:
-		return fan.generateApplicationFANotification(ctx, fa, referencedFormation, customerTenantContext)
+		return fan.generateApplicationFANotification(ctx, fa, referencedFormation, customerTenantContext, operation)
 	case model.FormationAssignmentTypeRuntime:
-		return fan.generateRuntimeFANotification(ctx, fa, referencedFormation, customerTenantContext)
+		return fan.generateRuntimeFANotification(ctx, fa, referencedFormation, customerTenantContext, operation)
 	case model.FormationAssignmentTypeRuntimeContext:
-		return fan.generateRuntimeContextFANotification(ctx, fa, referencedFormation, customerTenantContext)
+		return fan.generateRuntimeContextFANotification(ctx, fa, referencedFormation, customerTenantContext, operation)
 	default:
 		return nil, errors.Errorf("Unknown formation assignment type: %q", fa.TargetType)
 	}
@@ -238,7 +238,7 @@ func (fan *formationAssignmentNotificationService) getReverseBySourceAndTarget(c
 }
 
 // generateApplicationFANotification generates application formation assignment notification based on the reverse(source) type of the formation assignment
-func (fan *formationAssignmentNotificationService) generateApplicationFANotification(ctx context.Context, fa *model.FormationAssignment, referencedFormation *model.Formation, customerTenantContext *webhook.CustomerTenantContext) (*webhookclient.FormationAssignmentNotificationRequest, error) {
+func (fan *formationAssignmentNotificationService) generateApplicationFANotification(ctx context.Context, fa *model.FormationAssignment, referencedFormation *model.Formation, customerTenantContext *webhook.CustomerTenantContext, operation model.FormationOperation) (*webhookclient.FormationAssignmentNotificationRequest, error) {
 	tenantID := fa.TenantID
 	appID := fa.Target
 
@@ -271,7 +271,7 @@ func (fan *formationAssignmentNotificationService) generateApplicationFANotifica
 
 		log.C(ctx).Infof("Preparing join point details for application tenant mapping notification generation")
 		details, err := fan.notificationBuilder.PrepareDetailsForApplicationTenantMappingNotificationGeneration(
-			model.AssignFormation,
+			operation,
 			fa.FormationID,
 			referencedFormation.FormationTemplateID,
 			reverseAppTemplateWithLabels,
@@ -321,7 +321,7 @@ func (fan *formationAssignmentNotificationService) generateApplicationFANotifica
 
 		log.C(ctx).Infof("Preparing join point details for configuration change notification generation")
 		details, err := fan.notificationBuilder.PrepareDetailsForConfigurationChangeNotificationGeneration(
-			model.AssignFormation,
+			operation,
 			fa.FormationID,
 			referencedFormation.FormationTemplateID,
 			appTemplateWithLabels,
@@ -379,7 +379,7 @@ func (fan *formationAssignmentNotificationService) generateApplicationFANotifica
 
 		log.C(ctx).Infof("Preparing join point details for configuration change notification generation")
 		details, err := fan.notificationBuilder.PrepareDetailsForConfigurationChangeNotificationGeneration(
-			model.AssignFormation,
+			operation,
 			fa.FormationID,
 			referencedFormation.FormationTemplateID,
 			appTemplateWithLabels,
@@ -416,7 +416,7 @@ func (fan *formationAssignmentNotificationService) generateApplicationFANotifica
 }
 
 // generateRuntimeFANotification generates runtime formation assignment notification based on the reverse(source) type of the formation
-func (fan *formationAssignmentNotificationService) generateRuntimeFANotification(ctx context.Context, fa *model.FormationAssignment, referencedFormation *model.Formation, customerTenantContext *webhook.CustomerTenantContext) (*webhookclient.FormationAssignmentNotificationRequest, error) {
+func (fan *formationAssignmentNotificationService) generateRuntimeFANotification(ctx context.Context, fa *model.FormationAssignment, referencedFormation *model.Formation, customerTenantContext *webhook.CustomerTenantContext, operation model.FormationOperation) (*webhookclient.FormationAssignmentNotificationRequest, error) {
 	tenantID := fa.TenantID
 	runtimeID := fa.Target
 
@@ -457,7 +457,7 @@ func (fan *formationAssignmentNotificationService) generateRuntimeFANotification
 
 	log.C(ctx).Infof("Preparing join point details for configuration change notification generation")
 	details, err := fan.notificationBuilder.PrepareDetailsForConfigurationChangeNotificationGeneration(
-		model.AssignFormation,
+		operation,
 		fa.FormationID,
 		referencedFormation.FormationTemplateID,
 		appTemplateWithLabels,
@@ -485,7 +485,7 @@ func (fan *formationAssignmentNotificationService) generateRuntimeFANotification
 }
 
 // generateRuntimeContextFANotification generates runtime context formation assignment notification based on the reverse(source) type of the formation assignment
-func (fan *formationAssignmentNotificationService) generateRuntimeContextFANotification(ctx context.Context, fa *model.FormationAssignment, referencedFormation *model.Formation, customerTenantContext *webhook.CustomerTenantContext) (*webhookclient.FormationAssignmentNotificationRequest, error) {
+func (fan *formationAssignmentNotificationService) generateRuntimeContextFANotification(ctx context.Context, fa *model.FormationAssignment, referencedFormation *model.Formation, customerTenantContext *webhook.CustomerTenantContext, operation model.FormationOperation) (*webhookclient.FormationAssignmentNotificationRequest, error) {
 	tenantID := fa.TenantID
 	runtimeCtxID := fa.Target
 
@@ -533,7 +533,7 @@ func (fan *formationAssignmentNotificationService) generateRuntimeContextFANotif
 
 	log.C(ctx).Infof("Preparing join point details for configuration change notification generation")
 	details, err := fan.notificationBuilder.PrepareDetailsForConfigurationChangeNotificationGeneration(
-		model.AssignFormation,
+		operation,
 		fa.FormationID,
 		referencedFormation.FormationTemplateID,
 		appTemplateWithLabels,

--- a/components/director/internal/domain/formationassignment/notifications_test.go
+++ b/components/director/internal/domain/formationassignment/notifications_test.go
@@ -181,6 +181,7 @@ func Test_GenerateFormationAssignmentNotification(t *testing.T) {
 	testCases := []struct {
 		name                    string
 		formationAssignment     *model.FormationAssignment
+		formationOperation      model.FormationOperation
 		webhookRepo             func() *automock.WebhookRepository
 		webhookDataInputBuilder func() *databuilderautomock.DataInputBuilder
 		formationAssignmentRepo func() *automock.FormationAssignmentRepository
@@ -198,6 +199,7 @@ func Test_GenerateFormationAssignmentNotification(t *testing.T) {
 				return repo
 			},
 			formationAssignment: faWithInvalidTypes,
+			formationOperation:  model.AssignFormation,
 			tenantRepo: func() *automock.TenantRepository {
 				repo := &automock.TenantRepository{}
 				repo.On("Get", emptyCtx, faWithInvalidTypes.TenantID).Return(gaTenantObject, nil)
@@ -210,6 +212,7 @@ func Test_GenerateFormationAssignmentNotification(t *testing.T) {
 		{
 			name:                "Successfully generate application notification when source type is application and tenant is global account",
 			formationAssignment: faWithSourceAppAndTargetApp,
+			formationOperation:  model.AssignFormation,
 			tenantRepo: func() *automock.TenantRepository {
 				repo := &automock.TenantRepository{}
 				repo.On("Get", emptyCtx, faWithSourceAppAndTargetApp.TenantID).Return(gaTenantObject, nil)
@@ -250,6 +253,7 @@ func Test_GenerateFormationAssignmentNotification(t *testing.T) {
 		{
 			name:                "Successfully generate application notification when source type is application and tenant is resource group",
 			formationAssignment: faWithSourceAppAndTargetApp,
+			formationOperation:  model.AssignFormation,
 			tenantRepo: func() *automock.TenantRepository {
 				repo := &automock.TenantRepository{}
 				repo.On("Get", emptyCtx, faWithSourceAppAndTargetApp.TenantID).Return(rgTenantObject, nil)
@@ -290,6 +294,7 @@ func Test_GenerateFormationAssignmentNotification(t *testing.T) {
 		{
 			name:                "Success when application webhook is not found",
 			formationAssignment: faWithSourceAppAndTargetApp,
+			formationOperation:  model.AssignFormation,
 			tenantRepo: func() *automock.TenantRepository {
 				repo := &automock.TenantRepository{}
 				repo.On("Get", emptyCtx, faWithSourceAppAndTargetApp.TenantID).Return(gaTenantObject, nil)
@@ -329,6 +334,7 @@ func Test_GenerateFormationAssignmentNotification(t *testing.T) {
 		{
 			name:                "Error when getting formation by ID",
 			formationAssignment: faWithSourceAppAndTargetApp,
+			formationOperation:  model.AssignFormation,
 			tenantRepo: func() *automock.TenantRepository {
 				repo := &automock.TenantRepository{}
 				repo.On("Get", emptyCtx, faWithSourceAppAndTargetApp.TenantID).Return(gaTenantObject, nil)
@@ -345,6 +351,7 @@ func Test_GenerateFormationAssignmentNotification(t *testing.T) {
 		{
 			name:                "Error when getting tenant fails",
 			formationAssignment: faWithSourceAppAndTargetApp,
+			formationOperation:  model.AssignFormation,
 			tenantRepo: func() *automock.TenantRepository {
 				repo := &automock.TenantRepository{}
 				repo.On("Get", emptyCtx, faWithSourceAppAndTargetApp.TenantID).Return(nil, testErr)
@@ -355,6 +362,7 @@ func Test_GenerateFormationAssignmentNotification(t *testing.T) {
 		{
 			name:                "Error when getting parent customer id fails",
 			formationAssignment: faWithSourceAppAndTargetApp,
+			formationOperation:  model.AssignFormation,
 			tenantRepo: func() *automock.TenantRepository {
 				repo := &automock.TenantRepository{}
 				repo.On("Get", emptyCtx, faWithSourceAppAndTargetApp.TenantID).Return(gaTenantObject, nil)
@@ -366,6 +374,7 @@ func Test_GenerateFormationAssignmentNotification(t *testing.T) {
 		{
 			name:                "Error when getting application template webhook by ID and type",
 			formationAssignment: faWithSourceAppAndTargetApp,
+			formationOperation:  model.AssignFormation,
 			tenantRepo: func() *automock.TenantRepository {
 				repo := &automock.TenantRepository{}
 				repo.On("Get", emptyCtx, faWithSourceAppAndTargetApp.TenantID).Return(gaTenantObject, nil)
@@ -407,6 +416,7 @@ func Test_GenerateFormationAssignmentNotification(t *testing.T) {
 		{
 			name:                "Error when preparing app and app template with labels for source type application",
 			formationAssignment: faWithSourceAppAndTargetApp,
+			formationOperation:  model.AssignFormation,
 			tenantRepo: func() *automock.TenantRepository {
 				repo := &automock.TenantRepository{}
 				repo.On("Get", emptyCtx, faWithSourceAppAndTargetApp.TenantID).Return(gaTenantObject, nil)
@@ -428,6 +438,7 @@ func Test_GenerateFormationAssignmentNotification(t *testing.T) {
 		{
 			name:                "Error when preparing reverse app and app template with labels for source type application",
 			formationAssignment: faWithSourceAppAndTargetApp,
+			formationOperation:  model.AssignFormation,
 			tenantRepo: func() *automock.TenantRepository {
 				repo := &automock.TenantRepository{}
 				repo.On("Get", emptyCtx, faWithSourceAppAndTargetApp.TenantID).Return(gaTenantObject, nil)
@@ -450,6 +461,7 @@ func Test_GenerateFormationAssignmentNotification(t *testing.T) {
 		{
 			name:                "Error when getting reverse formation assignment by source and target for source type application",
 			formationAssignment: faWithSourceAppAndTargetApp,
+			formationOperation:  model.AssignFormation,
 			tenantRepo: func() *automock.TenantRepository {
 				repo := &automock.TenantRepository{}
 				repo.On("Get", emptyCtx, faWithSourceAppAndTargetApp.TenantID).Return(gaTenantObject, nil)
@@ -477,6 +489,7 @@ func Test_GenerateFormationAssignmentNotification(t *testing.T) {
 		{
 			name:                "Error when preparing details",
 			formationAssignment: faWithSourceAppAndTargetApp,
+			formationOperation:  model.AssignFormation,
 			tenantRepo: func() *automock.TenantRepository {
 				repo := &automock.TenantRepository{}
 				repo.On("Get", emptyCtx, faWithSourceAppAndTargetApp.TenantID).Return(gaTenantObject, nil)
@@ -511,6 +524,7 @@ func Test_GenerateFormationAssignmentNotification(t *testing.T) {
 		{
 			name:                "Error while building notification request",
 			formationAssignment: faWithSourceAppAndTargetApp,
+			formationOperation:  model.AssignFormation,
 			tenantRepo: func() *automock.TenantRepository {
 				repo := &automock.TenantRepository{}
 				repo.On("Get", emptyCtx, faWithSourceAppAndTargetApp.TenantID).Return(gaTenantObject, nil)
@@ -551,6 +565,7 @@ func Test_GenerateFormationAssignmentNotification(t *testing.T) {
 		{
 			name:                "Error when getting application webhook by ID and type",
 			formationAssignment: faWithSourceAppAndTargetApp,
+			formationOperation:  model.AssignFormation,
 			tenantRepo: func() *automock.TenantRepository {
 				repo := &automock.TenantRepository{}
 				repo.On("Get", emptyCtx, faWithSourceAppAndTargetApp.TenantID).Return(gaTenantObject, nil)
@@ -591,6 +606,7 @@ func Test_GenerateFormationAssignmentNotification(t *testing.T) {
 		{
 			name:                "Successfully generate application notification when source type is runtime",
 			formationAssignment: faWithSourceRuntimeAndTargetApp,
+			formationOperation:  model.AssignFormation,
 			tenantRepo: func() *automock.TenantRepository {
 				repo := &automock.TenantRepository{}
 				repo.On("Get", emptyCtx, faWithSourceRuntimeAndTargetApp.TenantID).Return(gaTenantObject, nil)
@@ -631,6 +647,7 @@ func Test_GenerateFormationAssignmentNotification(t *testing.T) {
 		{
 			name:                "Error when getting tenant fails",
 			formationAssignment: faWithSourceRuntimeAndTargetApp,
+			formationOperation:  model.AssignFormation,
 			tenantRepo: func() *automock.TenantRepository {
 				repo := &automock.TenantRepository{}
 				repo.On("Get", emptyCtx, faWithSourceRuntimeAndTargetApp.TenantID).Return(nil, testErr)
@@ -641,6 +658,7 @@ func Test_GenerateFormationAssignmentNotification(t *testing.T) {
 		{
 			name:                "Error when getting parent customer id fails",
 			formationAssignment: faWithSourceRuntimeAndTargetApp,
+			formationOperation:  model.AssignFormation,
 			tenantRepo: func() *automock.TenantRepository {
 				repo := &automock.TenantRepository{}
 				repo.On("Get", emptyCtx, faWithSourceRuntimeAndTargetApp.TenantID).Return(gaTenantObject, nil)
@@ -652,6 +670,7 @@ func Test_GenerateFormationAssignmentNotification(t *testing.T) {
 		{
 			name:                "Error when preparing app and app template with labels for source type runtime",
 			formationAssignment: faWithSourceRuntimeAndTargetApp,
+			formationOperation:  model.AssignFormation,
 			tenantRepo: func() *automock.TenantRepository {
 				repo := &automock.TenantRepository{}
 				repo.On("Get", emptyCtx, faWithSourceRuntimeAndTargetApp.TenantID).Return(gaTenantObject, nil)
@@ -673,6 +692,7 @@ func Test_GenerateFormationAssignmentNotification(t *testing.T) {
 		{
 			name:                "Error when preparing runtime and runtime context with labels for source type runtime",
 			formationAssignment: faWithSourceRuntimeAndTargetApp,
+			formationOperation:  model.AssignFormation,
 			tenantRepo: func() *automock.TenantRepository {
 				repo := &automock.TenantRepository{}
 				repo.On("Get", emptyCtx, faWithSourceRuntimeAndTargetApp.TenantID).Return(gaTenantObject, nil)
@@ -695,6 +715,7 @@ func Test_GenerateFormationAssignmentNotification(t *testing.T) {
 		{
 			name:                "Error when getting reverse formation assignment by source and target for source type runtime",
 			formationAssignment: faWithSourceRuntimeAndTargetApp,
+			formationOperation:  model.AssignFormation,
 			tenantRepo: func() *automock.TenantRepository {
 				repo := &automock.TenantRepository{}
 				repo.On("Get", emptyCtx, faWithSourceRuntimeAndTargetApp.TenantID).Return(gaTenantObject, nil)
@@ -722,6 +743,7 @@ func Test_GenerateFormationAssignmentNotification(t *testing.T) {
 		{
 			name:                "Error when preparing details for source type runtime",
 			formationAssignment: faWithSourceRuntimeAndTargetApp,
+			formationOperation:  model.AssignFormation,
 			tenantRepo: func() *automock.TenantRepository {
 				repo := &automock.TenantRepository{}
 				repo.On("Get", emptyCtx, faWithSourceRuntimeAndTargetApp.TenantID).Return(gaTenantObject, nil)
@@ -756,6 +778,7 @@ func Test_GenerateFormationAssignmentNotification(t *testing.T) {
 		{
 			name:                "Success when getting application webhook return not found error",
 			formationAssignment: faWithSourceRuntimeAndTargetApp,
+			formationOperation:  model.AssignFormation,
 			tenantRepo: func() *automock.TenantRepository {
 				repo := &automock.TenantRepository{}
 				repo.On("Get", emptyCtx, faWithSourceRuntimeAndTargetApp.TenantID).Return(gaTenantObject, nil)
@@ -795,6 +818,7 @@ func Test_GenerateFormationAssignmentNotification(t *testing.T) {
 		{
 			name:                "Error when getting application webhook by ID and type",
 			formationAssignment: faWithSourceRuntimeAndTargetApp,
+			formationOperation:  model.AssignFormation,
 			tenantRepo: func() *automock.TenantRepository {
 				repo := &automock.TenantRepository{}
 				repo.On("Get", emptyCtx, faWithSourceRuntimeAndTargetApp.TenantID).Return(gaTenantObject, nil)
@@ -834,6 +858,7 @@ func Test_GenerateFormationAssignmentNotification(t *testing.T) {
 		{
 			name:                "Error when building notification request for source type runtime",
 			formationAssignment: faWithSourceRuntimeAndTargetApp,
+			formationOperation:  model.AssignFormation,
 			tenantRepo: func() *automock.TenantRepository {
 				repo := &automock.TenantRepository{}
 				repo.On("Get", emptyCtx, faWithSourceRuntimeAndTargetApp.TenantID).Return(gaTenantObject, nil)
@@ -875,6 +900,7 @@ func Test_GenerateFormationAssignmentNotification(t *testing.T) {
 		{
 			name:                "Successfully generate application notification when source type is runtime context",
 			formationAssignment: faWithSourceRuntimeCtxAndTargetApp,
+			formationOperation:  model.AssignFormation,
 			tenantRepo: func() *automock.TenantRepository {
 				repo := &automock.TenantRepository{}
 				repo.On("Get", emptyCtx, faWithSourceRuntimeCtxAndTargetApp.TenantID).Return(gaTenantObject, nil)
@@ -916,6 +942,7 @@ func Test_GenerateFormationAssignmentNotification(t *testing.T) {
 		{
 			name:                "Error when getting tenant fails",
 			formationAssignment: faWithSourceRuntimeCtxAndTargetApp,
+			formationOperation:  model.AssignFormation,
 			tenantRepo: func() *automock.TenantRepository {
 				repo := &automock.TenantRepository{}
 				repo.On("Get", emptyCtx, faWithSourceRuntimeCtxAndTargetApp.TenantID).Return(nil, testErr)
@@ -926,6 +953,7 @@ func Test_GenerateFormationAssignmentNotification(t *testing.T) {
 		{
 			name:                "Error when getting parent customer id fails",
 			formationAssignment: faWithSourceRuntimeCtxAndTargetApp,
+			formationOperation:  model.AssignFormation,
 			tenantRepo: func() *automock.TenantRepository {
 				repo := &automock.TenantRepository{}
 				repo.On("Get", emptyCtx, faWithSourceRuntimeCtxAndTargetApp.TenantID).Return(gaTenantObject, nil)
@@ -937,6 +965,7 @@ func Test_GenerateFormationAssignmentNotification(t *testing.T) {
 		{
 			name:                "Error when preparing app and app template with labels for source type runtime context",
 			formationAssignment: faWithSourceRuntimeCtxAndTargetApp,
+			formationOperation:  model.AssignFormation,
 			tenantRepo: func() *automock.TenantRepository {
 				repo := &automock.TenantRepository{}
 				repo.On("Get", emptyCtx, faWithSourceRuntimeCtxAndTargetApp.TenantID).Return(gaTenantObject, nil)
@@ -958,6 +987,7 @@ func Test_GenerateFormationAssignmentNotification(t *testing.T) {
 		{
 			name:                "Error when preparing runtime context with labels for source type runtime context",
 			formationAssignment: faWithSourceRuntimeCtxAndTargetApp,
+			formationOperation:  model.AssignFormation,
 			tenantRepo: func() *automock.TenantRepository {
 				repo := &automock.TenantRepository{}
 				repo.On("Get", emptyCtx, faWithSourceRuntimeCtxAndTargetApp.TenantID).Return(gaTenantObject, nil)
@@ -980,6 +1010,7 @@ func Test_GenerateFormationAssignmentNotification(t *testing.T) {
 		{
 			name:                "Error when preparing runtime with labels for source type runtime context",
 			formationAssignment: faWithSourceRuntimeCtxAndTargetApp,
+			formationOperation:  model.AssignFormation,
 			tenantRepo: func() *automock.TenantRepository {
 				repo := &automock.TenantRepository{}
 				repo.On("Get", emptyCtx, faWithSourceRuntimeCtxAndTargetApp.TenantID).Return(gaTenantObject, nil)
@@ -1003,6 +1034,7 @@ func Test_GenerateFormationAssignmentNotification(t *testing.T) {
 		{
 			name:                "Error when getting reverse formation assignment by source and target for source type runtime context",
 			formationAssignment: faWithSourceRuntimeCtxAndTargetApp,
+			formationOperation:  model.AssignFormation,
 			tenantRepo: func() *automock.TenantRepository {
 				repo := &automock.TenantRepository{}
 				repo.On("Get", emptyCtx, faWithSourceRuntimeCtxAndTargetApp.TenantID).Return(gaTenantObject, nil)
@@ -1031,6 +1063,7 @@ func Test_GenerateFormationAssignmentNotification(t *testing.T) {
 		{
 			name:                "Error when preparing details for source type runtime context",
 			formationAssignment: faWithSourceRuntimeCtxAndTargetApp,
+			formationOperation:  model.AssignFormation,
 			tenantRepo: func() *automock.TenantRepository {
 				repo := &automock.TenantRepository{}
 				repo.On("Get", emptyCtx, faWithSourceRuntimeCtxAndTargetApp.TenantID).Return(gaTenantObject, nil)
@@ -1066,6 +1099,7 @@ func Test_GenerateFormationAssignmentNotification(t *testing.T) {
 		{
 			name:                "Success when getting application webhook by ID and type return not found error",
 			formationAssignment: faWithSourceRuntimeCtxAndTargetApp,
+			formationOperation:  model.AssignFormation,
 			tenantRepo: func() *automock.TenantRepository {
 				repo := &automock.TenantRepository{}
 				repo.On("Get", emptyCtx, faWithSourceRuntimeCtxAndTargetApp.TenantID).Return(gaTenantObject, nil)
@@ -1107,6 +1141,7 @@ func Test_GenerateFormationAssignmentNotification(t *testing.T) {
 		{
 			name:                "Error when getting application webhook by ID and type",
 			formationAssignment: faWithSourceRuntimeCtxAndTargetApp,
+			formationOperation:  model.AssignFormation,
 			tenantRepo: func() *automock.TenantRepository {
 				repo := &automock.TenantRepository{}
 				repo.On("Get", emptyCtx, faWithSourceRuntimeCtxAndTargetApp.TenantID).Return(gaTenantObject, nil)
@@ -1147,6 +1182,7 @@ func Test_GenerateFormationAssignmentNotification(t *testing.T) {
 		{
 			name:                "Error when building notification request for source type runtime context",
 			formationAssignment: faWithSourceRuntimeCtxAndTargetApp,
+			formationOperation:  model.AssignFormation,
 			tenantRepo: func() *automock.TenantRepository {
 				repo := &automock.TenantRepository{}
 				repo.On("Get", emptyCtx, faWithSourceRuntimeAndTargetApp.TenantID).Return(gaTenantObject, nil)
@@ -1189,6 +1225,7 @@ func Test_GenerateFormationAssignmentNotification(t *testing.T) {
 		{
 			name:                "Successfully generate runtime notification when source type is application",
 			formationAssignment: faWithSourceAppAndTargetRuntime,
+			formationOperation:  model.AssignFormation,
 			tenantRepo: func() *automock.TenantRepository {
 				repo := &automock.TenantRepository{}
 				repo.On("Get", emptyCtx, faWithSourceAppAndTargetRuntime.TenantID).Return(gaTenantObject, nil)
@@ -1229,6 +1266,7 @@ func Test_GenerateFormationAssignmentNotification(t *testing.T) {
 		{
 			name:                "Success when runtime webhook is not found",
 			formationAssignment: faWithSourceAppAndTargetRuntime,
+			formationOperation:  model.AssignFormation,
 			tenantRepo: func() *automock.TenantRepository {
 				repo := &automock.TenantRepository{}
 				repo.On("Get", emptyCtx, faWithSourceAppAndTargetRuntime.TenantID).Return(gaTenantObject, nil)
@@ -1249,6 +1287,7 @@ func Test_GenerateFormationAssignmentNotification(t *testing.T) {
 		{
 			name:                "Error when getting tenant fails",
 			formationAssignment: faWithSourceAppAndTargetRuntime,
+			formationOperation:  model.AssignFormation,
 			tenantRepo: func() *automock.TenantRepository {
 				repo := &automock.TenantRepository{}
 				repo.On("Get", emptyCtx, faWithSourceAppAndTargetRuntime.TenantID).Return(nil, testErr)
@@ -1259,6 +1298,7 @@ func Test_GenerateFormationAssignmentNotification(t *testing.T) {
 		{
 			name:                "Error when getting parent customer id fails",
 			formationAssignment: faWithSourceAppAndTargetRuntime,
+			formationOperation:  model.AssignFormation,
 			tenantRepo: func() *automock.TenantRepository {
 				repo := &automock.TenantRepository{}
 				repo.On("Get", emptyCtx, faWithSourceAppAndTargetRuntime.TenantID).Return(gaTenantObject, nil)
@@ -1270,6 +1310,7 @@ func Test_GenerateFormationAssignmentNotification(t *testing.T) {
 		{
 			name:                "Error when getting runtime webhook by ID and type for runtime target",
 			formationAssignment: faWithSourceAppAndTargetRuntime,
+			formationOperation:  model.AssignFormation,
 			tenantRepo: func() *automock.TenantRepository {
 				repo := &automock.TenantRepository{}
 				repo.On("Get", emptyCtx, faWithSourceAppAndTargetRuntime.TenantID).Return(gaTenantObject, nil)
@@ -1291,6 +1332,7 @@ func Test_GenerateFormationAssignmentNotification(t *testing.T) {
 		{
 			name:                "Error when source type is different than application for runtime target",
 			formationAssignment: faWithSourceInvalidAndTargetRuntime,
+			formationOperation:  model.AssignFormation,
 			tenantRepo: func() *automock.TenantRepository {
 				repo := &automock.TenantRepository{}
 				repo.On("Get", emptyCtx, faWithSourceInvalidAndTargetRuntime.TenantID).Return(gaTenantObject, nil)
@@ -1312,6 +1354,7 @@ func Test_GenerateFormationAssignmentNotification(t *testing.T) {
 		{
 			name:                "Error when preparing app and app template with labels for source type application and runtime target",
 			formationAssignment: faWithSourceAppAndTargetRuntime,
+			formationOperation:  model.AssignFormation,
 			tenantRepo: func() *automock.TenantRepository {
 				repo := &automock.TenantRepository{}
 				repo.On("Get", emptyCtx, faWithSourceAppAndTargetRuntime.TenantID).Return(gaTenantObject, nil)
@@ -1338,6 +1381,7 @@ func Test_GenerateFormationAssignmentNotification(t *testing.T) {
 		{
 			name:                "Error when preparing runtime with labels for source type application",
 			formationAssignment: faWithSourceAppAndTargetRuntime,
+			formationOperation:  model.AssignFormation,
 			tenantRepo: func() *automock.TenantRepository {
 				repo := &automock.TenantRepository{}
 				repo.On("Get", emptyCtx, faWithSourceAppAndTargetRuntime.TenantID).Return(gaTenantObject, nil)
@@ -1365,6 +1409,7 @@ func Test_GenerateFormationAssignmentNotification(t *testing.T) {
 		{
 			name:                "Error when getting reverse FA by application source and runtime target",
 			formationAssignment: faWithSourceAppAndTargetRuntime,
+			formationOperation:  model.AssignFormation,
 			tenantRepo: func() *automock.TenantRepository {
 				repo := &automock.TenantRepository{}
 				repo.On("Get", emptyCtx, faWithSourceAppAndTargetRuntime.TenantID).Return(gaTenantObject, nil)
@@ -1397,6 +1442,7 @@ func Test_GenerateFormationAssignmentNotification(t *testing.T) {
 		{
 			name:                "Error when preparing details for source type application and runtime target",
 			formationAssignment: faWithSourceAppAndTargetRuntime,
+			formationOperation:  model.AssignFormation,
 			tenantRepo: func() *automock.TenantRepository {
 				repo := &automock.TenantRepository{}
 				repo.On("Get", emptyCtx, faWithSourceAppAndTargetRuntime.TenantID).Return(gaTenantObject, nil)
@@ -1436,6 +1482,7 @@ func Test_GenerateFormationAssignmentNotification(t *testing.T) {
 		{
 			name:                "Error when building notification request for source type application and runtime target",
 			formationAssignment: faWithSourceAppAndTargetRuntime,
+			formationOperation:  model.AssignFormation,
 			tenantRepo: func() *automock.TenantRepository {
 				repo := &automock.TenantRepository{}
 				repo.On("Get", emptyCtx, faWithSourceRuntimeAndTargetApp.TenantID).Return(gaTenantObject, nil)
@@ -1477,6 +1524,7 @@ func Test_GenerateFormationAssignmentNotification(t *testing.T) {
 		{
 			name:                "Successfully generate runtime context notification when source type is application",
 			formationAssignment: faWithSourceAppCtxAndTargetRtmCtx,
+			formationOperation:  model.AssignFormation,
 			tenantRepo: func() *automock.TenantRepository {
 				repo := &automock.TenantRepository{}
 				repo.On("Get", emptyCtx, faWithSourceAppCtxAndTargetRtmCtx.TenantID).Return(gaTenantObject, nil)
@@ -1518,6 +1566,7 @@ func Test_GenerateFormationAssignmentNotification(t *testing.T) {
 		{
 			name:                "Error when getting tenant fails",
 			formationAssignment: faWithSourceAppCtxAndTargetRtmCtx,
+			formationOperation:  model.AssignFormation,
 			tenantRepo: func() *automock.TenantRepository {
 				repo := &automock.TenantRepository{}
 				repo.On("Get", emptyCtx, faWithSourceAppCtxAndTargetRtmCtx.TenantID).Return(nil, testErr)
@@ -1528,6 +1577,7 @@ func Test_GenerateFormationAssignmentNotification(t *testing.T) {
 		{
 			name:                "Error when getting parent customer id fails",
 			formationAssignment: faWithSourceAppCtxAndTargetRtmCtx,
+			formationOperation:  model.AssignFormation,
 			tenantRepo: func() *automock.TenantRepository {
 				repo := &automock.TenantRepository{}
 				repo.On("Get", emptyCtx, faWithSourceAppCtxAndTargetRtmCtx.TenantID).Return(gaTenantObject, nil)
@@ -1539,6 +1589,7 @@ func Test_GenerateFormationAssignmentNotification(t *testing.T) {
 		{
 			name:                "Error when preparing runtime context with labels for source type application",
 			formationAssignment: faWithSourceAppCtxAndTargetRtmCtx,
+			formationOperation:  model.AssignFormation,
 			tenantRepo: func() *automock.TenantRepository {
 				repo := &automock.TenantRepository{}
 				repo.On("Get", emptyCtx, faWithSourceAppCtxAndTargetRtmCtx.TenantID).Return(gaTenantObject, nil)
@@ -1560,6 +1611,7 @@ func Test_GenerateFormationAssignmentNotification(t *testing.T) {
 		{
 			name:                "Success when runtime webhook is not found for runtime context target",
 			formationAssignment: faWithSourceAppCtxAndTargetRtmCtx,
+			formationOperation:  model.AssignFormation,
 			tenantRepo: func() *automock.TenantRepository {
 				repo := &automock.TenantRepository{}
 				repo.On("Get", emptyCtx, faWithSourceAppCtxAndTargetRtmCtx.TenantID).Return(gaTenantObject, nil)
@@ -1585,6 +1637,7 @@ func Test_GenerateFormationAssignmentNotification(t *testing.T) {
 		{
 			name:                "Error when getting runtime webhook by ID and type for runtime context target",
 			formationAssignment: faWithSourceAppCtxAndTargetRtmCtx,
+			formationOperation:  model.AssignFormation,
 			tenantRepo: func() *automock.TenantRepository {
 				repo := &automock.TenantRepository{}
 				repo.On("Get", emptyCtx, faWithSourceAppCtxAndTargetRtmCtx.TenantID).Return(gaTenantObject, nil)
@@ -1611,6 +1664,7 @@ func Test_GenerateFormationAssignmentNotification(t *testing.T) {
 		{
 			name:                "Error when source type is different than application for runtime context target",
 			formationAssignment: faWithSourceInvalidAndTargetRtmCtx,
+			formationOperation:  model.AssignFormation,
 			tenantRepo: func() *automock.TenantRepository {
 				repo := &automock.TenantRepository{}
 				repo.On("Get", emptyCtx, faWithSourceInvalidAndTargetRtmCtx.TenantID).Return(gaTenantObject, nil)
@@ -1637,6 +1691,7 @@ func Test_GenerateFormationAssignmentNotification(t *testing.T) {
 		{
 			name:                "Error when preparing app and app template with labels for source type application and runtime ctx target",
 			formationAssignment: faWithSourceAppCtxAndTargetRtmCtx,
+			formationOperation:  model.AssignFormation,
 			tenantRepo: func() *automock.TenantRepository {
 				repo := &automock.TenantRepository{}
 				repo.On("Get", emptyCtx, faWithSourceAppCtxAndTargetRtmCtx.TenantID).Return(gaTenantObject, nil)
@@ -1664,6 +1719,7 @@ func Test_GenerateFormationAssignmentNotification(t *testing.T) {
 		{
 			name:                "Error when preparing runtime with labels for source type application and runtime ctx target",
 			formationAssignment: faWithSourceAppCtxAndTargetRtmCtx,
+			formationOperation:  model.AssignFormation,
 			tenantRepo: func() *automock.TenantRepository {
 				repo := &automock.TenantRepository{}
 				repo.On("Get", emptyCtx, faWithSourceAppCtxAndTargetRtmCtx.TenantID).Return(gaTenantObject, nil)
@@ -1692,6 +1748,7 @@ func Test_GenerateFormationAssignmentNotification(t *testing.T) {
 		{
 			name:                "Error when getting reverse FA by app source and runtime context target",
 			formationAssignment: faWithSourceAppCtxAndTargetRtmCtx,
+			formationOperation:  model.AssignFormation,
 			tenantRepo: func() *automock.TenantRepository {
 				repo := &automock.TenantRepository{}
 				repo.On("Get", emptyCtx, faWithSourceAppCtxAndTargetRtmCtx.TenantID).Return(gaTenantObject, nil)
@@ -1725,6 +1782,7 @@ func Test_GenerateFormationAssignmentNotification(t *testing.T) {
 		{
 			name:                "Error when building details source type application and runtime context target",
 			formationAssignment: faWithSourceAppCtxAndTargetRtmCtx,
+			formationOperation:  model.AssignFormation,
 			tenantRepo: func() *automock.TenantRepository {
 				repo := &automock.TenantRepository{}
 				repo.On("Get", emptyCtx, faWithSourceAppCtxAndTargetRtmCtx.TenantID).Return(gaTenantObject, nil)
@@ -1765,6 +1823,7 @@ func Test_GenerateFormationAssignmentNotification(t *testing.T) {
 		{
 			name:                "Error when building notification request for source type application and runtime context target",
 			formationAssignment: faWithSourceAppCtxAndTargetRtmCtx,
+			formationOperation:  model.AssignFormation,
 			tenantRepo: func() *automock.TenantRepository {
 				repo := &automock.TenantRepository{}
 				repo.On("Get", emptyCtx, faWithSourceRuntimeAndTargetApp.TenantID).Return(gaTenantObject, nil)
@@ -1844,7 +1903,7 @@ func Test_GenerateFormationAssignmentNotification(t *testing.T) {
 			defer mock.AssertExpectationsForObjects(t, faRepo, webhookRepo, tenantRepo, webhookDataInputBuilder)
 
 			// WHEN
-			notificationReq, err := faNotificationSvc.GenerateFormationAssignmentNotification(emptyCtx, tCase.formationAssignment)
+			notificationReq, err := faNotificationSvc.GenerateFormationAssignmentNotification(emptyCtx, tCase.formationAssignment, tCase.formationOperation)
 
 			// THEN
 			if tCase.expectedErrMsg != "" {

--- a/components/director/internal/formationmapping/auth_middleware.go
+++ b/components/director/internal/formationmapping/auth_middleware.go
@@ -53,7 +53,7 @@ type formationAssignmentStatusService interface {
 //
 //go:generate mockery --name=FormationAssignmentNotificationService --output=automock --outpkg=automock --case=underscore --disable-version-string
 type FormationAssignmentNotificationService interface {
-	GenerateFormationAssignmentNotification(ctx context.Context, formationAssignment *model.FormationAssignment) (*webhookclient.FormationAssignmentNotificationRequest, error)
+	GenerateFormationAssignmentNotification(ctx context.Context, formationAssignment *model.FormationAssignment, operation model.FormationOperation) (*webhookclient.FormationAssignmentNotificationRequest, error)
 }
 
 // formationService is responsible for the service-layer Formation operations

--- a/components/director/internal/formationmapping/handler.go
+++ b/components/director/internal/formationmapping/handler.go
@@ -231,7 +231,7 @@ func (h *Handler) UpdateFormationAssignmentStatus(w http.ResponseWriter, r *http
 		ctx = persistence.SaveToContext(ctx, tx)
 
 		log.C(ctx).Infof("Generating formation assignment notifications for ID: %q and formation ID: %q", fa.ID, fa.FormationID)
-		notificationReq, err := h.faNotificationService.GenerateFormationAssignmentNotification(ctx, fa)
+		notificationReq, err := h.faNotificationService.GenerateFormationAssignmentNotification(ctx, fa, model.AssignFormation)
 		if err != nil {
 			log.C(ctx).WithError(err).Errorf("An error occurred while generating formation assignment notifications for ID: %q and formation ID: %q", formationAssignmentID, formationID)
 			return
@@ -248,7 +248,7 @@ func (h *Handler) UpdateFormationAssignmentStatus(w http.ResponseWriter, r *http
 		}
 
 		log.C(ctx).Infof("Generating reverse formation assignment notifications for ID: %q and formation ID: %q", reverseFA.ID, reverseFA.FormationID)
-		reverseNotificationReq, err := h.faNotificationService.GenerateFormationAssignmentNotification(ctx, reverseFA)
+		reverseNotificationReq, err := h.faNotificationService.GenerateFormationAssignmentNotification(ctx, reverseFA, model.AssignFormation)
 		if err != nil {
 			log.C(ctx).WithError(err).Errorf("An error occurred while generating reverse formation assignment notifications for ID: %q and formation ID: %q", formationAssignmentID, formationID)
 			return


### PR DESCRIPTION
**Description**
Currently the operation in `GenerateFormationAssignmentNotification` is always `model.AssignFormation`, which is not the case with `resynchronizeFormationNotifications` 

Changes proposed in this pull request:
- add formation operation to `GenerateFormationAssignmentNotification`
- adapt resynchronize formation assignments to set operation based on formation assignment state

**Pull Request status**
- [x] Implementation
- [x] Unit tests
- [x] [N/A] Integration tests
- [x] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [x] Mocks are regenerated, using the automated script
