### PR TITLE
Add logs to e2e test execution

### DIFF
--- a/installation/scripts/testing.sh
+++ b/installation/scripts/testing.sh
@@ -155,7 +155,11 @@ do
         break
     fi
     if (( ${previousPrintTime} != ${min} )); then
-        echo "ClusterTestSuite not finished. Waiting..."
+        running_test=$(kubectl get cts ${suiteName} -o yaml | grep "status: Running" -B5 | head -n 1 | cut -d ':' -f 2 | tr -d " ")
+        if [ -z "$running_test" ]; then
+          running_test="none"
+        fi
+        echo "Running test is ${running_test}"
         previousPrintTime=${min}
     fi
     sleep 3


### PR DESCRIPTION
**Description**
Currently when e2e tests are running we don't have any information as to what's running. Only `ClusterTestSuite not finished. Waiting...` is printed over and over again. With this change we get to see where during the execution it is.

Changes proposed in this pull request:
- Add logs that show which test pod is currently executing

**Pull Request status**
<!-- Feel free to construct the checklist with whatever items seem most reasonable for your change. You could disassemble the Implementation part to even smaller separate checklist items if you're working on something big for example. But do make the effort to provide a checklist of some sort so that the core team as well as the community can have an idea about the progress of your Pull Request.
-->

- [ ] Implementation
- [ ] Unit tests
- [ ] Integration tests
- [ ] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [ ] Mocks are regenerated, using the automated script
