### PR TITLE
Change Ory container users

### DIFF
--- a/chart/ory/charts/hydra/templates/deployment.yaml
+++ b/chart/ory/charts/hydra/templates/deployment.yaml
@@ -64,9 +64,10 @@ spec:
               drop:
               - ALL
             privileged: false
-            runAsGroup: 65534
             runAsNonRoot: true
-            runAsUser: 65534
+            # Run as user 1337 to avoid networking problems caused by the Istio CNI approach
+            # https://istio.io/latest/docs/setup/additional-setup/cni/#compatibility-with-application-init-containers
+            runAsUser: 1337
         {{- end }}
         - name: {{ .Chart.Name }}-automigrate
           image: "{{ include "imageurl" (dict "reg" .Values.global.containerRegistry "img" .Values.global.images.hydra) }}"
@@ -95,9 +96,10 @@ spec:
               drop:
               - ALL
             privileged: false
-            runAsGroup: 1000
             runAsNonRoot: true
-            runAsUser: 1000
+            # Run as user 1337 to avoid networking problems caused by the Istio CNI approach
+            # https://istio.io/latest/docs/setup/additional-setup/cni/#compatibility-with-application-init-containers
+            runAsUser: 1337
     {{- end}}
       volumes:
         - name: {{ include "hydra.name" . }}-config-volume


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
With Kyma 2.8.4 we are introducing the Istio CNI plugin. With the introduction of this CNI plugin we have to make some changes in our initContainers that require network access. As stated in the [Istio docs](https://istio.io/latest/docs/setup/additional-setup/cni/#compatibility-with-application-init-containers), we need to use userid 1337(Istio proxy user) to give initContainers network access before the proxy is created.

The Ory changes are made seperate from the Kyma PR as they need to be introduced first. Otherwise, the Kyma upgrade from 2.7.3 to 2.8.4 fails due to the initContainers of Ory as Ory deployment stage is after Kyma installation stage in the pipelines.

Changes proposed in this pull request:
- change Ory initContainer user to 1337

**Pull Request status**

- [x] Implementation
- [ ] Unit tests
- [ ] Integration tests
- [ ] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [ ] Mocks are regenerated, using the automated script
