### PR TITLE
Fix benchmark job

### DIFF
--- a/installation/resources/compass-overrides-gke-benchmark.yaml
+++ b/installation/resources/compass-overrides-gke-benchmark.yaml
@@ -33,6 +33,8 @@ global:
     secrets:
       externalCertSvcSecret:
         manage: true
+      publicPrivateKeysSecret:
+        manage: true
   extSvcCertConfiguration:
     secrets:
       extSvcCertSvcSecret:


### PR DESCRIPTION
**Description**
I assume that since the benchmark job installs compass from main first and then from the PR branch, the cluster was probably installed successfully the first time and on the second installation, since the secret exists, passed. Now that #3460 is merged, the first installation does not have the overrides and fails.
I tested this out by removing the corresponding local overrides (compass-overrides-local.yaml), and the cluster installation failed the same way the benchmark job fails.

> Note: The benchmark job will not pass on this PR, but on the subsequent pull requests, as this needs to be in the main branch in order to be the first compass installation.

Changes proposed in this pull request:
- add overrides matching the local ones for benchmark job

**Related issue(s)**
- #3460

**Pull Request status**
- [x] [N/A] Implementation
- [x] [N/A] Unit tests
- [x]  [N/A]Integration tests
- [x] [N/A] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [x] [N/A] Mocks are regenerated, using the automated script
