### PR TITLE
Adapt sandbox tests after splitting director test definition

### DIFF
--- a/tests/director/Makefile
+++ b/tests/director/Makefile
@@ -52,7 +52,7 @@ run-formation:
 	@kubectl exec -n kyma-system oct-tp-compass-e2e-tests-compass-e2e-director-local-0 -c director-tests -- ./director-formation.test -test.run $(testName) -test.v
 
 run-runtime:
-	@kubectl exec -n kyma-system oct-tp-compass-e2e-tests-compass-e2e-director-local-0 -c director-tests -- ./director-formation.test -test.run $(testName) -test.v
+	@kubectl exec -n kyma-system oct-tp-compass-e2e-tests-compass-e2e-director-local-0 -c director-tests -- ./director-runtime.test -test.run $(testName) -test.v
 
 run-notification:
 	@kubectl exec -n kyma-system oct-tp-compass-e2e-tests-compass-e2e-director-local-0 -c director-tests -- ./director-notifications.test -test.run $(testName) -test.v

--- a/tests/director/Makefile
+++ b/tests/director/Makefile
@@ -44,6 +44,19 @@ sandbox-test:
 run:
 	@kubectl exec -n kyma-system oct-tp-compass-e2e-tests-compass-e2e-director-local-0 -c director-tests -- ./director.test -test.run $(testName) -test.v
 
+
+run-application:
+	@kubectl exec -n kyma-system oct-tp-compass-e2e-tests-compass-e2e-director-local-0 -c director-tests -- ./director-application.test -test.run $(testName) -test.v
+
+run-formation:
+	@kubectl exec -n kyma-system oct-tp-compass-e2e-tests-compass-e2e-director-local-0 -c director-tests -- ./director-formation.test -test.run $(testName) -test.v
+
+run-runtime:
+	@kubectl exec -n kyma-system oct-tp-compass-e2e-tests-compass-e2e-director-local-0 -c director-tests -- ./director-formation.test -test.run $(testName) -test.v
+
+run-notification:
+	@kubectl exec -n kyma-system oct-tp-compass-e2e-tests-compass-e2e-director-local-0 -c director-tests -- ./director-notifications.test -test.run $(testName) -test.v
+
 bench-run:
 	@kubectl exec -n kyma-system oct-tp-compass-e2e-tests-compass-e2e-director-local-0 -c director-tests -- ./director.bench -test.bench $(testName) -test.v
 
@@ -51,6 +64,23 @@ sandbox-deploy-test:
 	env GOOS=linux GOARCH=amd64 go test -c ./tests -o director.test
 	kubectl cp ./director.test kyma-system/oct-tp-compass-e2e-tests-compass-e2e-director-local-0:/ -c director-tests
 	rm ./director.test
+
+# This depends on the generic config, when we split the configuration these commands should be removed
+sandbox-deploy-test-all:
+	env GOOS=linux GOARCH=amd64 go test -c ./tests -o director.test
+	env GOOS=linux GOARCH=amd64 go test -c ./tests/notifications -o director-notifications.test
+	env GOOS=linux GOARCH=amd64 go test -c ./tests/application -o director-application.test
+	env GOOS=linux GOARCH=amd64 go test -c ./tests/formation -o director-formation.test
+	env GOOS=linux GOARCH=amd64 go test -c ./tests/runtime -o director-runtime.test
+	kubectl cp ./director.test kyma-system/oct-tp-compass-e2e-tests-compass-e2e-director-local-0:/ -c director-tests
+	kubectl cp ./director-notifications.test kyma-system/oct-tp-compass-e2e-tests-compass-e2e-director-local-0:/ -c director-tests
+	kubectl cp ./director-application.test kyma-system/oct-tp-compass-e2e-tests-compass-e2e-director-local-0:/ -c director-tests
+	kubectl cp ./director-formation.test kyma-system/oct-tp-compass-e2e-tests-compass-e2e-director-local-0:/ -c director-tests
+	kubectl cp ./director-runtime.test kyma-system/oct-tp-compass-e2e-tests-compass-e2e-director-local-0:/ -c director-tests
+	rm ./director-application.test
+	rm ./director-notifications.test
+	rm ./director-runtime.test
+	rm ./director-formation.test
 
 sandbox-deploy-bench-test:
 	env GOOS=linux GOARCH=amd64 go test -c ./bench -o director.bench

