### PR TITLE
Fix outdated director reference in e2e tests

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -212,7 +212,7 @@ global:
       name: compass-console
     e2e_tests:
       dir: dev/incubator/
-      version: "PR-3433"
+      version: "PR-3439"
       name: compass-e2e-tests
   isLocalEnv: false
   isForTesting: false

--- a/tests/director/tests/notifications/application_only_notifications_test.go
+++ b/tests/director/tests/notifications/application_only_notifications_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/kyma-incubator/compass/tests/pkg/token"
 	"github.com/stretchr/testify/require"
 	"github.com/tidwall/gjson"
+	"github.com/kyma-incubator/compass/components/director/pkg/templatehelper"
 )
 
 func TestFormationNotificationsWithApplicationOnlyParticipants(t *testing.T) {
@@ -2274,7 +2275,7 @@ func TestFormationNotificationsWithApplicationOnlyParticipants(t *testing.T) {
 		}
 		output := formationconstraintpkg.DoNotGenerateFormationAssignmentNotificationInput{}
 		unquoted := strings.ReplaceAll(originalInput.InputTemplate, "\\", "")
-		err = formationconstraintpkg.ParseInputTemplate(unquoted, struct {
+		err = templatehelper.ParseTemplate(&unquoted, struct {
 			SourceApplication *struct {
 				ID string `json:"id"`
 			} `json:"source_application"`

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/google/uuid v1.3.1
 	github.com/kyma-incubator/compass/components/connectivity-adapter v0.0.0-20231017062655-ff258cdc2e36
 	github.com/kyma-incubator/compass/components/connector v0.0.0-20231017062655-ff258cdc2e36
-	github.com/kyma-incubator/compass/components/director v0.0.0-20231030085146-0ea1613a0ad5
+	github.com/kyma-incubator/compass/components/director v0.0.0-20231103110302-3dedf920eace
 	github.com/kyma-incubator/compass/components/external-services-mock v0.0.0-20231102153640-94e42d2e1f5a
 	github.com/kyma-incubator/compass/components/gateway v0.0.0-20231017062655-ff258cdc2e36
 	github.com/kyma-incubator/compass/components/operations-controller v0.0.0-20231017062655-ff258cdc2e36

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -136,6 +136,8 @@ github.com/kyma-incubator/compass/components/connector v0.0.0-20231017062655-ff2
 github.com/kyma-incubator/compass/components/connector v0.0.0-20231017062655-ff258cdc2e36/go.mod h1:47kLUWcWfsljUrQK2DAXApTSj8avBCJoMMFbnIqdDIA=
 github.com/kyma-incubator/compass/components/director v0.0.0-20231030085146-0ea1613a0ad5 h1:eKv+WJ+XS2fHuzlGXfo5uwpq8mdyT1DL8LxQjiirp+I=
 github.com/kyma-incubator/compass/components/director v0.0.0-20231030085146-0ea1613a0ad5/go.mod h1:byH9lgW64t8VKsNqNyXp1HTq28sYsNvv45f/mlgnTeE=
+github.com/kyma-incubator/compass/components/director v0.0.0-20231103110302-3dedf920eace h1:DZ7mtqxOtPl73Z5T/F5UdLXTlb/PkL4QiPIui3+jnqE=
+github.com/kyma-incubator/compass/components/director v0.0.0-20231103110302-3dedf920eace/go.mod h1:byH9lgW64t8VKsNqNyXp1HTq28sYsNvv45f/mlgnTeE=
 github.com/kyma-incubator/compass/components/external-services-mock v0.0.0-20231017062655-ff258cdc2e36 h1:VBSCqdWKkQGv+1GgQj/DRuHB4eVcC361i4pYisdFv9s=
 github.com/kyma-incubator/compass/components/external-services-mock v0.0.0-20231017062655-ff258cdc2e36/go.mod h1:LZ1tUJmgc/o9z1XlvlsmzaX9IL1XKUW7OnkUUJ16JN0=
 github.com/kyma-incubator/compass/components/external-services-mock v0.0.0-20231102153640-94e42d2e1f5a h1:KipWREySK53juUtQ6xGBxT6XDf6ypgLGZ15tfQeGMMY=


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- https://github.com/kyma-incubator/compass/pull/3434

**Pull Request status**
<!-- Feel free to construct the checklist with whatever items seem most reasonable for your change. You could disassemble the Implementation part to even smaller separate checklist items if you're working on something big for example. But do make the effort to provide a checklist of some sort so that the core team as well as the community can have an idea about the progress of your Pull Request.
-->

- [x] Implementation
- [ ] Unit tests
- [ ] Integration tests
- [ ] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [ ] Mocks are regenerated, using the automated script
