### PR TITLE
Add not null consraint to created_at for Formation Constraint

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -175,7 +175,7 @@ global:
       name: compass-ord-service
     schema_migrator:
       dir: dev/incubator/
-      version: "PR-3294"
+      version: "PR-3305"
       name: compass-schema-migrator
     system_broker:
       dir: prod/incubator/

--- a/components/schema-migrator/migrations/director/20230913161837_not-null-created-at-fc.down.sql
+++ b/components/schema-migrator/migrations/director/20230913161837_not-null-created-at-fc.down.sql
@@ -3,4 +3,7 @@ BEGIN;
 ALTER TABLE formation_constraints
     ALTER COLUMN created_at DROP NOT NULL;
 
+ALTER TABLE formation_constraints
+    ALTER COLUMN created_at SET DEFAULT NULL;
+
 COMMIT;

--- a/components/schema-migrator/migrations/director/20230913161837_not-null-created-at-fc.down.sql
+++ b/components/schema-migrator/migrations/director/20230913161837_not-null-created-at-fc.down.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+ALTER TABLE formation_constraints
+    ALTER COLUMN created_at DROP NOT NULL;
+
+COMMIT;

--- a/components/schema-migrator/migrations/director/20230913161837_not-null-created-at-fc.up.sql
+++ b/components/schema-migrator/migrations/director/20230913161837_not-null-created-at-fc.up.sql
@@ -3,4 +3,7 @@ BEGIN;
 ALTER TABLE formation_constraints
     ALTER COLUMN created_at SET NOT NULL;
 
+ALTER TABLE formation_constraints
+    ALTER COLUMN created_at SET DEFAULT CURRENT_TIMESTAMP;
+
 COMMIT;

--- a/components/schema-migrator/migrations/director/20230913161837_not-null-created-at-fc.up.sql
+++ b/components/schema-migrator/migrations/director/20230913161837_not-null-created-at-fc.up.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+ALTER TABLE formation_constraints
+    ALTER COLUMN created_at SET NOT NULL;
+
+COMMIT;


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Created At field is required for Formation constraints. The field is set automatically when a constraint is created using the gql request. If the constraint is created mannually or via migration the field may be empty and cause errors during execution.

Changes proposed in this pull request:
- Add not null constraint for created_at property
- Add default value

**Pull Request status**
<!-- Feel free to construct the checklist with whatever items seem most reasonable for your change. You could disassemble the Implementation part to even smaller separate checklist items if you're working on something big for example. But do make the effort to provide a checklist of some sort so that the core team as well as the community can have an idea about the progress of your Pull Request.
-->

- [x] Implementation
- [x] Unit tests
- [x] Integration tests
- [x] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [x] Mocks are regenerated, using the automated script
