### PR TITLE
Reduce logs in asynchronous logs in notification tests

### DIFF
--- a/tests/director/tests/notifications/fixtures_test.go
+++ b/tests/director/tests/notifications/fixtures_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	formationconstraintpkg "github.com/kyma-incubator/compass/components/director/pkg/formationconstraint"
+	testingx "github.com/kyma-incubator/compass/tests/pkg/testing"
 
 	directordestinationcreator "github.com/kyma-incubator/compass/components/director/pkg/destinationcreator"
 	"github.com/kyma-incubator/compass/components/director/pkg/graphql"
@@ -89,43 +90,44 @@ func assertFormationAssignments(t *testing.T, ctx context.Context, tenantID, for
 
 func assertFormationAssignmentsAsynchronouslyWithEventually(t *testing.T, ctx context.Context, tenantID, formationID string, expectedAssignmentsCount int, expectedAssignments map[string]map[string]fixtures.AssignmentState, timeout, tick time.Duration) {
 	t.Logf("Asserting formation assignments with eventually...")
+	tOnce := testingx.NewLoggerWithOnlyOnce(t)
 	require.Eventually(t, func() (isOkay bool) {
-		t.Logf("Getting formation assignments...")
+		tOnce.Logf("Getting formation assignments...")
 		listFormationAssignmentsRequest := fixtures.FixListFormationAssignmentRequest(formationID, 200)
 		assignmentsPage := fixtures.ListFormationAssignments(t, ctx, certSecuredGraphQLClient, tenantID, listFormationAssignmentsRequest)
 		if expectedAssignmentsCount != assignmentsPage.TotalCount {
 			t.Logf("The expected assignments count: %d didn't match the actual: %d", expectedAssignmentsCount, assignmentsPage.TotalCount)
 			return
 		}
-		t.Logf("There is/are: %d assignment(s), assert them with the expected ones...", assignmentsPage.TotalCount)
+		tOnce.Logf("There is/are: %d assignment(s), assert them with the expected ones...", assignmentsPage.TotalCount)
 
 		assignments := assignmentsPage.Data
 		for _, assignment := range assignments {
 			sourceAssignmentsExpectations, ok := expectedAssignments[assignment.Source]
 			if !ok {
-				t.Logf("Could not find expectations for assignment with ID: %q and source ID: %q", assignment.ID, assignment.Source)
+				tOnce.Logf("Could not find expectations for assignment with ID: %q and source ID: %q", assignment.ID, assignment.Source)
 				return
 			}
 			assignmentExpectation, ok := sourceAssignmentsExpectations[assignment.Target]
 			if !ok {
-				t.Logf("Could not find expectations for assignment with ID: %q, source ID: %q and target ID: %q", assignment.ID, assignment.Source, assignment.Target)
+				tOnce.Logf("Could not find expectations for assignment with ID: %q, source ID: %q and target ID: %q", assignment.ID, assignment.Source, assignment.Target)
 				return
 			}
 			if assignmentExpectation.State != assignment.State {
-				t.Logf("The expected assignment state: %s doesn't match the actual: %s for assignment ID: %s", assignmentExpectation.State, assignment.State, assignment.ID)
+				tOnce.Logf("The expected assignment state: %s doesn't match the actual: %s for assignment ID: %s", assignmentExpectation.State, assignment.State, assignment.ID)
 				return
 			}
-			if isEqual := jsonutils.AssertJSONStringEquality(t, assignmentExpectation.Error, assignment.Error); !isEqual {
-				t.Logf("The expected assignment state: %s doesn't match the actual: %s for assignment ID: %s", str.PtrStrToStr(assignmentExpectation.Error), str.PtrStrToStr(assignment.Error), assignment.ID)
+			if isEqual := jsonutils.AssertJSONStringEquality(tOnce, assignmentExpectation.Error, assignment.Error); !isEqual {
+				tOnce.Logf("The expected assignment state: %s doesn't match the actual: %s for assignment ID: %s", str.PtrStrToStr(assignmentExpectation.Error), str.PtrStrToStr(assignment.Error), assignment.ID)
 				return
 			}
-			if isEqual := jsonutils.AssertJSONStringEquality(t, assignmentExpectation.Config, assignment.Configuration); !isEqual {
-				t.Logf("The expected assignment config: %s doesn't match the actual: %s for assignment ID: %s", str.PtrStrToStr(assignmentExpectation.Config), str.PtrStrToStr(assignment.Configuration), assignment.ID)
+			if isEqual := jsonutils.AssertJSONStringEquality(tOnce, assignmentExpectation.Config, assignment.Configuration); !isEqual {
+				tOnce.Logf("The expected assignment config: %s doesn't match the actual: %s for assignment ID: %s", str.PtrStrToStr(assignmentExpectation.Config), str.PtrStrToStr(assignment.Configuration), assignment.ID)
 				return
 			}
 		}
 
-		t.Logf("Successfully asserted formation asssignments asynchronously")
+		tOnce.Logf("Successfully asserted formation asssignments asynchronously")
 		return true
 	}, timeout, tick)
 }
@@ -519,38 +521,39 @@ func assertAsyncFormationNotificationFromCreationOrDeletionExpectDeletedWithEven
 	require.Equal(t, formationName, notificationForFormationDetails.Get("name").String())
 
 	t.Logf("Asserting formation with eventually...")
+	tOnce := testingx.NewLoggerWithOnlyOnce(t)
 	require.Eventually(t, func() (isOkay bool) {
-		t.Log("Assert formation lifecycle notifications are successfully processed...")
+		tOnce.Log("Assert formation lifecycle notifications are successfully processed...")
 		formationPage := fixtures.ListFormationsWithinTenant(t, ctx, tenantID, certSecuredGraphQLClient)
 		if shouldExpectDeleted {
 			if formationPage.TotalCount != 0 {
-				t.Logf("Formation lifecycle notification is expected to have deleted formation with ID %q, but it is still there", formationID)
+				tOnce.Logf("Formation lifecycle notification is expected to have deleted formation with ID %q, but it is still there", formationID)
 				return
 			}
 			if formationPage.Data != nil && len(formationPage.Data) > 0 {
-				t.Logf("Formation lifecycle notification is expected to have deleted formation with ID %q, but it is still there", formationID)
+				tOnce.Logf("Formation lifecycle notification is expected to have deleted formation with ID %q, but it is still there", formationID)
 				return
 			}
 		} else {
 			if formationPage.TotalCount != 1 {
-				t.Log("Formation count does not match")
+				tOnce.Log("Formation count does not match")
 				return
 			}
 			if formationPage.Data[0].State != formationState {
-				t.Logf("Formation state for formation with ID %q is %q, expected: %q", formationID, formationPage.Data[0].State, formationState)
+				tOnce.Logf("Formation state for formation with ID %q is %q, expected: %q", formationID, formationPage.Data[0].State, formationState)
 				return
 			}
 			if formationPage.Data[0].ID != formationID {
-				t.Logf("Formation ID is %q, expected: %q", formationPage.Data[0].ID, formationID)
+				tOnce.Logf("Formation ID is %q, expected: %q", formationPage.Data[0].ID, formationID)
 				return
 			}
 			if formationPage.Data[0].Name != formationName {
-				t.Logf("Formation name is %q, expected: %q", formationPage.Data[0].Name, formationName)
+				tOnce.Logf("Formation name is %q, expected: %q", formationPage.Data[0].Name, formationName)
 				return
 			}
 		}
 
-		t.Logf("Asynchronous formation lifecycle notifications are successfully validated for %q operation.", formationOperation)
+		tOnce.Logf("Asynchronous formation lifecycle notifications are successfully validated for %q operation.", formationOperation)
 		return true
 	}, timeout, tick)
 }

--- a/tests/pkg/json/utils_json.go
+++ b/tests/pkg/json/utils_json.go
@@ -3,7 +3,6 @@ package json
 import (
 	"encoding/json"
 	"strconv"
-	"testing"
 
 	"github.com/kyma-incubator/compass/components/director/pkg/str"
 	"github.com/stretchr/testify/assert"
@@ -46,7 +45,7 @@ func UnmarshalJSONSchema(t require.TestingT, schema *graphql.JSONSchema) interfa
 	return output
 }
 
-func AssertJSONStringEquality(t *testing.T, expectedValue, actualValue *string) bool {
+func AssertJSONStringEquality(t require.TestingT, expectedValue, actualValue *string) bool {
 	expectedValueStr := str.PtrStrToStr(expectedValue)
 	actualValueStr := str.PtrStrToStr(actualValue)
 	if !isJSONStringEmpty(expectedValueStr) && !isJSONStringEmpty(actualValueStr) {

--- a/tests/pkg/testing/testing.go
+++ b/tests/pkg/testing/testing.go
@@ -18,6 +18,48 @@ func NewT(t *testing.T) *T {
 	}
 }
 
+type Logger interface {
+	Log(args ...any)
+	Logf(format string, args ...any)
+	Errorf(format string, args ...interface{})
+	FailNow()
+}
+
+type LoggerWithOnlyOnce struct {
+	logger        Logger
+	alreadyLogged map[string]bool
+}
+
+func NewLoggerWithOnlyOnce(logger Logger) LoggerWithOnlyOnce {
+	return LoggerWithOnlyOnce{
+		logger:        logger,
+		alreadyLogged: map[string]bool{},
+	}
+}
+
+func (l *LoggerWithOnlyOnce) Log(log string, args ...any) {
+	if l.alreadyLogged[log] {
+		return
+	}
+	l.alreadyLogged[log] = true
+	l.logger.Log(append([]any{log}, args...)...)
+}
+
+func (l *LoggerWithOnlyOnce) Logf(format string, args ...any) {
+	if l.alreadyLogged[format] {
+		return
+	}
+	l.alreadyLogged[format] = true
+	l.logger.Logf(format, args...)
+}
+
+func (l LoggerWithOnlyOnce) Errorf(format string, args ...interface{}) {
+	l.logger.Errorf(format, args)
+}
+func (l LoggerWithOnlyOnce) FailNow() {
+	l.logger.FailNow()
+}
+
 func (t *T) Run(name string, f func(t *testing.T)) bool {
 	newF := f
 


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:
- add LogOnce logger that only prints the first instance of given log to reduce unnecessary logs in e2e tests

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- ...

**Pull Request status**
<!-- Feel free to construct the checklist with whatever items seem most reasonable for your change. You could disassemble the Implementation part to even smaller separate checklist items if you're working on something big for example. But do make the effort to provide a checklist of some sort so that the core team as well as the community can have an idea about the progress of your Pull Request.
-->

- [ ] Implementation
- [ ] Unit tests
- [ ] Integration tests
- [ ] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [ ] Mocks are regenerated, using the automated script
