### PR TITLE
Alerts audit

### DIFF
--- a/chart/compass/charts/gateway/templates/destinationrule-auditlog.yaml
+++ b/chart/compass/charts/gateway/templates/destinationrule-auditlog.yaml
@@ -6,6 +6,7 @@ metadata:
 spec:
   host: {{ .Values.global.auditlog.host }}
   trafficPolicy:
+  {{- if eq .Values.global.auditlog.tlsOrigination true }}
     portLevelSettings:
     # Enable TLS origination on audit log for better metrics
     - port:
@@ -13,6 +14,7 @@ spec:
       tls:
         mode: SIMPLE
         sni: {{ .Values.global.auditlog.host }}
+  {{- end }}
     outlierDetection:
       consecutive5xxErrors: 15
       interval: 10s

--- a/chart/compass/charts/gateway/templates/destinationrule-auditlog.yaml
+++ b/chart/compass/charts/gateway/templates/destinationrule-auditlog.yaml
@@ -13,7 +13,11 @@ spec:
         number: {{ .Values.global.auditlog.port }}
       tls:
         mode: SIMPLE
+        # use the system CA certificates to trust
+        caCertificates: system
         sni: {{ .Values.global.auditlog.host }}
+        subjectAltNames:
+        - {{ .Values.global.auditlog.host | quote }}
   {{- end }}
     outlierDetection:
       consecutive5xxErrors: 15

--- a/chart/compass/charts/gateway/templates/destinationrule-auditlog.yaml
+++ b/chart/compass/charts/gateway/templates/destinationrule-auditlog.yaml
@@ -6,6 +6,13 @@ metadata:
 spec:
   host: {{ .Values.global.auditlog.host }}
   trafficPolicy:
+    portLevelSettings:
+    # Enable TLS origination on audit log for better metrics
+    - port:
+        number: {{ .Values.global.auditlog.port }}
+      tls:
+        mode: SIMPLE
+        sni: {{ .Values.global.auditlog.host }}
     outlierDetection:
       consecutive5xxErrors: 15
       interval: 10s

--- a/chart/compass/charts/gateway/templates/serviceentry-auditlog.yaml
+++ b/chart/compass/charts/gateway/templates/serviceentry-auditlog.yaml
@@ -8,7 +8,8 @@ spec:
     - {{ .Values.global.auditlog.host }}
   ports:
     - number: {{ .Values.global.auditlog.port }}
-      name: {{ .Values.global.auditlog.protocol }}
-      protocol: {{ .Values.global.auditlog.protocol }}
+      name: http
+      # always http as there is TLS origination
+      protocol: HTTP
   location: MESH_EXTERNAL
   resolution: DNS

--- a/chart/compass/charts/gateway/templates/serviceentry-auditlog.yaml
+++ b/chart/compass/charts/gateway/templates/serviceentry-auditlog.yaml
@@ -8,8 +8,7 @@ spec:
     - {{ .Values.global.auditlog.host }}
   ports:
     - number: {{ .Values.global.auditlog.port }}
-      name: http
-      # always http as there is TLS origination
-      protocol: HTTP
+      name: {{ .Values.global.auditlog.protocol }}
+      protocol: {{ .Values.global.auditlog.protocol }}
   location: MESH_EXTERNAL
   resolution: DNS

--- a/chart/compass/templates/additional-prometheus-rules.yaml
+++ b/chart/compass/templates/additional-prometheus-rules.yaml
@@ -122,6 +122,7 @@ spec:
             > 0.3
           labels:
             severity: warning
