### PR TITLE
Adapt smoke test provision script to work with prod registry also

### DIFF
--- a/installation/scripts/prow/jobs/provision-compass-smoke-test.sh
+++ b/installation/scripts/prow/jobs/provision-compass-smoke-test.sh
@@ -59,7 +59,7 @@ if [[ "$ORD_IMAGE_DIR" == "dev" ]]; then
        ORD_PR_COMMIT_HASH=$(jq -r '.merge_commit_sha' <<< "${ORD_PR_DATA}")
    fi
 else
-  # When the image that is used is from prod registry the value in ORD_PR_NUMBER is actually the short commit hash due to the different naming convention for the dev and prod images
+  # When the image that is used is from prod registry the value under .global.images.ord_service.version is in the format "timestamp-short_hash". The short hash from the image version will be used to checkout the correct correct ORD service source
     ORD_PR_COMMIT_HASH=$(yq e .global.images.ord_service.version /home/prow/go/src/github.com/kyma-incubator/compass/chart/compass/values.yaml | cut -d '-' -f 2 | xargs)
 fi
 

--- a/installation/scripts/prow/jobs/provision-compass-smoke-test.sh
+++ b/installation/scripts/prow/jobs/provision-compass-smoke-test.sh
@@ -40,19 +40,27 @@ gcp::authenticate \
 chmod -R 0777 /home/prow/go/src/github.com/kyma-incubator/compass/.git
 mkdir -p /home/prow/go/src/github.com/kyma-incubator/compass/components/console/shared/build
 
-log::info "Get ORD commit ID"
-ORD_PR_NUMBER=$(yq e .global.images.ord_service.version /home/prow/go/src/github.com/kyma-incubator/compass/chart/compass/values.yaml | cut -d '-' -f 2 | xargs)
-log::info "ORD_PR_NUMBER PR is: ${ORD_PR_NUMBER}"
+ORD_IMAGE_DIR=$(yq e .global.images.ord_service.dir /home/prow/go/src/github.com/kyma-incubator/compass/chart/compass/values.yaml | cut -d '/' -f 1 | xargs)
+log::info "ORD_IMAGE_DIR is: ${ORD_IMAGE_DIR}"
 
-ORD_PR_DATA=$(curl -sS "https://api.github.com/repos/kyma-incubator/ord-service/pulls/${ORD_PR_NUMBER}")
-log::info "ORD_PR_DATA is: ${ORD_PR_DATA}"
+if [[ "$ORD_IMAGE_DIR" == "dev" ]]; then
+   log::info "Get ORD commit ID"
+   ORD_PR_NUMBER=$(yq e .global.images.ord_service.version /home/prow/go/src/github.com/kyma-incubator/compass/chart/compass/values.yaml | cut -d '-' -f 2 | xargs)
+   log::info "ORD_PR_NUMBER PR is: ${ORD_PR_NUMBER}"
 
-ORD_PR_STATE=$(jq -r '.state' <<< "${ORD_PR_DATA}")
+   ORD_PR_DATA=$(curl -sS "https://api.github.com/repos/kyma-incubator/ord-service/pulls/${ORD_PR_NUMBER}")
+   log::info "ORD_PR_DATA is: ${ORD_PR_DATA}"
 
-if [[ "$ORD_PR_STATE" == "open" ]]; then
-    ORD_PR_COMMIT_HASH=$(jq -r '.head.sha' <<< "${ORD_PR_DATA}")
+   ORD_PR_STATE=$(jq -r '.state' <<< "${ORD_PR_DATA}")
+
+   if [[ "$ORD_PR_STATE" == "open" ]]; then
+       ORD_PR_COMMIT_HASH=$(jq -r '.head.sha' <<< "${ORD_PR_DATA}")
+   else
+       ORD_PR_COMMIT_HASH=$(jq -r '.merge_commit_sha' <<< "${ORD_PR_DATA}")
+   fi
 else
-    ORD_PR_COMMIT_HASH=$(jq -r '.merge_commit_sha' <<< "${ORD_PR_DATA}")
+  # When the image that is used is from prod registry the value in ORD_PR_NUMBER is actually the short commit hash due to the different naming convention for the dev and prod images
+    ORD_PR_COMMIT_HASH=$(yq e .global.images.ord_service.version /home/prow/go/src/github.com/kyma-incubator/compass/chart/compass/values.yaml | cut -d '-' -f 2 | xargs)
 fi
 
 log::info "ORD_PR_COMMIT_HASH is: ${ORD_PR_COMMIT_HASH}"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
The smoke test script determines the commit hash from which ORD service should be installed by getting the suffix from the component version which for dev images is a PR number. The the commit hash is taken from the PR.
For prod images the suffix is not a PR number but short commit hash of the commit created from merging a PR in main branch.  Due to the different naming conventions the smoke test script fails to find PR and fetches the sources from the main branch when the image is fomr the prod registry.

Changes proposed in this pull request:
- use the short hash from the image version when prod image registry is used

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- ...

**Pull Request status**
<!-- Feel free to construct the checklist with whatever items seem most reasonable for your change. You could disassemble the Implementation part to even smaller separate checklist items if you're working on something big for example. But do make the effort to provide a checklist of some sort so that the core team as well as the community can have an idea about the progress of your Pull Request.
-->

- [X] Implementation
- [ ] Unit tests
- [ ] Integration tests
- [ ] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [ ] Mocks are regenerated, using the automated script
