### PR TITLE
Fix formation assignment clone in formation assignment resynchronization

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -143,7 +143,7 @@ global:
       name: compass-pairing-adapter
     director:
       dir: dev/incubator/
-      version: "PR-3310"
+      version: "PR-3313"
       name: compass-director
     hydrator:
       dir: dev/incubator/

--- a/components/director/internal/domain/formation/fixtures_test.go
+++ b/components/director/internal/domain/formation/fixtures_test.go
@@ -1410,10 +1410,7 @@ func fixFormationAssignmentPairWithNoReverseAssignment(request *webhookclient.Fo
 				Request:             request,
 				FormationAssignment: assignment,
 			},
-			ReverseAssignmentReqMapping: &formationassignment.FormationAssignmentRequestMapping{
-				Request:             nil,
-				FormationAssignment: nil,
-			},
+			ReverseAssignmentReqMapping: nil,
 		},
 	}
 

--- a/components/director/internal/domain/formation/service.go
+++ b/components/director/internal/domain/formation/service.go
@@ -1115,16 +1115,21 @@ func (s *service) resynchronizeFormationAssignmentNotifications(ctx context.Cont
 			}
 		}
 
+		var reverseReqMapping *formationassignment.FormationAssignmentRequestMapping
+		if reverseFA != nil || notificationForFA != nil {
+			reverseReqMapping = &formationassignment.FormationAssignmentRequestMapping{
+				Request:             notificationForReverseFA,
+				FormationAssignment: reverseFA,
+			}
+		}
+
 		assignmentPair := formationassignment.AssignmentMappingPairWithOperation{
 			AssignmentMappingPair: &formationassignment.AssignmentMappingPair{
 				AssignmentReqMapping: &formationassignment.FormationAssignmentRequestMapping{
 					Request:             notificationForFA,
 					FormationAssignment: fa,
 				},
-				ReverseAssignmentReqMapping: &formationassignment.FormationAssignmentRequestMapping{
-					Request:             notificationForReverseFA,
-					FormationAssignment: reverseFA,
-				},
+				ReverseAssignmentReqMapping: reverseReqMapping,
 			},
 		}
 		switch fa.State {

--- a/components/director/internal/domain/formation/service.go
+++ b/components/director/internal/domain/formation/service.go
@@ -1116,7 +1116,7 @@ func (s *service) resynchronizeFormationAssignmentNotifications(ctx context.Cont
 		}
 
 		var reverseReqMapping *formationassignment.FormationAssignmentRequestMapping
-		if reverseFA != nil || notificationForFA != nil {
+		if reverseFA != nil || notificationForReverseFA != nil {
 			reverseReqMapping = &formationassignment.FormationAssignmentRequestMapping{
 				Request:             notificationForReverseFA,
 				FormationAssignment: reverseFA,

--- a/components/director/internal/domain/formationassignment/service.go
+++ b/components/director/internal/domain/formationassignment/service.go
@@ -1015,9 +1015,9 @@ func (f *FormationAssignmentRequestMapping) Clone() *FormationAssignmentRequestM
 	if f.Request != nil {
 		request = f.Request.Clone()
 	}
-	return &FormationAssignmentRequestMapping{
-		Request: request,
-		FormationAssignment: &model.FormationAssignment{
+	var formationAssignment *model.FormationAssignment
+	if f.FormationAssignment != nil {
+		formationAssignment = &model.FormationAssignment{
 			ID:          f.FormationAssignment.ID,
 			FormationID: f.FormationAssignment.FormationID,
 			TenantID:    f.FormationAssignment.TenantID,
@@ -1028,7 +1028,12 @@ func (f *FormationAssignmentRequestMapping) Clone() *FormationAssignmentRequestM
 			State:       f.FormationAssignment.State,
 			Value:       f.FormationAssignment.Value,
 			Error:       f.FormationAssignment.Error,
-		},
+		}
+	}
+
+	return &FormationAssignmentRequestMapping{
+		Request:             request,
+		FormationAssignment: formationAssignment,
 	}
 }
 


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:
- make reverse request mapping nil in case both properties are `nil`, as we assume if it is populated, that at least the formation assignment is not nil
- add check for `nil` formation assignment in the `Clone` method

**Pull Request status**
- [x] Implementation
- [x] Unit tests
- [x] [N/A] Integration tests
- [x] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [x] [N/A] Mocks are regenerated, using the automated script
