### PR TITLE
Fix error handling in the destination creator operator

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -139,7 +139,7 @@ global:
       name: compass-pairing-adapter
     director:
       dir: dev/incubator/
-      version: "PR-3135"
+      version: "PR-3152"
       name: compass-director
     hydrator:
       dir: dev/incubator/

--- a/components/director/internal/domain/formation/service.go
+++ b/components/director/internal/domain/formation/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+
 	"github.com/hashicorp/go-multierror"
 
 	"github.com/kyma-incubator/compass/components/director/internal/domain/formationassignment"

--- a/components/director/internal/domain/formationassignment/status_service.go
+++ b/components/director/internal/domain/formationassignment/status_service.go
@@ -101,6 +101,11 @@ func (fau *formationAssignmentStatusService) DeleteWithConstraints(ctx context.C
 		return errors.Wrapf(err, "while getting formation assignment with id %q for tenant with id %q", id, tenantID)
 	}
 
+	fa.State = string(model.ReadyAssignmentState)
+	if err := fau.repo.Update(ctx, fa); err != nil {
+		return errors.Wrapf(err, "while updating formation asssignment with ID: %s to: %q state", id, model.ReadyAssignmentState)
+	}
+
 	joinPointDetails, err := fau.faNotificationService.PrepareDetailsForNotificationStatusReturned(ctx, tenantID, fa, model.UnassignFormation)
 	if err != nil {
 		return errors.Wrap(err, "while preparing details for NotificationStatusReturned")

--- a/components/director/internal/domain/formationassignment/status_service.go
+++ b/components/director/internal/domain/formationassignment/status_service.go
@@ -102,6 +102,7 @@ func (fau *formationAssignmentStatusService) DeleteWithConstraints(ctx context.C
 	}
 
 	fa.State = string(model.ReadyAssignmentState)
+	fa.Value = nil
 	if err := fau.repo.Update(ctx, fa); err != nil {
 		return errors.Wrapf(err, "while updating formation asssignment with ID: %s to: %q state", id, model.ReadyAssignmentState)
 	}

--- a/components/director/internal/domain/formationassignment/status_service_test.go
+++ b/components/director/internal/domain/formationassignment/status_service_test.go
@@ -338,6 +338,9 @@ func TestStatusService_DeleteWithConstraints(t *testing.T) {
 	preJoinPointDetails := fixNotificationStatusReturnedDetails(model.ApplicationResourceType, appSubtype, fa, reverseFa, formationconstraint.PreNotificationStatusReturned)
 	postJoinPointDetails := fixNotificationStatusReturnedDetails(model.ApplicationResourceType, appSubtype, fa, reverseFa, formationconstraint.PostNotificationStatusReturned)
 
+	faWithReadyState := fixFormationAssignmentModelWithFormationID(TestFormationID)
+	faWithReadyState.State = string(model.ReadyAssignmentState)
+
 	// GIVEN
 	testCases := []struct {
 		Name                    string
@@ -356,6 +359,7 @@ func TestStatusService_DeleteWithConstraints(t *testing.T) {
 				repo := &automock.FormationAssignmentRepository{}
 				repo.On("Get", ctxWithTenant, TestID, TestTenantID).Return(fa, nil).Once()
 				repo.On("Delete", ctxWithTenant, TestID, TestTenantID).Return(nil).Once()
+				repo.On("Update", ctxWithTenant, faWithReadyState).Return(nil).Once()
 				return repo
 			},
 			ConstraintEngine: func() *automock.ConstraintEngine {
@@ -371,12 +375,42 @@ func TestStatusService_DeleteWithConstraints(t *testing.T) {
 			},
 		},
 		{
+			Name:             "Returns error when there is no tenant in the context",
+			Context:          emptyCtx,
+			InputID:          TestID,
+			ExpectedErrorMsg: "while loading tenant from context",
+		},
+		{
+			Name:    "Returns error when can't get the formation assignment",
+			Context: ctxWithTenant,
+			InputID: TestID,
+			FormationAssignmentRepo: func() *automock.FormationAssignmentRepository {
+				repo := &automock.FormationAssignmentRepository{}
+				repo.On("Get", ctxWithTenant, TestID, TestTenantID).Return(nil, testErr).Once()
+				return repo
+			},
+			ExpectedErrorMsg: testErr.Error(),
+		},
+		{
+			Name:    "Returns error when can't update the formation assignment",
+			Context: ctxWithTenant,
+			InputID: TestID,
+			FormationAssignmentRepo: func() *automock.FormationAssignmentRepository {
+				repo := &automock.FormationAssignmentRepository{}
+				repo.On("Get", ctxWithTenant, TestID, TestTenantID).Return(fa, nil).Once()
+				repo.On("Update", ctxWithTenant, faWithReadyState).Return(testErr).Once()
+				return repo
+			},
+			ExpectedErrorMsg: testErr.Error(),
+		},
+		{
 			Name:    "Returns error when can't enforce post constraints",
 			Context: ctxWithTenant,
 			InputID: TestID,
 			FormationAssignmentRepo: func() *automock.FormationAssignmentRepository {
 				repo := &automock.FormationAssignmentRepository{}
 				repo.On("Get", ctxWithTenant, TestID, TestTenantID).Return(fa, nil).Once()
+				repo.On("Update", ctxWithTenant, faWithReadyState).Return(nil).Once()
 				repo.On("Delete", ctxWithTenant, TestID, TestTenantID).Return(nil).Once()
 				return repo
 			},
@@ -400,6 +434,7 @@ func TestStatusService_DeleteWithConstraints(t *testing.T) {
 			FormationAssignmentRepo: func() *automock.FormationAssignmentRepository {
 				repo := &automock.FormationAssignmentRepository{}
 				repo.On("Get", ctxWithTenant, TestID, TestTenantID).Return(fa, nil).Once()
+				repo.On("Update", ctxWithTenant, faWithReadyState).Return(nil).Once()
 				repo.On("Delete", ctxWithTenant, TestID, TestTenantID).Return(testErr).Once()
 				return repo
 			},
@@ -422,6 +457,7 @@ func TestStatusService_DeleteWithConstraints(t *testing.T) {
 			FormationAssignmentRepo: func() *automock.FormationAssignmentRepository {
 				repo := &automock.FormationAssignmentRepository{}
 				repo.On("Get", ctxWithTenant, TestID, TestTenantID).Return(fa, nil).Once()
+				repo.On("Update", ctxWithTenant, faWithReadyState).Return(nil).Once()
 				return repo
 			},
 			ConstraintEngine: func() *automock.ConstraintEngine {
@@ -443,23 +479,13 @@ func TestStatusService_DeleteWithConstraints(t *testing.T) {
 			FormationAssignmentRepo: func() *automock.FormationAssignmentRepository {
 				repo := &automock.FormationAssignmentRepository{}
 				repo.On("Get", ctxWithTenant, TestID, TestTenantID).Return(fa, nil).Once()
+				repo.On("Update", ctxWithTenant, faWithReadyState).Return(nil).Once()
 				return repo
 			},
 			NotificationSvc: func() *automock.FaNotificationService {
 				notificationSvc := &automock.FaNotificationService{}
 				notificationSvc.On("PrepareDetailsForNotificationStatusReturned", ctxWithTenant, TestTenantID, fa, model.UnassignFormation).Return(nil, testErr).Once()
 				return notificationSvc
-			},
-			ExpectedErrorMsg: testErr.Error(),
-		},
-		{
-			Name:    "Returns error when can't get the formation assignment",
-			Context: ctxWithTenant,
-			InputID: TestID,
-			FormationAssignmentRepo: func() *automock.FormationAssignmentRepository {
-				repo := &automock.FormationAssignmentRepository{}
-				repo.On("Get", ctxWithTenant, TestID, TestTenantID).Return(nil, testErr).Once()
-				return repo
 			},
 			ExpectedErrorMsg: testErr.Error(),
 		},

--- a/components/director/internal/domain/formationassignment/status_service_test.go
+++ b/components/director/internal/domain/formationassignment/status_service_test.go
@@ -338,8 +338,8 @@ func TestStatusService_DeleteWithConstraints(t *testing.T) {
 	preJoinPointDetails := fixNotificationStatusReturnedDetails(model.ApplicationResourceType, appSubtype, fa, reverseFa, formationconstraint.PreNotificationStatusReturned)
 	postJoinPointDetails := fixNotificationStatusReturnedDetails(model.ApplicationResourceType, appSubtype, fa, reverseFa, formationconstraint.PostNotificationStatusReturned)
 
-	faWithReadyState := fixFormationAssignmentModelWithFormationID(TestFormationID)
-	faWithReadyState.State = string(model.ReadyAssignmentState)
+	faWithReadyStateAndNoConfig := fixFormationAssignmentModel(nil)
+	faWithReadyStateAndNoConfig.State = string(model.ReadyAssignmentState)
 
 	// GIVEN
 	testCases := []struct {
@@ -359,7 +359,7 @@ func TestStatusService_DeleteWithConstraints(t *testing.T) {
 				repo := &automock.FormationAssignmentRepository{}
 				repo.On("Get", ctxWithTenant, TestID, TestTenantID).Return(fa, nil).Once()
 				repo.On("Delete", ctxWithTenant, TestID, TestTenantID).Return(nil).Once()
-				repo.On("Update", ctxWithTenant, faWithReadyState).Return(nil).Once()
+				repo.On("Update", ctxWithTenant, faWithReadyStateAndNoConfig).Return(nil).Once()
 				return repo
 			},
 			ConstraintEngine: func() *automock.ConstraintEngine {
@@ -398,7 +398,7 @@ func TestStatusService_DeleteWithConstraints(t *testing.T) {
 			FormationAssignmentRepo: func() *automock.FormationAssignmentRepository {
 				repo := &automock.FormationAssignmentRepository{}
 				repo.On("Get", ctxWithTenant, TestID, TestTenantID).Return(fa, nil).Once()
-				repo.On("Update", ctxWithTenant, faWithReadyState).Return(testErr).Once()
+				repo.On("Update", ctxWithTenant, faWithReadyStateAndNoConfig).Return(testErr).Once()
 				return repo
 			},
 			ExpectedErrorMsg: testErr.Error(),
@@ -410,7 +410,7 @@ func TestStatusService_DeleteWithConstraints(t *testing.T) {
 			FormationAssignmentRepo: func() *automock.FormationAssignmentRepository {
 				repo := &automock.FormationAssignmentRepository{}
 				repo.On("Get", ctxWithTenant, TestID, TestTenantID).Return(fa, nil).Once()
-				repo.On("Update", ctxWithTenant, faWithReadyState).Return(nil).Once()
+				repo.On("Update", ctxWithTenant, faWithReadyStateAndNoConfig).Return(nil).Once()
 				repo.On("Delete", ctxWithTenant, TestID, TestTenantID).Return(nil).Once()
 				return repo
 			},
@@ -434,7 +434,7 @@ func TestStatusService_DeleteWithConstraints(t *testing.T) {
 			FormationAssignmentRepo: func() *automock.FormationAssignmentRepository {
 				repo := &automock.FormationAssignmentRepository{}
 				repo.On("Get", ctxWithTenant, TestID, TestTenantID).Return(fa, nil).Once()
-				repo.On("Update", ctxWithTenant, faWithReadyState).Return(nil).Once()
+				repo.On("Update", ctxWithTenant, faWithReadyStateAndNoConfig).Return(nil).Once()
 				repo.On("Delete", ctxWithTenant, TestID, TestTenantID).Return(testErr).Once()
 				return repo
 			},
@@ -457,7 +457,7 @@ func TestStatusService_DeleteWithConstraints(t *testing.T) {
 			FormationAssignmentRepo: func() *automock.FormationAssignmentRepository {
 				repo := &automock.FormationAssignmentRepository{}
 				repo.On("Get", ctxWithTenant, TestID, TestTenantID).Return(fa, nil).Once()
-				repo.On("Update", ctxWithTenant, faWithReadyState).Return(nil).Once()
+				repo.On("Update", ctxWithTenant, faWithReadyStateAndNoConfig).Return(nil).Once()
 				return repo
 			},
 			ConstraintEngine: func() *automock.ConstraintEngine {
@@ -479,7 +479,7 @@ func TestStatusService_DeleteWithConstraints(t *testing.T) {
 			FormationAssignmentRepo: func() *automock.FormationAssignmentRepository {
 				repo := &automock.FormationAssignmentRepository{}
 				repo.On("Get", ctxWithTenant, TestID, TestTenantID).Return(fa, nil).Once()
-				repo.On("Update", ctxWithTenant, faWithReadyState).Return(nil).Once()
+				repo.On("Update", ctxWithTenant, faWithReadyStateAndNoConfig).Return(nil).Once()
 				return repo
 			},
 			NotificationSvc: func() *automock.FaNotificationService {

--- a/components/director/internal/domain/formationconstraint/operators/destination_creator_operator.go
+++ b/components/director/internal/domain/formationconstraint/operators/destination_creator_operator.go
@@ -84,47 +84,17 @@ func (e *ConstraintEngine) DestinationCreator(ctx context.Context, input Operato
 			for _, destDetails := range assignmentConfig.Destinations {
 				statusCode, err := e.destinationSvc.CreateDesignTimeDestinations(ctx, destDetails, formationAssignment)
 				if err != nil {
-					log.C(ctx).Warnf("An error occurred while creating design time destination with subaccount ID: %q and name: %q: %v", destDetails.SubaccountID, destDetails.Name, err)
-					if transactionErr := e.transaction(ctx, func(ctxWithTransact context.Context) error {
-						if err := e.setAssignmentToErrorState(ctx, formationAssignment, err.Error()); err != nil {
-							return errors.Wrapf(err, "while setting formation assignment with ID: %q to error state: %q", formationAssignment.ID, model.CreateErrorAssignmentState)
-						}
-						return nil
-					}); transactionErr != nil {
-						return false, transactionErr
-					}
-
-					return true, nil
+					return false, errors.Wrapf(err, "while creating design time destination with name: %q", destDetails.Name)
 				}
 
 				if statusCode == http.StatusConflict {
 					log.C(ctx).Infof("The destination with name: %q already exists. Will be deleted and created again...", destDetails.Name)
 					if err := e.destinationSvc.DeleteDestinationFromDestinationService(ctx, destDetails.Name, destDetails.SubaccountID, formationAssignment); err != nil {
-						log.C(ctx).Warnf("An error occurred while deleting design time destination with subaccount ID: %q and name: %q when handling conflict case: %v", destDetails.SubaccountID, destDetails.Name, err)
-						if transactionErr := e.transaction(ctx, func(ctxWithTransact context.Context) error {
-							if err := e.setAssignmentToErrorState(ctx, formationAssignment, err.Error()); err != nil {
-								return errors.Wrapf(err, "while setting formation assignment with ID: %q to error state: %q", formationAssignment.ID, model.CreateErrorAssignmentState)
-							}
-							return nil
-						}); transactionErr != nil {
-							return false, transactionErr
-						}
-
-						return true, nil
+						return false, errors.Wrapf(err, "while deleting design time destination with name: %q", destDetails.Name)
 					}
 
 					if _, err = e.destinationSvc.CreateDesignTimeDestinations(ctx, destDetails, formationAssignment); err != nil {
-						log.C(ctx).Warnf("An error occurred while creating design time destination with subaccount ID: %q and name: %q when handling conflict case: %v", destDetails.SubaccountID, destDetails.Name, err)
-						if transactionErr := e.transaction(ctx, func(ctxWithTransact context.Context) error {
-							if err := e.setAssignmentToErrorState(ctx, formationAssignment, err.Error()); err != nil {
-								return errors.Wrapf(err, "while setting formation assignment with ID: %q to error state: %q", formationAssignment.ID, model.CreateErrorAssignmentState)
-							}
-							return nil
-						}); transactionErr != nil {
-							return false, transactionErr
-						}
-
-						return true, nil
+						return false, errors.Wrapf(err, "while creating design time destination with name: %q", destDetails.Name)
 					}
 				}
 			}
@@ -136,47 +106,17 @@ func (e *ConstraintEngine) DestinationCreator(ctx context.Context, input Operato
 					for i, destDetails := range samlAssertionDetails.Destinations {
 						certData, statusCode, err := e.destinationSvc.CreateCertificateInDestinationService(ctx, destDetails, formationAssignment)
 						if err != nil {
-							log.C(ctx).Warnf("An error occurred while creating SAML assertion certificate with name: %q in the destination service: %v", destDetails.Name, err)
-							if transactionErr := e.transaction(ctx, func(ctxWithTransact context.Context) error {
-								if err := e.setAssignmentToErrorState(ctx, formationAssignment, err.Error()); err != nil {
-									return errors.Wrapf(err, "while setting formation assignment with ID: %q to error state: %q", formationAssignment.ID, model.CreateErrorAssignmentState)
-								}
-								return nil
-							}); transactionErr != nil {
-								return false, transactionErr
-							}
-
-							return true, nil
+							return false, errors.Wrapf(err, "while creating SAML assertion certificate with name: %q", destDetails.Name)
 						}
 
 						if statusCode == http.StatusConflict {
 							log.C(ctx).Infof("The certificate with name: %q already exists. Will be deleted and created again...", destDetails.Name)
 							if err := e.destinationSvc.DeleteCertificateFromDestinationService(ctx, destDetails.Name, destDetails.SubaccountID, formationAssignment); err != nil {
-								log.C(ctx).Warnf("An error occurred while deleting SAML assertion certificate with name: %q from the destination service: %v", destDetails.Name, err)
-								if transactionErr := e.transaction(ctx, func(ctxWithTransact context.Context) error {
-									if err := e.setAssignmentToErrorState(ctx, formationAssignment, err.Error()); err != nil {
-										return errors.Wrapf(err, "while setting formation assignment with ID: %q to error state: %q", formationAssignment.ID, model.CreateErrorAssignmentState)
-									}
-									return nil
-								}); transactionErr != nil {
-									return false, transactionErr
-								}
-
-								return true, nil
+								return false, errors.Wrapf(err, "while deleting SAML assertion certificate with name: %q", destDetails.Name)
 							}
 
 							if certData, _, err = e.destinationSvc.CreateCertificateInDestinationService(ctx, destDetails, formationAssignment); err != nil {
-								log.C(ctx).Warnf("An error occurred while creating SAML assertion certificate with name: %q in the destination service: %v", destDetails.Name, err)
-								if transactionErr := e.transaction(ctx, func(ctxWithTransact context.Context) error {
-									if err := e.setAssignmentToErrorState(ctx, formationAssignment, err.Error()); err != nil {
-										return errors.Wrapf(err, "while setting formation assignment with ID: %q to error state: %q", formationAssignment.ID, model.CreateErrorAssignmentState)
-									}
-									return nil
-								}); transactionErr != nil {
-									return false, transactionErr
-								}
-
-								return true, nil
+								return false, errors.Wrapf(err, "while creating SAML assertion certificate with name: %q", destDetails.Name)
 							}
 						}
 
@@ -231,47 +171,17 @@ func (e *ConstraintEngine) DestinationCreator(ctx context.Context, input Operato
 				for _, destDetails := range basicAuthDetails.Destinations {
 					statusCode, err := e.destinationSvc.CreateBasicCredentialDestinations(ctx, destDetails, *basicAuthCreds, formationAssignment, basicAuthDetails.CorrelationIDs)
 					if err != nil {
-						log.C(ctx).Warnf("An error occurred while creating basic destination with subaccount ID: %q and name: %q: %v", destDetails.SubaccountID, destDetails.Name, err)
-						if transactionErr := e.transaction(ctx, func(ctxWithTransact context.Context) error {
-							if err := e.setAssignmentToErrorState(ctx, formationAssignment, err.Error()); err != nil {
-								return errors.Wrapf(err, "while setting formation assignment with ID: %q to error state: %q", formationAssignment.ID, model.CreateErrorAssignmentState)
-							}
-							return nil
-						}); transactionErr != nil {
-							return false, transactionErr
-						}
-
-						return true, nil
+						return false, errors.Wrapf(err, "while creating basic destination with name: %q", destDetails.Name)
 					}
 
 					if statusCode == http.StatusConflict {
 						log.C(ctx).Infof("The destination with name: %q already exists. Will be deleted and created again...", destDetails.Name)
 						if err := e.destinationSvc.DeleteDestinationFromDestinationService(ctx, destDetails.Name, destDetails.SubaccountID, formationAssignment); err != nil {
-							log.C(ctx).Warnf("An error occurred while deleting basic destination with subaccount ID: %q and name: %q when handling conflict case: %v", destDetails.SubaccountID, destDetails.Name, err)
-							if transactionErr := e.transaction(ctx, func(ctxWithTransact context.Context) error {
-								if err := e.setAssignmentToErrorState(ctx, formationAssignment, err.Error()); err != nil {
-									return errors.Wrapf(err, "while setting formation assignment with ID: %q to error state: %q", formationAssignment.ID, model.CreateErrorAssignmentState)
-								}
-								return nil
-							}); transactionErr != nil {
-								return false, transactionErr
-							}
-
-							return true, nil
+							return false, errors.Wrapf(err, "while deleting basic destination with name: %q", destDetails.Name)
 						}
 
 						if _, err = e.destinationSvc.CreateBasicCredentialDestinations(ctx, destDetails, *basicAuthCreds, formationAssignment, basicAuthDetails.CorrelationIDs); err != nil {
-							log.C(ctx).Warnf("An error occurred while creating basic destination with subaccount ID: %q and name: %q when handling conflict case: %v", destDetails.SubaccountID, destDetails.Name, err)
-							if transactionErr := e.transaction(ctx, func(ctxWithTransact context.Context) error {
-								if err := e.setAssignmentToErrorState(ctx, formationAssignment, err.Error()); err != nil {
-									return errors.Wrapf(err, "while setting formation assignment with ID: %q to error state: %q", formationAssignment.ID, model.CreateErrorAssignmentState)
-								}
-								return nil
-							}); transactionErr != nil {
-								return false, transactionErr
-							}
-
-							return true, nil
+							return false, errors.Wrapf(err, "while creating basic destination with name: %q", destDetails.Name)
 						}
 					}
 				}
@@ -284,47 +194,17 @@ func (e *ConstraintEngine) DestinationCreator(ctx context.Context, input Operato
 				for _, destDetails := range samlAssertionDetails.Destinations {
 					statusCode, err := e.destinationSvc.CreateSAMLAssertionDestination(ctx, destDetails, samlAuthCreds, formationAssignment, samlAssertionDetails.CorrelationIDs)
 					if err != nil {
-						log.C(ctx).Warnf("An error occurred while creating SAML assertion destination with subaccount ID: %q and name: %q: %v", destDetails.SubaccountID, destDetails.Name, err)
-						if transactionErr := e.transaction(ctx, func(ctxWithTransact context.Context) error {
-							if err := e.setAssignmentToErrorState(ctx, formationAssignment, err.Error()); err != nil {
-								return errors.Wrapf(err, "while setting formation assignment with ID: %q to error state: %q", formationAssignment.ID, model.CreateErrorAssignmentState)
-							}
-							return nil
-						}); transactionErr != nil {
-							return false, transactionErr
-						}
-
-						return true, nil
+						return false, errors.Wrapf(err, "while creating SAML assertion destination with name: %q", destDetails.Name)
 					}
 
 					if statusCode == http.StatusConflict {
 						log.C(ctx).Infof("The destination with name: %q already exists. Will be deleted and created again...", destDetails.Name)
 						if err := e.destinationSvc.DeleteDestinationFromDestinationService(ctx, destDetails.Name, destDetails.SubaccountID, formationAssignment); err != nil {
-							log.C(ctx).Warnf("An error occurred while deleting SAML assertion destination with subaccount ID: %q and name: %q when handling conflict case: %v", destDetails.SubaccountID, destDetails.Name, err)
-							if transactionErr := e.transaction(ctx, func(ctxWithTransact context.Context) error {
-								if err := e.setAssignmentToErrorState(ctx, formationAssignment, err.Error()); err != nil {
-									return errors.Wrapf(err, "while setting formation assignment with ID: %q to error state: %q", formationAssignment.ID, model.CreateErrorAssignmentState)
-								}
-								return nil
-							}); transactionErr != nil {
-								return false, transactionErr
-							}
-
-							return true, nil
+							return false, errors.Wrapf(err, "while deleting SAML assertion destination with name: %q", destDetails.Name)
 						}
 
 						if _, err = e.destinationSvc.CreateSAMLAssertionDestination(ctx, destDetails, samlAuthCreds, formationAssignment, samlAssertionDetails.CorrelationIDs); err != nil {
-							log.C(ctx).Warnf("An error occurred while creating SAML assertion destination with subaccount ID: %q and name: %q when handling conflict case: %v", destDetails.SubaccountID, destDetails.Name, err)
-							if transactionErr := e.transaction(ctx, func(ctxWithTransact context.Context) error {
-								if err := e.setAssignmentToErrorState(ctx, formationAssignment, err.Error()); err != nil {
-									return errors.Wrapf(err, "while setting formation assignment with ID: %q to error state: %q", formationAssignment.ID, model.CreateErrorAssignmentState)
-								}
-								return nil
-							}); transactionErr != nil {
-								return false, transactionErr
-							}
-
-							return true, nil
+							return false, errors.Wrapf(err, "while creating SAML assertion destination with name: %q", destDetails.Name)
 						}
 					}
 				}

--- a/components/director/internal/domain/formationconstraint/operators/utils.go
+++ b/components/director/internal/domain/formationconstraint/operators/utils.go
@@ -2,14 +2,11 @@ package operators
 
 import (
 	"context"
-	"encoding/json"
 	"runtime/debug"
 	"unsafe"
 
-	"github.com/kyma-incubator/compass/components/director/internal/domain/formationassignment"
 	"github.com/kyma-incubator/compass/components/director/internal/model"
 	"github.com/kyma-incubator/compass/components/director/pkg/log"
-	"github.com/kyma-incubator/compass/components/director/pkg/persistence"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
@@ -29,43 +26,4 @@ func RetrieveFormationAssignmentPointer(ctx context.Context, jointPointDetailsAs
 	jointPointAssignmentPointer := (*model.FormationAssignment)(unsafe.Pointer(jointPointDetailsAssignmentMemoryAddress))
 
 	return jointPointAssignmentPointer, nil
-}
-
-func (e *ConstraintEngine) transaction(ctx context.Context, dbCall func(ctxWithTransact context.Context) error) error {
-	tx, err := e.transact.Begin()
-	if err != nil {
-		log.C(ctx).WithError(err).Error("Failed to begin DB transaction")
-		return err
-	}
-	defer e.transact.RollbackUnlessCommitted(ctx, tx)
-
-	ctx = persistence.SaveToContext(ctx, tx)
-
-	if err = dbCall(ctx); err != nil {
-		return err
-	}
-
-	if err = tx.Commit(); err != nil {
-		log.C(ctx).WithError(err).Error("Failed to commit database transaction")
-		return err
-	}
-	return nil
-}
-
-func (e *ConstraintEngine) setAssignmentToErrorState(ctx context.Context, assignment *model.FormationAssignment, errorMessage string) error {
-	assignment.State = string(model.CreateErrorAssignmentState)
-	assignmentError := formationassignment.AssignmentErrorWrapper{Error: formationassignment.AssignmentError{
-		Message:   errorMessage,
-		ErrorCode: formationassignment.ClientError,
-	}}
-	marshaled, err := json.Marshal(assignmentError)
-	if err != nil {
-		return errors.Wrapf(err, "While preparing error message for assignment with ID %q", assignment.ID)
-	}
-	assignment.Value = marshaled
-	if err := e.formationAssignmentRepo.Update(ctx, assignment); err != nil {
-		return errors.Wrapf(err, "While updating formation assignment with id %q", assignment.ID)
-	}
-	log.C(ctx).Infof("Assignment with ID %s set to state %s", assignment.ID, assignment.State)
-	return nil
 }

--- a/components/director/internal/formationmapping/auth_middleware.go
+++ b/components/director/internal/formationmapping/auth_middleware.go
@@ -40,6 +40,7 @@ type FormationAssignmentService interface {
 	ProcessFormationAssignmentPair(ctx context.Context, mappingPair *formationassignment.AssignmentMappingPairWithOperation) (bool, error)
 	Delete(ctx context.Context, id string) error
 	ListFormationAssignmentsForObjectID(ctx context.Context, formationID, objectID string) ([]*model.FormationAssignment, error)
+	SetAssignmentToErrorState(ctx context.Context, assignment *model.FormationAssignment, errorMessage string, errorCode formationassignment.AssignmentErrorCode, state model.FormationAssignmentState) error
 }
 
 //go:generate mockery --exported --name=formationAssignmentStatusService --output=automock --outpkg=automock --case=underscore --disable-version-string

--- a/components/director/internal/formationmapping/automock/formation_assignment_service.go
+++ b/components/director/internal/formationmapping/automock/formation_assignment_service.go
@@ -121,6 +121,20 @@ func (_m *FormationAssignmentService) ProcessFormationAssignmentPair(ctx context
 	return r0, r1
 }
 
+// SetAssignmentToErrorState provides a mock function with given fields: ctx, assignment, errorMessage, errorCode, state
+func (_m *FormationAssignmentService) SetAssignmentToErrorState(ctx context.Context, assignment *model.FormationAssignment, errorMessage string, errorCode formationassignment.AssignmentErrorCode, state model.FormationAssignmentState) error {
+	ret := _m.Called(ctx, assignment, errorMessage, errorCode, state)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, *model.FormationAssignment, string, formationassignment.AssignmentErrorCode, model.FormationAssignmentState) error); ok {
+		r0 = rf(ctx, assignment, errorMessage, errorCode, state)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 type mockConstructorTestingTNewFormationAssignmentService interface {
 	mock.TestingT
 	Cleanup(func())

--- a/components/director/internal/formationmapping/handler.go
+++ b/components/director/internal/formationmapping/handler.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 
+	"github.com/kyma-incubator/compass/components/director/pkg/apperrors"
+
 	"github.com/kyma-incubator/compass/components/director/pkg/graphql"
 
 	"github.com/kyma-incubator/compass/components/director/pkg/correlation"
@@ -143,6 +145,12 @@ func (h *Handler) UpdateFormationAssignmentStatus(w http.ResponseWriter, r *http
 	if fa.State == string(model.DeletingAssignmentState) {
 		isFADeleted, err := h.processFormationAssignmentUnassignStatusUpdate(ctx, fa, reqBody)
 		if err != nil {
+			if commitErr := tx.Commit(); commitErr != nil {
+				log.C(ctx).WithError(err).Error("An error occurred while closing database transaction")
+				respondWithError(ctx, w, http.StatusInternalServerError, errResp)
+				return
+			}
+
 			log.C(ctx).WithError(err).Errorf("An error occurred while processing formation assignment staus update for %q operation", model.UnassignFormation)
 			respondWithError(ctx, w, http.StatusInternalServerError, errResp)
 			return
@@ -469,6 +477,16 @@ func (h *Handler) processFormationAssignmentUnassignStatusUpdate(ctx context.Con
 	}
 
 	if err := h.faStatusService.DeleteWithConstraints(ctx, fa.ID); err != nil {
+		log.C(ctx).WithError(err).Infof("An error occurred while deleting the assignment with ID: %q with constraints", fa.ID)
+		if apperrors.IsNotFoundError(err) {
+			log.C(ctx).Infof("Assignment with ID %q has already been deleted", fa.ID)
+			return false, nil
+		}
+
+		if updateError := h.faService.SetAssignmentToErrorState(ctx, fa, err.Error(), formationassignment.TechnicalError, model.DeleteErrorAssignmentState); updateError != nil {
+			return false, errors.Wrapf(updateError, "while updating error state: %s", errors.Wrapf(err, "while deleting formation assignment with id %q", fa.ID).Error())
+		}
+
 		return false, errors.Wrapf(err, "while deleting formation assignment with ID: %q", fa.ID)
 	}
 

--- a/components/director/internal/formationmapping/handler.go
+++ b/components/director/internal/formationmapping/handler.go
@@ -480,7 +480,7 @@ func (h *Handler) processFormationAssignmentUnassignStatusUpdate(ctx context.Con
 		log.C(ctx).WithError(err).Infof("An error occurred while deleting the assignment with ID: %q with constraints", fa.ID)
 		if apperrors.IsNotFoundError(err) {
 			log.C(ctx).Infof("Assignment with ID %q has already been deleted", fa.ID)
-			return false, nil
+			return true, nil
 		}
 
 		if updateError := h.faService.SetAssignmentToErrorState(ctx, fa, err.Error(), formationassignment.TechnicalError, model.DeleteErrorAssignmentState); updateError != nil {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Currently, in the destination creator formation "constraint" operator we have special error handling if something fails during destination creation to update the formation assignment in an error state and to return no errors. But with that behaviour, we do not stop the formation notifications propagation whereas we should.

Changes proposed in this pull request:
- remove the "special" error handling in the destination creator operator and return the error, the rest of the code will handle it independently
- During "delete with constraints" before deleting the formation assignment we need to update it to "READY" state

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- https://github.com/kyma-incubator/compass/pull/3092

**Pull Request status**
<!-- Feel free to construct the checklist with whatever items seem most reasonable for your change. You could disassemble the Implementation part to even smaller separate checklist items if you're working on something big for example. But do make the effort to provide a checklist of some sort so that the core team as well as the community can have an idea about the progress of your Pull Request.
-->

- [x] Implementation
- [x] Unit tests
- [ ] Integration tests
- [x] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [x] Mocks are regenerated, using the automated script
