### PR TITLE
Forbid creation of cert subject mappings with the same subject

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -138,8 +138,8 @@ global:
       version: "v20230714-506a64e8"
       name: compass-pairing-adapter
     director:
-      dir: prod/incubator/
-      version: "v20230714-3366c756"
+      dir: dev/incubator/
+      version: "3176"
       name: compass-director
     hydrator:
       dir: prod/incubator/

--- a/components/director/internal/domain/certsubjectmapping/automock/cert_mapping_repository.go
+++ b/components/director/internal/domain/certsubjectmapping/automock/cert_mapping_repository.go
@@ -63,6 +63,27 @@ func (_m *CertMappingRepository) Exists(ctx context.Context, id string) (bool, e
 	return r0, r1
 }
 
+// ExistsBySubject provides a mock function with given fields: ctx, subject
+func (_m *CertMappingRepository) ExistsBySubject(ctx context.Context, subject string) (bool, error) {
+	ret := _m.Called(ctx, subject)
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func(context.Context, string) bool); ok {
+		r0 = rf(ctx, subject)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, subject)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // Get provides a mock function with given fields: ctx, id
 func (_m *CertMappingRepository) Get(ctx context.Context, id string) (*model.CertSubjectMapping, error) {
 	ret := _m.Called(ctx, id)
@@ -79,6 +100,29 @@ func (_m *CertMappingRepository) Get(ctx context.Context, id string) (*model.Cer
 	var r1 error
 	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
 		r1 = rf(ctx, id)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// GetBySubject provides a mock function with given fields: ctx, subject
+func (_m *CertMappingRepository) GetBySubject(ctx context.Context, subject string) (*model.CertSubjectMapping, error) {
+	ret := _m.Called(ctx, subject)
+
+	var r0 *model.CertSubjectMapping
+	if rf, ok := ret.Get(0).(func(context.Context, string) *model.CertSubjectMapping); ok {
+		r0 = rf(ctx, subject)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*model.CertSubjectMapping)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, subject)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/components/director/internal/domain/certsubjectmapping/automock/cert_subject_mapping_service.go
+++ b/components/director/internal/domain/certsubjectmapping/automock/cert_subject_mapping_service.go
@@ -70,6 +70,27 @@ func (_m *CertSubjectMappingService) Exists(ctx context.Context, id string) (boo
 	return r0, r1
 }
 
+// ExistsBySubject provides a mock function with given fields: ctx, subject
+func (_m *CertSubjectMappingService) ExistsBySubject(ctx context.Context, subject string) (bool, error) {
+	ret := _m.Called(ctx, subject)
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func(context.Context, string) bool); ok {
+		r0 = rf(ctx, subject)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, subject)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // Get provides a mock function with given fields: ctx, id
 func (_m *CertSubjectMappingService) Get(ctx context.Context, id string) (*model.CertSubjectMapping, error) {
 	ret := _m.Called(ctx, id)

--- a/components/director/internal/domain/certsubjectmapping/fixtures_test.go
+++ b/components/director/internal/domain/certsubjectmapping/fixtures_test.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	TestID           = "455e47ea-5eab-49c5-ba35-a67e1d9125f6"
-	TestSubject      = "C=DE, L=test, O=SAP SE, OU=TestRegion, OU=SAP Cloud Platform Clients, OU=2c0fe288-bb13-4814-ac49-ac88c4a76b10, CN=test-compass"
+	TestSubject      = "C=DE, L=test, O=SAP SE, OU=TestRegion, OU=Test Cloud Platform Clients, OU=2c0fe288-bb13-4814-ac49-ac88c4a76b10, CN=test-compass"
 	TestConsumerType = inputvalidation.RuntimeType
 )
 

--- a/components/director/internal/domain/certsubjectmapping/repository_test.go
+++ b/components/director/internal/domain/certsubjectmapping/repository_test.go
@@ -3,6 +3,7 @@ package certsubjectmapping_test
 import (
 	"database/sql/driver"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
@@ -62,6 +63,36 @@ func TestRepository_Get(t *testing.T) {
 		ExpectedModelEntity:       CertSubjectMappingModel,
 		ExpectedDBEntity:          CertSubjectMappingEntity,
 		MethodArgs:                []interface{}{TestID},
+		DisableConverterErrorTest: false,
+	}
+
+	suite.Run(t)
+}
+
+func TestRepository_GetBySubject(t *testing.T) {
+	suite := testdb.RepoGetTestSuite{
+		Name:       "Get certificate subject mapping by ID",
+		MethodName: "GetBySubject",
+		SQLQueryDetails: []testdb.SQLQueryDetails{
+			{
+				Query:    regexp.QuoteMeta(`SELECT id, subject, consumer_type, internal_consumer_id, tenant_access_levels FROM public.cert_subject_mapping WHERE subject ILIKE $1`),
+				Args:     []driver.Value{strings.ReplaceAll(TestSubject, ",", "_")},
+				IsSelect: true,
+				ValidRowsProvider: func() []*sqlmock.Rows {
+					return []*sqlmock.Rows{sqlmock.NewRows(fixColumns()).AddRow(CertSubjectMappingEntity.ID, CertSubjectMappingEntity.Subject, CertSubjectMappingEntity.ConsumerType, CertSubjectMappingEntity.InternalConsumerID, CertSubjectMappingEntity.TenantAccessLevels)}
+				},
+				InvalidRowsProvider: func() []*sqlmock.Rows {
+					return []*sqlmock.Rows{sqlmock.NewRows(fixColumns())}
+				},
+			},
+		},
+		ConverterMockProvider: func() testdb.Mock {
+			return &automock.EntityConverter{}
+		},
+		RepoConstructorFunc:       certsubjectmapping.NewRepository,
+		ExpectedModelEntity:       CertSubjectMappingModel,
+		ExpectedDBEntity:          CertSubjectMappingEntity,
+		MethodArgs:                []interface{}{TestSubject},
 		DisableConverterErrorTest: false,
 	}
 
@@ -139,6 +170,35 @@ func TestRepository_Exists(t *testing.T) {
 		IsGlobal:   true,
 		MethodName: "Exists",
 		MethodArgs: []interface{}{TestID},
+	}
+
+	suite.Run(t)
+}
+
+func TestRepository_ExistsBySubject(t *testing.T) {
+	suite := testdb.RepoExistTestSuite{
+		Name: "Exists certificate subject mapping by Subject",
+		SQLQueryDetails: []testdb.SQLQueryDetails{
+			{
+				Query:    regexp.QuoteMeta(`SELECT 1 FROM public.cert_subject_mapping WHERE subject ILIKE $1`),
+				Args:     []driver.Value{strings.ReplaceAll(TestSubject, ",", "_")},
+				IsSelect: true,
+				ValidRowsProvider: func() []*sqlmock.Rows {
+					return []*sqlmock.Rows{testdb.RowWhenObjectExist()}
+				},
+				InvalidRowsProvider: func() []*sqlmock.Rows {
+					return []*sqlmock.Rows{testdb.RowWhenObjectDoesNotExist()}
+				},
+			},
+		},
+		RepoConstructorFunc: certsubjectmapping.NewRepository,
+		ConverterMockProvider: func() testdb.Mock {
+			return &automock.EntityConverter{}
+		},
+		TargetID:   TestID,
+		IsGlobal:   true,
+		MethodName: "ExistsBySubject",
+		MethodArgs: []interface{}{TestSubject},
 	}
 
 	suite.Run(t)

--- a/components/director/internal/domain/certsubjectmapping/resolver_test.go
+++ b/components/director/internal/domain/certsubjectmapping/resolver_test.go
@@ -247,6 +247,7 @@ func TestResolver_CreateCertificateSubjectMapping(t *testing.T) {
 			},
 			CertSubjectMappingSvcFn: func() *automock.CertSubjectMappingService {
 				certSubjectMappingSvc := &automock.CertSubjectMappingService{}
+				certSubjectMappingSvc.On("ExistsBySubject", txtest.CtxWithDBMatcher(), CertSubjectMappingModel.Subject).Return(false, nil).Once()
 				certSubjectMappingSvc.On("Create", txtest.CtxWithDBMatcher(), CertSubjectMappingModel).Return(TestID, nil).Once()
 				certSubjectMappingSvc.On("Get", txtest.CtxWithDBMatcher(), TestID).Return(CertSubjectMappingModel, nil).Once()
 				return certSubjectMappingSvc
@@ -282,6 +283,7 @@ func TestResolver_CreateCertificateSubjectMapping(t *testing.T) {
 			},
 			CertSubjectMappingSvcFn: func() *automock.CertSubjectMappingService {
 				certSubjectMappingSvc := &automock.CertSubjectMappingService{}
+				certSubjectMappingSvc.On("ExistsBySubject", txtest.CtxWithDBMatcher(), CertSubjectMappingModel.Subject).Return(false, nil).Once()
 				certSubjectMappingSvc.On("Create", txtest.CtxWithDBMatcher(), CertSubjectMappingModel).Return("", testErr).Once()
 				return certSubjectMappingSvc
 			},
@@ -304,6 +306,7 @@ func TestResolver_CreateCertificateSubjectMapping(t *testing.T) {
 			},
 			CertSubjectMappingSvcFn: func() *automock.CertSubjectMappingService {
 				certSubjectMappingSvc := &automock.CertSubjectMappingService{}
+				certSubjectMappingSvc.On("ExistsBySubject", txtest.CtxWithDBMatcher(), CertSubjectMappingModel.Subject).Return(false, nil).Once()
 				certSubjectMappingSvc.On("Create", txtest.CtxWithDBMatcher(), CertSubjectMappingModel).Return(TestID, nil).Once()
 				certSubjectMappingSvc.On("Get", txtest.CtxWithDBMatcher(), TestID).Return(nil, testErr).Once()
 				return certSubjectMappingSvc
@@ -327,6 +330,7 @@ func TestResolver_CreateCertificateSubjectMapping(t *testing.T) {
 			},
 			CertSubjectMappingSvcFn: func() *automock.CertSubjectMappingService {
 				certSubjectMappingSvc := &automock.CertSubjectMappingService{}
+				certSubjectMappingSvc.On("ExistsBySubject", txtest.CtxWithDBMatcher(), CertSubjectMappingModel.Subject).Return(false, nil).Once()
 				certSubjectMappingSvc.On("Create", txtest.CtxWithDBMatcher(), CertSubjectMappingModel).Return(TestID, nil).Once()
 				certSubjectMappingSvc.On("Get", txtest.CtxWithDBMatcher(), TestID).Return(CertSubjectMappingModel, nil).Once()
 				return certSubjectMappingSvc
@@ -338,6 +342,30 @@ func TestResolver_CreateCertificateSubjectMapping(t *testing.T) {
 			},
 			ExpectedOutput: nil,
 			ExpectedError:  testErr,
+		},
+		{
+			Name:            "Error when checking if certificate subject mapping exists",
+			Input:           CertSubjectMappingGQLModelInput,
+			TransactionerFn: txGen.ThatDoesntExpectCommit,
+			CertSubjectMappingSvcFn: func() *automock.CertSubjectMappingService {
+				certSubjectMappingSvc := &automock.CertSubjectMappingService{}
+				certSubjectMappingSvc.On("ExistsBySubject", txtest.CtxWithDBMatcher(), CertSubjectMappingModel.Subject).Return(false, testErr).Once()
+				return certSubjectMappingSvc
+			},
+			ExpectedOutput: nil,
+			ExpectedError:  testErr,
+		},
+		{
+			Name:            "Error when certificate subject mapping with the same subject exists",
+			Input:           CertSubjectMappingGQLModelInput,
+			TransactionerFn: txGen.ThatDoesntExpectCommit,
+			CertSubjectMappingSvcFn: func() *automock.CertSubjectMappingService {
+				certSubjectMappingSvc := &automock.CertSubjectMappingService{}
+				certSubjectMappingSvc.On("ExistsBySubject", txtest.CtxWithDBMatcher(), CertSubjectMappingModel.Subject).Return(true, nil).Once()
+				return certSubjectMappingSvc
+			},
+			ExpectedOutput: nil,
+			ExpectedError:  errors.Errorf("Certificate subject mapping with Subject %q already exists", CertSubjectMappingModel.Subject),
 		},
 	}
 

--- a/components/director/internal/domain/certsubjectmapping/service.go
+++ b/components/director/internal/domain/certsubjectmapping/service.go
@@ -15,9 +15,11 @@ import (
 type CertMappingRepository interface {
 	Create(ctx context.Context, item *model.CertSubjectMapping) error
 	Get(ctx context.Context, id string) (*model.CertSubjectMapping, error)
+	GetBySubject(ctx context.Context, subject string) (*model.CertSubjectMapping, error)
 	Update(ctx context.Context, model *model.CertSubjectMapping) error
 	Delete(ctx context.Context, id string) error
 	Exists(ctx context.Context, id string) (bool, error)
+	ExistsBySubject(ctx context.Context, subject string) (bool, error)
 	List(ctx context.Context, pageSize int, cursor string) (*model.CertSubjectMappingPage, error)
 }
 
@@ -63,6 +65,14 @@ func (s *service) Update(ctx context.Context, in *model.CertSubjectMapping) erro
 		return apperrors.NewNotFoundError(resource.CertSubjectMapping, in.ID)
 	}
 
+	certSubjectMapping, err := s.repo.GetBySubject(ctx, in.Subject)
+	if err != nil {
+		return errors.Wrapf(err, "while checking certificate subject mapping existence for Subject: %q", in.Subject)
+	}
+	if certSubjectMapping.ID != in.ID {
+		return errors.Errorf("Certificate subject mapping with Subject %q already exists", in.Subject)
+	}
+
 	if err := s.repo.Update(ctx, in); err != nil {
 		return errors.Wrapf(err, "while updating certificate subject mapping with ID: %s", in.ID)
 	}
@@ -85,6 +95,16 @@ func (s *service) Exists(ctx context.Context, id string) (bool, error) {
 	exists, err := s.repo.Exists(ctx, id)
 	if err != nil {
 		return false, errors.Wrapf(err, "while checking certificate subject mapping existence for ID: %s", id)
+	}
+	return exists, nil
+}
+
+// ExistsBySubject check if a certificate subject mapping with subject `subject` exists
+func (s *service) ExistsBySubject(ctx context.Context, subject string) (bool, error) {
+	log.C(ctx).Infof("Checking certificate subject mapping existence for Subject: %q", subject)
+	exists, err := s.repo.ExistsBySubject(ctx, subject)
+	if err != nil {
+		return false, errors.Wrapf(err, "while checking certificate subject mapping existence for Subject: %q", subject)
 	}
 	return exists, nil
 }

--- a/tests/pkg/fixtures/application_requests.go
+++ b/tests/pkg/fixtures/application_requests.go
@@ -2,8 +2,9 @@ package fixtures
 
 import (
 	"fmt"
-	"github.com/kyma-incubator/compass/components/director/pkg/graphql/graphqlizer"
 	"strings"
+
+	"github.com/kyma-incubator/compass/components/director/pkg/graphql/graphqlizer"
 
 	"github.com/stretchr/testify/require"
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Currently, it is possible to create cert subject mappings with the same subjects if their delimiter is different. For example, instead of comma(',') you use plus sign('+') for delimiter. This should be forbidden and this PR does that.

Changes proposed in this pull request:
- Forbid creation of cert subject mappings with the same subject

**Pull Request status**
<!-- Feel free to construct the checklist with whatever items seem most reasonable for your change. You could disassemble the Implementation part to even smaller separate checklist items if you're working on something big for example. But do make the effort to provide a checklist of some sort so that the core team as well as the community can have an idea about the progress of your Pull Request.
-->

- [ ] Implementation
- [ ] Unit tests
- [ ] Integration tests
- [ ] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [ ] Mocks are regenerated, using the automated script
