### PR TITLE
Observe operation type when reschedule operations

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -143,7 +143,7 @@ global:
       name: compass-pairing-adapter
     director:
       dir: dev/incubator/
-      version: "PR-3259"
+      version: "PR-3268"
       name: compass-director
     hydrator:
       dir: dev/incubator/

--- a/components/director/internal/domain/operation/automock/operation_repository.go
+++ b/components/director/internal/domain/operation/automock/operation_repository.go
@@ -97,13 +97,13 @@ func (_m *OperationRepository) PriorityQueueListByType(ctx context.Context, queu
 	return r0, r1
 }
 
-// RescheduleHangedOperations provides a mock function with given fields: ctx, hangPeriod
-func (_m *OperationRepository) RescheduleHangedOperations(ctx context.Context, hangPeriod time.Duration) error {
-	ret := _m.Called(ctx, hangPeriod)
+// RescheduleHangedOperations provides a mock function with given fields: ctx, operationType, hangPeriod
+func (_m *OperationRepository) RescheduleHangedOperations(ctx context.Context, operationType model.OperationType, hangPeriod time.Duration) error {
+	ret := _m.Called(ctx, operationType, hangPeriod)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, time.Duration) error); ok {
-		r0 = rf(ctx, hangPeriod)
+	if rf, ok := ret.Get(0).(func(context.Context, model.OperationType, time.Duration) error); ok {
+		r0 = rf(ctx, operationType, hangPeriod)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -111,13 +111,13 @@ func (_m *OperationRepository) RescheduleHangedOperations(ctx context.Context, h
 	return r0
 }
 
-// RescheduleOperations provides a mock function with given fields: ctx, reschedulePeriod
-func (_m *OperationRepository) RescheduleOperations(ctx context.Context, reschedulePeriod time.Duration) error {
-	ret := _m.Called(ctx, reschedulePeriod)
+// RescheduleOperations provides a mock function with given fields: ctx, operationType, reschedulePeriod
+func (_m *OperationRepository) RescheduleOperations(ctx context.Context, operationType model.OperationType, reschedulePeriod time.Duration) error {
+	ret := _m.Called(ctx, operationType, reschedulePeriod)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, time.Duration) error); ok {
-		r0 = rf(ctx, reschedulePeriod)
+	if rf, ok := ret.Get(0).(func(context.Context, model.OperationType, time.Duration) error); ok {
+		r0 = rf(ctx, operationType, reschedulePeriod)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/components/director/internal/domain/operation/repository_test.go
+++ b/components/director/internal/domain/operation/repository_test.go
@@ -261,14 +261,14 @@ func TestRepository_RescheduleOperations(t *testing.T) {
 		operationRepo := operation.NewRepository(mockConverter)
 		db, dbMock := testdb.MockDatabase(t)
 		defer dbMock.AssertExpectations(t)
-		expectedQuery := regexp.QuoteMeta("UPDATE public.operation SET status = $1, updated_at = $2 WHERE status IN ($3, $4) AND updated_at < $5")
+		expectedQuery := regexp.QuoteMeta("UPDATE public.operation SET status = $1, updated_at = $2 WHERE status IN ($3, $4) AND op_type = $5 AND updated_at < $6")
 		dbMock.ExpectExec(expectedQuery).
 			WillReturnResult(sqlmock.NewResult(-1, 1))
 
 		ctx := persistence.SaveToContext(context.TODO(), db)
 
 		// WHEN
-		err := operationRepo.RescheduleOperations(ctx, time.Second)
+		err := operationRepo.RescheduleOperations(ctx, model.OperationTypeOrdAggregation, time.Second)
 
 		// THEN
 		require.NoError(t, err)
@@ -283,14 +283,14 @@ func TestRepository_RescheduleHangedOperations(t *testing.T) {
 		operationRepo := operation.NewRepository(mockConverter)
 		db, dbMock := testdb.MockDatabase(t)
 		defer dbMock.AssertExpectations(t)
-		expectedQuery := regexp.QuoteMeta("UPDATE public.operation SET status = $1, updated_at = $2 WHERE status = $3 AND updated_at < $4")
+		expectedQuery := regexp.QuoteMeta("UPDATE public.operation SET status = $1, updated_at = $2 WHERE status = $3 AND op_type = $4 AND updated_at < $5")
 		dbMock.ExpectExec(expectedQuery).
 			WillReturnResult(sqlmock.NewResult(-1, 1))
 
 		ctx := persistence.SaveToContext(context.TODO(), db)
 
 		// WHEN
-		err := operationRepo.RescheduleHangedOperations(ctx, time.Second)
+		err := operationRepo.RescheduleHangedOperations(ctx, model.OperationTypeOrdAggregation, time.Second)
 
 		// THEN
 		require.NoError(t, err)

--- a/components/director/internal/domain/operation/service.go
+++ b/components/director/internal/domain/operation/service.go
@@ -23,8 +23,8 @@ type OperationRepository interface {
 	Update(ctx context.Context, model *model.Operation) error
 	PriorityQueueListByType(ctx context.Context, queueLimit int, opType model.OperationType) ([]*model.Operation, error)
 	LockOperation(ctx context.Context, operationID string) (bool, error)
-	RescheduleOperations(ctx context.Context, reschedulePeriod time.Duration) error
-	RescheduleHangedOperations(ctx context.Context, hangPeriod time.Duration) error
+	RescheduleOperations(ctx context.Context, operationType model.OperationType, reschedulePeriod time.Duration) error
+	RescheduleHangedOperations(ctx context.Context, operationType model.OperationType, hangPeriod time.Duration) error
 }
 
 // UIDService is responsible for service-layer uid operations
@@ -158,13 +158,13 @@ func (s *service) LockOperation(ctx context.Context, operationID string) (bool, 
 }
 
 // RescheduleOperations reschedules all old operations
-func (s *service) RescheduleOperations(ctx context.Context, reschedulePeriod time.Duration) error {
-	return s.opRepo.RescheduleOperations(ctx, reschedulePeriod)
+func (s *service) RescheduleOperations(ctx context.Context, operationType model.OperationType, reschedulePeriod time.Duration) error {
+	return s.opRepo.RescheduleOperations(ctx, operationType, reschedulePeriod)
 }
 
 // RescheduleHangedOperations reschedules all hanged operations
-func (s *service) RescheduleHangedOperations(ctx context.Context, hangPeriod time.Duration) error {
-	return s.opRepo.RescheduleHangedOperations(ctx, hangPeriod)
+func (s *service) RescheduleHangedOperations(ctx context.Context, operationType model.OperationType, hangPeriod time.Duration) error {
+	return s.opRepo.RescheduleHangedOperations(ctx, operationType, hangPeriod)
 }
 
 // Get loads operation with specified ID

--- a/components/director/internal/domain/operation/service_test.go
+++ b/components/director/internal/domain/operation/service_test.go
@@ -518,24 +518,27 @@ func TestService_RescheduleOperations(t *testing.T) {
 		Name         string
 		RepositoryFn func() *automock.OperationRepository
 		Input        time.Duration
+		Type         model.OperationType
 		ExpectedErr  error
 	}{
 		{
 			Name: "Success",
 			RepositoryFn: func() *automock.OperationRepository {
 				repo := &automock.OperationRepository{}
-				repo.On("RescheduleOperations", ctx, time.Minute).Return(nil).Once()
+				repo.On("RescheduleOperations", ctx, model.OperationTypeOrdAggregation, time.Minute).Return(nil).Once()
 				return repo
 			},
+			Type:  model.OperationTypeOrdAggregation,
 			Input: time.Minute,
 		},
 		{
 			Name: "Error while rescheduling operations",
 			RepositoryFn: func() *automock.OperationRepository {
 				repo := &automock.OperationRepository{}
-				repo.On("RescheduleOperations", ctx, time.Minute).Return(testErr).Once()
+				repo.On("RescheduleOperations", ctx, model.OperationTypeOrdAggregation, time.Minute).Return(testErr).Once()
 				return repo
 			},
+			Type:        model.OperationTypeOrdAggregation,
 			Input:       time.Minute,
 			ExpectedErr: testErr,
 		},
@@ -549,7 +552,7 @@ func TestService_RescheduleOperations(t *testing.T) {
 			svc := operation.NewService(repo, nil)
 
 			// WHEN
-			err := svc.RescheduleOperations(ctx, testCase.Input)
+			err := svc.RescheduleOperations(ctx, testCase.Type, testCase.Input)
 
 			// THEN
 			if testCase.ExpectedErr != nil {
@@ -573,6 +576,7 @@ func TestService_RescheduleHangedOperations(t *testing.T) {
 	testCases := []struct {
 		Name         string
 		RepositoryFn func() *automock.OperationRepository
+		Type         model.OperationType
 		Input        time.Duration
 		ExpectedErr  error
 	}{
@@ -580,18 +584,20 @@ func TestService_RescheduleHangedOperations(t *testing.T) {
 			Name: "Success",
 			RepositoryFn: func() *automock.OperationRepository {
 				repo := &automock.OperationRepository{}
-				repo.On("RescheduleHangedOperations", ctx, time.Minute).Return(nil).Once()
+				repo.On("RescheduleHangedOperations", ctx, model.OperationTypeOrdAggregation, time.Minute).Return(nil).Once()
 				return repo
 			},
+			Type:  model.OperationTypeOrdAggregation,
 			Input: time.Minute,
 		},
 		{
 			Name: "Error while rescheduling operations",
 			RepositoryFn: func() *automock.OperationRepository {
 				repo := &automock.OperationRepository{}
-				repo.On("RescheduleHangedOperations", ctx, time.Minute).Return(testErr).Once()
+				repo.On("RescheduleHangedOperations", ctx, model.OperationTypeOrdAggregation, time.Minute).Return(testErr).Once()
 				return repo
 			},
+			Type:        model.OperationTypeOrdAggregation,
 			Input:       time.Minute,
 			ExpectedErr: testErr,
 		},
@@ -605,7 +611,7 @@ func TestService_RescheduleHangedOperations(t *testing.T) {
 			svc := operation.NewService(repo, nil)
 
 			// WHEN
-			err := svc.RescheduleHangedOperations(ctx, testCase.Input)
+			err := svc.RescheduleHangedOperations(ctx, testCase.Type, testCase.Input)
 
 			// THEN
 			if testCase.ExpectedErr != nil {

--- a/components/director/internal/operations_manager/automock/operation_service.go
+++ b/components/director/internal/operations_manager/automock/operation_service.go
@@ -125,13 +125,13 @@ func (_m *OperationService) MarkAsFailed(ctx context.Context, id string, errorMs
 	return r0
 }
 
-// RescheduleHangedOperations provides a mock function with given fields: ctx, hangPeriod
-func (_m *OperationService) RescheduleHangedOperations(ctx context.Context, hangPeriod time.Duration) error {
-	ret := _m.Called(ctx, hangPeriod)
+// RescheduleHangedOperations provides a mock function with given fields: ctx, operationType, hangPeriod
+func (_m *OperationService) RescheduleHangedOperations(ctx context.Context, operationType model.OperationType, hangPeriod time.Duration) error {
+	ret := _m.Called(ctx, operationType, hangPeriod)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, time.Duration) error); ok {
-		r0 = rf(ctx, hangPeriod)
+	if rf, ok := ret.Get(0).(func(context.Context, model.OperationType, time.Duration) error); ok {
+		r0 = rf(ctx, operationType, hangPeriod)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -153,13 +153,13 @@ func (_m *OperationService) RescheduleOperation(ctx context.Context, operationID
 	return r0
 }
 
-// RescheduleOperations provides a mock function with given fields: ctx, reschedulePeriod
-func (_m *OperationService) RescheduleOperations(ctx context.Context, reschedulePeriod time.Duration) error {
-	ret := _m.Called(ctx, reschedulePeriod)
+// RescheduleOperations provides a mock function with given fields: ctx, operationType, reschedulePeriod
+func (_m *OperationService) RescheduleOperations(ctx context.Context, operationType model.OperationType, reschedulePeriod time.Duration) error {
+	ret := _m.Called(ctx, operationType, reschedulePeriod)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, time.Duration) error); ok {
-		r0 = rf(ctx, reschedulePeriod)
+	if rf, ok := ret.Get(0).(func(context.Context, model.OperationType, time.Duration) error); ok {
+		r0 = rf(ctx, operationType, reschedulePeriod)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/components/director/internal/operations_manager/interfaces.go
+++ b/components/director/internal/operations_manager/interfaces.go
@@ -18,8 +18,8 @@ type OperationService interface {
 	LockOperation(ctx context.Context, operationID string) (bool, error)
 	Get(ctx context.Context, operationID string) (*model.Operation, error)
 	Update(ctx context.Context, input *model.Operation) error
-	RescheduleOperations(ctx context.Context, reschedulePeriod time.Duration) error
-	RescheduleHangedOperations(ctx context.Context, hangPeriod time.Duration) error
+	RescheduleOperations(ctx context.Context, operationType model.OperationType, reschedulePeriod time.Duration) error
+	RescheduleHangedOperations(ctx context.Context, operationType model.OperationType, hangPeriod time.Duration) error
 	RescheduleOperation(ctx context.Context, operationID string, priority int) error
 }
 

--- a/components/director/pkg/operations_manager/operations_manager.go
+++ b/components/director/pkg/operations_manager/operations_manager.go
@@ -151,7 +151,7 @@ func (om *OperationsManager) startRescheduleOperationsJob(ctx context.Context) e
 			defer om.transact.RollbackUnlessCommitted(ctx, tx)
 			ctx = persistence.SaveToContext(ctx, tx)
 
-			if err := om.opSvc.RescheduleOperations(ctx, om.cfg.OperationReschedulePeriod); err != nil {
+			if err := om.opSvc.RescheduleOperations(ctx, om.opType, om.cfg.OperationReschedulePeriod); err != nil {
 				log.C(jobCtx).Errorf("Error during execution of RescheduleOperationsJob %v", err)
 			}
 			err = tx.Commit()
@@ -179,7 +179,7 @@ func (om *OperationsManager) startRescheduleHangedOperationsJob(ctx context.Cont
 			defer om.transact.RollbackUnlessCommitted(ctx, tx)
 			ctx = persistence.SaveToContext(ctx, tx)
 
-			if err := om.opSvc.RescheduleHangedOperations(ctx, om.cfg.OperationHangPeriod); err != nil {
+			if err := om.opSvc.RescheduleHangedOperations(ctx, om.opType, om.cfg.OperationHangPeriod); err != nil {
 				log.C(jobCtx).Errorf("Error during execution of RescheduleHangedOperationsJob %v", err)
 			}
 			err = tx.Commit()


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:
- Observe operation type when reschedule operations

**Pull Request status**
- [x] Implementation
- [x] Unit tests
- [ ] Integration tests
- [x] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [x] Mocks are regenerated, using the automated script
