### PR TITLE
Fix e2e tests kubernetes jobs pending termination

### DIFF
--- a/chart/compass/templates/tests/director/director-test.yaml
+++ b/chart/compass/templates/tests/director/director-test.yaml
@@ -304,7 +304,7 @@ rules:
   - apiGroups: ["*"]
     resources: ["jobs"]
     resourceNames: [{{ .Values.global.tests.subscription.externalCertTestJobName }}]
-    verbs: ["get", "delete"]
+    verbs: ["get", "delete", "patch"]
   - apiGroups: ["*"]
     resources: ["jobs"]
     resourceNames: []

--- a/chart/compass/templates/tests/ord-service/ord-service-test.yaml
+++ b/chart/compass/templates/tests/ord-service/ord-service-test.yaml
@@ -249,7 +249,7 @@ rules:
 - apiGroups: ["*"]
   resources: ["jobs"]
   resourceNames: [{{ .Values.global.tests.subscription.externalCertTestJobName }}]
-  verbs: ["get", "delete"]
+  verbs: ["get", "delete", "patch"]
 - apiGroups: ["*"]
   resources: ["jobs"]
   resourceNames: []

--- a/chart/compass/templates/tests/system-fetcher/system-fetcher-test.yaml
+++ b/chart/compass/templates/tests/system-fetcher/system-fetcher-test.yaml
@@ -99,7 +99,7 @@ rules:
 - apiGroups: ["*"]
   resources: ["jobs"]
   resourceNames: ["system-fetcher-test", "system-fetcher-test2"]
-  verbs: ["get", "delete"]
+  verbs: ["get", "delete", "patch"]
 - apiGroups: ["*"]
   resources: ["jobs"]
   resourceNames: []

--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -187,8 +187,8 @@ global:
       version: "v20230421-e8840c18"
       name: compass-console
     e2e_tests:
-      dir: prod/incubator/
-      version: "v20230717-b79d6643"
+      dir: dev/incubator/
+      version: "PR-3174"
       name: compass-e2e-tests
   isLocalEnv: false
   isForTesting: false

--- a/tests/director/tests/kyma_tenant_mapping_adapter_test.go
+++ b/tests/director/tests/kyma_tenant_mapping_adapter_test.go
@@ -3,12 +3,13 @@ package tests
 import (
 	"context"
 	"fmt"
+	"testing"
+
 	"github.com/kyma-incubator/compass/components/director/pkg/graphql"
 	"github.com/kyma-incubator/compass/components/director/pkg/str"
 	"github.com/kyma-incubator/compass/tests/pkg/fixtures"
 	"github.com/kyma-incubator/compass/tests/pkg/testctx"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func TestKymaTenantMappingAdapter(t *testing.T) {

--- a/tests/pkg/k8s/jobs.go
+++ b/tests/pkg/k8s/jobs.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/davecgh/go-spew/spew"
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/stretchr/testify/require"
@@ -105,7 +104,6 @@ func DeleteJob(t *testing.T, ctx context.Context, k8sClient *kubernetes.Clientse
 			}
 
 			if _, err = k8sClient.BatchV1().Jobs(namespace).Patch(ctx, jobName, types.MergePatchType, patchBytes, metav1.PatchOptions{}); err != nil {
-				spew.Dump(err)
 				t.Fatalf("Can't patch job %q finalizers: %v. Exiting...", jobName, err)
 			}
 		case <-elapsed:

--- a/tests/pkg/k8s/jobs.go
+++ b/tests/pkg/k8s/jobs.go
@@ -4,12 +4,13 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"github.com/davecgh/go-spew/spew"
 	"io"
-	"k8s.io/apimachinery/pkg/types"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/davecgh/go-spew/spew"
+	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/batch/v1"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Currently, the e2e tests are flapping due to unsuccessful job deletion. The problem is that the job goes into a terminating state and can't be deleted or recreated, the only solution is to remove it's finalizers by force(patching it).

Changes proposed in this pull request:
- Fix test jobs pending termination

**Pull Request status**
<!-- Feel free to construct the checklist with whatever items seem most reasonable for your change. You could disassemble the Implementation part to even smaller separate checklist items if you're working on something big for example. But do make the effort to provide a checklist of some sort so that the core team as well as the community can have an idea about the progress of your Pull Request.
-->

- [ ] Implementation
- [ ] Unit tests
- [ ] Integration tests
- [ ] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [ ] Mocks are regenerated, using the automated script