--- a/tests/director/tests/application/Makefile
+++ b/tests/director/tests/application/Makefile
@@ -1,0 +1,42 @@
+APP_NAME = compass-director-tests
+APP_PATH = tests/director-tests
+BUILDPACK = eu.gcr.io/kyma-project/test-infra/buildpack-golang:go1.18
+SCRIPTS_DIR = $(realpath $(shell pwd)/../../../../)/scripts
+INSTALLATION_SCRIPTS_DIR = $(realpath $(shell pwd)/../../../../)/installation/scripts
+DIRECTOR_GRAPHQL_API = "http://compass-dev-director:3000"
+export DIRECTOR_GRAPHQL_API
+export GO111MODULE = on
+export SKIP_STEP_MESSAGE = "Do nothing for Go modules project"
+include $(SCRIPTS_DIR)/generic_make_go.mk
+
+# We have to override test-local, because we need to run director with database as docker containers and connected with custom network
+# and the container itself has to be connected to the network
+test-local:
+	@echo ${SKIP_STEP_MESSAGE}
+
+errcheck-local:
+	errcheck -blank -asserts -ignoregenerated ./...
+
+e2e-test:
+	@$(INSTALLATION_SCRIPTS_DIR)/testing.sh director-application
+
+e2e-test-clean:
+	@kubectl delete clustertestsuites.testing.kyma-project.io compass-e2e-tests || true
+
+generate-examples:
+	@../../generate_examples.sh
+
+sandbox-test:
+	@../../../sandbox.sh director-application
+
+run:
+	@kubectl exec -n kyma-system oct-tp-compass-e2e-tests-compass-e2e-director-application-local-0 -c director-application-tests -- ./director-application.test -test.run $(testName) -test.v
+
+sandbox-deploy-test:
+	env GOOS=linux GOARCH=amd64 go test -c . -o director-application.test
+	kubectl cp ./director-application.test kyma-system/oct-tp-compass-e2e-tests-compass-e2e-director-application-local-0:/ -c director-application-tests
+	rm ./director-application.test
+
+sandbox-test-clean:
+	@kubectl delete testdefinitions.testing.kyma-project.io -n kyma-system compass-e2e-director-application-local || true
+	@kubectl delete clustertestsuites.testing.kyma-project.io compass-e2e-tests || true

--- a/tests/director/tests/formation/Makefile
+++ b/tests/director/tests/formation/Makefile
@@ -1,0 +1,42 @@
+APP_NAME = compass-director-tests
+APP_PATH = tests/director-tests
+BUILDPACK = eu.gcr.io/kyma-project/test-infra/buildpack-golang:go1.18
+SCRIPTS_DIR = $(realpath $(shell pwd)/../../../../)/scripts
+INSTALLATION_SCRIPTS_DIR = $(realpath $(shell pwd)/../../../../)/installation/scripts
+DIRECTOR_GRAPHQL_API = "http://compass-dev-director:3000"
+export DIRECTOR_GRAPHQL_API
+export GO111MODULE = on
+export SKIP_STEP_MESSAGE = "Do nothing for Go modules project"
+include $(SCRIPTS_DIR)/generic_make_go.mk
+
+# We have to override test-local, because we need to run director with database as docker containers and connected with custom network
+# and the container itself has to be connected to the network
+test-local:
+	@echo ${SKIP_STEP_MESSAGE}
+
+errcheck-local:
+	errcheck -blank -asserts -ignoregenerated ./...
+
+e2e-test:
+	@$(INSTALLATION_SCRIPTS_DIR)/testing.sh director-formation
+
+e2e-test-clean:
+	@kubectl delete clustertestsuites.testing.kyma-project.io compass-e2e-tests || true
+
+generate-examples:
+	@../../generate_examples.sh
+
+sandbox-test:
+	@../../../sandbox.sh director-formation
+
+run:
+	@kubectl exec -n kyma-system oct-tp-compass-e2e-tests-compass-e2e-director-formation-local-0 -c director-formation-tests -- ./director-formation.test -test.run $(testName) -test.v
+
+sandbox-deploy-test:
+	env GOOS=linux GOARCH=amd64 go test -c . -o director-formation.test
+	kubectl cp ./director-formation.test kyma-system/oct-tp-compass-e2e-tests-compass-e2e-director-formation-local-0:/ -c director-formation-tests
+	rm ./director-formation.test
+
+sandbox-test-clean:
+	@kubectl delete testdefinitions.testing.kyma-project.io -n kyma-system compass-e2e-director-formation-local || true
+	@kubectl delete clustertestsuites.testing.kyma-project.io compass-e2e-tests || true

