### PR TITLE
Fix notification response with empty error message

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -217,7 +217,7 @@ global:
       version: "0a651695"
     external_services_mock:
       dir: dev/incubator/
-      version: "PR-3484"
+      version: "PR-3498"
       name: compass-external-services-mock
     console:
       dir: prod/incubator/
@@ -225,7 +225,7 @@ global:
       name: compass-console
     e2e_tests:
       dir: dev/incubator/
-      version: "PR-3483"
+      version: "PR-3498"
       name: compass-e2e-tests
   isLocalEnv: false
   isForTesting: false

--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -168,7 +168,7 @@ global:
       name: compass-pairing-adapter
     director:
       dir: dev/incubator/
-      version: "PR-3492"
+      version: "PR-3498"
       name: compass-director
     hydrator:
       dir: dev/incubator/

--- a/components/director/internal/domain/formationassignment/status_service.go
+++ b/components/director/internal/domain/formationassignment/status_service.go
@@ -57,7 +57,6 @@ func (fau *formationAssignmentStatusService) UpdateWithConstraints(ctx context.C
 	fa.State = stateFromReport
 
 	if isErrorState(model.FormationAssignmentState(stateFromReport)) {
-		assignmentError := json.RawMessage{}
 		if notificationStatusReport.Error != "" {
 			assignmentErrorWrapper := AssignmentErrorWrapper{AssignmentError{
 				Message:   notificationStatusReport.Error,
@@ -67,9 +66,8 @@ func (fau *formationAssignmentStatusService) UpdateWithConstraints(ctx context.C
 			if err != nil {
 				return errors.Wrapf(err, "While preparing error message for assignment with ID %q", fa.ID)
 			}
-			assignmentError = marshaled
+			fa.Error = marshaled
 		}
-		fa.Error = assignmentError
 	}
 
 	if !isErrorState(model.FormationAssignmentState(stateFromReport)) {

--- a/components/external-services-mock/cmd/main.go
+++ b/components/external-services-mock/cmd/main.go
@@ -6,11 +6,12 @@ import (
 	"crypto/rsa"
 	"crypto/tls"
 	"fmt"
-	"github.com/kyma-incubator/compass/components/director/pkg/credloader"
 	"net/http"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/kyma-incubator/compass/components/director/pkg/credloader"
 
 	"github.com/kyma-incubator/compass/components/external-services-mock/pkg/claims"
 
@@ -409,6 +410,8 @@ func initDefaultCertServer(cfg config, key *rsa.PrivateKey, staticMappingClaims 
 	router.HandleFunc("/formation-callback/async-fail-once/{tenantId}/{applicationId}", notificationHandler.AsyncFailOnce).Methods(http.MethodDelete)
 	router.HandleFunc("/formation-callback/async-fail/{tenantId}", notificationHandler.AsyncFail).Methods(http.MethodPatch)
 	router.HandleFunc("/formation-callback/async-fail/{tenantId}/{applicationId}", notificationHandler.AsyncFail).Methods(http.MethodDelete)
+	router.HandleFunc("/formation-callback/async-fail-no-error/{tenantId}", notificationHandler.AsyncFailNoError).Methods(http.MethodPatch)
+	router.HandleFunc("/formation-callback/async-fail-no-error/{tenantId}/{applicationId}", notificationHandler.AsyncFailNoError).Methods(http.MethodDelete)
 	// formation assignment notifications handler for the destination creation/deletion
 	router.HandleFunc("/formation-callback/destinations/configuration/{tenantId}", notificationHandler.RespondWithIncompleteAndDestinationDetails).Methods(http.MethodPatch)
 	router.HandleFunc("/formation-callback/destinations/configuration/{tenantId}/{applicationId}", notificationHandler.DestinationDelete).Methods(http.MethodDelete)

--- a/components/external-services-mock/internal/formationnotification/handler.go
+++ b/components/external-services-mock/internal/formationnotification/handler.go
@@ -739,7 +739,7 @@ func (h *Handler) executeFormationAssignmentStatusUpdateRequest(certSecuredHTTPC
 
 	request.Header.Add(correlation.RequestIDHeaderKey, correlationID)
 	request.Header.Add(httphelpers.ContentTypeHeaderKey, httphelpers.ContentTypeApplicationJSON)
-	log.C(ctx).Infof("Calling status API for formation assignment status update with the following data - formation ID: %s, assignment with ID: %s, state: %s and config: %s", formationID, formationAssignmentID, state, testConfig)
+	log.C(ctx).Infof("Calling status API for formation assignment status update with the following data - formation ID: %s, assignment with ID: %s, state: %s and config: %v", formationID, formationAssignmentID, state, testConfig)
 	_, err = certSecuredHTTPClient.Do(request)
 	return err
 }

--- a/components/external-services-mock/internal/formationnotification/handler.go
+++ b/components/external-services-mock/internal/formationnotification/handler.go
@@ -627,9 +627,7 @@ func (h *Handler) AsyncNoResponseUnassign(writer http.ResponseWriter, r *http.Re
 func (h *Handler) AsyncFailOnce(writer http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	operation := Assign
-	if r.Method == http.MethodPatch {
-		operation = Assign
-	} else if r.Method == http.MethodDelete {
+	if r.Method == http.MethodDelete {
 		operation = Unassign
 	}
 	responseFunc := func(client *http.Client, correlationID, formationID, formationAssignmentID, config string) {
@@ -659,9 +657,7 @@ func (h *Handler) AsyncFailOnce(writer http.ResponseWriter, r *http.Request) {
 func (h *Handler) AsyncFail(writer http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	operation := Assign
-	if r.Method == http.MethodPatch {
-		operation = Assign
-	} else if r.Method == http.MethodDelete {
+	if r.Method == http.MethodDelete {
 		operation = Unassign
 	}
 	responseFunc := func(client *http.Client, correlationID, formationID, formationAssignmentID, config string) {
@@ -683,9 +679,7 @@ func (h *Handler) AsyncFail(writer http.ResponseWriter, r *http.Request) {
 func (h *Handler) AsyncFailNoError(writer http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	operation := Assign
-	if r.Method == http.MethodPatch {
-		operation = Assign
-	} else if r.Method == http.MethodDelete {
+	if r.Method == http.MethodDelete {
 		operation = Unassign
 	}
 	responseFunc := func(client *http.Client, correlationID, formationID, formationAssignmentID, config string) {

--- a/tests/director/tests/notifications/application_only_notifications_test.go
+++ b/tests/director/tests/notifications/application_only_notifications_test.go
@@ -2432,7 +2432,7 @@ func TestFormationNotificationsWithApplicationOnlyParticipants(t *testing.T) {
 			cleanupNotificationsFromExternalSvcMock(t, certSecuredHTTPClient)
 			defer cleanupNotificationsFromExternalSvcMock(t, certSecuredHTTPClient)
 
-			urlTemplateAsyncApplication := "{\\\"path\\\":\\\"" + conf.ExternalServicesMockMtlsSecuredURL + "/formation-callback/async-fail/{{.TargetApplication.ID}}{{if eq .Operation \\\"unassign\\\"}}/{{.SourceApplication.ID}}{{end}}\\\",\\\"method\\\":\\\"{{if eq .Operation \\\"assign\\\"}}PATCH{{else}}DELETE{{end}}\\\"}"
+			urlTemplateAsyncApplication := "{\\\"path\\\":\\\"" + conf.ExternalServicesMockMtlsSecuredURL + "/formation-callback/async-fail-no-error/{{.TargetApplication.ID}}{{if eq .Operation \\\"unassign\\\"}}/{{.SourceApplication.ID}}{{end}}\\\",\\\"method\\\":\\\"{{if eq .Operation \\\"assign\\\"}}PATCH{{else}}DELETE{{end}}\\\"}"
 			inputTemplateAsyncApplication := "{\\\"ucl-formation-id\\\":\\\"{{.FormationID}}\\\",\\\"globalAccountId\\\":\\\"{{.CustomerTenantContext.AccountID}}\\\",\\\"crmId\\\":\\\"{{.CustomerTenantContext.CustomerID}}\\\",\\\"formation-assignment-id\\\":\\\"{{ .Assignment.ID }}\\\",\\\"items\\\":[{\\\"region\\\":\\\"{{ if .SourceApplication.Labels.region }}{{.SourceApplication.Labels.region}}{{ else }}{{.SourceApplicationTemplate.Labels.region}}{{ end }}\\\",\\\"application-namespace\\\":\\\"{{.SourceApplicationTemplate.ApplicationNamespace}}\\\",\\\"tenant-id\\\":\\\"{{.SourceApplication.LocalTenantID}}\\\",\\\"ucl-system-tenant-id\\\":\\\"{{.SourceApplication.ID}}\\\"}]}"
 			outputTemplateAsyncApplication := "{\\\"config\\\":\\\"{{.Body.config}}\\\", \\\"location\\\":\\\"{{.Headers.Location}}\\\",\\\"error\\\": \\\"{{.Body.error}}\\\",\\\"success_status_code\\\": 202}"
 
@@ -2449,7 +2449,7 @@ func TestFormationNotificationsWithApplicationOnlyParticipants(t *testing.T) {
 			require.Equal(t, formation.State, assignedFormation.State)
 
 			expectedAssignments := map[string]map[string]fixtures.AssignmentState{
-				app1.ID: {app1.ID: fixtures.AssignmentState{State: "CREATE_ERROR", Config: nil, Value: fixtures.StatusAPIAsyncErrorMessageJSON, Error: fixtures.StatusAPIAsyncErrorMessageJSON}},
+				app1.ID: {app1.ID: fixtures.AssignmentState{State: "CREATE_ERROR", Config: nil, Value: nil, Error: nil}},
 			}
 			assertFormationAssignmentsAsynchronouslyWithEventually(t, ctx, tnt, formation.ID, 1, expectedAssignments, eventuallyTimeout, eventuallyTick)
 
@@ -2483,7 +2483,7 @@ func TestFormationNotificationsWithApplicationOnlyParticipants(t *testing.T) {
 			require.Equal(t, formationName, unassignFormation.Name)
 
 			expectedAssignments = map[string]map[string]fixtures.AssignmentState{
-				app1.ID: {app1.ID: fixtures.AssignmentState{State: "DELETE_ERROR", Config: nil, Value: fixtures.StatusAPIAsyncErrorMessageJSON, Error: fixtures.StatusAPIAsyncErrorMessageJSON}},
+				app1.ID: {app1.ID: fixtures.AssignmentState{State: "DELETE_ERROR", Config: nil, Value: nil, Error: nil}},
 			}
 			assertFormationAssignmentsAsynchronouslyWithEventually(t, ctx, tnt, formation.ID, 1, expectedAssignments, eventuallyTimeout, eventuallyTick)
 


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:
- set error only if there is error, so that we don't fall into the `json.RawMessage{}` case, in which it tries to update the formation assignment error with a non-nil value that is `""`, which is not a valid JSON.
- adapt e2e test to cover this case
- add external services mock response with error state and no message

**Related issue(s)**
- #3484

**Pull Request status**
<!-- Feel free to construct the checklist with whatever items seem most reasonable for your change. You could disassemble the Implementation part to even smaller separate checklist items if you're working on something big for example. But do make the effort to provide a checklist of some sort so that the core team as well as the community can have an idea about the progress of your Pull Request.
-->

- [x] Implementation
- [x] [N/A] Unit tests
- [x] Integration tests
- [x] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [x] [N/A] Mocks are regenerated, using the automated script
