### PR TITLE
[HOTFIX] Fa race condition fix

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -142,8 +142,8 @@ global:
       version: "v20230822-5727fc10"
       name: compass-pairing-adapter
     director:
-      dir: prod/incubator/
-      version: "v20230824-8da53d33"
+      dir: dev/incubator/
+      version: "PR-3264"
       name: compass-director
     hydrator:
       dir: prod/incubator/

--- a/components/director/internal/domain/formation/automock/formation_assignment_service.go
+++ b/components/director/internal/domain/formation/automock/formation_assignment_service.go
@@ -71,15 +71,15 @@ func (_m *FormationAssignmentService) DeleteAssignmentsForObjectID(ctx context.C
 }
 
 // GenerateAssignments provides a mock function with given fields: ctx, tnt, objectID, objectType, _a4
-func (_m *FormationAssignmentService) GenerateAssignments(ctx context.Context, tnt string, objectID string, objectType graphql.FormationObjectType, _a4 *model.Formation) ([]*model.FormationAssignment, error) {
+func (_m *FormationAssignmentService) GenerateAssignments(ctx context.Context, tnt string, objectID string, objectType graphql.FormationObjectType, _a4 *model.Formation) ([]*model.FormationAssignmentInput, error) {
 	ret := _m.Called(ctx, tnt, objectID, objectType, _a4)
 
-	var r0 []*model.FormationAssignment
-	if rf, ok := ret.Get(0).(func(context.Context, string, string, graphql.FormationObjectType, *model.Formation) []*model.FormationAssignment); ok {
+	var r0 []*model.FormationAssignmentInput
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, graphql.FormationObjectType, *model.Formation) []*model.FormationAssignmentInput); ok {
 		r0 = rf(ctx, tnt, objectID, objectType, _a4)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]*model.FormationAssignment)
+			r0 = ret.Get(0).([]*model.FormationAssignmentInput)
 		}
 	}
 
