### PR TITLE
Benchmark grep fix

### DIFF
--- a/installation/scripts/prow/jobs/compass-gke-benchmark.sh
+++ b/installation/scripts/prow/jobs/compass-gke-benchmark.sh
@@ -353,8 +353,9 @@ for POD in $PODS; do
     log::info "Performance comparison statistics"
     echo "$STATS"
 
-    DELTA=$(echo -n "$STATS" | tail +2 | { grep -v '~' || true; } | awk '{print $(NF-2)}')
-    if [[ $DELTA == +* ]]; then # If delta is positive
+    # Delta - difference between performance - a positive value denotes performance degradation
+    DELTA=$(echo -n "$STATS" | tail +2 | { grep -v '~' || true; } | awk '{print $(NF-2)}' | grep '^+')
+    if [[ -n "$DELTA" ]]; then # grep will only catch positive values that indicate degradation
       log::error "There is significant performance degradation in the new release!"
       CHECK_FAILED=true
       FAILED_TESTS="$CONTAINER\\n$FAILED_TESTS"

--- a/installation/scripts/prow/jobs/compass-gke-benchmark.sh
+++ b/installation/scripts/prow/jobs/compass-gke-benchmark.sh
@@ -354,7 +354,8 @@ for POD in $PODS; do
     echo "$STATS"
 
     # Delta - difference between performance - a positive value denotes performance degradation
-    DELTA=$(echo -n "$STATS" | tail +2 | { grep -v '~' || true; } | awk '{print $(NF-2)}' | grep '^+')
+    # '|| true' is needed as grep returns exit code 1 when it cannot find a line and breaks the pipeline
+    DELTA=$(echo -n "$STATS" | tail +2 | { grep -v '~' || true; } | awk '{print $(NF-2)}' | grep '^+' || true)
     if [[ -n "$DELTA" ]]; then # grep will only catch positive values that indicate degradation
       log::error "There is significant performance degradation in the new release!"
       CHECK_FAILED=true


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Currently, the benchmark test does not fail when there is performance degradation. This is due to the grep function that relied on a different output format of the benchstat Go tool.

Changes proposed in this pull request:
- grep only positive values that indicate regression

**Pull Request status**
<!-- Feel free to construct the checklist with whatever items seem most reasonable for your change. You could disassemble the Implementation part to even smaller separate checklist items if you're working on something big for example. But do make the effort to provide a checklist of some sort so that the core team as well as the community can have an idea about the progress of your Pull Request.
-->

- [x] Implementation
- [ ] Unit tests
- [ ] Integration tests
- [ ] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [ ] Mocks are regenerated, using the automated script
