### PR TITLE
Change gql query used in e2e test

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -143,7 +143,7 @@ global:
       name: compass-pairing-adapter
     director:
       dir: dev/incubator/
-      version: "PR-3271"
+      version: "PR-3280"
       name: compass-director
     hydrator:
       dir: prod/incubator/
@@ -192,7 +192,7 @@ global:
       name: compass-console
     e2e_tests:
       dir: dev/incubator/
-      version: "PR-3271"
+      version: "PR-3280"
       name: compass-e2e-tests
   isLocalEnv: false
   isForTesting: false

--- a/components/director/pkg/graphql/graphqlizer/fields.go
+++ b/components/director/pkg/graphql/graphqlizer/fields.go
@@ -117,6 +117,28 @@ func (fp *GqlFieldsProvider) ForApplication(ctx ...FieldCtx) string {
 		ctx, []string{"Application.bundle", "Application.apiDefinition", "Application.eventDefinition"})
 }
 
+// ForApplicationMinimal missing godoc
+func (fp *GqlFieldsProvider) ForApplicationMinimal(ctx ...FieldCtx) string {
+	return `
+		id
+		name
+		providerName
+		description
+		baseUrl
+		systemNumber
+		systemStatus
+		integrationSystemID
+		applicationTemplateID
+		labels
+		deletedAt
+		updatedAt
+		error
+		status {condition timestamp}
+		healthCheckURL
+		eventingConfiguration { defaultURL }
+	`
+}
+
 // ForApplicationTemplate missing godoc
 func (fp *GqlFieldsProvider) ForApplicationTemplate(ctx ...FieldCtx) string {
 	return fmt.Sprintf(`

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/kyma-incubator/compass/components/connectivity-adapter v0.0.0-20230714114052-e8783b9b2e95
 	github.com/kyma-incubator/compass/components/connector v0.0.0-20230714114052-e8783b9b2e95
-	github.com/kyma-incubator/compass/components/director v0.0.0-20230828161804-c863b3168e46
+	github.com/kyma-incubator/compass/components/director v0.0.0-20230830082505-f8c974775c08
 	github.com/kyma-incubator/compass/components/external-services-mock v0.0.0-20230811093753-e055922ba086
 	github.com/kyma-incubator/compass/components/gateway v0.0.0-20230714114052-e8783b9b2e95
 	github.com/kyma-incubator/compass/components/operations-controller v0.0.0-20230714114052-e8783b9b2e95

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -132,6 +132,8 @@ github.com/kyma-incubator/compass/components/connector v0.0.0-20230714114052-e87
 github.com/kyma-incubator/compass/components/connector v0.0.0-20230714114052-e8783b9b2e95/go.mod h1:E3TYhimO9Ry5kBTmPVUz0Z1SSLt2PNLT5md4eSc2NYI=
 github.com/kyma-incubator/compass/components/director v0.0.0-20230828161804-c863b3168e46 h1:3ya7s8DhG2QVCLM8IN8IRmPAwaxtd5zfE+ewRyHLOlg=
 github.com/kyma-incubator/compass/components/director v0.0.0-20230828161804-c863b3168e46/go.mod h1:my5lL6/8ejfQ7p3lnKpHUbXXOAEI9ypJ+87a8Fh8KNU=
+github.com/kyma-incubator/compass/components/director v0.0.0-20230830082505-f8c974775c08 h1:mJA/+bOC89sNlTB6ld9VrgkJxOlj+8XtiTLztRLKO0w=
+github.com/kyma-incubator/compass/components/director v0.0.0-20230830082505-f8c974775c08/go.mod h1:my5lL6/8ejfQ7p3lnKpHUbXXOAEI9ypJ+87a8Fh8KNU=
 github.com/kyma-incubator/compass/components/external-services-mock v0.0.0-20230811093753-e055922ba086 h1:+gRI3RIotKJZBbP1SbUkh5MpN/a4DMQ5WtXD8B5UdCk=
 github.com/kyma-incubator/compass/components/external-services-mock v0.0.0-20230811093753-e055922ba086/go.mod h1:ewK2cbElHlwn8wgACD+qGHCcnca6dyMX0FtgEEFjg1E=
 github.com/kyma-incubator/compass/components/gateway v0.0.0-20230714114052-e8783b9b2e95 h1:1JUpSoNNQv4KsO0NTUoSrz6a0z+H3VE0ooUpmen9bs4=

--- a/tests/ord-service/tests/subscription_flow_test.go
+++ b/tests/ord-service/tests/subscription_flow_test.go
@@ -527,7 +527,7 @@ func TestConsumerProviderFlow(stdT *testing.T) {
 
 		// Find the provider application ID
 		stdT.Logf("List applications with tenant %q", secondaryTenant)
-		appPage := fixtures.GetApplicationPage(stdT, ctx, certSecuredGraphQLClient, secondaryTenant)
+		appPage := fixtures.GetApplicationPageMinimal(stdT, ctx, certSecuredGraphQLClient, secondaryTenant)
 		var providerApp graphql.Application
 		for _, app := range appPage.Data {
 			if app.Name == conf.SubscriptionProviderAppNameValue {

--- a/tests/pkg/fixtures/application_queries.go
+++ b/tests/pkg/fixtures/application_queries.go
@@ -39,6 +39,16 @@ func GetApplicationPage(t require.TestingT, ctx context.Context, gqlClient *gcli
 	return apps
 }
 
+func GetApplicationPageMinimal(t require.TestingT, ctx context.Context, gqlClient *gcli.Client, tenant string) graphql.ApplicationPage {
+	getAppReq := FixGetApplicationsRequestWithPaginationMinimal()
+	apps := graphql.ApplicationPage{}
+
+	// THEN
+	err := testctx.Tc.RunOperationWithCustomTenant(ctx, gqlClient, tenant, getAppReq, &apps)
+	require.NoError(t, err)
+	return apps
+}
+
 func GetApplicationPageExt(t require.TestingT, ctx context.Context, gqlClient *gcli.Client, tenant string) graphql.ApplicationPageExt {
 	getAppReq := FixGetApplicationsRequestWithPagination()
 	apps := graphql.ApplicationPageExt{}

--- a/tests/pkg/fixtures/application_requests.go
+++ b/tests/pkg/fixtures/application_requests.go
@@ -353,6 +353,16 @@ func FixGetApplicationsRequestWithPagination() *gcli.Request {
 			testctx.Tc.GQLFieldsProvider.Page(testctx.Tc.GQLFieldsProvider.ForApplication())))
 }
 
+func FixGetApplicationsRequestWithPaginationMinimal() *gcli.Request {
+	return gcli.NewRequest(
+		fmt.Sprintf(`query {
+				result: applications {
+						%s
+					}
+				}`,
+			testctx.Tc.GQLFieldsProvider.Page(testctx.Tc.GQLFieldsProvider.ForApplicationMinimal())))
+}
+
 func FixApplicationsFilteredPageableRequest(labelFilterInGQL string, first int, after string) *gcli.Request {
 	return gcli.NewRequest(
 		fmt.Sprintf(`query {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Currently there is a tenant on dev with around 150 systems each having bundles, apis, events. This tenant is used in the e2e tests executed on real env. When a gql query for getting all the Apps, bundles, apis, events is executed it times out.

This PR offers initial mitigation of this issue by using a gql query which expands only the fields of the App and skips the bundles, apis, events.

Changes proposed in this pull request:
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- ...

**Pull Request status**
<!-- Feel free to construct the checklist with whatever items seem most reasonable for your change. You could disassemble the Implementation part to even smaller separate checklist items if you're working on something big for example. But do make the effort to provide a checklist of some sort so that the core team as well as the community can have an idea about the progress of your Pull Request.
-->

- [ ] Implementation
- [ ] Unit tests
- [ ] Integration tests
- [ ] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [ ] Mocks are regenerated, using the automated script
