### PR TITLE
IAS Adapter: handle the case with missing IAS apps during Unassign

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -151,7 +151,7 @@ global:
       name: compass-hydrator
     ias_adapter:
       dir: dev/incubator/
-      version: "PR-3314"
+      version: "PR-3315"
       name: compass-ias-adapter
     kyma_adapter:
       dir: dev/incubator/


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:
- Currently `UpdateApplicationConsumedAPIs` relies that `data.ProviderApplicationID` is always present.
- We allow missing IAS applications on Unassign. In this particular case we do not have the `ProviderApplicationID` of the other application. We should skip the update of the current IAS application.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- N/A

**Pull Request status**
<!-- Feel free to construct the checklist with whatever items seem most reasonable for your change. You could disassemble the Implementation part to even smaller separate checklist items if you're working on something big for example. But do make the effort to provide a checklist of some sort so that the core team as well as the community can have an idea about the progress of your Pull Request.
-->

- [x] Implementation
- [ ] Unit tests (the file does not have tests)
- [ ] Integration tests
- [ ] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [ ] Mocks are regenerated, using the automated script
