### PR TITLE
Fix self-referenced formation assignment notification e2e test

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -195,7 +195,7 @@ global:
       version: "v20230421-e8840c18"
       name: compass-console
     e2e_tests:
-      dir: prod/incubator/
+      dir: dev/incubator/
       version: "PR-3329"
       name: compass-e2e-tests
   isLocalEnv: false

--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -196,7 +196,7 @@ global:
       name: compass-console
     e2e_tests:
       dir: prod/incubator/
-      version: "v20230921-5e551701"
+      version: "PR-3329"
       name: compass-e2e-tests
   isLocalEnv: false
   isForTesting: false

--- a/tests/director/tests/formation_api_test.go
+++ b/tests/director/tests/formation_api_test.go
@@ -3321,7 +3321,7 @@ func TestFormationNotificationsWithApplicationOnlyParticipants(t *testing.T) {
 			}
 			assertFormationAssignments(t, ctx, tnt, formation.ID, 1, expectedAssignments)
 			assertFormationStatus(t, ctx, tnt, formation.ID, graphql.FormationStatus{Condition: graphql.FormationStatusConditionInProgress, Errors: nil})
-			assertFormationAssignmentsAsynchronously(t, ctx, tnt, formation.ID, 0, nil, 0)
+			assertFormationAssignmentsAsynchronously(t, ctx, tnt, formation.ID, 0, nil, 2)
 			assertFormationStatus(t, ctx, tnt, formation.ID, graphql.FormationStatus{Condition: graphql.FormationStatusConditionReady, Errors: nil})
 
 		})
@@ -3489,7 +3489,7 @@ func TestFormationNotificationsWithApplicationOnlyParticipants(t *testing.T) {
 			}
 			assertFormationAssignments(t, ctx, tnt, formation.ID, 1, expectedAssignments)
 			assertFormationStatus(t, ctx, tnt, formation.ID, graphql.FormationStatus{Condition: graphql.FormationStatusConditionInProgress, Errors: nil})
-			assertFormationAssignmentsAsynchronously(t, ctx, tnt, formation.ID, 0, nil, 0)
+			assertFormationAssignmentsAsynchronously(t, ctx, tnt, formation.ID, 0, nil, 2)
 		})
 		t.Run("Resynchronize should correctly send notifications for multiple participants", func(t *testing.T) {
 			cleanupNotificationsFromExternalSvcMock(t, certSecuredHTTPClient)


### PR DESCRIPTION
**Description**
Because the additional delay is 0, sometimes we haven't processed the formation assignment cleanup and the test fails. The additional delay is set to `2` in most other tests.

Changes proposed in this pull request:
- change the additional delay to `2`

**Related issue(s)**
- #3284

**Pull Request status**
<!-- Feel free to construct the checklist with whatever items seem most reasonable for your change. You could disassemble the Implementation part to even smaller separate checklist items if you're working on something big for example. But do make the effort to provide a checklist of some sort so that the core team as well as the community can have an idea about the progress of your Pull Request.
-->

- [x] [N/A] Implementation
- [x] [N/A]  Unit tests
- [x] Integration tests
- [x] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [x] [N/A]  Mocks are regenerated, using the automated script
