### PR TITLE
Test pods eviction fix

### DIFF
--- a/chart/compass/templates/bench/director/director-bench.yaml
+++ b/chart/compass/templates/bench/director/director-bench.yaml
@@ -17,7 +17,7 @@ spec:
     metadata:
       annotations:
         sidecar.istio.io/inject: "true"
-        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
       labels:
         app: {{ .Chart.Name }}-director-bench-app
     spec:

--- a/chart/compass/templates/bench/ord-service/ord-service-bench.yaml
+++ b/chart/compass/templates/bench/ord-service/ord-service-bench.yaml
@@ -17,7 +17,7 @@ spec:
     metadata:
       annotations:
         sidecar.istio.io/inject: "true"
-        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
       labels:
         app: {{ .Chart.Name }}-ord-service-bench-app
     spec:

--- a/chart/compass/templates/tests/connectivity-adapter/connectivity-adapter-test.yaml
+++ b/chart/compass/templates/tests/connectivity-adapter/connectivity-adapter-test.yaml
@@ -17,7 +17,7 @@ spec:
     metadata:
       annotations:
         sidecar.istio.io/inject: "true"
-        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
       labels:
         app: {{ .Chart.Name }}-connectivity-adapter-tests-app
     spec:

--- a/chart/compass/templates/tests/connector/connector-test.yaml
+++ b/chart/compass/templates/tests/connector/connector-test.yaml
@@ -16,7 +16,7 @@ spec:
     metadata:
       annotations:
         sidecar.istio.io/inject: "true"
-        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
       labels:
         app: {{ .Chart.Name }}-connector-tests-app
     spec:

--- a/chart/compass/templates/tests/director/director-test.yaml
+++ b/chart/compass/templates/tests/director/director-test.yaml
@@ -16,7 +16,7 @@ spec:
     metadata:
       annotations:
         sidecar.istio.io/inject: "true"
-        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
       labels:
         app: {{ .Chart.Name }}-director-tests-app
     spec:

--- a/chart/compass/templates/tests/external-services-mock/external-services-mock-test.yaml
+++ b/chart/compass/templates/tests/external-services-mock/external-services-mock-test.yaml
@@ -17,7 +17,7 @@ spec:
     metadata:
       annotations:
         sidecar.istio.io/inject: "true"
-        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
       labels:
         app: {{ .Chart.Name }}-external-services-mock-tests-app
     spec:

--- a/chart/compass/templates/tests/gateway/gateway-test.yaml
+++ b/chart/compass/templates/tests/gateway/gateway-test.yaml
@@ -16,7 +16,7 @@ spec:
     metadata:
       annotations:
         sidecar.istio.io/inject: "true"
-        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
       labels:
         app: {{ .Chart.Name }}-gateway-tests-app
     spec:

--- a/chart/compass/templates/tests/istio/istio-test.yaml
+++ b/chart/compass/templates/tests/istio/istio-test.yaml
@@ -16,7 +16,7 @@ spec:
     metadata:
       annotations:
         sidecar.istio.io/inject: "true"
-        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
       labels:
         app: {{ .Chart.Name }}-istio-tests-app
     spec:

--- a/chart/compass/templates/tests/ns-adapter/ns-adapter-test.yaml
+++ b/chart/compass/templates/tests/ns-adapter/ns-adapter-test.yaml
@@ -16,7 +16,7 @@ spec:
     metadata:
       annotations:
         sidecar.istio.io/inject: "true"
-        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
       labels:
         app: {{ .Chart.Name }}-ns-adapter-tests-app
     spec:

--- a/chart/compass/templates/tests/ord-aggregator/ord-aggregator-test.yaml
+++ b/chart/compass/templates/tests/ord-aggregator/ord-aggregator-test.yaml
@@ -16,7 +16,7 @@ spec:
     metadata:
       annotations:
         sidecar.istio.io/inject: "true"
-        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
       labels:
         app: {{ .Chart.Name }}-ord-aggregator-tests-app
     spec:

--- a/chart/compass/templates/tests/ord-service/ord-service-test.yaml
+++ b/chart/compass/templates/tests/ord-service/ord-service-test.yaml
@@ -16,7 +16,7 @@ spec:
     metadata:
       annotations:
         sidecar.istio.io/inject: "true"
-        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
       labels:
         app: {{ .Chart.Name }}-ord-service-tests-app
     spec:

--- a/chart/compass/templates/tests/pairing-adapter/pairing-adapter-test.yaml
+++ b/chart/compass/templates/tests/pairing-adapter/pairing-adapter-test.yaml
@@ -16,7 +16,7 @@ spec:
     metadata:
       annotations:
         sidecar.istio.io/inject: "true"
-        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
       labels:
         app: {{ .Chart.Name }}-pairing-adapter-tests-app
     spec:

--- a/chart/compass/templates/tests/system-broker/system-broker-test.yaml
+++ b/chart/compass/templates/tests/system-broker/system-broker-test.yaml
@@ -16,7 +16,7 @@ spec:
     metadata:
       annotations:
         sidecar.istio.io/inject: "true"
-        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
       labels:
         app: {{ .Chart.Name }}-system-broker-tests-app
     spec:

--- a/chart/compass/templates/tests/system-fetcher/system-fetcher-test.yaml
+++ b/chart/compass/templates/tests/system-fetcher/system-fetcher-test.yaml
@@ -17,7 +17,7 @@ spec:
     metadata:
       annotations:
         sidecar.istio.io/inject: "true"
-        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
       labels:
         app: {{ .Chart.Name }}-system-fetcher-tests-app
     spec:

--- a/chart/compass/templates/tests/tenant-fetcher/tenant-fetcher-test.yaml
+++ b/chart/compass/templates/tests/tenant-fetcher/tenant-fetcher-test.yaml
@@ -16,7 +16,7 @@ spec:
     metadata:
       annotations:
         sidecar.istio.io/inject: "true"
-        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
       labels:
         app: {{ .Chart.Name }}-tenant-fetcher-tests-app
     spec:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
The pods of the TestDefinitions can be removed during node downsizing. If that were to happen the tests fail; the test pods need to run to completion.

A warning may be shown in the GKE dashboard, but that should not block node updates. After the tests are finished executing, the Octopus controller deletes the pods and node downsizing can proceed normally.

More info on downsizing prevention can be found [here](https://cloud.google.com/kubernetes-engine/docs/concepts/cluster-autoscaler#scheduling-and-disruption)

Changes proposed in this pull request:
- change safe-to-evict to **false** to block the autoscaler from deleting the pods during node downsizing

**Pull Request status**
<!-- Feel free to construct the checklist with whatever items seem most reasonable for your change. You could disassemble the Implementation part to even smaller separate checklist items if you're working on something big for example. But do make the effort to provide a checklist of some sort so that the core team as well as the community can have an idea about the progress of your Pull Request.
-->

- [X] Implementation
- [ ] Unit tests
- [ ] Integration tests
- [X] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [ ] Mocks are regenerated, using the automated script
