### PR TITLE
Remove region value for test tenant

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -126,7 +126,6 @@ global:
       id: 777ce47b-d901-4647-9223-14e94819830b
       type: subaccount
       parent: 5577cf46-4f78-45fa-b55f-a42a3bdba868
-      region: "eu-1"
   images:
     containerRegistry:
       path: europe-docker.pkg.dev/kyma-project


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Default region value fro testing is different for local and real env setup. When setting the env explicintly it is used as is and is not overriden based on the landscape

Changes proposed in this pull request:

- remove the explicint region value as it is intended to be the same as the default

