### PR TITLE
Adapt local env octopus

### DIFF
--- a/installation/scripts/install-compass.sh
+++ b/installation/scripts/install-compass.sh
@@ -96,7 +96,7 @@ echo "Compass installation status ${STATUS}"
 
 if [[ $(uname -m) == "arm64" ]]; then
   echo "Patching image on octopus for arm64..."
- 	kubectl set image -n compass-system statefulset/compass-octopus "manager=europe-west1-docker.pkg.dev/sap-cp-cmp-dev/ucl-dev/octopus:5f353cd5"
+ 	kubectl set image -n "${RELEASE_NS}" statefulset/compass-octopus "manager=europe-west1-docker.pkg.dev/sap-cp-cmp-dev/ucl-dev/octopus:5f353cd5"
 fi
 
 if [[ ${SQL_HELM_BACKEND} ]]; then

--- a/installation/scripts/install-compass.sh
+++ b/installation/scripts/install-compass.sh
@@ -94,6 +94,11 @@ echo "Compass installation finished successfully"
 STATUS=$(helm status compass -n compass-system -o json | jq .info.status)
 echo "Compass installation status ${STATUS}"
 
+if [[ $(uname -m) == "arm64" ]]; then
+  echo "Patching image on octopus for arm64..."
+ 	kubectl set image -n compass-system statefulset/compass-octopus "manager=europe-west1-docker.pkg.dev/sap-cp-cmp-dev/ucl-dev/octopus:5f353cd5"
+fi
+
 if [[ ${SQL_HELM_BACKEND} ]]; then
     pkill kubectl
 fi


### PR DESCRIPTION
**Description**
Currently when running e2e tests on an arm machine, it uses the amd64 image of the octopus manager and it sometimes schedules pods before they should be, reaching `running > concurrency` and practically running multiple test pods at the same time. This leads to failed tests, as they conflict with the resources, because it is usually the same test pod.

Changes proposed in this pull request:
- patch image for arm64 machines to use arm64 image of octopus


**Pull Request status**
<!-- Feel free to construct the checklist with whatever items seem most reasonable for your change. You could disassemble the Implementation part to even smaller separate checklist items if you're working on something big for example. But do make the effort to provide a checklist of some sort so that the core team as well as the community can have an idea about the progress of your Pull Request.
-->

- [x] [N/A] Implementation
- [x] [N/A] Unit tests
- [x] [N/A] Integration tests
- [x] [N/A] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [x] [N/A] Mocks are regenerated, using the automated script
