### PR TITLE
Expose APIs and Events under System Instances in ORD Service

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -200,7 +200,7 @@ global:
       name: compass-operations-controller
     ord_service:
       dir: dev/incubator/
-      version: "PR-112"
+      version: "PR-116"
       name: compass-ord-service
     schema_migrator:
       dir: dev/incubator/

--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -225,7 +225,7 @@ global:
       name: compass-console
     e2e_tests:
       dir: dev/incubator/
-      version: "PR-3527"
+      version: "PR-3538"
       name: compass-e2e-tests
   isLocalEnv: false
   isForTesting: false

--- a/tests/ord-service/tests/api_test.go
+++ b/tests/ord-service/tests/api_test.go
@@ -357,6 +357,22 @@ func TestORDService(stdT *testing.T) {
 			require.Equal(t, testData.appInput.Name, gjson.Get(respBody, "value.0.title").String())
 			require.Equal(t, *testData.appInput.Description, gjson.Get(respBody, "value.0.description").String())
 		})
+		t.Run(fmt.Sprintf("Requesting System Instances with apis for tenant %s returns them as expected", testData.msg), func(t *testing.T) {
+			respBody := makeRequestWithHeaders(t, testData.client, testData.url+"/systemInstances?$format=json&$expand=apis", testData.headers)
+			require.Equal(t, 1, len(gjson.Get(respBody, "value").Array()))
+			require.Equal(t, testData.appInput.Name, gjson.Get(respBody, "value.0.title").String())
+			require.Equal(t, *testData.appInput.Description, gjson.Get(respBody, "value.0.description").String())
+
+			assertEqualAPIDefinitions(t, testData.appInput.Bundles[0].APIDefinitions, gjson.Get(respBody, "value.0.apis").String(), testData.apisMap, testData.client, testData.headers)
+		})
+		t.Run(fmt.Sprintf("Requesting System Instances with events for tenant %s returns them as expected", testData.msg), func(t *testing.T) {
+			respBody := makeRequestWithHeaders(t, testData.client, testData.url+"/systemInstances?$format=json&$expand=events", testData.headers)
+			require.Equal(t, 1, len(gjson.Get(respBody, "value").Array()))
+			require.Equal(t, testData.appInput.Name, gjson.Get(respBody, "value.0.title").String())
+			require.Equal(t, *testData.appInput.Description, gjson.Get(respBody, "value.0.description").String())
+
+			assertEqualEventDefinitions(t, testData.appInput.Bundles[0].EventDefinitions, gjson.Get(respBody, "value.0.events").String(), testData.eventsMap, testData.client, testData.headers)
+		})
 
 		t.Run(fmt.Sprintf("Requesting Bundles for tenant %s returns them as expected", testData.msg), func(t *testing.T) {
 			respBody := makeRequestWithHeaders(t, testData.client, testData.url+"/consumptionBundles?$format=json", testData.headers)
@@ -369,146 +385,13 @@ func TestORDService(stdT *testing.T) {
 		t.Run(fmt.Sprintf("Requesting APIs and their specs for tenant %s returns them as expected", testData.msg), func(t *testing.T) {
 			respBody := makeRequestWithHeaders(t, testData.client, testData.url+"/apis?$format=json", testData.headers)
 
-			require.Equal(t, len(testData.appInput.Bundles[0].APIDefinitions), len(gjson.Get(respBody, "value").Array()))
-
-			for i := range testData.appInput.Bundles[0].APIDefinitions {
-				name := gjson.Get(respBody, fmt.Sprintf("value.%d.title", i)).String()
-				require.NotEmpty(t, name)
-
-				expectedAPI, exists := testData.apisMap[name]
-				require.True(t, exists)
-
-				require.Equal(t, *expectedAPI.Description, gjson.Get(respBody, fmt.Sprintf("value.%d.description", i)).String())
-				require.Equal(t, expectedAPI.TargetURL, gjson.Get(respBody, fmt.Sprintf("value.%d.entryPoints.0.value", i)).String())
-				require.NotEmpty(t, gjson.Get(respBody, fmt.Sprintf("value.%d.partOfConsumptionBundles", i)).String())
-
-				releaseStatus := gjson.Get(respBody, fmt.Sprintf("value.%d.releaseStatus", i)).String()
-				switch releaseStatus {
-				case "decommissioned":
-					require.True(t, *expectedAPI.Version.ForRemoval)
-					require.True(t, *expectedAPI.Version.Deprecated)
-				case "deprecated":
-					require.False(t, *expectedAPI.Version.ForRemoval)
-					require.True(t, *expectedAPI.Version.Deprecated)
-				case "active":
-					require.False(t, *expectedAPI.Version.ForRemoval)
-					require.False(t, *expectedAPI.Version.Deprecated)
-				default:
-					panic(errors.New(fmt.Sprintf("Unknown release status: %s", releaseStatus)))
-				}
-
-				apiProtocol := gjson.Get(respBody, fmt.Sprintf("value.%d.apiProtocol", i)).String()
-				switch apiProtocol {
-				case "odata-v2":
-					require.Equal(t, expectedAPI.Spec.Type, directorSchema.APISpecTypeOdata)
-				case "rest":
-					require.Equal(t, expectedAPI.Spec.Type, directorSchema.APISpecTypeOpenAPI)
-				default:
-					t.Log(fmt.Sprintf("API Protocol for API %s is %s. It does not match a predefined spec type.", name, apiProtocol))
-				}
-
-				specs := gjson.Get(respBody, fmt.Sprintf("value.%d.resourceDefinitions", i)).Array()
-				require.Equal(t, 1, len(specs))
-
-				specType := specs[0].Get("type").String()
-				switch specType {
-				case "edmx":
-					require.Equal(t, expectedAPI.Spec.Type, directorSchema.APISpecTypeOdata)
-				case "openapi-v3":
-					require.Equal(t, expectedAPI.Spec.Type, directorSchema.APISpecTypeOpenAPI)
-				default:
-					panic(errors.New(fmt.Sprintf("Unknown spec type: %s", specType)))
-				}
-
-				specFormat := specs[0].Get("mediaType").String()
-				switch specFormat {
-				case "text/yaml":
-					require.Equal(t, expectedAPI.Spec.Format, directorSchema.SpecFormatYaml)
-				case "application/json":
-					require.Equal(t, expectedAPI.Spec.Format, directorSchema.SpecFormatJSON)
-				case "application/xml":
-					require.Equal(t, expectedAPI.Spec.Format, directorSchema.SpecFormatXML)
-				default:
-					panic(errors.New(fmt.Sprintf("Unknown spec format: %s", specFormat)))
-				}
-
-				apiID := gjson.Get(respBody, fmt.Sprintf("value.%d.id", i)).String()
-				require.NotEmpty(t, apiID)
-
-				specURL := specs[0].Get("url").String()
-				specPath := fmt.Sprintf("/api/%s/specification", apiID)
-				require.Contains(t, specURL, conf.ORDServiceStaticPrefix+specPath)
-
-				respBody := makeRequestWithHeaders(t, testData.client, specURL, testData.headers)
-
-				require.Equal(t, string(*expectedAPI.Spec.Data), respBody)
-			}
+			assertEqualAPIDefinitions(t, testData.appInput.Bundles[0].APIDefinitions, gjson.Get(respBody, "value").String(), testData.apisMap, testData.client, testData.headers)
 		})
 
 		t.Run(fmt.Sprintf("Requesting Events and their specs for tenant %s returns them as expected", testData.msg), func(t *testing.T) {
 			respBody := makeRequestWithHeaders(t, testData.client, testData.url+"/events?$format=json", testData.headers)
 
-			require.Equal(t, len(testData.appInput.Bundles[0].EventDefinitions), len(gjson.Get(respBody, "value").Array()))
-
-			for i := range testData.appInput.Bundles[0].EventDefinitions {
-				name := gjson.Get(respBody, fmt.Sprintf("value.%d.title", i)).String()
-				require.NotEmpty(t, name)
-
-				expectedEvent, exists := testData.eventsMap[name]
-				require.True(t, exists)
-
-				require.Equal(t, *expectedEvent.Description, gjson.Get(respBody, fmt.Sprintf("value.%d.description", i)).String())
-				require.NotEmpty(t, gjson.Get(respBody, fmt.Sprintf("value.%d.partOfConsumptionBundles", i)).String())
-
-				releaseStatus := gjson.Get(respBody, fmt.Sprintf("value.%d.releaseStatus", i)).String()
-				switch releaseStatus {
-				case "decommissioned":
-					require.True(t, *expectedEvent.Version.ForRemoval)
-					require.True(t, *expectedEvent.Version.Deprecated)
-				case "deprecated":
-					require.False(t, *expectedEvent.Version.ForRemoval)
-					require.True(t, *expectedEvent.Version.Deprecated)
-				case "active":
-					require.False(t, *expectedEvent.Version.ForRemoval)
-					require.False(t, *expectedEvent.Version.Deprecated)
-				default:
-					panic(errors.New(fmt.Sprintf("Unknown release status: %s", releaseStatus)))
-				}
-
-				specs := gjson.Get(respBody, fmt.Sprintf("value.%d.resourceDefinitions", i)).Array()
-				require.Equal(t, 1, len(specs))
-
-				specType := specs[0].Get("type").String()
-				switch specType {
-				case "asyncapi-v2":
-					require.Equal(t, expectedEvent.Spec.Type, directorSchema.EventSpecTypeAsyncAPI)
-				default:
-					panic(errors.New(fmt.Sprintf("Unknown spec type: %s", specType)))
-				}
-
-				specFormat := specs[0].Get("mediaType").String()
-				switch specFormat {
-				case "text/yaml":
-					require.Equal(t, expectedEvent.Spec.Format, directorSchema.SpecFormatYaml)
-				case "application/json":
-					require.Equal(t, expectedEvent.Spec.Format, directorSchema.SpecFormatJSON)
-				case "application/xml":
-					require.Equal(t, expectedEvent.Spec.Format, directorSchema.SpecFormatXML)
-				default:
-					panic(errors.New(fmt.Sprintf("Unknown spec format: %s", specFormat)))
-				}
-
-				eventID := gjson.Get(respBody, fmt.Sprintf("value.%d.id", i)).String()
-				require.NotEmpty(t, eventID)
-
-				specURL := specs[0].Get("url").String()
-				specPath := fmt.Sprintf("/event/%s/specification", eventID)
-				require.Contains(t, specURL, conf.ORDServiceStaticPrefix+specPath)
-
-				respBody := makeRequestWithHeaders(t, testData.client, specURL, testData.headers)
-
-				require.Equal(t, string(*expectedEvent.Spec.Data), respBody)
-			}
+			assertEqualEventDefinitions(t, testData.appInput.Bundles[0].EventDefinitions, gjson.Get(respBody, "value").String(), testData.eventsMap, testData.client, testData.headers)
 		})
 
 		// Paging:
@@ -755,6 +638,148 @@ func TestORDService(stdT *testing.T) {
 			require.Equal(t, expectedProductType, gjson.Get(respBody, "productType").String())
 		})
 	})
