### PR TITLE
Add missing transaction commit in aggregator

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -138,8 +138,8 @@ global:
       version: "v20230728-78b68ef0"
       name: compass-pairing-adapter
     director:
-      dir: prod/incubator/
-      version: "v20230815-ef70d64e"
+      dir: dev/incubator/
+      version: "PR-3236"
       name: compass-director
     hydrator:
       dir: prod/incubator/

--- a/components/director/internal/open_resource_discovery/client.go
+++ b/components/director/internal/open_resource_discovery/client.go
@@ -83,6 +83,7 @@ func (c *client) FetchOpenResourceDiscoveryDocuments(ctx context.Context, resour
 		tenantValue = tntFromCtx.ExternalID
 	}
 
+	log.C(ctx).Infof("Fetching ORD well-known config")
 	config, err := c.fetchConfig(ctx, resource, webhook, tenantValue, requestObject)
 	if err != nil {
 		return nil, "", err

--- a/components/director/internal/open_resource_discovery/service.go
+++ b/components/director/internal/open_resource_discovery/service.go
@@ -213,6 +213,7 @@ func (s *Service) ProcessApplications(ctx context.Context, cfg MetricsConfig, ap
 		return nil
 	}
 
+	log.C(ctx).Infof("Retrieving global ORD resources")
 	globalResourcesOrdIDs := s.retrieveGlobalResources(ctx)
 	for _, appID := range appIDs {
 		if err := s.processApplication(ctx, cfg, globalResourcesOrdIDs, appID); err != nil {
@@ -230,7 +231,8 @@ func (s *Service) processApplication(ctx context.Context, cfg MetricsConfig, glo
 
 	for _, wh := range webhooks {
 		if wh.Type == model.WebhookTypeOpenResourceDiscovery && wh.URL != nil {
-			if err := s.processApplicationWebhook(ctx, cfg, wh, appID, globalResourcesOrdIDs); err != nil {
+			log.C(ctx).Infof("Process Webhook ID %s for Application with ID %s", wh.ID, appID)
+			if err = s.processApplicationWebhook(ctx, cfg, wh, appID, globalResourcesOrdIDs); err != nil {
 				return errors.Wrapf(err, "processing of ORD webhook for application with id %q failed", appID)
 			}
 		}
@@ -244,6 +246,7 @@ func (s *Service) ProcessApplicationTemplates(ctx context.Context, cfg MetricsCo
 		return nil
 	}
 
+	log.C(ctx).Infof("Retrieving global ORD resources")
 	globalResourcesOrdIDs := s.retrieveGlobalResources(ctx)
 	for _, appTemplateID := range appTemplateIDs {
 		if err := s.processApplicationTemplate(ctx, cfg, globalResourcesOrdIDs, appTemplateID); err != nil {
@@ -261,7 +264,9 @@ func (s *Service) processApplicationTemplate(ctx context.Context, cfg MetricsCon
 
 	for _, wh := range webhooks {
 		if wh.Type == model.WebhookTypeOpenResourceDiscovery && wh.URL != nil {
-			if err := s.processApplicationTemplateWebhook(ctx, cfg, wh, appTemplateID, globalResourcesOrdIDs); err != nil {
+
+			log.C(ctx).Infof("Processing Webhook ID %s for Application Tempalate with ID %s", wh.ID, appTemplateID)
+			if err = s.processApplicationTemplateWebhook(ctx, cfg, wh, appTemplateID, globalResourcesOrdIDs); err != nil {
 				return err
 			}
 
@@ -271,7 +276,7 @@ func (s *Service) processApplicationTemplate(ctx context.Context, cfg MetricsCon
 			}
 
 			for _, app := range apps {
-				if err := s.processApplicationWebhook(ctx, cfg, wh, app.ID, globalResourcesOrdIDs); err != nil {
+				if err = s.processApplicationWebhook(ctx, cfg, wh, app.ID, globalResourcesOrdIDs); err != nil {
 					return errors.Wrapf(err, "processing of ORD webhook for application with id %q failed", app.ID)
 				}
 			}
@@ -1803,6 +1808,10 @@ func (s *Service) processWebhookAndDocuments(ctx context.Context, cfg MetricsCon
 			return errors.Wrapf(err, "error while retrieving app with id %q", resource.ID)
 		}
 
+		if err = tx.Commit(); err != nil {
+			return err
+		}
+
 		appBaseURL = app.BaseURL
 	}
 
@@ -1834,7 +1843,7 @@ func (s *Service) processWebhookAndDocuments(ctx context.Context, cfg MetricsCon
 	}
 
 	if len(documents) > 0 {
-		log.C(ctx).Info("Processing ORD documents")
+		log.C(ctx).Info("Processing ORD documents for resource %s with ID %s", resource.Type, resource.ID)
 		var validationErrors error
 
 		err = s.processDocuments(ctx, resource, webhookBaseURL, str.PtrStrToStr(webhook.ProxyURL), ordRequestObject, documents, globalResourcesOrdIDs, &validationErrors)
@@ -1984,7 +1993,7 @@ func (s *Service) processApplicationWebhook(ctx context.Context, cfg MetricsConf
 		LocalTenantID: app.LocalTenantID,
 	}
 	if err = s.processWebhookAndDocuments(ctx, cfg, webhook, resource, globalResourcesOrdIDs, ordWebhookMapping); err != nil {
-		return err
+		return errors.Wrapf(err, "while processing webhook %s for application %s", webhook.ID, appID)
 	}
 
 	return nil

--- a/components/director/internal/open_resource_discovery/service.go
+++ b/components/director/internal/open_resource_discovery/service.go
@@ -1843,7 +1843,7 @@ func (s *Service) processWebhookAndDocuments(ctx context.Context, cfg MetricsCon
 	}
 
 	if len(documents) > 0 {
-		log.C(ctx).Info("Processing ORD documents for resource %s with ID %s", resource.Type, resource.ID)
+		log.C(ctx).Infof("Processing ORD documents for resource %s with ID %s", resource.Type, resource.ID)
 		var validationErrors error
 
 		err = s.processDocuments(ctx, resource, webhookBaseURL, str.PtrStrToStr(webhook.ProxyURL), ordRequestObject, documents, globalResourcesOrdIDs, &validationErrors)

--- a/components/director/internal/open_resource_discovery/service_test.go
+++ b/components/director/internal/open_resource_discovery/service_test.go
@@ -3959,7 +3959,7 @@ func TestService_SyncORDDocuments(t *testing.T) {
 			Name: "Does not resync resources if event spec list fails",
 			TransactionerFn: func() (*persistenceautomock.PersistenceTx, *persistenceautomock.Transactioner) {
 				persistTx := &persistenceautomock.PersistenceTx{}
-				persistTx.On("Commit").Return(nil).Times(24)
+				persistTx.On("Commit").Return(nil).Times(25)
 
 				transact := &persistenceautomock.Transactioner{}
 				transact.On("Begin").Return(persistTx, nil).Times(26)


### PR DESCRIPTION
Description

Due to missing transaction commit the ORD aggregator holds the established DB connection for too long. Subsequent request are processed very slow or timeout as they are waiting for the connection to be freed.