### PR TITLE
Improve certificate rotation jobs logs.

### DIFF
--- a/chart/compass/charts/director/files/certificate_rotation.sh
+++ b/chart/compass/charts/director/files/certificate_rotation.sh
@@ -80,7 +80,7 @@ else
  echo "$CERT_SVC_OAUTH_CLIENT_KEY" | openssl enc -base64 -d -A -out /tmp/client-key.pem
 fi
 
-TOKEN=$(curl \
+TOKEN_RESPONSE=$(curl \
   -s $SKIP_SSL_VALIDATION_FLAG \
   -m 30 \
   -X POST \
@@ -89,11 +89,13 @@ TOKEN=$(curl \
   "$CERT_SVC_OAUTH_URL$CERT_SVC_TOKEN_PATH" \
   -H "Content-Type: application/x-www-form-urlencoded" \
   -H "Accept: application/json" \
-  -d "grant_type=client_credentials&token_format=bearer&client_id=$CERT_SVC_CLIENT_ID" \
-  | jq -r .access_token)
+  -d "grant_type=client_credentials&token_format=bearer&client_id=$CERT_SVC_CLIENT_ID")
+
+TOKEN=$(echo $TOKEN_RESPONSE | jq -r .access_token)
 
 if [[ -z "$TOKEN" || $TOKEN == "null" ]]; then
-  echo -e "${RED}Bearer token should not be empty or null. Exiting... ${NC}"
+  echo -e "${RED}Token response: $TOKEN_RESPONSE${NC}"
+  echo -e "${RED}Bearer token is missing. Exiting... ${NC}"
   exit 1
 fi
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Currently, when one of the certificate rotation jobs fails on the token fetching, the script returns just "Bearer token should not be empty or null. Exiting..." which makes debugging the script impossible. This PR enhances the script logs.

Changes proposed in this pull request:
- Enhance rotation jobs logs.

**Pull Request status**
<!-- Feel free to construct the checklist with whatever items seem most reasonable for your change. You could disassemble the Implementation part to even smaller separate checklist items if you're working on something big for example. But do make the effort to provide a checklist of some sort so that the core team as well as the community can have an idea about the progress of your Pull Request.
-->

- [ ] Implementation
- [ ] Unit tests
- [ ] Integration tests
- [ ] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [ ] Mocks are regenerated, using the automated script
