### PR TITLE
Fix applicationTemplate query to return Not Found error

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -155,7 +155,7 @@ global:
       name: compass-pairing-adapter
     director:
       dir: dev/incubator/
-      version: "PR-3419"
+      version: "PR-3431"
       name: compass-director
     hydrator:
       dir: dev/incubator/
@@ -212,7 +212,7 @@ global:
       name: compass-console
     e2e_tests:
       dir: dev/incubator/
-      version: "PR-3419"
+      version: "PR-3431"
       name: compass-e2e-tests
   isLocalEnv: false
   isForTesting: false

--- a/components/director/internal/domain/apptemplate/resolver.go
+++ b/components/director/internal/domain/apptemplate/resolver.go
@@ -162,14 +162,10 @@ func (r *Resolver) ApplicationTemplate(ctx context.Context, id string) (*graphql
 
 	appTemplate, err := r.appTemplateSvc.Get(ctx, id)
 	if err != nil {
-		if apperrors.IsNotFoundError(err) {
-			return nil, tx.Commit()
-		}
 		return nil, err
 	}
 
-	err = tx.Commit()
-	if err != nil {
+	if err := tx.Commit(); err != nil {
 		return nil, err
 	}
 

--- a/components/director/internal/domain/apptemplate/resolver_test.go
+++ b/components/director/internal/domain/apptemplate/resolver_test.go
@@ -82,8 +82,8 @@ func TestResolver_ApplicationTemplate(t *testing.T) {
 			ExpectedOutput: gqlAppTemplate,
 		},
 		{
-			Name: "Returns nil when application template not found",
-			TxFn: txGen.ThatSucceeds,
+			Name: "Returns NotFoundError when application template not found",
+			TxFn: txGen.ThatDoesntExpectCommit,
 			AppTemplateSvcFn: func() *automock.ApplicationTemplateService {
 				appTemplateSvc := &automock.ApplicationTemplateService{}
 				appTemplateSvc.On("Get", txtest.CtxWithDBMatcher(), testID).Return(nil, apperrors.NewNotFoundError(resource.ApplicationTemplate, "")).Once()
@@ -92,7 +92,7 @@ func TestResolver_ApplicationTemplate(t *testing.T) {
 			AppTemplateConvFn: UnusedAppTemplateConv,
 			WebhookConvFn:     UnusedWebhookConv,
 			WebhookSvcFn:      UnusedWebhookSvc,
-			ExpectedOutput:    nil,
+			ExpectedError:     apperrors.NewNotFoundError(resource.ApplicationTemplate, ""),
 		},
 		{
 			Name: "Returns error when getting application template failed",

--- a/tests/pkg/fixtures/application_template_queries.go
+++ b/tests/pkg/fixtures/application_template_queries.go
@@ -39,7 +39,7 @@ func GetApplicationTemplate(t require.TestingT, ctx context.Context, gqlClient *
 	appTpl := graphql.ApplicationTemplate{}
 
 	err := testctx.Tc.RunOperationWithCustomTenant(ctx, gqlClient, tenant, req, &appTpl)
-	require.NoError(t, err)
+	assertions.AssertNoErrorForOtherThanNotFound(t, err)
 	return appTpl
 }
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:
- Make applicationTempalte query return NotFoundError when the provided app template does not exist

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- ...

**Pull Request status**
<!-- Feel free to construct the checklist with whatever items seem most reasonable for your change. You could disassemble the Implementation part to even smaller separate checklist items if you're working on something big for example. But do make the effort to provide a checklist of some sort so that the core team as well as the community can have an idea about the progress of your Pull Request.
-->

- [x] Implementation
- [x] Unit tests
- [x] Integration tests
- [x] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [ ] Mocks are regenerated, using the automated script
