### PR TITLE
[HOTFIX] Fix assert in e2e tests

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -187,8 +187,8 @@ global:
       version: "v20230421-e8840c18"
       name: compass-console
     e2e_tests:
-      dir: prod/incubator/
-      version: "v20230815-71fc5609"
+      dir: dev/incubator/
+      version: "PR-3218"
       name: compass-e2e-tests
   isLocalEnv: false
   isForTesting: false

--- a/tests/director/tests/formation_api_test.go
+++ b/tests/director/tests/formation_api_test.go
@@ -5707,6 +5707,11 @@ func verifyFormationAssignmentNotification(t *testing.T, notification gjson.Resu
 			return err
 		}
 
+		modifiedNotification, err = sjson.Delete(notification.String(), "RequestBody.receiverTenant.configuration.credentials.inboundCommunication.samlAssertion.assertionIssuer")
+		if err != nil {
+			return err
+		}
+
 		modifiedConfig := gjson.Get(modifiedNotification, "RequestBody.receiverTenant.configuration").String()
 		assert.JSONEq(t, expectedConfiguration, modifiedConfig, "RequestBody.receiverTenant.configuration does not match")
 	} else {
@@ -5961,13 +5966,6 @@ func validateDestinationCertData(t *testing.T, assignmentConfig *string, path st
 	require.NoError(t, err)
 
 	return modifiedConfig
-}
-
-func enrichAssignmentConfigWithSAMLDestinationCertData(t *testing.T, destinationDetailsConfig, destinationCertificateName string) string {
-	destinationDetailsConfigEnrichedWithCertData, err := sjson.Set(destinationDetailsConfig, samlDestinationAssertionIssuerPath, destinationCertificateName)
-	require.NoError(t, err)
-
-	return destinationDetailsConfigEnrichedWithCertData
 }
 
 func assertFormationAssignmentsAsynchronously(t *testing.T, ctx context.Context, tenantID, formationID string, expectedAssignmentsCount int, expectedAssignments map[string]map[string]fixtures.AssignmentState, asyncStatusAPIProcessingDelay int64) {

--- a/tests/director/tests/formation_api_test.go
+++ b/tests/director/tests/formation_api_test.go
@@ -3365,8 +3365,6 @@ func TestFormationNotificationsWithApplicationSubscription(stdT *testing.T) {
 			destinationDetailsConfig := fmt.Sprintf(destinationDetailsConfigWithPlaceholders, noAuthDestinationName, noAuthDestinationURL, basicDestinationName, basicDestinationURL, samlAssertionDestinationName, samlAssertionDestinationURL, clientCertAuthDestinationName, clientCertAuthDestinationURL)
 			destinationCredentialsConfig := "{\"credentials\":{\"outboundCommunication\":{\"basicAuthentication\":{\"url\":\"https://e2e-basic-destination-url.com\",\"username\":\"e2e-basic-destination-username\",\"password\":\"e2e-basic-destination-password\"},\"samlAssertion\":{\"url\":\"http://e2e-saml-url-example.com\"},\"clientCertificateAuthentication\":{\"url\":\"http://e2e-client-cert-auth-url-example.com\"}}}}"
 
-			destinationDetailsConfigEnrichedWithCertData := enrichAssignmentConfigWithSAMLDestinationCertData(t, destinationDetailsConfig, samlAssertionDestinationCertName)
-
 			expectedAssignmentsBySourceID = map[string]map[string]fixtures.AssignmentState{
 				app1.ID: {
 					app2.ID: fixtures.AssignmentState{State: "CONFIG_PENDING", Config: str.Ptr(destinationDetailsConfig)},
@@ -3431,7 +3429,7 @@ func TestFormationNotificationsWithApplicationSubscription(stdT *testing.T) {
 					objectID:                               app2.ID,
 					localTenantID:                          localTenantID2,
 					objectRegion:                           appRegion,
-					configuration:                          destinationDetailsConfigEnrichedWithCertData,
+					configuration:                          destinationDetailsConfig,
 					tenant:                                 subscriptionConsumerAccountID,
 					customerID:                             emptyParentCustomerID,
 					shouldRemoveDestinationCertificateData: true,

--- a/tests/director/tests/formation_api_test.go
+++ b/tests/director/tests/formation_api_test.go
@@ -5707,7 +5707,7 @@ func verifyFormationAssignmentNotification(t *testing.T, notification gjson.Resu
 			return err
 		}
 
-		modifiedNotification, err = sjson.Delete(notification.String(), "RequestBody.receiverTenant.configuration.credentials.inboundCommunication.samlAssertion.assertionIssuer")
+		modifiedNotification, err = sjson.Delete(modifiedNotification, "RequestBody.receiverTenant.configuration.credentials.inboundCommunication.samlAssertion.assertionIssuer")
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Fix assert in the destination creator e2e tests that is regarding destinations with certificate data. That certificate data is dynamically added and every time its value is different. So in the test we assert it's not empty and remove it from the configuration - in FA config as well as in some cases in the notification request body config

Changes proposed in this pull request:
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- ...

**Pull Request status**
<!-- Feel free to construct the checklist with whatever items seem most reasonable for your change. You could disassemble the Implementation part to even smaller separate checklist items if you're working on something big for example. But do make the effort to provide a checklist of some sort so that the core team as well as the community can have an idea about the progress of your Pull Request.
-->

- [ ] Implementation
- [ ] Unit tests
- [ ] Integration tests
- [x] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [ ] Mocks are regenerated, using the automated script
