### PR TITLE
[HOTFIX] Fix correlation ID in the status API

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -139,7 +139,7 @@ global:
       name: compass-pairing-adapter
     director:
       dir: dev/incubator/
-      version: "PR-3141"
+      version: "PR-3143"
       name: compass-director
     hydrator:
       dir: dev/incubator/

--- a/components/director/internal/domain/destination/service.go
+++ b/components/director/internal/domain/destination/service.go
@@ -688,8 +688,7 @@ func (s *Service) executeCreateRequest(ctx context.Context, url string, reqBody 
 		log.C(ctx).Warn("Unable to provide client_user. Using correlation ID as client_user header...")
 		clientUser = correlation.CorrelationIDFromContext(ctx)
 		if clientUser == "" {
-			log.C(ctx).Warnf("The correlation ID is empty, generating random UUID and using it as client user")
-			clientUser = s.uidSvc.Generate()
+			return defaultRespBody, defaultStatusCode, errors.New("The correlation ID is empty and cannot be used as value for the client user header since the request will fail")
 		}
 	}
 
@@ -729,6 +728,9 @@ func (s *Service) executeDeleteRequest(ctx context.Context, url string, entityNa
 	if err != nil || clientUser == "" {
 		log.C(ctx).Warn("unable to provide client_user. Using correlation ID as client_user header...")
 		clientUser = correlation.CorrelationIDFromContext(ctx)
+		if clientUser == "" {
+			return errors.New("The correlation ID is empty and cannot be used as value for the client user header since the request will fail")
+		}
 	}
 
 	req, err := http.NewRequest(http.MethodDelete, url, nil)

--- a/components/director/internal/domain/formationconstraint/operators/destination_creator_operator.go
+++ b/components/director/internal/domain/formationconstraint/operators/destination_creator_operator.go
@@ -150,7 +150,7 @@ func (e *ConstraintEngine) DestinationCreator(ctx context.Context, input Operato
 						}
 
 						if statusCode == http.StatusConflict {
-							log.C(ctx).Infof("The destination with name: %q already exists. Will be deleted and created again...", destDetails.Name)
+							log.C(ctx).Infof("The certificate with name: %q already exists. Will be deleted and created again...", destDetails.Name)
 							if err := e.destinationSvc.DeleteCertificateFromDestinationService(ctx, destDetails.Name, destDetails.SubaccountID, formationAssignment); err != nil {
 								log.C(ctx).Warnf("An error occurred while deleting SAML assertion certificate with name: %q from the destination service: %v", destDetails.Name, err)
 								if transactionErr := e.transaction(ctx, func(ctxWithTransact context.Context) error {

--- a/components/director/internal/formationmapping/handler.go
+++ b/components/director/internal/formationmapping/handler.go
@@ -216,9 +216,10 @@ func (h *Handler) UpdateFormationAssignmentStatus(w http.ResponseWriter, r *http
 		ctx, cancel := context.WithCancel(context.TODO())
 		defer cancel()
 
-		correlationIDKey := correlation.RequestIDHeaderKey
-		correlation.SaveCorrelationIDHeaderToContext(ctx, &correlationIDKey, &correlationID)
 		ctx = tenant.SaveToContext(ctx, fa.TenantID, "")
+
+		logger := log.C(ctx).WithField(correlation.RequestIDHeaderKey, correlationID)
+		ctx = log.ContextWithLogger(ctx, logger)
 
 		log.C(ctx).Info("Configuration is provided in the request body. Starting formation assignment asynchronous notifications processing...")
 

--- a/components/director/internal/formationmapping/handler.go
+++ b/components/director/internal/formationmapping/handler.go
@@ -218,6 +218,9 @@ func (h *Handler) UpdateFormationAssignmentStatus(w http.ResponseWriter, r *http
 
 		ctx = tenant.SaveToContext(ctx, fa.TenantID, "")
 
+		correlationIDKey := correlation.RequestIDHeaderKey
+		ctx = correlation.SaveCorrelationIDHeaderToContext(ctx, &correlationIDKey, &correlationID)
+
 		logger := log.C(ctx).WithField(correlation.RequestIDHeaderKey, correlationID)
 		ctx = log.ContextWithLogger(ctx, logger)
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
With the recent changes in the status API we're using a go routine to execute the reverse formation notifications logic and the correlation ID was not properly configured in the context/logger.

Changes proposed in this pull request:
- Add the correlation ID in the context, also, add correlation ID field in the logger and update the context with it.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- https://github.com/kyma-incubator/compass/pull/3092

**Pull Request status**
<!-- Feel free to construct the checklist with whatever items seem most reasonable for your change. You could disassemble the Implementation part to even smaller separate checklist items if you're working on something big for example. But do make the effort to provide a checklist of some sort so that the core team as well as the community can have an idea about the progress of your Pull Request.
-->

- [x] Implementation
- [ ] Unit tests
- [ ] Integration tests
- [x] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [ ] Mocks are regenerated, using the automated script