+}
+
+func assertEqualAPIDefinitions(t *testing.T, expectedAPIDefinitions []*directorSchema.APIDefinitionInput, actualAPIDefinitions string, apisMap map[string]directorSchema.APIDefinitionInput, client *http.Client, headers map[string][]string) {
+	require.Equal(t, len(expectedAPIDefinitions), len(gjson.Parse(actualAPIDefinitions).Array()))
+
+	for i := range expectedAPIDefinitions {
+		name := gjson.Get(actualAPIDefinitions, fmt.Sprintf("%d.title", i)).String()
+		require.NotEmpty(t, name)
+
+		expectedAPI, exists := apisMap[name]
+		require.True(t, exists)
+
+		require.Equal(t, *expectedAPI.Description, gjson.Get(actualAPIDefinitions, fmt.Sprintf("%d.description", i)).String())
+		require.Equal(t, expectedAPI.TargetURL, gjson.Get(actualAPIDefinitions, fmt.Sprintf("%d.entryPoints.0.value", i)).String())
+		require.NotEmpty(t, gjson.Get(actualAPIDefinitions, fmt.Sprintf("%d.partOfConsumptionBundles", i)).String())
+
+		releaseStatus := gjson.Get(actualAPIDefinitions, fmt.Sprintf("%d.releaseStatus", i)).String()
+		switch releaseStatus {
+		case "decommissioned":
+			require.True(t, *expectedAPI.Version.ForRemoval)
+			require.True(t, *expectedAPI.Version.Deprecated)
+		case "deprecated":
+			require.False(t, *expectedAPI.Version.ForRemoval)
+			require.True(t, *expectedAPI.Version.Deprecated)
+		case "active":
+			require.False(t, *expectedAPI.Version.ForRemoval)
+			require.False(t, *expectedAPI.Version.Deprecated)
+		default:
+			panic(errors.New(fmt.Sprintf("Unknown release status: %s", releaseStatus)))
+		}
+
+		apiProtocol := gjson.Get(actualAPIDefinitions, fmt.Sprintf("%d.apiProtocol", i)).String()
+		switch apiProtocol {
+		case "odata-v2":
+			require.Equal(t, expectedAPI.Spec.Type, directorSchema.APISpecTypeOdata)
+		case "rest":
+			require.Equal(t, expectedAPI.Spec.Type, directorSchema.APISpecTypeOpenAPI)
+		default:
+			t.Log(fmt.Sprintf("API Protocol for API %s is %s. It does not match a predefined spec type.", name, apiProtocol))
+		}
+
+		specs := gjson.Get(actualAPIDefinitions, fmt.Sprintf("%d.resourceDefinitions", i)).Array()
+		require.Equal(t, 1, len(specs))
+
+		specType := specs[0].Get("type").String()
+		switch specType {
+		case "edmx":
+			require.Equal(t, expectedAPI.Spec.Type, directorSchema.APISpecTypeOdata)
+		case "openapi-v3":
+			require.Equal(t, expectedAPI.Spec.Type, directorSchema.APISpecTypeOpenAPI)
+		default:
+			panic(errors.New(fmt.Sprintf("Unknown spec type: %s", specType)))
+		}
+
+		specFormat := specs[0].Get("mediaType").String()
+		switch specFormat {
+		case "text/yaml":
+			require.Equal(t, expectedAPI.Spec.Format, directorSchema.SpecFormatYaml)
+		case "application/json":
+			require.Equal(t, expectedAPI.Spec.Format, directorSchema.SpecFormatJSON)
+		case "application/xml":
+			require.Equal(t, expectedAPI.Spec.Format, directorSchema.SpecFormatXML)
+		default:
+			panic(errors.New(fmt.Sprintf("Unknown spec format: %s", specFormat)))
+		}
+
+		apiID := gjson.Get(actualAPIDefinitions, fmt.Sprintf("%d.id", i)).String()
+		require.NotEmpty(t, apiID)
+
+		specURL := specs[0].Get("url").String()
+		specPath := fmt.Sprintf("/api/%s/specification", apiID)
+		require.Contains(t, specURL, conf.ORDServiceStaticPrefix+specPath)
+
+		respBody := makeRequestWithHeaders(t, client, specURL, headers)
+
+		require.Equal(t, string(*expectedAPI.Spec.Data), respBody)
+
+	}
+}
+
+func assertEqualEventDefinitions(t *testing.T, expectedEventDefinitions []*directorSchema.EventDefinitionInput, actualEventDefinitions string, eventsMap map[string]directorSchema.EventDefinitionInput, client *http.Client, headers map[string][]string) {
+	require.Equal(t, len(expectedEventDefinitions), len(gjson.Parse(actualEventDefinitions).Array()))
+
+	for i := range expectedEventDefinitions {
+		name := gjson.Get(actualEventDefinitions, fmt.Sprintf("%d.title", i)).String()
+		require.NotEmpty(t, name)
+
+		expectedEvent, exists := eventsMap[name]
+		require.True(t, exists)
+
+		require.Equal(t, *expectedEvent.Description, gjson.Get(actualEventDefinitions, fmt.Sprintf("%d.description", i)).String())
+		require.NotEmpty(t, gjson.Get(actualEventDefinitions, fmt.Sprintf("%d.partOfConsumptionBundles", i)).String())
+
+		releaseStatus := gjson.Get(actualEventDefinitions, fmt.Sprintf("%d.releaseStatus", i)).String()
+		switch releaseStatus {
+		case "decommissioned":
+			require.True(t, *expectedEvent.Version.ForRemoval)
+			require.True(t, *expectedEvent.Version.Deprecated)
+		case "deprecated":
+			require.False(t, *expectedEvent.Version.ForRemoval)
+			require.True(t, *expectedEvent.Version.Deprecated)
+		case "active":
+			require.False(t, *expectedEvent.Version.ForRemoval)
+			require.False(t, *expectedEvent.Version.Deprecated)
+		default:
+			panic(errors.New(fmt.Sprintf("Unknown release status: %s", releaseStatus)))
+		}
+
+		specs := gjson.Get(actualEventDefinitions, fmt.Sprintf("%d.resourceDefinitions", i)).Array()
+		require.Equal(t, 1, len(specs))
+
+		specType := specs[0].Get("type").String()
+		switch specType {
+		case "asyncapi-v2":
+			require.Equal(t, expectedEvent.Spec.Type, directorSchema.EventSpecTypeAsyncAPI)
+		default:
+			panic(errors.New(fmt.Sprintf("Unknown spec type: %s", specType)))
+		}
+
+		specFormat := specs[0].Get("mediaType").String()
+		switch specFormat {
+		case "text/yaml":
+			require.Equal(t, expectedEvent.Spec.Format, directorSchema.SpecFormatYaml)
+		case "application/json":
+			require.Equal(t, expectedEvent.Spec.Format, directorSchema.SpecFormatJSON)
+		case "application/xml":
+			require.Equal(t, expectedEvent.Spec.Format, directorSchema.SpecFormatXML)
+		default:
+			panic(errors.New(fmt.Sprintf("Unknown spec format: %s", specFormat)))
+		}
+
+		eventID := gjson.Get(actualEventDefinitions, fmt.Sprintf("%d.id", i)).String()
+		require.NotEmpty(t, eventID)
+
+		specURL := specs[0].Get("url").String()
+		specPath := fmt.Sprintf("/event/%s/specification", eventID)
+		require.Contains(t, specURL, conf.ORDServiceStaticPrefix+specPath)
+
+		respBody := makeRequestWithHeaders(t, client, specURL, headers)
+
+		require.Equal(t, string(*expectedEvent.Spec.Data), respBody)
+	}
 }
 
 func makeRequestWithHeaders(t require.TestingT, httpClient *http.Client, url string, headers map[string][]string) string {

--- a/tests/ord-service/tests/api_test.go
+++ b/tests/ord-service/tests/api_test.go
@@ -358,7 +358,7 @@ func TestORDService(stdT *testing.T) {
 			require.Equal(t, *testData.appInput.Description, gjson.Get(respBody, "value.0.description").String())
 		})
 		t.Run(fmt.Sprintf("Requesting System Instances with apis for tenant %s returns them as expected", testData.msg), func(t *testing.T) {
-			respBody := makeRequestWithHeaders(t, testData.client, testData.url+"/systemInstances?$format=json&$expand=apis", testData.headers)
+			respBody := makeRequestWithHeaders(t, testData.client, testData.url+"/systemInstances?$expand=apis&$format=json", testData.headers)
 			require.Equal(t, 1, len(gjson.Get(respBody, "value").Array()))
 			require.Equal(t, testData.appInput.Name, gjson.Get(respBody, "value.0.title").String())
 			require.Equal(t, *testData.appInput.Description, gjson.Get(respBody, "value.0.description").String())
@@ -366,7 +366,7 @@ func TestORDService(stdT *testing.T) {
 			assertEqualAPIDefinitions(t, testData.appInput.Bundles[0].APIDefinitions, gjson.Get(respBody, "value.0.apis").String(), testData.apisMap, testData.client, testData.headers)
 		})
 		t.Run(fmt.Sprintf("Requesting System Instances with events for tenant %s returns them as expected", testData.msg), func(t *testing.T) {
-			respBody := makeRequestWithHeaders(t, testData.client, testData.url+"/systemInstances?$format=json&$expand=events", testData.headers)
+			respBody := makeRequestWithHeaders(t, testData.client, testData.url+"/systemInstances?$expand=events&$format=json", testData.headers)
 			require.Equal(t, 1, len(gjson.Get(respBody, "value").Array()))
 			require.Equal(t, testData.appInput.Name, gjson.Get(respBody, "value.0.title").String())
 			require.Equal(t, *testData.appInput.Description, gjson.Get(respBody, "value.0.description").String())


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:
- bump ORD service version
- add e2e test that validates systems instances have exposed APIs and Events

**Related issue(s)**
- kyma-incubator/ord-service#116

**Pull Request status**
<!-- Feel free to construct the checklist with whatever items seem most reasonable for your change. You could disassemble the Implementation part to even smaller separate checklist items if you're working on something big for example. But do make the effort to provide a checklist of some sort so that the core team as well as the community can have an idea about the progress of your Pull Request.
-->

- [x] [N/A] Implementation
- [x] [N/A] Unit tests
- [x] Integration tests
- [x] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [x] [N/A] Mocks are regenerated, using the automated script
