### PR TITLE
[HOTFIX] Add template ID in input when registering application from template

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -139,7 +139,7 @@ global:
       name: compass-pairing-adapter
     director:
       dir: dev/incubator/
-      version: "PR-3137"
+      version: "PR-3139"
       name: compass-director
     hydrator:
       dir: dev/incubator/
@@ -188,7 +188,7 @@ global:
       name: compass-console
     e2e_tests:
       dir: dev/incubator/
-      version: "PR-3132"
+      version: "PR-3139"
       name: compass-e2e-tests
   isLocalEnv: false
   isForTesting: false

--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -188,7 +188,7 @@ global:
       name: compass-console
     e2e_tests:
       dir: dev/incubator/
-      version: "PR-3092"
+      version: "PR-3132"
       name: compass-e2e-tests
   isLocalEnv: false
   isForTesting: false

--- a/components/director/internal/domain/apptemplate/resolver.go
+++ b/components/director/internal/domain/apptemplate/resolver.go
@@ -666,8 +666,10 @@ func (r *Resolver) retrieveAppTemplate(ctx context.Context,
 	}
 
 	if appTemplateID != nil {
+		log.C(ctx).Infof("searching for application template with ID: %s", *appTemplateID)
 		for _, appTemplate := range appTemplates {
 			if appTemplate.ID == *appTemplateID {
+				log.C(ctx).Infof("found application template with ID: %s", *appTemplateID)
 				return appTemplate, nil
 			}
 		}

--- a/components/director/internal/domain/apptemplate/resolver_test.go
+++ b/components/director/internal/domain/apptemplate/resolver_test.go
@@ -1262,29 +1262,37 @@ func TestResolver_RegisterApplicationFromTemplate(t *testing.T) {
 	modelAppWithLabelCreateInput := fixModelApplicationWithLabelCreateInput(testName)
 	gqlAppCreateInput := fixGQLApplicationCreateInput(testName)
 
+	customID := "customTemplateID"
 	modelAppTemplate := fixModelAppTemplateWithAppInputJSON(testID, testName, jsonAppCreateInput, fixModelApplicationTemplateWebhooks(testWebhookID, testID))
+	modelAppTemplateCustomID := fixModelAppTemplateWithAppInputJSON(customID, testName, jsonAppCreateInput, fixModelApplicationTemplateWebhooks(testWebhookID, customID))
 
 	modelApplication := fixModelApplication(testID, testName)
 	gqlApplication := fixGQLApplication(testID, testName)
 
 	gqlAppFromTemplateInput := fixGQLApplicationFromTemplateInput(testName)
+	gqlAppFromTemplateWithIDInput := fixGQLApplicationFromTemplateInput(testName)
+	gqlAppFromTemplateWithIDInput.ID = &customID
 	modelAppFromTemplateInput := fixModelApplicationFromTemplateInput(testName)
+	modelAppFromTemplateWithIDInput := fixModelApplicationFromTemplateInput(testName)
+	modelAppFromTemplateWithIDInput.ID = &customID
 
 	testCases := []struct {
-		Name              string
-		TxFn              func() (*persistenceautomock.PersistenceTx, *persistenceautomock.Transactioner)
-		AppTemplateSvcFn  func() *automock.ApplicationTemplateService
-		AppTemplateConvFn func() *automock.ApplicationTemplateConverter
-		WebhookSvcFn      func() *automock.WebhookService
-		WebhookConvFn     func() *automock.WebhookConverter
-		AppSvcFn          func() *automock.ApplicationService
-		AppConvFn         func() *automock.ApplicationConverter
-		ExpectedOutput    *graphql.Application
-		ExpectedError     error
+		Name                 string
+		AppFromTemplateInput graphql.ApplicationFromTemplateInput
+		TxFn                 func() (*persistenceautomock.PersistenceTx, *persistenceautomock.Transactioner)
+		AppTemplateSvcFn     func() *automock.ApplicationTemplateService
+		AppTemplateConvFn    func() *automock.ApplicationTemplateConverter
+		WebhookSvcFn         func() *automock.WebhookService
+		WebhookConvFn        func() *automock.WebhookConverter
+		AppSvcFn             func() *automock.ApplicationService
+		AppConvFn            func() *automock.ApplicationConverter
+		ExpectedOutput       *graphql.Application
+		ExpectedError        error
 	}{
 		{
-			Name: "Success",
-			TxFn: txGen.ThatSucceeds,
+			Name:                 "Success",
+			TxFn:                 txGen.ThatSucceeds,
+			AppFromTemplateInput: gqlAppFromTemplateInput,
 			AppTemplateSvcFn: func() *automock.ApplicationTemplateService {
 				appTemplateSvc := &automock.ApplicationTemplateService{}
 				appTemplateSvc.On("ListByFilters", txtest.CtxWithDBMatcher(), filters).Return([]*model.ApplicationTemplate{}, nil).Once()
@@ -1317,20 +1325,58 @@ func TestResolver_RegisterApplicationFromTemplate(t *testing.T) {
 			ExpectedError:  nil,
 		},
 		{
-			Name:              "Returns error when transaction begin fails",
-			TxFn:              txGen.ThatFailsOnBegin,
-			AppTemplateSvcFn:  UnusedAppTemplateSvc,
-			AppTemplateConvFn: UnusedAppTemplateConv,
-			AppSvcFn:          UnusedAppSvc,
-			AppConvFn:         UnusedAppConv,
-			WebhookConvFn:     UnusedWebhookConv,
-			WebhookSvcFn:      UnusedWebhookSvc,
-			ExpectedOutput:    nil,
-			ExpectedError:     testError,
+			Name:                 "SuccessWithIDField",
+			AppFromTemplateInput: gqlAppFromTemplateWithIDInput,
+			TxFn:                 txGen.ThatSucceeds,
+			AppTemplateSvcFn: func() *automock.ApplicationTemplateService {
+				appTemplateSvc := &automock.ApplicationTemplateService{}
+				appTemplateSvc.On("ListByFilters", txtest.CtxWithDBMatcher(), filters).Return([]*model.ApplicationTemplate{}, nil).Once()
+				appTemplateSvc.On("ListByName", txtest.CtxWithDBMatcher(), testName).Return([]*model.ApplicationTemplate{modelAppTemplate, modelAppTemplateCustomID}, nil).Once()
+				appTemplateSvc.On("GetLabel", txtest.CtxWithDBMatcher(), customID, globalSubaccountIDLabelKey).Return(nil, apperrors.NewNotFoundError(resource.Label, "id")).Once()
+				appTemplateSvc.On("GetLabel", txtest.CtxWithDBMatcher(), testID, globalSubaccountIDLabelKey).Return(nil, apperrors.NewNotFoundError(resource.Label, "id")).Once()
+				appTemplateSvc.On("PrepareApplicationCreateInputJSON", modelAppTemplateCustomID, modelAppFromTemplateWithIDInput.Values).Return(jsonAppCreateInput, nil).Once()
+				return appTemplateSvc
+			},
+			AppTemplateConvFn: func() *automock.ApplicationTemplateConverter {
+				appTemplateConv := &automock.ApplicationTemplateConverter{}
+				appTemplateConv.On("ApplicationFromTemplateInputFromGraphQL", modelAppTemplateCustomID, gqlAppFromTemplateWithIDInput).Return(modelAppFromTemplateWithIDInput, nil).Once()
+				return appTemplateConv
+			},
+			AppSvcFn: func() *automock.ApplicationService {
+				appSvc := &automock.ApplicationService{}
+				appSvc.On("CreateFromTemplate", txtest.CtxWithDBMatcher(), modelAppWithLabelCreateInput, str.Ptr(customID)).Return(testID, nil).Once()
+				appSvc.On("Get", txtest.CtxWithDBMatcher(), testID).Return(&modelApplication, nil).Once()
+				return appSvc
+			},
+			AppConvFn: func() *automock.ApplicationConverter {
+				appConv := &automock.ApplicationConverter{}
+				appConv.On("CreateRegisterInputJSONToGQL", jsonAppCreateInput).Return(gqlAppCreateInput, nil).Once()
+				appConv.On("CreateInputFromGraphQL", mock.Anything, gqlAppCreateInput).Return(modelAppWithLabelCreateInput, nil).Once()
+				appConv.On("ToGraphQL", &modelApplication).Return(&gqlApplication).Once()
+				return appConv
+			},
+			WebhookConvFn:  UnusedWebhookConv,
+			WebhookSvcFn:   UnusedWebhookSvc,
+			ExpectedOutput: &gqlApplication,
+			ExpectedError:  nil,
 		},
 		{
-			Name: "Returns error when list application templates by filters fails",
-			TxFn: txGen.ThatDoesntExpectCommit,
+			Name:                 "Returns error when transaction begin fails",
+			AppFromTemplateInput: gqlAppFromTemplateInput,
+			TxFn:                 txGen.ThatFailsOnBegin,
+			AppTemplateSvcFn:     UnusedAppTemplateSvc,
+			AppTemplateConvFn:    UnusedAppTemplateConv,
+			AppSvcFn:             UnusedAppSvc,
+			AppConvFn:            UnusedAppConv,
+			WebhookConvFn:        UnusedWebhookConv,
+			WebhookSvcFn:         UnusedWebhookSvc,
+			ExpectedOutput:       nil,
+			ExpectedError:        testError,
+		},
+		{
+			Name:                 "Returns error when list application templates by filters fails",
+			AppFromTemplateInput: gqlAppFromTemplateInput,
+			TxFn:                 txGen.ThatDoesntExpectCommit,
 			AppTemplateSvcFn: func() *automock.ApplicationTemplateService {
 				appTemplateSvc := &automock.ApplicationTemplateService{}
 				appTemplateSvc.On("ListByFilters", txtest.CtxWithDBMatcher(), filters).Return(nil, testError).Once()
@@ -1348,8 +1394,9 @@ func TestResolver_RegisterApplicationFromTemplate(t *testing.T) {
 			ExpectedError:  testError,
 		},
 		{
-			Name: "Returns error when list application templates by name fails",
-			TxFn: txGen.ThatDoesntExpectCommit,
+			Name:                 "Returns error when list application templates by name fails",
+			AppFromTemplateInput: gqlAppFromTemplateInput,
+			TxFn:                 txGen.ThatDoesntExpectCommit,
 			AppTemplateSvcFn: func() *automock.ApplicationTemplateService {
 				appTemplateSvc := &automock.ApplicationTemplateService{}
 				appTemplateSvc.On("ListByFilters", txtest.CtxWithDBMatcher(), filters).Return([]*model.ApplicationTemplate{}, nil).Once()
@@ -1368,8 +1415,9 @@ func TestResolver_RegisterApplicationFromTemplate(t *testing.T) {
 			ExpectedError:  testError,
 		},
 		{
-			Name: "Returns error when get application template label fails",
-			TxFn: txGen.ThatDoesntExpectCommit,
+			Name:                 "Returns error when get application template label fails",
+			AppFromTemplateInput: gqlAppFromTemplateInput,
+			TxFn:                 txGen.ThatDoesntExpectCommit,
 			AppTemplateSvcFn: func() *automock.ApplicationTemplateService {
 				appTemplateSvc := &automock.ApplicationTemplateService{}
 				appTemplateSvc.On("ListByFilters", txtest.CtxWithDBMatcher(), filters).Return([]*model.ApplicationTemplate{}, nil).Once()
@@ -1389,8 +1437,9 @@ func TestResolver_RegisterApplicationFromTemplate(t *testing.T) {
 			ExpectedError:  testError,
 		},
 		{
-			Name: "Returns error when list application templates by name cannot find application template",
-			TxFn: txGen.ThatDoesntExpectCommit,
+			Name:                 "Returns error when list application templates by name cannot find application template",
+			AppFromTemplateInput: gqlAppFromTemplateInput,
+			TxFn:                 txGen.ThatDoesntExpectCommit,
 			AppTemplateSvcFn: func() *automock.ApplicationTemplateService {
 				appTemplateSvc := &automock.ApplicationTemplateService{}
 				appTemplateSvc.On("ListByFilters", txtest.CtxWithDBMatcher(), filters).Return([]*model.ApplicationTemplate{}, nil).Once()
@@ -1409,8 +1458,9 @@ func TestResolver_RegisterApplicationFromTemplate(t *testing.T) {
 			ExpectedError:  errors.New("application template with name \"bar\" and consumer id \"consumer-id\" not found"),
 		},
 		{
-			Name: "Returns error when list application templates by name return more than one application template",
-			TxFn: txGen.ThatDoesntExpectCommit,
+			Name:                 "Returns error when list application templates by name return more than one application template",
+			AppFromTemplateInput: gqlAppFromTemplateInput,
+			TxFn:                 txGen.ThatDoesntExpectCommit,
 			AppTemplateSvcFn: func() *automock.ApplicationTemplateService {
 				appTemplateSvc := &automock.ApplicationTemplateService{}
 				appTemplateSvc.On("ListByFilters", txtest.CtxWithDBMatcher(), filters).Return([]*model.ApplicationTemplate{}, nil).Once()
@@ -1430,8 +1480,9 @@ func TestResolver_RegisterApplicationFromTemplate(t *testing.T) {
 			ExpectedError:  errors.New("unexpected number of application templates. found 2"),
 		},
 		{
-			Name: "Returns error when preparing ApplicationCreateInputJSON fails",
-			TxFn: txGen.ThatDoesntExpectCommit,
+			Name:                 "Returns error when preparing ApplicationCreateInputJSON fails",
+			AppFromTemplateInput: gqlAppFromTemplateInput,
+			TxFn:                 txGen.ThatDoesntExpectCommit,
 			AppTemplateSvcFn: func() *automock.ApplicationTemplateService {
 				appTemplateSvc := &automock.ApplicationTemplateService{}
 				appTemplateSvc.On("ListByFilters", txtest.CtxWithDBMatcher(), filters).Return([]*model.ApplicationTemplate{modelAppTemplate}, nil).Once()
@@ -1451,8 +1502,9 @@ func TestResolver_RegisterApplicationFromTemplate(t *testing.T) {
 			ExpectedError:  testError,
 		},
 		{
-			Name: "Returns error when CreateRegisterInputJSONToGQL fails",
-			TxFn: txGen.ThatDoesntExpectCommit,
+			Name:                 "Returns error when CreateRegisterInputJSONToGQL fails",
+			AppFromTemplateInput: gqlAppFromTemplateInput,
+			TxFn:                 txGen.ThatDoesntExpectCommit,
 			AppTemplateSvcFn: func() *automock.ApplicationTemplateService {
 				appTemplateSvc := &automock.ApplicationTemplateService{}
 				appTemplateSvc.On("ListByFilters", txtest.CtxWithDBMatcher(), filters).Return([]*model.ApplicationTemplate{modelAppTemplate}, nil).Once()
@@ -1476,8 +1528,9 @@ func TestResolver_RegisterApplicationFromTemplate(t *testing.T) {
 			ExpectedError:  testError,
 		},
 		{
-			Name: "Returns error when ApplicationCreateInput validation fails",
-			TxFn: txGen.ThatDoesntExpectCommit,
+			Name:                 "Returns error when ApplicationCreateInput validation fails",
+			AppFromTemplateInput: gqlAppFromTemplateInput,
+			TxFn:                 txGen.ThatDoesntExpectCommit,
 			AppTemplateSvcFn: func() *automock.ApplicationTemplateService {
 				appTemplateSvc := &automock.ApplicationTemplateService{}
 				appTemplateSvc.On("ListByFilters", txtest.CtxWithDBMatcher(), filters).Return([]*model.ApplicationTemplate{modelAppTemplate}, nil).Once()
@@ -1501,8 +1554,9 @@ func TestResolver_RegisterApplicationFromTemplate(t *testing.T) {
 			ExpectedError:  errors.New("name=cannot be blank"),
 		},
 		{
-			Name: "Returns error when creating Application fails",
-			TxFn: txGen.ThatDoesntExpectCommit,
+			Name:                 "Returns error when creating Application fails",
+			AppFromTemplateInput: gqlAppFromTemplateInput,
+			TxFn:                 txGen.ThatDoesntExpectCommit,
 			AppTemplateSvcFn: func() *automock.ApplicationTemplateService {
 				appTemplateSvc := &automock.ApplicationTemplateService{}
 				appTemplateSvc.On("ListByFilters", txtest.CtxWithDBMatcher(), filters).Return([]*model.ApplicationTemplate{modelAppTemplate}, nil).Once()
@@ -1531,8 +1585,9 @@ func TestResolver_RegisterApplicationFromTemplate(t *testing.T) {
 			ExpectedError:  testError,
 		},
 		{
-			Name: "Returns error when getting Application fails",
-			TxFn: txGen.ThatDoesntExpectCommit,
+			Name:                 "Returns error when getting Application fails",
+			AppFromTemplateInput: gqlAppFromTemplateInput,
+			TxFn:                 txGen.ThatDoesntExpectCommit,
 			AppTemplateSvcFn: func() *automock.ApplicationTemplateService {
 				appTemplateSvc := &automock.ApplicationTemplateService{}
 				appTemplateSvc.On("ListByFilters", txtest.CtxWithDBMatcher(), filters).Return([]*model.ApplicationTemplate{modelAppTemplate}, nil).Once()
@@ -1562,8 +1617,9 @@ func TestResolver_RegisterApplicationFromTemplate(t *testing.T) {
 			ExpectedError:  testError,
 		},
 		{
-			Name: "Returns error when committing transaction fails",
-			TxFn: txGen.ThatFailsOnCommit,
+			Name:                 "Returns error when committing transaction fails",
+			AppFromTemplateInput: gqlAppFromTemplateInput,
+			TxFn:                 txGen.ThatFailsOnCommit,
 			AppTemplateSvcFn: func() *automock.ApplicationTemplateService {
 				appTemplateSvc := &automock.ApplicationTemplateService{}
 				appTemplateSvc.On("ListByFilters", txtest.CtxWithDBMatcher(), filters).Return([]*model.ApplicationTemplate{modelAppTemplate}, nil).Once()
@@ -1592,6 +1648,24 @@ func TestResolver_RegisterApplicationFromTemplate(t *testing.T) {
 			ExpectedOutput: nil,
 			ExpectedError:  testError,
 		},
+		{
+			Name:                 "ErrorWhenNoTemplatesWithGivenIDFound",
+			AppFromTemplateInput: gqlAppFromTemplateWithIDInput,
+			TxFn:                 txGen.ThatDoesntExpectCommit,
+			AppTemplateSvcFn: func() *automock.ApplicationTemplateService {
+				appTemplateSvc := &automock.ApplicationTemplateService{}
+				appTemplateSvc.On("ListByFilters", txtest.CtxWithDBMatcher(), filters).Return([]*model.ApplicationTemplate{}, nil).Once()
+				appTemplateSvc.On("ListByName", txtest.CtxWithDBMatcher(), testName).Return([]*model.ApplicationTemplate{modelAppTemplate}, nil).Once()
+				appTemplateSvc.On("GetLabel", txtest.CtxWithDBMatcher(), testID, globalSubaccountIDLabelKey).Return(nil, apperrors.NewNotFoundError(resource.Label, "id")).Once()
+				return appTemplateSvc
+			},
+			AppTemplateConvFn: UnusedAppTemplateConv,
+			AppSvcFn:          UnusedAppSvc,
+			AppConvFn:         UnusedAppConv,
+			WebhookConvFn:     UnusedWebhookConv,
+			WebhookSvcFn:      UnusedWebhookSvc,
+			ExpectedError:     errors.New("application template with id customTemplateID and consumer id \"consumer-id\" not found"),
+		},
 	}
 
 	for _, testCase := range testCases {
@@ -1607,7 +1681,7 @@ func TestResolver_RegisterApplicationFromTemplate(t *testing.T) {
 			resolver := apptemplate.NewResolver(transact, appSvc, appConv, appTemplateSvc, appTemplateConv, webhookSvc, webhookConverter, nil, nil, "")
 
 			// WHEN
-			result, err := resolver.RegisterApplicationFromTemplate(ctx, gqlAppFromTemplateInput)
+			result, err := resolver.RegisterApplicationFromTemplate(ctx, testCase.AppFromTemplateInput)
 
 			// THEN
 			if testCase.ExpectedError != nil {
@@ -1966,7 +2040,7 @@ func TestResolver_UpdateApplicationTemplate(t *testing.T) {
 				return srm
 			},
 			WebhookConvFn: UnusedWebhookConv,
-			WebhookSvcFn:   SuccessfulWebhookSvc(gqlAppTemplateUpdateInputWithProvider.Webhooks, gqlAppTemplateUpdateInputWithProvider.Webhooks),
+			WebhookSvcFn:  SuccessfulWebhookSvc(gqlAppTemplateUpdateInputWithProvider.Webhooks, gqlAppTemplateUpdateInputWithProvider.Webhooks),
 			Input:         gqlAppTemplateUpdateInput,
 			ExpectedError: testError,
 		},
@@ -1992,7 +2066,7 @@ func TestResolver_UpdateApplicationTemplate(t *testing.T) {
 				return srm
 			},
 			WebhookConvFn: UnusedWebhookConv,
-			WebhookSvcFn:   SuccessfulWebhookSvc(gqlAppTemplateUpdateInputWithProvider.Webhooks, gqlAppTemplateUpdateInputWithProvider.Webhooks),
+			WebhookSvcFn:  SuccessfulWebhookSvc(gqlAppTemplateUpdateInputWithProvider.Webhooks, gqlAppTemplateUpdateInputWithProvider.Webhooks),
 			Input:         gqlAppTemplateUpdateInput,
 			ExpectedError: testError,
 		},

--- a/components/director/internal/model/app_template.go
+++ b/components/director/internal/model/app_template.go
@@ -51,6 +51,7 @@ const (
 
 // ApplicationFromTemplateInput missing godoc
 type ApplicationFromTemplateInput struct {
+	ID                  *string
 	TemplateName        string
 	Values              ApplicationFromTemplateInputValues
 	PlaceholdersPayload *string

--- a/components/director/pkg/graphql/graphqlizer/graphqlizer.go
+++ b/components/director/pkg/graphql/graphqlizer/graphqlizer.go
@@ -697,6 +697,25 @@ func (g *Graphqlizer) ApplicationFromTemplateInputToGQL(in graphql.ApplicationFr
 	}`)
 }
 
+// ApplicationFromTemplateInputWithTemplateIDToGQL missing godoc
+func (g *Graphqlizer) ApplicationFromTemplateInputWithTemplateIDToGQL(in graphql.ApplicationFromTemplateInput) (string, error) {
+	return g.genericToGQL(in, `{
+		{{- if .ID }}
+		id: "{{ .ID }}"
+		{{- end }}
+		templateName: "{{.TemplateName}}"
+		{{- if .Values }}
+		values: [
+			{{- range $i, $e := .Values }}
+				{{- if $i}}, {{- end}} {{ TemplateValueInput $e }}
+			{{- end }} ],
+		{{- end }}
+		{{- if .PlaceholdersPayload }}
+		placeholdersPayload:  "{{.PlaceholdersPayload}}"
+		{{- end }}
+	}`)
+}
+
 // BundleCreateInputToGQL missing godoc
 func (g *Graphqlizer) BundleCreateInputToGQL(in graphql.BundleCreateInput) (string, error) {
 	return g.genericToGQL(in, `{

--- a/components/director/pkg/graphql/models_gen.go
+++ b/components/director/pkg/graphql/models_gen.go
@@ -75,6 +75,7 @@ type ApplicationEventingConfiguration struct {
 
 // **Validation:** provided placeholders' names are unique
 type ApplicationFromTemplateInput struct {
+	ID *string `json:"id"`
 	// **Validation:** ASCII printable characters, max=100
 	TemplateName string `json:"templateName"`
 	// **Validation:** if provided, placeholdersPayload not required

--- a/components/director/pkg/graphql/schema.graphql
+++ b/components/director/pkg/graphql/schema.graphql
@@ -319,6 +319,7 @@ input APISpecInput {
 **Validation:** provided placeholders' names are unique
 """
 input ApplicationFromTemplateInput {
+	id: ID
 	"""
 	**Validation:** ASCII printable characters, max=100
 	"""

--- a/components/director/pkg/graphql/schema_gen.go
+++ b/components/director/pkg/graphql/schema_gen.go
@@ -5304,6 +5304,7 @@ input APISpecInput {
 **Validation:** provided placeholders' names are unique
 """
 input ApplicationFromTemplateInput {
+	id: ID
 	"""
 	**Validation:** ASCII printable characters, max=100
 	"""
@@ -31087,6 +31088,12 @@ func (ec *executionContext) unmarshalInputApplicationFromTemplateInput(ctx conte
 
 	for k, v := range asMap {
 		switch k {
+		case "id":
+			var err error
+			it.ID, err = ec.unmarshalOID2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
 		case "templateName":
 			var err error
 			it.TemplateName, err = ec.unmarshalNString2string(ctx, v)

--- a/tests/director/tests/application_templates_api_test.go
+++ b/tests/director/tests/application_templates_api_test.go
@@ -1079,7 +1079,7 @@ func TestRegisterApplicationFromTemplateWithTemplateID(t *testing.T) {
 			},
 		},
 	}
-	appFromTmplGQL, err := testctx.Tc.Graphqlizer.ApplicationFromTemplateInputToGQL(appFromTmpl)
+	appFromTmplGQL, err := testctx.Tc.Graphqlizer.ApplicationFromTemplateInputWithTemplateIDToGQL(appFromTmpl)
 	require.NoError(t, err)
 	createAppFromTmplRequest := fixtures.FixRegisterApplicationFromTemplate(appFromTmplGQL)
 	outputApp := graphql.ApplicationExt{}

--- a/tests/director/tests/application_templates_api_test.go
+++ b/tests/director/tests/application_templates_api_test.go
@@ -1053,11 +1053,12 @@ func TestRegisterApplicationFromTemplateWithTemplateID(t *testing.T) {
 	tenantId := tenant.TestTenants.GetDefaultTenantID()
 
 	appTmpl1, err := fixtures.CreateApplicationTemplateFromInput(t, ctx, certSecuredGraphQLClient, tenantId, appTmplInput)
+	require.NoError(t, err)
 	defer fixtures.CleanupApplicationTemplate(t, ctx, certSecuredGraphQLClient, tenantId, appTmpl1)
+	appTmplInput2 := fixAppTemplateInputWithDistinguishLabel(appTemplateName, "other-distinguished-label")
+	appTmpl2, err := fixtures.CreateApplicationTemplateFromInput(t, ctx, certSecuredGraphQLClient, tenantId, appTmplInput2)
 	require.NoError(t, err)
-	appTmpl2, err := fixtures.CreateApplicationTemplateFromInput(t, ctx, certSecuredGraphQLClient, tenantId, appTmplInput)
 	defer fixtures.CleanupApplicationTemplate(t, ctx, certSecuredGraphQLClient, tenantId, appTmpl2)
-	require.NoError(t, err)
 
 	appFromTmpl := graphql.ApplicationFromTemplateInput{
 		ID:           &appTmpl2.ID,

--- a/tests/director/tests/application_templates_api_test.go
+++ b/tests/director/tests/application_templates_api_test.go
@@ -1033,32 +1033,33 @@ func TestRegisterApplicationFromTemplateWithTemplateID(t *testing.T) {
 	//GIVEN
 	ctx := context.Background()
 	appTemplateName := createAppTemplateName("template")
+	tenantId := tenant.TestTenants.GetDefaultTenantID()
 
 	t.Log("Create application template in the first region")
 	appTemplateOneInput := fixAppTemplateInputWithDefaultDistinguishLabel(appTemplateName)
-	appTemplateOne, err := fixtures.CreateApplicationTemplateFromInput(t, ctx, certSecuredGraphQLClient, tenant.TestTenants.GetDefaultTenantID(), appTemplateOneInput)
-	defer fixtures.CleanupApplicationTemplate(t, ctx, certSecuredGraphQLClient, tenant.TestTenants.GetDefaultTenantID(), appTemplateOne)
+	appTemplateOne, err := fixtures.CreateApplicationTemplateFromInput(t, ctx, certSecuredGraphQLClient, tenantId, appTemplateOneInput)
+	defer fixtures.CleanupApplicationTemplate(t, ctx, certSecuredGraphQLClient, tenantId, appTemplateOne)
 
 	require.NoError(t, err)
 	require.NotEmpty(t, appTemplateOne.ID)
 	require.Equal(t, appTemplateName, appTemplateOne.Name)
 
 	t.Log("Check if application template in the first region was created")
-	appTemplateOneOutput := fixtures.GetApplicationTemplate(t, ctx, certSecuredGraphQLClient, tenant.TestTenants.GetDefaultTenantID(), appTemplateOne.ID)
+	appTemplateOneOutput := fixtures.GetApplicationTemplate(t, ctx, certSecuredGraphQLClient, tenantId, appTemplateOne.ID)
 	require.NotEmpty(t, appTemplateOneOutput)
 
 	t.Log("Create application template in the second region")
 	appTemplateTwoInput := fixAppTemplateInputWithDistinguishLabel(appTemplateName, "other-distinguished-label")
 	directorCertClientForAnotherRegion := createDirectorCertClientForAnotherRegion(t, ctx)
-	appTemplateTwo, err := fixtures.CreateApplicationTemplateFromInput(t, ctx, directorCertClientForAnotherRegion, tenant.TestTenants.GetDefaultTenantID(), appTemplateTwoInput)
-	defer fixtures.CleanupApplicationTemplate(t, ctx, directorCertClientForAnotherRegion, tenant.TestTenants.GetDefaultTenantID(), appTemplateTwo)
+	appTemplateTwo, err := fixtures.CreateApplicationTemplateFromInput(t, ctx, directorCertClientForAnotherRegion, tenantId, appTemplateTwoInput)
+	defer fixtures.CleanupApplicationTemplate(t, ctx, directorCertClientForAnotherRegion, tenantId, appTemplateTwo)
 
 	require.NoError(t, err)
 	require.NotEmpty(t, appTemplateTwo.ID)
 	require.Equal(t, appTemplateName, appTemplateTwo.Name)
 
 	t.Log("Check if application template in the second region was created")
-	appTemplateTwoOutput := fixtures.GetApplicationTemplate(t, ctx, certSecuredGraphQLClient, tenant.TestTenants.GetDefaultTenantID(), appTemplateTwo.ID)
+	appTemplateTwoOutput := fixtures.GetApplicationTemplate(t, ctx, certSecuredGraphQLClient, tenantId, appTemplateTwo.ID)
 	require.NotEmpty(t, appTemplateTwoOutput)
 
 	require.NotEqual(t, appTemplateOne.ID, appTemplateTwo.ID)

--- a/tests/director/tests/application_templates_api_test.go
+++ b/tests/director/tests/application_templates_api_test.go
@@ -1030,8 +1030,9 @@ func TestRegisterApplicationFromTemplate(t *testing.T) {
 }
 
 func TestRegisterApplicationFromTemplateWithTemplateID(t *testing.T) {
+	//GIVEN
 	ctx := context.Background()
-	appTemplateName := "SAP app-template"
+	appTemplateName := createAppTemplateName("template")
 
 	t.Log("Create application template in the first region")
 	appTemplateOneInput := fixAppTemplateInputWithDefaultDistinguishLabel(appTemplateName)
@@ -1091,7 +1092,7 @@ func TestRegisterApplicationFromTemplateWithTemplateID(t *testing.T) {
 	require.Equal(t, appTemplateTwo.ID, *outputApp.Application.ApplicationTemplateID)
 	require.NotNil(t, outputApp.Application.Description)
 	require.Equal(t, "test app-display-name", *outputApp.Application.Description)
-	saveExample(t, createAppFromTmplRequest.Query(), "register application from template using template namd and id")
+	saveExample(t, createAppFromTmplRequest.Query(), "register application from template using template name and id")
 }
 
 func TestRegisterApplicationFromTemplatewithPlaceholderPayload(t *testing.T) {

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/kyma-incubator/compass/components/connectivity-adapter v0.0.0-20230607082115-977757624f7e
 	github.com/kyma-incubator/compass/components/connector v0.0.0-20230607082115-977757624f7e
-	github.com/kyma-incubator/compass/components/director v0.0.0-20230621152103-7ac7a3ef9abc
+	github.com/kyma-incubator/compass/components/director v0.0.0-20230622134229-93a602e32fde
 	github.com/kyma-incubator/compass/components/external-services-mock v0.0.0-20230607082115-977757624f7e
 	github.com/kyma-incubator/compass/components/gateway v0.0.0-20230607082115-977757624f7e
 	github.com/kyma-incubator/compass/components/operations-controller v0.0.0-20230607082115-977757624f7e

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/kyma-incubator/compass/components/connectivity-adapter v0.0.0-20230607082115-977757624f7e
 	github.com/kyma-incubator/compass/components/connector v0.0.0-20230607082115-977757624f7e
-	github.com/kyma-incubator/compass/components/director v0.0.0-20230621103719-f9ce0ce57f1c
+	github.com/kyma-incubator/compass/components/director v0.0.0-20230621152103-7ac7a3ef9abc
 	github.com/kyma-incubator/compass/components/external-services-mock v0.0.0-20230607082115-977757624f7e
 	github.com/kyma-incubator/compass/components/gateway v0.0.0-20230607082115-977757624f7e
 	github.com/kyma-incubator/compass/components/operations-controller v0.0.0-20230607082115-977757624f7e

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/kyma-incubator/compass/components/connectivity-adapter v0.0.0-20230607082115-977757624f7e
 	github.com/kyma-incubator/compass/components/connector v0.0.0-20230607082115-977757624f7e
-	github.com/kyma-incubator/compass/components/director v0.0.0-20230622134229-93a602e32fde
+	github.com/kyma-incubator/compass/components/director v0.0.0-20230622142035-64c4a86bc347
 	github.com/kyma-incubator/compass/components/external-services-mock v0.0.0-20230607082115-977757624f7e
 	github.com/kyma-incubator/compass/components/gateway v0.0.0-20230607082115-977757624f7e
 	github.com/kyma-incubator/compass/components/operations-controller v0.0.0-20230607082115-977757624f7e

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -127,8 +127,8 @@ github.com/kyma-incubator/compass/components/connectivity-adapter v0.0.0-2023060
 github.com/kyma-incubator/compass/components/connectivity-adapter v0.0.0-20230607082115-977757624f7e/go.mod h1:wu4vtgHm698Rf6A52QI0+EkO8rlS7kAOSsoHtzKraD8=
 github.com/kyma-incubator/compass/components/connector v0.0.0-20230607082115-977757624f7e h1:gcJyTTwZyUvEDhSQ/VcfVWWaLam6Ht/HH1Npv03G520=
 github.com/kyma-incubator/compass/components/connector v0.0.0-20230607082115-977757624f7e/go.mod h1:K740+tPkGSt9EDSesTwrtHPfRHAiFnj/wJyYaLvuDYU=
-github.com/kyma-incubator/compass/components/director v0.0.0-20230621103719-f9ce0ce57f1c h1:9eQ4jCTpOSFL4KY0R3Zz7ZSDlgmtO1MnDcgBLKhTwyo=
-github.com/kyma-incubator/compass/components/director v0.0.0-20230621103719-f9ce0ce57f1c/go.mod h1:F0ddNAyJvaLwGGzR/jo7KMzVUWAn7dhzYAGfvTs2zXs=
+github.com/kyma-incubator/compass/components/director v0.0.0-20230621152103-7ac7a3ef9abc h1:BJyrPY7epnu5b7lxOIp0K2zTdy4dtTN1pT3Lu0237h8=
+github.com/kyma-incubator/compass/components/director v0.0.0-20230621152103-7ac7a3ef9abc/go.mod h1:F0ddNAyJvaLwGGzR/jo7KMzVUWAn7dhzYAGfvTs2zXs=
 github.com/kyma-incubator/compass/components/external-services-mock v0.0.0-20230607082115-977757624f7e h1:9iWqUgbVTFyX94Eeg6Sl/CraWScoq22+1xo3Vw+kR4g=
 github.com/kyma-incubator/compass/components/external-services-mock v0.0.0-20230607082115-977757624f7e/go.mod h1:FZ3omoYpzcGNWatm1rQavxzZmUN3Z4UyhCSXjT+4ZNM=
 github.com/kyma-incubator/compass/components/gateway v0.0.0-20230607082115-977757624f7e h1:anb5oeC6tjN8gjiyDAaekGh1XWLfPx1HnmY5NIRrdA4=

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -127,8 +127,8 @@ github.com/kyma-incubator/compass/components/connectivity-adapter v0.0.0-2023060
 github.com/kyma-incubator/compass/components/connectivity-adapter v0.0.0-20230607082115-977757624f7e/go.mod h1:wu4vtgHm698Rf6A52QI0+EkO8rlS7kAOSsoHtzKraD8=
 github.com/kyma-incubator/compass/components/connector v0.0.0-20230607082115-977757624f7e h1:gcJyTTwZyUvEDhSQ/VcfVWWaLam6Ht/HH1Npv03G520=
 github.com/kyma-incubator/compass/components/connector v0.0.0-20230607082115-977757624f7e/go.mod h1:K740+tPkGSt9EDSesTwrtHPfRHAiFnj/wJyYaLvuDYU=
-github.com/kyma-incubator/compass/components/director v0.0.0-20230622134229-93a602e32fde h1:whUUAXLB/8I16NwbzLtUlW1Sa2+xWTwP6BbTk7mpJ3U=
-github.com/kyma-incubator/compass/components/director v0.0.0-20230622134229-93a602e32fde/go.mod h1:F0ddNAyJvaLwGGzR/jo7KMzVUWAn7dhzYAGfvTs2zXs=
+github.com/kyma-incubator/compass/components/director v0.0.0-20230622142035-64c4a86bc347 h1:aMK+pPCLNDi0cdckGJo0EUCFTXHzDP/CLe4suZ5+pDc=
+github.com/kyma-incubator/compass/components/director v0.0.0-20230622142035-64c4a86bc347/go.mod h1:F0ddNAyJvaLwGGzR/jo7KMzVUWAn7dhzYAGfvTs2zXs=
 github.com/kyma-incubator/compass/components/external-services-mock v0.0.0-20230607082115-977757624f7e h1:9iWqUgbVTFyX94Eeg6Sl/CraWScoq22+1xo3Vw+kR4g=
 github.com/kyma-incubator/compass/components/external-services-mock v0.0.0-20230607082115-977757624f7e/go.mod h1:FZ3omoYpzcGNWatm1rQavxzZmUN3Z4UyhCSXjT+4ZNM=
 github.com/kyma-incubator/compass/components/gateway v0.0.0-20230607082115-977757624f7e h1:anb5oeC6tjN8gjiyDAaekGh1XWLfPx1HnmY5NIRrdA4=

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -127,8 +127,8 @@ github.com/kyma-incubator/compass/components/connectivity-adapter v0.0.0-2023060
 github.com/kyma-incubator/compass/components/connectivity-adapter v0.0.0-20230607082115-977757624f7e/go.mod h1:wu4vtgHm698Rf6A52QI0+EkO8rlS7kAOSsoHtzKraD8=
 github.com/kyma-incubator/compass/components/connector v0.0.0-20230607082115-977757624f7e h1:gcJyTTwZyUvEDhSQ/VcfVWWaLam6Ht/HH1Npv03G520=
 github.com/kyma-incubator/compass/components/connector v0.0.0-20230607082115-977757624f7e/go.mod h1:K740+tPkGSt9EDSesTwrtHPfRHAiFnj/wJyYaLvuDYU=
-github.com/kyma-incubator/compass/components/director v0.0.0-20230621152103-7ac7a3ef9abc h1:BJyrPY7epnu5b7lxOIp0K2zTdy4dtTN1pT3Lu0237h8=
-github.com/kyma-incubator/compass/components/director v0.0.0-20230621152103-7ac7a3ef9abc/go.mod h1:F0ddNAyJvaLwGGzR/jo7KMzVUWAn7dhzYAGfvTs2zXs=
+github.com/kyma-incubator/compass/components/director v0.0.0-20230622134229-93a602e32fde h1:whUUAXLB/8I16NwbzLtUlW1Sa2+xWTwP6BbTk7mpJ3U=
+github.com/kyma-incubator/compass/components/director v0.0.0-20230622134229-93a602e32fde/go.mod h1:F0ddNAyJvaLwGGzR/jo7KMzVUWAn7dhzYAGfvTs2zXs=
 github.com/kyma-incubator/compass/components/external-services-mock v0.0.0-20230607082115-977757624f7e h1:9iWqUgbVTFyX94Eeg6Sl/CraWScoq22+1xo3Vw+kR4g=
 github.com/kyma-incubator/compass/components/external-services-mock v0.0.0-20230607082115-977757624f7e/go.mod h1:FZ3omoYpzcGNWatm1rQavxzZmUN3Z4UyhCSXjT+4ZNM=
 github.com/kyma-incubator/compass/components/gateway v0.0.0-20230607082115-977757624f7e h1:anb5oeC6tjN8gjiyDAaekGh1XWLfPx1HnmY5NIRrdA4=


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Support specifying exact application template by its ID when creating application from template

Changes proposed in this pull request:
- add "id" field in applicationFromTemplateInputh in gql schema

**Pull Request status**
<!-- Feel free to construct the checklist with whatever items seem most reasonable for your change. You could disassemble the Implementation part to even smaller separate checklist items if you're working on something big for example. But do make the effort to provide a checklist of some sort so that the core team as well as the community can have an idea about the progress of your Pull Request.
-->

- [X] Implementation
- [X] Unit tests
- [X] Integration tests
- [X] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
