### PR TITLE
Change benchmark test Kubernetes version

### DIFF
--- a/installation/scripts/prow/jobs/compass-gke-benchmark.sh
+++ b/installation/scripts/prow/jobs/compass-gke-benchmark.sh
@@ -127,7 +127,7 @@ function createCluster() {
   gcp::provision_k8s_cluster \
         -c "$COMMON_NAME" \
         -p "$CLOUDSDK_CORE_PROJECT" \
-        -v "1.24.16" \
+        -v "1.25.10" \
         -i "cos_containerd" \
         -C "stable" \
         -j "$JOB_NAME" \


### PR DESCRIPTION
**Description**
With the introduction of Kyma 2.9.3 (https://github.com/kyma-incubator/compass/pull/3397) we changed our setup around Kubernetes 1.25. This follow-up PR changes the Kubernetes version of the cluster created in the benchmark.

Changes proposed in this pull request:
- update bechmark k8s to 1.25

**Pull Request status**

- [x] Implementation
- [ ] Unit tests
- [ ] Integration tests
- [ ] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [ ] Mocks are regenerated, using the automated script
