### PR TITLE
Fix audience url when creating SAML destinations

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -139,7 +139,7 @@ global:
       name: compass-pairing-adapter
     director:
       dir: dev/incubator/
-      version: "PR-3127"
+      version: "PR-3148"
       name: compass-director
     hydrator:
       dir: dev/incubator/

--- a/components/director/internal/domain/destination/service.go
+++ b/components/director/internal/domain/destination/service.go
@@ -282,9 +282,9 @@ func (s *Service) CreateSAMLAssertionDestination(ctx context.Context, destinatio
 	}
 	destReqBody.AdditionalProperties = enrichedProperties
 
-	app, err := s.applicationRepository.GetByID(ctx, formationAssignment.TenantID, formationAssignment.Target)
+	app, err := s.applicationRepository.GetByID(ctx, formationAssignment.TenantID, formationAssignment.Source)
 	if err != nil {
-		return defaultStatusCode, errors.Wrapf(err, "while getting application with ID: %q", formationAssignment.Target)
+		return defaultStatusCode, errors.Wrapf(err, "while getting application with ID: %q", formationAssignment.Source)
 	}
 	if app.BaseURL != nil {
 		destReqBody.Audience = *app.BaseURL


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

When creating a SAML Assertion destination, get the audience url from the source App instead of the target one.

**Pull Request status**
<!-- Feel free to construct the checklist with whatever items seem most reasonable for your change. You could disassemble the Implementation part to even smaller separate checklist items if you're working on something big for example. But do make the effort to provide a checklist of some sort so that the core team as well as the community can have an idea about the progress of your Pull Request.
-->

- [ ] Implementation
- [ ] Unit tests
- [ ] Integration tests
- [ ] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [ ] Mocks are regenerated, using the automated script