+      {{- if eq .Values.global.auditlog.tlsOrigination true }}
         - alert: Auditlog-WorkloadFailures-5xx
           annotations:
             description: From source_workload={{`{{`}} $labels.source_workload {{`}}`}} to external Audit Log service ({{`{{`}}
@@ -132,6 +133,7 @@ spec:
           for: 10m
           labels:
             severity: warning
+      {{- end }}
       {{- if eq .Values.global.portieris.isEnabled true }}
         - alert: CompassPortierisDeniedImage
           annotations:

--- a/chart/compass/templates/additional-prometheus-rules.yaml
+++ b/chart/compass/templates/additional-prometheus-rules.yaml
@@ -128,7 +128,7 @@ spec:
             description: From source_workload={{`{{`}} $labels.source_workload {{`}}`}} to external Audit Log service ({{`{{`}}
               $labels.destination_service {{`}}`}}) its 5xx failure rate ({{`{{`}} $value | humanizePercentage {{`}}`}} > 30%) in the past 5 minutes.
           expr: (sum by (source_workload)(rate(istio_requests_total{destination_service={{ .Values.global.auditlog.host | quote }}, response_code=~"5.*"}[5m]))
-            / sum by (source_workload)(rate(istio_requests_total{destination_service={{ .Values.global.auditlog.host | quote }}[5m])))
+            / sum by (source_workload)(rate(istio_requests_total{destination_service={{ .Values.global.auditlog.host | quote }}}[5m])))
             > 0.3
           for: 10m
           labels:

--- a/chart/compass/templates/additional-prometheus-rules.yaml
+++ b/chart/compass/templates/additional-prometheus-rules.yaml
@@ -122,6 +122,16 @@ spec:
             > 0.3
           labels:
             severity: warning
+        - alert: Auditlog-WorkloadFailures-5xx
+          annotations:
+            description: From source_workload={{`{{`}} $labels.source_workload {{`}}`}} to external Audit Log service ({{`{{`}}
+              $labels.destination_service {{`}}`}}) its 5xx failure rate ({{`{{`}} $value | humanizePercentage {{`}}`}} > 30%) in the past 5 minutes.
+          expr: (sum by (source_workload)(rate(istio_requests_total{destination_service={{ .Values.global.auditlog.host | quote }}, response_code=~"5.*"}[5m]))
+            / sum by (source_workload)(rate(istio_requests_total{destination_service={{ .Values.global.auditlog.host | quote }}[5m])))
+            > 0.3
+          for: 10m
+          labels:
+            severity: warning
       {{- if eq .Values.global.portieris.isEnabled true }}
         - alert: CompassPortierisDeniedImage
           annotations:

--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -394,7 +394,6 @@ global:
             outputTemplate: '{"error":"{{.Body.error}}","success_status_code": 202}'
   auditlog:
     configMapName: "compass-gateway-auditlog-config"
-    protocol: HTTP
     host: compass-external-services-mock.compass-system.svc.cluster.local
     port: 8080
     mtlsTokenPath: "/cert/token"

--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -394,6 +394,8 @@ global:
             outputTemplate: '{"error":"{{.Body.error}}","success_status_code": 202}'
   auditlog:
     configMapName: "compass-gateway-auditlog-config"
+    protocol: HTTP
+    tlsOrigination: false
     host: compass-external-services-mock.compass-system.svc.cluster.local
     port: 8080
     mtlsTokenPath: "/cert/token"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
There should be an alert that notifies whenever the external audit log service is not available

Changes proposed in this pull request:
- add TLS origination to compass-gateway Helm chart to improve metrics gather by Istio ([security guidelines](https://istio.io/latest/docs/ops/best-practices/security/#configure-tls-verification-in-destination-rule-when-using-tls-origination))
- add PrometheusRule that creates an alert whenever requests to the audit log service have >30% erronous rate

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- ...

**Pull Request status**
<!-- Feel free to construct the checklist with whatever items seem most reasonable for your change. You could disassemble the Implementation part to even smaller separate checklist items if you're working on something big for example. But do make the effort to provide a checklist of some sort so that the core team as well as the community can have an idea about the progress of your Pull Request.
-->

- [x] Implementation
- [ ] Unit tests
- [ ] Integration tests
- [x] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [ ] Mocks are regenerated, using the automated script
