### PR TITLE
Add execution time details in test logs

### DIFF
--- a/installation/scripts/testing.sh
+++ b/installation/scripts/testing.sh
@@ -201,7 +201,11 @@ do
 
   min=$((duration/60))
   sec=$((duration%60))
-  echo "$podName:  duration $min:$sec"
+  minString=""
+  if ((min > 0)); then
+    minString="${min}m"
+  fi
+  echo "$podName execution time: ${minString}${sec}s"
 done <<< "$podInfo"
 
 if [[ ! "${BENCHMARK}" == "true" ]]

--- a/installation/scripts/testing.sh
+++ b/installation/scripts/testing.sh
@@ -190,7 +190,7 @@ podInfo=$(kubectl get cts ${suiteName} -o=go-template --template='{{range .statu
 if [ "$(uname)" == "Darwin" ]; then
   extra_flags="-j -f %Y-%m-%dT%H:%M:%SZ"
 else
-  extra_flags="-d -D %Y-%m-%dT%H:%M:%SZ"
+  extra_flags="-D %Y-%m-%dT%H:%M:%SZ -d"
 fi
 
 while read -r podName startTime endTime;

--- a/installation/scripts/testing.sh
+++ b/installation/scripts/testing.sh
@@ -184,6 +184,20 @@ cleanupExitCode=$?
 echo "ClusterTestSuite details:"
 kubectl get cts ${suiteName} -oyaml
 
+echo "Pod execution time details:"
+podInfo=$(kubectl get cts ${suiteName} -o=go-template --template='{{range .status.results}}{{range .executions }}{{printf "%s %s %s\n" .id .startTime .completionTime }}{{end}}{{end}}')
+
+while read -r podName startTime endTime;
+do
+  startTimeTimestamp=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$startTime" +%s)
+  endTimeTimestamp=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$endTime" +%s)
+  duration=$((endTimeTimestamp - startTimeTimestamp))
+
+  min=$((duration/60))
+  sec=$((duration%60))
+  echo "$podName:  duration $min:$sec"
+done <<< "$podInfo"
+
 if [[ ! "${BENCHMARK}" == "true" ]]
 then
   kubectl delete cts ${suiteName}

--- a/installation/scripts/testing.sh
+++ b/installation/scripts/testing.sh
@@ -187,10 +187,16 @@ kubectl get cts ${suiteName} -oyaml
 echo "Pod execution time details:"
 podInfo=$(kubectl get cts ${suiteName} -o=go-template --template='{{range .status.results}}{{range .executions }}{{printf "%s %s %s\n" .id .startTime .completionTime }}{{end}}{{end}}')
 
+if [ "$(uname)" == "Darwin" ]; then
+  extra_flags="-j -f %Y-%m-%dT%H:%M:%SZ"
+else
+  extra_flags="-d"
+fi
+
 while read -r podName startTime endTime;
 do
-  startTimeTimestamp=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$startTime" +%s)
-  endTimeTimestamp=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$endTime" +%s)
+  startTimeTimestamp=$(date $extra_flags "$startTime" +%s)
+  endTimeTimestamp=$(date $extra_flags "$endTime" +%s)
   duration=$((endTimeTimestamp - startTimeTimestamp))
 
   min=$((duration/60))

--- a/installation/scripts/testing.sh
+++ b/installation/scripts/testing.sh
@@ -190,7 +190,7 @@ podInfo=$(kubectl get cts ${suiteName} -o=go-template --template='{{range .statu
 if [ "$(uname)" == "Darwin" ]; then
   extra_flags="-j -f %Y-%m-%dT%H:%M:%SZ"
 else
-  extra_flags="-d"
+  extra_flags="-d -D %Y-%m-%dT%H:%M:%SZ"
 fi
 
 while read -r podName startTime endTime;


### PR DESCRIPTION
**Description**
Currently we have relatively the time in which a pod lives based on the amount of times it prints `Running test is X`. This PR uses the `startTime` and `completionTime` in the `ClusterTestSuite` to determine the execution time for each pod.

Changes proposed in this pull request:
- add logs for execution time in tests

**Pull Request status**

- [x] Implementation
- [x] [N/A] Unit tests
- [x] [N/A] Integration tests
- [x] [N/A] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [x] [N/A] Mocks are regenerated, using the automated script