@@ -247,6 +247,29 @@ func (_m *FormationAssignmentService) ListFormationAssignmentsForObjectID(ctx co
 	var r1 error
 	if rf, ok := ret.Get(1).(func(context.Context, string, string) error); ok {
 		r1 = rf(ctx, formationID, objectID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// PersistAssignments provides a mock function with given fields: ctx, tnt, assignments
+func (_m *FormationAssignmentService) PersistAssignments(ctx context.Context, tnt string, assignments []*model.FormationAssignmentInput) ([]*model.FormationAssignment, error) {
+	ret := _m.Called(ctx, tnt, assignments)
+
+	var r0 []*model.FormationAssignment
+	if rf, ok := ret.Get(0).(func(context.Context, string, []*model.FormationAssignmentInput) []*model.FormationAssignment); ok {
+		r0 = rf(ctx, tnt, assignments)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*model.FormationAssignment)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, string, []*model.FormationAssignmentInput) error); ok {
+		r1 = rf(ctx, tnt, assignments)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/components/director/internal/domain/formation/resolver.go
+++ b/components/director/internal/domain/formation/resolver.go
@@ -53,7 +53,8 @@ type formationAssignmentService interface {
 	ListFormationAssignmentsForObjectID(ctx context.Context, formationID, objectID string) ([]*model.FormationAssignment, error)
 	ProcessFormationAssignments(ctx context.Context, formationAssignmentsForObject []*model.FormationAssignment, runtimeContextIDToRuntimeIDMapping map[string]string, applicationIDToApplicationTemplateIDMapping map[string]string, requests []*webhookclient.FormationAssignmentNotificationRequest, operation func(context.Context, *formationassignment.AssignmentMappingPairWithOperation) (bool, error), formationOperation model.FormationOperation) error
 	ProcessFormationAssignmentPair(ctx context.Context, mappingPair *formationassignment.AssignmentMappingPairWithOperation) (bool, error)
-	GenerateAssignments(ctx context.Context, tnt, objectID string, objectType graphql.FormationObjectType, formation *model.Formation) ([]*model.FormationAssignment, error)
+	GenerateAssignments(ctx context.Context, tnt, objectID string, objectType graphql.FormationObjectType, formation *model.Formation) ([]*model.FormationAssignmentInput, error)
+	PersistAssignments(ctx context.Context, tnt string, assignments []*model.FormationAssignmentInput) ([]*model.FormationAssignment, error)
 	CleanupFormationAssignment(ctx context.Context, mappingPair *formationassignment.AssignmentMappingPairWithOperation) (bool, error)
 	GetAssignmentsForFormation(ctx context.Context, tenantID, formationID string) ([]*model.FormationAssignment, error)
 	Update(ctx context.Context, id string, fa *model.FormationAssignment) error

--- a/components/director/internal/domain/formation/service.go
+++ b/components/director/internal/domain/formation/service.go
@@ -561,14 +561,14 @@ func (s *service) AssignFormation(ctx context.Context, tnt, objectID string, obj
 			defer s.transact.RollbackUnlessCommitted(transactionCtx, tx)
 
 			if deferError := s.formationAssignmentService.DeleteAssignmentsForObjectID(transactionCtx, formationFromDB.ID, objectID); deferError != nil {
-				log.C(ctx).WithError(deferError).Errorf("Failed to delete assignemnts fo object with ID %q of type %q to formation %q", objectID, objectType, formation.Name)
+				log.C(ctx).WithError(deferError).Errorf("Failed to delete assignments fo object with ID %q of type %q to formation %q", objectID, objectType, formation.Name)
 			}
 
 			if deferError := s.unassign(transactionCtx, tnt, objectID, objectType, formationFromDB); deferError != nil {
 				log.C(ctx).WithError(deferError).Errorf("Failed to unassign object with ID %q of type %q from formation %q", objectID, objectType, formation.Name)
 			}
 
-			if deferError = tx.Commit(); err != nil {
+			if deferError = tx.Commit(); deferError != nil {
 				log.C(ctx).Infof("Failed to commit transaction for deleting leftover resources")
 			}
 		}()

--- a/components/director/internal/domain/formation/service.go
+++ b/components/director/internal/domain/formation/service.go
@@ -521,7 +521,7 @@ func (s *service) AssignFormation(ctx context.Context, tnt, objectID string, obj
 		// The defer statement after the formation assignment persistence depends on the value of the variable err.
 		// If err is used for the name of the returned error value a new variable that shadows the err variable from the outer scope
 		// is created. As the defer statement is declared in the scope of the case fragment of the switch it will be bound to the err variable in the same scope
-		//which is the new one. Then the deffer will not execute its logic in case of error in the outer scope.
+		// which is the new one. Then the deffer will not execute its logic in case of error in the outer scope.
 		assignmentInputs, terr := s.formationAssignmentService.GenerateAssignments(ctx, tnt, objectID, objectType, formationFromDB)
 		if terr != nil {
 			return nil, terr

--- a/components/director/internal/domain/formationassignment/fixtures_test.go
+++ b/components/director/internal/domain/formationassignment/fixtures_test.go
@@ -498,6 +498,82 @@ func fixFormationAssignmentsWithObjectTypeAndID(objectType model.FormationAssign
 	}
 }
 
+func fixFormationAssignmentInputsWithObjectTypeAndID(objectType model.FormationAssignmentType, objectID, appID, rtmID, rtmCtxID string) []*model.FormationAssignmentInput {
+	return []*model.FormationAssignmentInput{
+		{
+			FormationID: "ID",
+			Source:      objectID,
+			SourceType:  objectType,
+			Target:      appID,
+			TargetType:  model.FormationAssignmentTypeApplication,
+			State:       string(model.InitialAssignmentState),
+			Value:       nil,
+			Error:       nil,
+		},
+		{
+			FormationID: "ID",
+			Source:      appID,
+			SourceType:  model.FormationAssignmentTypeApplication,
+			Target:      objectID,
+			TargetType:  objectType,
+			State:       string(model.InitialAssignmentState),
+			Value:       nil,
+			Error:       nil,
+		},
+		{
+			FormationID: "ID",
+			Source:      objectID,
+			SourceType:  objectType,
+			Target:      rtmID,
+			TargetType:  model.FormationAssignmentTypeRuntime,
+			State:       string(model.InitialAssignmentState),
+			Value:       nil,
+			Error:       nil,
+		},
+		{
+			FormationID: "ID",
+			Source:      rtmID,
+			SourceType:  model.FormationAssignmentTypeRuntime,
+			Target:      objectID,
+			TargetType:  objectType,
+			State:       string(model.InitialAssignmentState),
+			Value:       nil,
+			Error:       nil,
+		},
+		{
+			FormationID: "ID",
+			Source:      objectID,
+			SourceType:  objectType,
+			Target:      rtmCtxID,
+			TargetType:  model.FormationAssignmentTypeRuntimeContext,
+			State:       string(model.InitialAssignmentState),
+			Value:       nil,
+			Error:       nil,
+		},
+		{
+			FormationID: "ID",
+			Source:      rtmCtxID,
+			SourceType:  model.FormationAssignmentTypeRuntimeContext,
+			Target:      objectID,
+			TargetType:  objectType,
+			State:       string(model.InitialAssignmentState),
+			Value:       nil,
+			Error:       nil,
+		},
+		// Self formation assignments
+		{
+			FormationID: "ID",
+			Source:      objectID,
+			SourceType:  objectType,
+			Target:      objectID,
+			TargetType:  objectType,
+			State:       string(model.ReadyAssignmentState),
+			Value:       nil,
+			Error:       nil,
+		},
+	}
+}
+
 func fixFormationAssignmentsForSelf(appID, rtmID, rtmCtxID string) []*model.FormationAssignment {
 	return []*model.FormationAssignment{
 		{
@@ -528,6 +604,41 @@ func fixFormationAssignmentsForSelf(appID, rtmID, rtmCtxID string) []*model.Form
 			ID:          "ID10",
 			FormationID: "ID",
 			TenantID:    TestTenantID,
+			Source:      rtmCtxID,
+			SourceType:  model.FormationAssignmentTypeRuntimeContext,
+			Target:      rtmCtxID,
+			TargetType:  model.FormationAssignmentTypeRuntimeContext,
+			State:       string(model.ReadyAssignmentState),
+			Value:       nil,
+			Error:       nil,
+		},
+	}
+}
+
+func fixFormationAssignmentInputsForSelf(appID, rtmID, rtmCtxID string) []*model.FormationAssignmentInput {
+	return []*model.FormationAssignmentInput{
+		{
+			FormationID: "ID",
+			Source:      appID,
+			SourceType:  model.FormationAssignmentTypeApplication,
+			Target:      appID,
+			TargetType:  model.FormationAssignmentTypeApplication,
+			State:       string(model.ReadyAssignmentState),
+			Value:       nil,
+			Error:       nil,
+		},
+		{
+			FormationID: "ID",
+			Source:      rtmID,
+			SourceType:  model.FormationAssignmentTypeRuntime,
+			Target:      rtmID,
+			TargetType:  model.FormationAssignmentTypeRuntime,
+			State:       string(model.ReadyAssignmentState),
+			Value:       nil,
+			Error:       nil,
+		},
+		{
+			FormationID: "ID",
 			Source:      rtmCtxID,
 			SourceType:  model.FormationAssignmentTypeRuntimeContext,
 			Target:      rtmCtxID,
@@ -593,6 +704,61 @@ func fixFormationAssignmentsForRtmCtxWithAppAndRtmCtx(objectType model.Formation
 			ID:          "ID5",
 			FormationID: "ID",
 			TenantID:    TestTenantID,
+			Source:      objectID,
+			SourceType:  objectType,
+			Target:      objectID,
+			TargetType:  objectType,
+			State:       string(model.ReadyAssignmentState),
+			Value:       nil,
+			Error:       nil,
+		},
+	}
+}
+
+func fixFormationAssignmentInputsForRtmCtxWithAppAndRtmCtx(objectType model.FormationAssignmentType, objectID, appID, rtmCtxID string) []*model.FormationAssignmentInput {
+	return []*model.FormationAssignmentInput{
+		{
+			FormationID: "ID",
+			Source:      objectID,
+			SourceType:  objectType,
+			Target:      appID,
+			TargetType:  model.FormationAssignmentTypeApplication,
+			State:       string(model.InitialAssignmentState),
+			Value:       nil,
+			Error:       nil,
+		},
+		{
+			FormationID: "ID",
+			Source:      appID,
+			SourceType:  model.FormationAssignmentTypeApplication,
+			Target:      objectID,
+			TargetType:  objectType,
+			State:       string(model.InitialAssignmentState),
+			Value:       nil,
+			Error:       nil,
+		},
+		{
+			FormationID: "ID",
+			Source:      objectID,
+			SourceType:  objectType,
+			Target:      rtmCtxID,
+			TargetType:  model.FormationAssignmentTypeRuntimeContext,
+			State:       string(model.InitialAssignmentState),
+			Value:       nil,
+			Error:       nil,
+		},
+		{
+			FormationID: "ID",
+			Source:      rtmCtxID,
+			SourceType:  model.FormationAssignmentTypeRuntimeContext,
+			Target:      objectID,
+			TargetType:  objectType,
+			State:       string(model.InitialAssignmentState),
+			Value:       nil,
+			Error:       nil,
+		},
+		{
+			FormationID: "ID",
 			Source:      objectID,
 			SourceType:  objectType,
 			Target:      objectID,

--- a/components/director/internal/domain/formationassignment/repository.go
+++ b/components/director/internal/domain/formationassignment/repository.go
@@ -290,6 +290,10 @@ func (r *repository) ListAllForObject(ctx context.Context, tenant, formationID, 
 
 // ListAllForObjectIDs retrieves all FormationAssignment objects for formation with ID `formationID` that have any of the objectIDs as `target` or `source` from the database that are visible for `tenant`
 func (r *repository) ListAllForObjectIDs(ctx context.Context, tenant, formationID string, objectIDs []string) ([]*model.FormationAssignment, error) {
+	if len(objectIDs) == 0 {
+		return nil, nil
+	}
+
 	var entities EntityCollection
 	conditions := repo.And(
 		&repo.ConditionTree{Operand: repo.NewEqualCondition("formation_id", formationID)},

--- a/components/director/internal/domain/formationassignment/service.go
+++ b/components/director/internal/domain/formationassignment/service.go
@@ -407,12 +407,12 @@ func (s *service) Exists(ctx context.Context, id string) (bool, error) {
 	return exists, nil
 }
 
-// GenerateAssignments creates and persists two formation assignments per participant in the formation `formation`.
+// GenerateAssignments generates two formation assignments per participant in the formation `formation`.
 // For the first formation assignment the source is the objectID and the target is participant's ID.
 // For the second assignment the source and target are swapped.
 //
 // In case of objectType==RUNTIME_CONTEXT formationAssignments for the object and it's parent runtime are not generated.
-func (s *service) GenerateAssignments(ctx context.Context, tnt, objectID string, objectType graphql.FormationObjectType, formation *model.Formation) ([]*model.FormationAssignment, error) {
+func (s *service) GenerateAssignments(ctx context.Context, tnt, objectID string, objectType graphql.FormationObjectType, formation *model.Formation) ([]*model.FormationAssignmentInput, error) {
 	applications, err := s.applicationRepository.ListByScenariosNoPaging(ctx, tnt, []string{formation.Name})
 	if err != nil {
 		return nil, err
@@ -512,6 +512,11 @@ func (s *service) GenerateAssignments(ctx context.Context, tnt, objectID string,
 		Error:       nil,
 	})
 
+	return assignments, nil
+}
+
+// PersistAssignments persists the provided formation assignments
+func (s *service) PersistAssignments(ctx context.Context, tnt string, assignments []*model.FormationAssignmentInput) ([]*model.FormationAssignment, error) {
 	ids := make([]string, 0, len(assignments))
 	for _, assignment := range assignments {
 		id, err := s.CreateIfNotExists(ctx, assignment)

--- a/components/director/internal/domain/formationassignment/service_test.go
+++ b/components/director/internal/domain/formationassignment/service_test.go
@@ -1308,6 +1308,11 @@ func TestService_GenerateAssignments(t *testing.T) {
 
 	allAssignments := append(append(formationAssignmentsForApplication, append(formationAssignmentsForRuntime, append(formationAssignmentsForRuntimeContext, formationAssignmentsForRuntimeContextWithParentInTheFormation...)...)...), formationAssignmentsForSelf...)
 
+	formationAssignmentInputsForApplication := fixFormationAssignmentInputsWithObjectTypeAndID(model.FormationAssignmentTypeApplication, objectID, applications[0].ID, runtimes[0].ID, runtimeContexts[0].ID)
+	formationAssignmentInputsForRuntime := fixFormationAssignmentInputsWithObjectTypeAndID(model.FormationAssignmentTypeRuntime, objectID, applications[0].ID, runtimes[0].ID, runtimeContexts[0].ID)
+	formationAssignmentInputsForRuntimeContext := fixFormationAssignmentInputsWithObjectTypeAndID(model.FormationAssignmentTypeRuntimeContext, objectID, applications[0].ID, runtimes[0].ID, runtimeContexts[0].ID)
+	formationAssignmentInputsForRuntimeContextWithParentInTheFormation := fixFormationAssignmentInputsForRtmCtxWithAppAndRtmCtx(model.FormationAssignmentTypeRuntimeContext, objectID, applications[0].ID, runtimeContexts[0].ID)
+
 	formationAssignmentIDs := []string{"ID1", "ID2", "ID3", "ID4", "ID5", "ID6", "ID7"}
 	formationAssignmentIDsRtmCtxParentInFormation := []string{"ID1", "ID2", "ID3", "ID4", "ID5"}
 
@@ -1324,7 +1329,7 @@ func TestService_GenerateAssignments(t *testing.T) {
 		RuntimeRepo             func() *automock.RuntimeRepository
 		RuntimeContextRepo      func() *automock.RuntimeContextRepository
 		UIDService              func() *automock.UIDService
-		ExpectedOutput          []*model.FormationAssignment
+		ExpectedOutput          []*model.FormationAssignmentInput
 		ExpectedErrorMsg        string
 	}{
 		{
@@ -1334,12 +1339,6 @@ func TestService_GenerateAssignments(t *testing.T) {
 			FormationAssignmentRepo: func() *automock.FormationAssignmentRepository {
 				repo := &automock.FormationAssignmentRepository{}
 				repo.On("ListAllForObjectIDs", ctxWithTenant, TestTenantID, formation.ID, formationParticipantsIDs).Return(allAssignments, nil).Once()
-				for i := range formationAssignmentsForApplication {
-					repo.On("GetByTargetAndSource", ctxWithTenant, formationAssignmentsForApplication[i].Target, formationAssignmentsForApplication[i].Source, TestTenantID, formationAssignmentsForApplication[i].FormationID).Return(nil, apperrors.NewNotFoundErrorWithType(resource.FormationAssignment)).Once()
-					repo.On("Create", ctxWithTenant, formationAssignmentsForApplication[i]).Return(nil).Once()
-				}
-				repo.On("ListForIDs", ctxWithTenant, TestTenantID, formationAssignmentIDs).Return(formationAssignmentsForApplication, nil).Once()
-
 				return repo
 			},
 			UIDService: func() *automock.UIDService {
@@ -1364,7 +1363,7 @@ func TestService_GenerateAssignments(t *testing.T) {
 				repo.On("ListByScenarios", ctxWithTenant, TestTenantID, []string{formation.Name}).Return(runtimeContexts, nil).Once()
 				return repo
 			},
-			ExpectedOutput: formationAssignmentsForApplication,
+			ExpectedOutput: formationAssignmentInputsForApplication,
 		},
 		{
 			Name:       "Success does not create formation assignment for entity that is being unassigned asynchronously",
@@ -1374,12 +1373,6 @@ func TestService_GenerateAssignments(t *testing.T) {
 				repo := &automock.FormationAssignmentRepository{}
 				unassignAppFormationAssignments := fixFormationAssignmentsWithObjectTypeAndID(model.FormationAssignmentTypeApplication, objectID, applications[0].ID, runtimes[0].ID, runtimeContexts[0].ID)
 				repo.On("ListAllForObjectIDs", ctxWithTenant, TestTenantID, formation.ID, []string{applications[0].ID, objectID, runtimes[0].ID, runtimeContexts[0].ID}).Return(append(allAssignments, unassignAppFormationAssignments...), nil).Once()
-				for i := range formationAssignmentsForApplication {
-					repo.On("GetByTargetAndSource", ctxWithTenant, formationAssignmentsForApplication[i].Target, formationAssignmentsForApplication[i].Source, TestTenantID, formationAssignmentsForApplication[i].FormationID).Return(nil, apperrors.NewNotFoundErrorWithType(resource.FormationAssignment)).Once()
-					repo.On("Create", ctxWithTenant, formationAssignmentsForApplication[i]).Return(nil).Once()
-				}
-				repo.On("ListForIDs", ctxWithTenant, TestTenantID, formationAssignmentIDs).Return(formationAssignmentsForApplication, nil).Once()
-
 				return repo
 			},
 			UIDService: func() *automock.UIDService {
@@ -1404,7 +1397,7 @@ func TestService_GenerateAssignments(t *testing.T) {
 				repo.On("ListByScenarios", ctxWithTenant, TestTenantID, []string{formation.Name}).Return(runtimeContexts, nil).Once()
 				return repo
 			},
-			ExpectedOutput: formationAssignmentsForApplication,
+			ExpectedOutput: formationAssignmentInputsForApplication,
 		},
 		{
 			Name:       "Success does not create formation assignment for application and itself",
@@ -1413,12 +1406,6 @@ func TestService_GenerateAssignments(t *testing.T) {
 			FormationAssignmentRepo: func() *automock.FormationAssignmentRepository {
 				repo := &automock.FormationAssignmentRepository{}
 				repo.On("ListAllForObjectIDs", ctxWithTenant, TestTenantID, formation.ID, []string{applications[0].ID, objectID, runtimes[0].ID, runtimeContexts[0].ID}).Return(allAssignments, nil).Once()
-				for i := range formationAssignmentsForApplication {
-					repo.On("GetByTargetAndSource", ctxWithTenant, formationAssignmentsForApplication[i].Target, formationAssignmentsForApplication[i].Source, TestTenantID, formationAssignmentsForApplication[i].FormationID).Return(nil, apperrors.NewNotFoundErrorWithType(resource.FormationAssignment)).Once()
-					repo.On("Create", ctxWithTenant, formationAssignmentsForApplication[i]).Return(nil).Once()
-				}
-				repo.On("ListForIDs", ctxWithTenant, TestTenantID, formationAssignmentIDs).Return(formationAssignmentsForApplication, nil).Once()
-
 				return repo
 			},
 			UIDService: func() *automock.UIDService {
@@ -1443,7 +1430,7 @@ func TestService_GenerateAssignments(t *testing.T) {
 				repo.On("ListByScenarios", ctxWithTenant, TestTenantID, []string{formation.Name}).Return(runtimeContexts, nil).Once()
 				return repo
 			},
-			ExpectedOutput: formationAssignmentsForApplication,
+			ExpectedOutput: formationAssignmentInputsForApplication,
 		},
 		{
 			Name:       "Success does not create formation assignment for runtime and itself",
@@ -1452,12 +1439,6 @@ func TestService_GenerateAssignments(t *testing.T) {
 			FormationAssignmentRepo: func() *automock.FormationAssignmentRepository {
 				repo := &automock.FormationAssignmentRepository{}
 				repo.On("ListAllForObjectIDs", ctxWithTenant, TestTenantID, formation.ID, []string{applications[0].ID, runtimes[0].ID, objectID, runtimeContexts[0].ID}).Return(allAssignments, nil).Once()
-				for i := range formationAssignmentsForRuntime {
-					repo.On("GetByTargetAndSource", ctxWithTenant, formationAssignmentsForRuntime[i].Target, formationAssignmentsForRuntime[i].Source, TestTenantID, formationAssignmentsForApplication[i].FormationID).Return(nil, apperrors.NewNotFoundErrorWithType(resource.FormationAssignment)).Once()
-					repo.On("Create", ctxWithTenant, formationAssignmentsForRuntime[i]).Return(nil).Once()
-				}
-				repo.On("ListForIDs", ctxWithTenant, TestTenantID, formationAssignmentIDs).Return(formationAssignmentsForRuntime, nil).Once()
-
 				return repo
 			},
 			UIDService: func() *automock.UIDService {
@@ -1482,7 +1463,7 @@ func TestService_GenerateAssignments(t *testing.T) {
 				repo.On("ListByScenarios", ctxWithTenant, TestTenantID, []string{formation.Name}).Return(runtimeContexts, nil).Once()
 				return repo
 			},
-			ExpectedOutput: formationAssignmentsForRuntime,
+			ExpectedOutput: formationAssignmentInputsForRuntime,
 		},
 		{
 			Name:       "Success does not create formation assignment for runtime context and itself",
@@ -1491,12 +1472,6 @@ func TestService_GenerateAssignments(t *testing.T) {
 			FormationAssignmentRepo: func() *automock.FormationAssignmentRepository {
 				repo := &automock.FormationAssignmentRepository{}
 				repo.On("ListAllForObjectIDs", ctxWithTenant, TestTenantID, formation.ID, append(formationParticipantsIDs, objectID)).Return(allAssignments, nil).Once()
-				for i := range formationAssignmentsForRuntimeContext {
-					repo.On("GetByTargetAndSource", ctxWithTenant, formationAssignmentsForRuntimeContext[i].Target, formationAssignmentsForRuntimeContext[i].Source, TestTenantID, formationAssignmentsForApplication[i].FormationID).Return(nil, apperrors.NewNotFoundErrorWithType(resource.FormationAssignment)).Once()
-					repo.On("Create", ctxWithTenant, formationAssignmentsForRuntimeContext[i]).Return(nil).Once()
-				}
-				repo.On("ListForIDs", ctxWithTenant, TestTenantID, formationAssignmentIDs).Return(formationAssignmentsForRuntimeContext, nil).Once()
-
 				return repo
 			},
 			UIDService: func() *automock.UIDService {
@@ -1522,7 +1497,7 @@ func TestService_GenerateAssignments(t *testing.T) {
 				repo.On("GetByID", ctxWithTenant, TestTenantID, objectID).Return(&model.RuntimeContext{RuntimeID: "random"}, nil)
 				return repo
 			},
-			ExpectedOutput: formationAssignmentsForRuntimeContext,
+			ExpectedOutput: formationAssignmentInputsForRuntimeContext,
 		},
 		{
 			Name:       "Success does not create formation assignment for runtime context and it's parent runtime",
@@ -1531,12 +1506,6 @@ func TestService_GenerateAssignments(t *testing.T) {
 			FormationAssignmentRepo: func() *automock.FormationAssignmentRepository {
 				repo := &automock.FormationAssignmentRepository{}
 				repo.On("ListAllForObjectIDs", ctxWithTenant, TestTenantID, formation.ID, append(formationParticipantsIDs, objectID)).Return(allAssignments, nil).Once()
-				for i := range formationAssignmentsForRuntimeContextWithParentInTheFormation {
-					repo.On("GetByTargetAndSource", ctxWithTenant, formationAssignmentsForRuntimeContextWithParentInTheFormation[i].Target, formationAssignmentsForRuntimeContextWithParentInTheFormation[i].Source, TestTenantID, formationAssignmentsForApplication[i].FormationID).Return(nil, apperrors.NewNotFoundErrorWithType(resource.FormationAssignment)).Once()
-					repo.On("Create", ctxWithTenant, formationAssignmentsForRuntimeContextWithParentInTheFormation[i]).Return(nil).Once()
-				}
-				repo.On("ListForIDs", ctxWithTenant, TestTenantID, formationAssignmentIDsRtmCtxParentInFormation).Return(formationAssignmentsForRuntimeContextWithParentInTheFormation, nil).Once()
-
 				return repo
 			},
 			UIDService: func() *automock.UIDService {
@@ -1562,7 +1531,7 @@ func TestService_GenerateAssignments(t *testing.T) {
 				repo.On("GetByID", ctxWithTenant, TestTenantID, objectID).Return(&model.RuntimeContext{RuntimeID: runtimes[0].ID}, nil)
 				return repo
 			},
-			ExpectedOutput: formationAssignmentsForRuntimeContextWithParentInTheFormation,
+			ExpectedOutput: formationAssignmentInputsForRuntimeContextWithParentInTheFormation,
 		},
 		{
 			Name:                    "Error while listing applications",
@@ -1682,80 +1651,6 @@ func TestService_GenerateAssignments(t *testing.T) {
 			ExpectedOutput:   nil,
 			ExpectedErrorMsg: testErr.Error(),
 		},
-		{
-			Name:       "Error while creating formation assignment",
-			Context:    ctxWithTenant,
-			ObjectType: graphql.FormationObjectTypeRuntimeContext,
-			FormationAssignmentRepo: func() *automock.FormationAssignmentRepository {
-				repo := &automock.FormationAssignmentRepository{}
-				repo.On("ListAllForObjectIDs", ctxWithTenant, TestTenantID, formation.ID, append(formationParticipantsIDs, objectID)).Return(allAssignments, nil).Once()
-				repo.On("GetByTargetAndSource", ctxWithTenant, formationAssignmentsForRuntimeContext[0].Target, formationAssignmentsForRuntimeContext[0].Source, TestTenantID, formationAssignmentsForRuntimeContext[0].FormationID).Return(nil, testErr).Once()
-				return repo
-			},
-			UIDService: func() *automock.UIDService {
-				uidSvc := &automock.UIDService{}
-				uidSvc.On("Generate").Return(formationAssignmentIDs[0]).Once()
-				return uidSvc
-			},
-			ApplicationRepo: func() *automock.ApplicationRepository {
-				repo := &automock.ApplicationRepository{}
-				repo.On("ListByScenariosNoPaging", ctxWithTenant, TestTenantID, []string{formation.Name}).Return(applications, nil).Once()
-				return repo
-			},
-			RuntimeRepo: func() *automock.RuntimeRepository {
-				repo := &automock.RuntimeRepository{}
-				repo.On("ListByScenarios", ctxWithTenant, TestTenantID, []string{formation.Name}).Return(runtimes, nil).Once()
-				return repo
-			},
-			RuntimeContextRepo: func() *automock.RuntimeContextRepository {
-				repo := &automock.RuntimeContextRepository{}
-				repo.On("ListByScenarios", ctxWithTenant, TestTenantID, []string{formation.Name}).Return(append(runtimeContexts, &model.RuntimeContext{ID: objectID}), nil).Once()
-				repo.On("GetByID", ctxWithTenant, TestTenantID, objectID).Return(&model.RuntimeContext{RuntimeID: "random"}, nil)
-				return repo
-			},
-			ExpectedOutput:   nil,
-			ExpectedErrorMsg: testErr.Error(),
-		},
-		{
-			Name:       "Error while listing formation assignments",
-			Context:    ctxWithTenant,
-			ObjectType: graphql.FormationObjectTypeApplication,
-			FormationAssignmentRepo: func() *automock.FormationAssignmentRepository {
-				repo := &automock.FormationAssignmentRepository{}
-				repo.On("ListAllForObjectIDs", ctxWithTenant, TestTenantID, formation.ID, formationParticipantsIDs).Return(allAssignments, nil).Once()
-				for i := range formationAssignmentsForApplication {
-					repo.On("GetByTargetAndSource", ctxWithTenant, formationAssignmentsForApplication[i].Target, formationAssignmentsForApplication[i].Source, TestTenantID, formationAssignmentsForApplication[i].FormationID).Return(nil, apperrors.NewNotFoundErrorWithType(resource.FormationAssignment)).Once()
-					repo.On("Create", ctxWithTenant, formationAssignmentsForApplication[i]).Return(nil).Once()
-				}
-				repo.On("ListForIDs", ctxWithTenant, TestTenantID, formationAssignmentIDs).Return(nil, testErr).Once()
-
-				return repo
-			},
-			UIDService: func() *automock.UIDService {
-				uidSvc := &automock.UIDService{}
-				for i := range formationAssignmentIDs {
-					uidSvc.On("Generate").Return(formationAssignmentIDs[i]).Once()
-				}
-				return uidSvc
-			},
-			ApplicationRepo: func() *automock.ApplicationRepository {
-				repo := &automock.ApplicationRepository{}
-				repo.On("ListByScenariosNoPaging", ctxWithTenant, TestTenantID, []string{formation.Name}).Return(applications, nil).Once()
-				return repo
-			},
-			RuntimeRepo: func() *automock.RuntimeRepository {
-				repo := &automock.RuntimeRepository{}
-				repo.On("ListByScenarios", ctxWithTenant, TestTenantID, []string{formation.Name}).Return(runtimes, nil).Once()
-				return repo
-			},
-			RuntimeContextRepo: func() *automock.RuntimeContextRepository {
-				repo := &automock.RuntimeContextRepository{}
-				repo.On("ListByScenarios", ctxWithTenant, TestTenantID, []string{formation.Name}).Return(runtimeContexts, nil).Once()
-				return repo
-			},
-			ExpectedOutput:   nil,
-			ExpectedErrorMsg: testErr.Error(),
-		},
 	}
 
 	for _, testCase := range testCases {
@@ -1781,6 +1676,129 @@ func TestService_GenerateAssignments(t *testing.T) {
 			require.Equal(t, testCase.ExpectedOutput, r)
 
 			mock.AssertExpectationsForObjects(t, formationAssignmentRepo, appRepo, runtimeRepo, runtimeContextRepo)
+		})
+	}
+}
+
+func TestService_PersistAssignments(t *testing.T) {
+	// GIVEN
+	objectID := "objectID"
+	applications := []*model.Application{{BaseEntity: &model.BaseEntity{ID: "app"}}}
+	runtimes := []*model.Runtime{{ID: "runtime"}}
+	runtimeContexts := []*model.RuntimeContext{{ID: "runtimeContext"}}
+
+	formationAssignments := fixFormationAssignmentsWithObjectTypeAndID(model.FormationAssignmentTypeApplication, objectID, applications[0].ID, runtimes[0].ID, runtimeContexts[0].ID)
+	formationAssignmentInputs := fixFormationAssignmentInputsWithObjectTypeAndID(model.FormationAssignmentTypeApplication, objectID, applications[0].ID, runtimes[0].ID, runtimeContexts[0].ID)
+
+	formationAssignmentIDs := []string{"ID1", "ID2", "ID3", "ID4", "ID5", "ID6", "ID7"}
+	testCases := []struct {
+		Name                    string
+		Context                 context.Context
+		Input                   []*model.FormationAssignmentInput
+		FormationAssignmentRepo func() *automock.FormationAssignmentRepository
+		UIDService              func() *automock.UIDService
+		ExpectedOutput          []*model.FormationAssignment
+		ExpectedErrorMsg        string
+	}{
+		{
+			Name:    "Success",
+			Context: ctxWithTenant,
+			Input:   formationAssignmentInputs,
+			FormationAssignmentRepo: func() *automock.FormationAssignmentRepository {
+				repo := &automock.FormationAssignmentRepository{}
+				for i := range formationAssignments {
+					repo.On("GetByTargetAndSource", ctxWithTenant, formationAssignments[i].Target, formationAssignments[i].Source, TestTenantID, formationAssignments[i].FormationID).Return(nil, apperrors.NewNotFoundErrorWithType(resource.FormationAssignment)).Once()
+					repo.On("Create", ctxWithTenant, formationAssignments[i]).Return(nil).Once()
+				}
+				repo.On("ListForIDs", ctxWithTenant, TestTenantID, formationAssignmentIDs).Return(formationAssignments, nil).Once()
+				return repo
+			},
+			UIDService: func() *automock.UIDService {
+				uidSvc := &automock.UIDService{}
+				for i := range formationAssignmentIDs {
+					uidSvc.On("Generate").Return(formationAssignmentIDs[i]).Once()
+				}
+				return uidSvc
+			},
+			ExpectedOutput: formationAssignments,
+		},
+		{
+			Name:    "error while listing for ids",
+			Context: ctxWithTenant,
+			Input:   formationAssignmentInputs,
+			FormationAssignmentRepo: func() *automock.FormationAssignmentRepository {
+				repo := &automock.FormationAssignmentRepository{}
+				for i := range formationAssignments {
+					repo.On("GetByTargetAndSource", ctxWithTenant, formationAssignments[i].Target, formationAssignments[i].Source, TestTenantID, formationAssignments[i].FormationID).Return(nil, apperrors.NewNotFoundErrorWithType(resource.FormationAssignment)).Once()
+					repo.On("Create", ctxWithTenant, formationAssignments[i]).Return(nil).Once()
+				}
+				repo.On("ListForIDs", ctxWithTenant, TestTenantID, formationAssignmentIDs).Return(nil, testErr).Once()
+				return repo
+			},
+			UIDService: func() *automock.UIDService {
+				uidSvc := &automock.UIDService{}
+				for i := range formationAssignmentIDs {
+					uidSvc.On("Generate").Return(formationAssignmentIDs[i]).Once()
+				}
+				return uidSvc
+			},
+			ExpectedErrorMsg: "while listing formationAssignments",
+		},
+		{
+			Name:    "error while creating formation assignments",
+			Context: ctxWithTenant,
+			Input:   formationAssignmentInputs,
+			FormationAssignmentRepo: func() *automock.FormationAssignmentRepository {
+				repo := &automock.FormationAssignmentRepository{}
+				repo.On("GetByTargetAndSource", ctxWithTenant, formationAssignments[0].Target, formationAssignments[0].Source, TestTenantID, formationAssignments[0].FormationID).Return(nil, apperrors.NewNotFoundErrorWithType(resource.FormationAssignment)).Once()
+				repo.On("Create", ctxWithTenant, formationAssignments[0]).Return(testErr).Once()
+				return repo
+			},
+			UIDService: func() *automock.UIDService {
+				uidSvc := &automock.UIDService{}
+				uidSvc.On("Generate").Return(formationAssignmentIDs[0]).Once()
+				return uidSvc
+			},
+			ExpectedErrorMsg: "while creating formationAssignment for formation",
+		},
+		{
+			Name:    "error while getting formation assignments",
+			Context: ctxWithTenant,
+			Input:   formationAssignmentInputs,
+			FormationAssignmentRepo: func() *automock.FormationAssignmentRepository {
+				repo := &automock.FormationAssignmentRepository{}
+				repo.On("GetByTargetAndSource", ctxWithTenant, formationAssignments[0].Target, formationAssignments[0].Source, TestTenantID, formationAssignments[0].FormationID).Return(nil, testErr).Once()
+				return repo
+			},
+			UIDService: func() *automock.UIDService {
+				uidSvc := &automock.UIDService{}
+				uidSvc.On("Generate").Return(formationAssignmentIDs[0]).Once()
+				return uidSvc
+			},
+			ExpectedErrorMsg: "while getting formation assignment by target",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Name, func(t *testing.T) {
+			formationAssignmentRepo := testCase.FormationAssignmentRepo()
+			uidSvc := testCase.UIDService()
+			svc := formationassignment.NewService(formationAssignmentRepo, uidSvc, nil, nil, nil, nil, nil, nil, nil, nil, "", "")
+
+			// WHEN
+			r, err := svc.PersistAssignments(testCase.Context, TestTenantID, formationAssignmentInputs)
+
+			if testCase.ExpectedErrorMsg != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), testCase.ExpectedErrorMsg)
+			} else {
+				require.NoError(t, err)
+			}
+
+			// THEN
+			require.Equal(t, testCase.ExpectedOutput, r)
+
+			mock.AssertExpectationsForObjects(t, formationAssignmentRepo)
 		})
 	}
 }


### PR DESCRIPTION
**Description**
If we have async TM notification receiver, when we notify them, they may be faster to report status than the transaction that created the respective assignment.

This will result in a status report before the assignments are persisted and commited in the DB. Then the status API will not see such assignment and will fail with Not Found.

Changes proposed in this pull request:

- persist FAs before processing the notifications
- delete the persisted resources in case the forrmation assignment has failed after ther persisting
