### PR TITLE
Fix unstable notification lifecycle test

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -225,7 +225,7 @@ global:
       name: compass-console
     e2e_tests:
       dir: dev/incubator/
-      version: "PR-3539"
+      version: "PR-3545"
       name: compass-e2e-tests
   isLocalEnv: false
   isForTesting: false

--- a/tests/director/tests/notifications/application_only_notifications_test.go
+++ b/tests/director/tests/notifications/application_only_notifications_test.go
@@ -784,7 +784,11 @@ func TestFormationNotificationsWithApplicationOnlyParticipantsOldFormat(t *testi
 				app2.ID: fixtures.AssignmentState{State: "READY", Config: nil, Value: nil, Error: nil},
 			},
 		}
-		assertFormationAssignmentsAsynchronouslyWithEventually(t, ctx, tnt, formation.ID, 4, expectedAssignments, time.Second*8, eventuallyTick)
+
+		// Formation creation actually sets the formation to READY state before sending notifications, so in some cases the timeout can be insufficient.
+		// The asynchronous assert passes whenever the formation is visibly READY, and we reach this assert,
+		// which usually starts after notifications are sent, but in this case it could be before/during sending of the notifications.
+		assertFormationAssignmentsAsynchronouslyWithEventually(t, ctx, tnt, formation.ID, 4, expectedAssignments, eventuallyTimeout*2, eventuallyTick)
 		assertFormationStatus(t, ctx, tnt, formation.ID, graphql.FormationStatus{Condition: graphql.FormationStatusConditionReady, Errors: nil})
 
 		body = getNotificationsFromExternalSvcMock(t, certSecuredHTTPClient)


### PR DESCRIPTION
**Description**
The test currently is unstable, as the timeout is not enough. Unlike other asserts, in this one the start of the check sometimes is before notifications are sent at all, so on slow executions it could fail. Depending on when it fails, it could leave garbage and lead to failures of other tests and the second execution.

Changes proposed in this pull request:
- increase timeout so that it doesn't fail
- add clarification as to why it isn't enough in this test

**Related issue(s)**
- #3485

**Pull Request status**
- [x] [N/A] Implementation
- [x] [N/A] Unit tests
- [x] Integration tests
- [x] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [x] [N/A] Mocks are regenerated, using the automated script