--- a/tests/director/tests/notifications/Makefile
+++ b/tests/director/tests/notifications/Makefile
@@ -1,0 +1,42 @@
+APP_NAME = compass-director-tests
+APP_PATH = tests/director-tests
+BUILDPACK = eu.gcr.io/kyma-project/test-infra/buildpack-golang:go1.18
+SCRIPTS_DIR = $(realpath $(shell pwd)/../../../../)/scripts
+INSTALLATION_SCRIPTS_DIR = $(realpath $(shell pwd)/../../../../)/installation/scripts
+DIRECTOR_GRAPHQL_API = "http://compass-dev-director:3000"
+export DIRECTOR_GRAPHQL_API
+export GO111MODULE = on
+export SKIP_STEP_MESSAGE = "Do nothing for Go modules project"
+include $(SCRIPTS_DIR)/generic_make_go.mk
+
+# We have to override test-local, because we need to run director with database as docker containers and connected with custom network
+# and the container itself has to be connected to the network
+test-local:
+	@echo ${SKIP_STEP_MESSAGE}
+
+errcheck-local:
+	errcheck -blank -asserts -ignoregenerated ./...
+
+e2e-test:
+	@$(INSTALLATION_SCRIPTS_DIR)/testing.sh director-notifications
+
+e2e-test-clean:
+	@kubectl delete clustertestsuites.testing.kyma-project.io compass-e2e-tests || true
+
+generate-examples:
+	@../../generate_examples.sh
+
+sandbox-test:
+	@../../../sandbox.sh director-notifications
+
+run:
+	@kubectl exec -n kyma-system oct-tp-compass-e2e-tests-compass-e2e-director-notifications-local-0 -c director-notifications-tests -- ./director-notifications.test -test.run $(testName) -test.v
+
+sandbox-deploy-test:
+	env GOOS=linux GOARCH=amd64 go test -c . -o director-notifications.test
+	kubectl cp ./director-notifications.test kyma-system/oct-tp-compass-e2e-tests-compass-e2e-director-notifications-local-0:/ -c director-notifications-tests
+	rm ./director-notifications.test
+
+sandbox-test-clean:
+	@kubectl delete testdefinitions.testing.kyma-project.io -n kyma-system compass-e2e-director-notifications-local || true
+	@kubectl delete clustertestsuites.testing.kyma-project.io compass-e2e-tests || true

--- a/tests/director/tests/runtime/Makefile
+++ b/tests/director/tests/runtime/Makefile
@@ -1,0 +1,42 @@
+APP_NAME = compass-director-tests
+APP_PATH = tests/director-tests
+BUILDPACK = eu.gcr.io/kyma-project/test-infra/buildpack-golang:go1.18
+SCRIPTS_DIR = $(realpath $(shell pwd)/../../../../)/scripts
+INSTALLATION_SCRIPTS_DIR = $(realpath $(shell pwd)/../../../../)/installation/scripts
+DIRECTOR_GRAPHQL_API = "http://compass-dev-director:3000"
+export DIRECTOR_GRAPHQL_API
+export GO111MODULE = on
+export SKIP_STEP_MESSAGE = "Do nothing for Go modules project"
+include $(SCRIPTS_DIR)/generic_make_go.mk
+
+# We have to override test-local, because we need to run director with database as docker containers and connected with custom network
+# and the container itself has to be connected to the network
+test-local:
+	@echo ${SKIP_STEP_MESSAGE}
+
+errcheck-local:
+	errcheck -blank -asserts -ignoregenerated ./...
+
+e2e-test:
+	@$(INSTALLATION_SCRIPTS_DIR)/testing.sh director-runtime
+
+e2e-test-clean:
+	@kubectl delete clustertestsuites.testing.kyma-project.io compass-e2e-tests || true
+
+generate-examples:
+	@../generate_examples.sh
+
+sandbox-test:
+	@../../../sandbox.sh director-runtime
+
+run:
+	@kubectl exec -n kyma-system oct-tp-compass-e2e-tests-compass-e2e-director-runtime-local-0 -c director-runtime-tests -- ./director-runtime.test -test.run $(testName) -test.v
+
+sandbox-deploy-test:
+	env GOOS=linux GOARCH=amd64 go test -c . -o director-runtime.test
+	kubectl cp ./director-runtime.test kyma-system/oct-tp-compass-e2e-tests-compass-e2e-director-runtime-local-0:/ -c director-runtime-tests
+	rm ./director-runtime.test
+
+sandbox-test-clean:
+	@kubectl delete testdefinitions.testing.kyma-project.io -n kyma-system compass-e2e-director-runtime-local || true
+	@kubectl delete clustertestsuites.testing.kyma-project.io compass-e2e-tests || true


### PR DESCRIPTION
**Description**
After splitting the director test definition, the sandbox commands were not adapted. This PR adds specific Makefiles for each new test definition.

Changes proposed in this pull request:
- add Makefile in each new director test definition

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- #3321

**Pull Request status**
<!-- Feel free to construct the checklist with whatever items seem most reasonable for your change. You could disassemble the Implementation part to even smaller separate checklist items if you're working on something big for example. But do make the effort to provide a checklist of some sort so that the core team as well as the community can have an idea about the progress of your Pull Request.
-->

- [ ] Implementation
- [ ] Unit tests
- [ ] Integration tests
- [ ] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [ ] Mocks are regenerated, using the automated script
