### PR TITLE
Add flag for generating examples in the sandbox test runs

### DIFF
--- a/tests/director/Makefile
+++ b/tests/director/Makefile
@@ -4,6 +4,7 @@ BUILDPACK = europe-docker.pkg.dev/kyma-project/prod/test-infra/buildpack-golang:
 SCRIPTS_DIR = $(realpath $(shell pwd)/../..)/scripts
 INSTALLATION_SCRIPTS_DIR = $(realpath $(shell pwd)/../..)/installation/scripts
 DIRECTOR_GRAPHQL_API = "http://compass-dev-director:3000"
+withExamples=false
 export DIRECTOR_GRAPHQL_API
 export GO111MODULE = on
 export SKIP_STEP_MESSAGE = "Do nothing for Go modules project"

--- a/tests/director/Makefile
+++ b/tests/director/Makefile
@@ -43,6 +43,10 @@ sandbox-test:
 
 run:
 	@kubectl exec -n kyma-system oct-tp-compass-e2e-tests-compass-e2e-director-local-0 -c director-tests -- ./director.test -test.run $(testName) -test.v
+	@if [[ ${withExamples} = true ]]; then\
+		echo "Generating examples...";\
+		./copy-examples.sh;\
+	fi
 
 
 run-application:

--- a/tests/director/copy-examples.sh
+++ b/tests/director/copy-examples.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+docker cp k3d-kyma-agent-0:/examples/ ../../components/director/
+
+if [[ $? != 0 ]]
+then
+  echo "Searching examples in k3d-kyma-server-0..."
+  docker cp k3d-kyma-server-0:/examples/ ../../components/director/
+fi
+
+../../components/director/hack/prettify-examples.sh

--- a/tests/director/generate_examples.sh
+++ b/tests/director/generate_examples.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 
 make e2e-test
-#make e2e-test-application
-#make e2e-test-notification
-#make e2e-test-runtime
-#make e2e-test-formation
+make e2e-test-application
+make e2e-test-notification
+make e2e-test-runtime
+make e2e-test-formation
 
 ./copy-examples.sh

--- a/tests/director/generate_examples.sh
+++ b/tests/director/generate_examples.sh
@@ -1,17 +1,9 @@
 #!/usr/bin/env bash
 
 make e2e-test
-make e2e-test-application
-make e2e-test-notification
-make e2e-test-runtime
-make e2e-test-formation
+#make e2e-test-application
+#make e2e-test-notification
+#make e2e-test-runtime
+#make e2e-test-formation
 
-docker cp k3d-kyma-agent-0:/examples/ ../../components/director/
-
-if [[ $? != 0 ]]
-then
-  echo "Searching examples in k3d-kyma-server-0..."
-  docker cp k3d-kyma-server-0:/examples/ ../../components/director/
-fi
-
-../../components/director/hack/prettify-examples.sh
+./copy-examples.sh


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Currently, if we want to generate examples from the e2e tests we are running the make target `generate-examples` which will run all of the e2e tests and then generate the examples. With this PR I'm adding a flag `withExamples` in the sandbox run which will run a given e2e test and then will generate its examples. That way if we introduce a new e2e test that saves the new example, we can run only the new test and generate its example and not run all of the e2e tests.
Usage: `make testName=TestQueryRootTenant withExamples=true run`. If you don't want to generate examples you run the test the old way: `make testName=TestQueryRootTenant run`.
Note: the `withExamples` env var can be placed everywhere after `make`.

Changes proposed in this pull request:
- Add a flag in the `run` make target for generating examples

**Pull Request status**
<!-- Feel free to construct the checklist with whatever items seem most reasonable for your change. You could disassemble the Implementation part to even smaller separate checklist items if you're working on something big for example. But do make the effort to provide a checklist of some sort so that the core team as well as the community can have an idea about the progress of your Pull Request.
-->

- [ ] Implementation
- [ ] Unit tests
- [ ] Integration tests
- [ ] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [ ] Mocks are regenerated, using the automated script
