### PR TITLE
Add discovery consumers allowlist to formation templates

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -200,7 +200,7 @@ global:
       name: compass-operations-controller
     ord_service:
       dir: dev/incubator/
-      version: "PR-115"
+      version: "PR-118"
       name: compass-ord-service
     schema_migrator:
       dir: dev/incubator/

--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -168,7 +168,7 @@ global:
       name: compass-pairing-adapter
     director:
       dir: dev/incubator/
-      version: "PR-3556"
+      version: "PR-3566"
       name: compass-director
     hydrator:
       dir: dev/incubator/
@@ -204,7 +204,7 @@ global:
       name: compass-ord-service
     schema_migrator:
       dir: dev/incubator/
-      version: "PR-3536"
+      version: "PR-3566"
       name: compass-schema-migrator
     system_broker:
       dir: dev/incubator/

--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -225,7 +225,7 @@ global:
       name: compass-console
     e2e_tests:
       dir: dev/incubator/
-      version: "PR-3564"
+      version: "PR-3566"
       name: compass-e2e-tests
   isLocalEnv: false
   isForTesting: false

--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -175,8 +175,8 @@ global:
       version: "PR-3561"
       name: compass-hydrator
     ias_adapter:
-      dir: dev/incubator/
-      version: "PR-3511"
+      dir: prod/incubator/
+      version: "v20231129-66fafbe9"
       name: compass-ias-adapter
     kyma_adapter:
       dir: dev/incubator/

--- a/components/director/internal/domain/formationtemplate/converter.go
+++ b/components/director/internal/domain/formationtemplate/converter.go
@@ -171,7 +171,7 @@ func (c *converter) ToEntity(in *model.FormationTemplate) (*Entity, error) {
 	}
 	marshalledDiscoveryConsumers, err := json.Marshal(in.DiscoveryConsumers)
 	if err != nil {
-		return nil, errors.Wrap(err, "while marshalling leading product IDs")
+		return nil, errors.Wrap(err, "while marshalling discovery consumers")
 	}
 
 	runtimeArtifactKind := repo.NewNullableString(nil)

--- a/components/director/internal/domain/formationtemplate/converter.go
+++ b/components/director/internal/domain/formationtemplate/converter.go
@@ -57,6 +57,7 @@ func (c *converter) FromInputGraphQL(in *graphql.FormationTemplateInput) (*model
 		Webhooks:               webhooks,
 		LeadingProductIDs:      in.LeadingProductIDs,
 		SupportsReset:          supportsReset,
+		DiscoveryConsumers:     in.DiscoveryConsumers,
 	}, nil
 }
 
@@ -89,6 +90,7 @@ func (c *converter) FromModelInputToModel(in *model.FormationTemplateInput, id, 
 		Webhooks:               webhooks,
 		LeadingProductIDs:      in.LeadingProductIDs,
 		SupportsReset:          in.SupportsReset,
+		DiscoveryConsumers:     in.DiscoveryConsumers,
 	}
 }
 
@@ -124,6 +126,7 @@ func (c *converter) ToGraphQL(in *model.FormationTemplate) (*graphql.FormationTe
 		Webhooks:               webhooks,
 		LeadingProductIDs:      in.LeadingProductIDs,
 		SupportsReset:          in.SupportsReset,
+		DiscoveryConsumers:     in.DiscoveryConsumers,
 	}, nil
 }
 
@@ -166,6 +169,10 @@ func (c *converter) ToEntity(in *model.FormationTemplate) (*Entity, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "while marshalling leading product IDs")
 	}
+	marshalledDiscoveryConsumers, err := json.Marshal(in.DiscoveryConsumers)
+	if err != nil {
+		return nil, errors.Wrap(err, "while marshalling leading product IDs")
+	}
 
 	runtimeArtifactKind := repo.NewNullableString(nil)
 	if in.RuntimeArtifactKind != nil {
@@ -183,6 +190,7 @@ func (c *converter) ToEntity(in *model.FormationTemplate) (*Entity, error) {
 		LeadingProductIDs:      repo.NewValidNullableString(string(marshalledLeadingProductIDs)),
 		TenantID:               repo.NewNullableString(in.TenantID),
 		SupportsReset:          in.SupportsReset,
+		DiscoveryConsumers:     repo.NewValidNullableString(string(marshalledDiscoveryConsumers)),
 	}, nil
 }
 
@@ -216,6 +224,15 @@ func (c *converter) FromEntity(in *Entity) (*model.FormationTemplate, error) {
 		}
 	}
 
+	var unmarshalledDiscoveryConsumers []string
+	discoveryConsumers := repo.JSONRawMessageFromNullableString(in.DiscoveryConsumers)
+	if discoveryConsumers != nil {
+		err = json.Unmarshal(discoveryConsumers, &unmarshalledDiscoveryConsumers)
+		if err != nil {
+			return nil, errors.Wrap(err, "while unmarshalling discovery consumers")
+		}
+	}
+
 	var runtimeArtifactKind *model.RuntimeArtifactKind
 	if kindPtr := repo.StringPtrFromNullableString(in.RuntimeArtifactKind); kindPtr != nil {
 		kind := model.RuntimeArtifactKind(*kindPtr)
@@ -232,5 +249,6 @@ func (c *converter) FromEntity(in *Entity) (*model.FormationTemplate, error) {
 		LeadingProductIDs:      unmarshalledLeadingProductIDs,
 		TenantID:               repo.StringPtrFromNullableString(in.TenantID),
 		SupportsReset:          in.SupportsReset,
+		DiscoveryConsumers:     unmarshalledDiscoveryConsumers,
 	}, nil
 }

--- a/components/director/internal/domain/formationtemplate/entity.go
+++ b/components/director/internal/domain/formationtemplate/entity.go
@@ -13,6 +13,7 @@ type Entity struct {
 	LeadingProductIDs      sql.NullString `db:"leading_product_ids"`
 	TenantID               sql.NullString `db:"tenant_id"`
 	SupportsReset          bool           `db:"supports_reset"`
+	DiscoveryConsumers     sql.NullString `db:"discovery_consumers"`
 }
 
 // EntityCollection is a collection of formation template entities.

--- a/components/director/internal/domain/formationtemplate/fixtures_test.go
+++ b/components/director/internal/domain/formationtemplate/fixtures_test.go
@@ -16,14 +16,15 @@ import (
 )
 
 const (
-	testID                    = "d1fddec6-5456-4a1e-9ae0-74447f5d6ae9"
-	formationTemplateName     = "formation-template-name"
-	applicationTypesAsString  = "[\"some-application-type\"]"
-	runtimeTypesAsString      = "[\"some-runtime-type\"]"
-	testTenantID              = "d9fddec6-5456-4a1e-9ae0-74447f5d6ae9"
-	testParentTenantID        = "d8fddec6-5456-4a1e-9ae0-74447f5d6ae9"
-	testWebhookID             = "test-wh-id"
-	leadingProductIDsAsString = "[\"leading-product-id\",\"leading-product-id-2\"]"
+	testID                     = "d1fddec6-5456-4a1e-9ae0-74447f5d6ae9"
+	formationTemplateName      = "formation-template-name"
+	applicationTypesAsString   = "[\"some-application-type\"]"
+	runtimeTypesAsString       = "[\"some-runtime-type\"]"
+	testTenantID               = "d9fddec6-5456-4a1e-9ae0-74447f5d6ae9"
+	testParentTenantID         = "d8fddec6-5456-4a1e-9ae0-74447f5d6ae9"
+	testWebhookID              = "test-wh-id"
+	leadingProductIDsAsString  = "[\"leading-product-id\",\"leading-product-id-2\"]"
+	discoveryConsumersAsString = "[\"some-application-type\",\"some-runtime-type\"]"
 )
 
 var (
@@ -39,6 +40,7 @@ var (
 	applicationTypes            = []string{"some-application-type"}
 	runtimeTypes                = []string{"some-runtime-type"}
 	leadingProductIDs           = []string{"leading-product-id", "leading-product-id-2"}
+	discoveryConsumers          = []string{"some-application-type", "some-runtime-type"}
 	shouldReset                 = true
 	formationTemplateModelInput = model.FormationTemplateInput{
 		Name:                   formationTemplateName,
@@ -47,6 +49,7 @@ var (
 		RuntimeTypeDisplayName: &runtimeTypeDisplayName,
 		RuntimeArtifactKind:    &runtimeArtifactKind,
 		LeadingProductIDs:      leadingProductIDs,
+		DiscoveryConsumers:     discoveryConsumers,
 		Webhooks:               fixModelWebhookInput(),
 	}
 	formationTemplateModelWithResetInput = model.FormationTemplateInput{
@@ -56,6 +59,7 @@ var (
 		RuntimeTypeDisplayName: &runtimeTypeDisplayName,
 		RuntimeArtifactKind:    &runtimeArtifactKind,
 		LeadingProductIDs:      leadingProductIDs,
+		DiscoveryConsumers:     discoveryConsumers,
 		Webhooks:               fixModelWebhookInput(),
 		SupportsReset:          shouldReset,
 	}
@@ -66,6 +70,7 @@ var (
 		RuntimeTypeDisplayName: str.Ptr(runtimeTypeDisplayName),
 		RuntimeArtifactKind:    &artifactKind,
 		LeadingProductIDs:      leadingProductIDs,
+		DiscoveryConsumers:     discoveryConsumers,
 		Webhooks:               fixGQLWebhookInput(),
 	}
 	formationTemplateWithResetGraphQLInput = graphql.FormationTemplateInput{
@@ -75,29 +80,33 @@ var (
 		RuntimeTypeDisplayName: str.Ptr(runtimeTypeDisplayName),
 		RuntimeArtifactKind:    &artifactKind,
 		LeadingProductIDs:      leadingProductIDs,
+		DiscoveryConsumers:     discoveryConsumers,
 		Webhooks:               fixGQLWebhookInput(),
 		SupportsReset:          &shouldReset,
 	}
 
 	formationTemplateModelInputAppOnly = model.FormationTemplateInput{
-		Name:              formationTemplateName,
-		ApplicationTypes:  applicationTypes,
-		LeadingProductIDs: leadingProductIDs,
-		Webhooks:          fixModelWebhookInput(),
+		Name:               formationTemplateName,
+		ApplicationTypes:   applicationTypes,
+		LeadingProductIDs:  leadingProductIDs,
+		DiscoveryConsumers: discoveryConsumers,
+		Webhooks:           fixModelWebhookInput(),
 	}
 	formationTemplateGraphQLInputAppOnly = graphql.FormationTemplateInput{
-		Name:              formationTemplateName,
-		ApplicationTypes:  applicationTypes,
-		LeadingProductIDs: leadingProductIDs,
-		Webhooks:          fixGQLWebhookInput(),
+		Name:               formationTemplateName,
+		ApplicationTypes:   applicationTypes,
+		LeadingProductIDs:  leadingProductIDs,
+		DiscoveryConsumers: discoveryConsumers,
+		Webhooks:           fixGQLWebhookInput(),
 	}
 	formationTemplateModelAppOnly = model.FormationTemplate{
-		ID:                testID,
-		Name:              formationTemplateName,
-		ApplicationTypes:  applicationTypes,
-		LeadingProductIDs: leadingProductIDs,
-		TenantID:          str.Ptr(testTenantID),
-		Webhooks:          []*model.Webhook{fixFormationTemplateModelWebhook()},
+		ID:                 testID,
+		Name:               formationTemplateName,
+		ApplicationTypes:   applicationTypes,
+		LeadingProductIDs:  leadingProductIDs,
+		DiscoveryConsumers: discoveryConsumers,
+		TenantID:           str.Ptr(testTenantID),
+		Webhooks:           []*model.Webhook{fixFormationTemplateModelWebhook()},
 	}
 
 	formationTemplateModel = model.FormationTemplate{
@@ -108,6 +117,7 @@ var (
 		RuntimeTypeDisplayName: &runtimeTypeDisplayName,
 		RuntimeArtifactKind:    &runtimeArtifactKind,
 		LeadingProductIDs:      leadingProductIDs,
+		DiscoveryConsumers:     discoveryConsumers,
 		TenantID:               str.Ptr(testTenantID),
 		Webhooks:               []*model.Webhook{fixFormationTemplateModelWebhook()},
 	}
@@ -119,6 +129,7 @@ var (
 		RuntimeTypeDisplayName: &runtimeTypeDisplayName,
 		RuntimeArtifactKind:    &runtimeArtifactKind,
 		LeadingProductIDs:      leadingProductIDs,
+		DiscoveryConsumers:     discoveryConsumers,
 		TenantID:               nil,
 	}
 	formationTemplateEntity = formationtemplate.Entity{
@@ -130,6 +141,7 @@ var (
 		RuntimeArtifactKind:    repo.NewValidNullableString(artifactKindAsString),
 		LeadingProductIDs:      repo.NewNullableStringFromJSONRawMessage(json.RawMessage(leadingProductIDsAsString)),
 		TenantID:               repo.NewValidNullableString(testTenantID),
+		DiscoveryConsumers:     repo.NewNullableStringFromJSONRawMessage(json.RawMessage(discoveryConsumersAsString)),
 	}
 	formationTemplateEntityNullTenant = formationtemplate.Entity{
 		ID:                     testID,
@@ -140,6 +152,7 @@ var (
 		RuntimeArtifactKind:    repo.NewValidNullableString(artifactKindAsString),
 		LeadingProductIDs:      repo.NewNullableStringFromJSONRawMessage(json.RawMessage(leadingProductIDsAsString)),
 		TenantID:               repo.NewValidNullableString(""),
+		DiscoveryConsumers:     repo.NewNullableStringFromJSONRawMessage(json.RawMessage(discoveryConsumersAsString)),
 	}
 	graphQLFormationTemplate = graphql.FormationTemplate{
 		ID:                     testID,
@@ -149,6 +162,7 @@ var (
 		RuntimeTypeDisplayName: &runtimeTypeDisplayName,
 		RuntimeArtifactKind:    &artifactKind,
 		LeadingProductIDs:      leadingProductIDs,
+		DiscoveryConsumers:     discoveryConsumers,
 		Webhooks:               []*graphql.Webhook{fixFormationTemplateGQLWebhook()},
 	}
 	formationTemplateModelPage = model.FormationTemplatePage{
@@ -308,7 +322,7 @@ func fixFormationTemplateGQLWebhook() *graphql.Webhook {
 }
 
 func fixColumns() []string {
-	return []string{"id", "name", "application_types", "runtime_types", "runtime_type_display_name", "runtime_artifact_kind", "leading_product_ids", "tenant_id"}
+	return []string{"id", "name", "application_types", "runtime_types", "runtime_type_display_name", "runtime_artifact_kind", "leading_product_ids", "supports_reset", "discovery_consumers", "tenant_id"}
 }
 
 func UnusedFormationTemplateService() *automock.FormationTemplateService {

--- a/components/director/internal/domain/formationtemplate/repository.go
+++ b/components/director/internal/domain/formationtemplate/repository.go
@@ -21,7 +21,7 @@ const (
 
 var (
 	idTableColumns            = []string{idColumn}
-	updatableTableColumns     = []string{"name", "application_types", "runtime_types", "runtime_type_display_name", "runtime_artifact_kind", "leading_product_ids", "supports_reset"}
+	updatableTableColumns     = []string{"name", "application_types", "runtime_types", "runtime_type_display_name", "runtime_artifact_kind", "leading_product_ids", "supports_reset", "discovery_consumers"}
 	tenantTableColumn         = []string{tenantIDColumn}
 	tableColumnsWithoutTenant = append(idTableColumns, updatableTableColumns...)
 	tableColumns              = append(tableColumnsWithoutTenant, tenantTableColumn...)

--- a/components/director/internal/domain/formationtemplate/repository_test.go
+++ b/components/director/internal/domain/formationtemplate/repository_test.go
@@ -20,11 +20,11 @@ func TestRepository_Get(t *testing.T) {
 		MethodName: "Get",
 		SQLQueryDetails: []testdb.SQLQueryDetails{
 			{
-				Query:    regexp.QuoteMeta(`SELECT id, name, application_types, runtime_types, runtime_type_display_name, runtime_artifact_kind, leading_product_ids, supports_reset, tenant_id FROM public.formation_templates WHERE id = $1`),
+				Query:    regexp.QuoteMeta(`SELECT id, name, application_types, runtime_types, runtime_type_display_name, runtime_artifact_kind, leading_product_ids, supports_reset, discovery_consumers, tenant_id FROM public.formation_templates WHERE id = $1`),
 				Args:     []driver.Value{testID},
 				IsSelect: true,
 				ValidRowsProvider: func() []*sqlmock.Rows {
-					return []*sqlmock.Rows{sqlmock.NewRows(fixColumns()).AddRow(formationTemplateEntity.ID, formationTemplateEntity.Name, formationTemplateEntity.ApplicationTypes, formationTemplateEntity.RuntimeTypes, formationTemplateEntity.RuntimeTypeDisplayName, formationTemplateEntity.RuntimeArtifactKind, formationTemplateEntity.LeadingProductIDs, formationTemplateEntity.TenantID)}
+					return []*sqlmock.Rows{sqlmock.NewRows(fixColumns()).AddRow(formationTemplateEntity.ID, formationTemplateEntity.Name, formationTemplateEntity.ApplicationTypes, formationTemplateEntity.RuntimeTypes, formationTemplateEntity.RuntimeTypeDisplayName, formationTemplateEntity.RuntimeArtifactKind, formationTemplateEntity.LeadingProductIDs, formationTemplateEntity.SupportsReset, formationTemplateEntity.DiscoveryConsumers, formationTemplateEntity.TenantID)}
 				},
 				InvalidRowsProvider: func() []*sqlmock.Rows {
 					return []*sqlmock.Rows{sqlmock.NewRows(fixColumns())}
@@ -50,11 +50,11 @@ func TestRepository_GetByNameAndTenant(t *testing.T) {
 		MethodName: "GetByNameAndTenant",
 		SQLQueryDetails: []testdb.SQLQueryDetails{
 			{
-				Query:    regexp.QuoteMeta(`SELECT id, name, application_types, runtime_types, runtime_type_display_name, runtime_artifact_kind, leading_product_ids, supports_reset, tenant_id FROM public.formation_templates WHERE tenant_id = $1 AND name = $2`),
+				Query:    regexp.QuoteMeta(`SELECT id, name, application_types, runtime_types, runtime_type_display_name, runtime_artifact_kind, leading_product_ids, supports_reset, discovery_consumers, tenant_id FROM public.formation_templates WHERE tenant_id = $1 AND name = $2`),
 				Args:     []driver.Value{testTenantID, formationTemplateName},
 				IsSelect: true,
 				ValidRowsProvider: func() []*sqlmock.Rows {
-					return []*sqlmock.Rows{sqlmock.NewRows(fixColumns()).AddRow(formationTemplateEntity.ID, formationTemplateEntity.Name, formationTemplateEntity.ApplicationTypes, formationTemplateEntity.RuntimeTypes, formationTemplateEntity.RuntimeTypeDisplayName, formationTemplateEntity.RuntimeArtifactKind, formationTemplateEntity.LeadingProductIDs, formationTemplateEntity.TenantID)}
+					return []*sqlmock.Rows{sqlmock.NewRows(fixColumns()).AddRow(formationTemplateEntity.ID, formationTemplateEntity.Name, formationTemplateEntity.ApplicationTypes, formationTemplateEntity.RuntimeTypes, formationTemplateEntity.RuntimeTypeDisplayName, formationTemplateEntity.RuntimeArtifactKind, formationTemplateEntity.LeadingProductIDs, formationTemplateEntity.SupportsReset, formationTemplateEntity.DiscoveryConsumers, formationTemplateEntity.TenantID)}
 				},
 				InvalidRowsProvider: func() []*sqlmock.Rows {
 					return []*sqlmock.Rows{sqlmock.NewRows(fixColumns())}
@@ -72,11 +72,11 @@ func TestRepository_GetByNameAndTenant(t *testing.T) {
 		ExpectNotFoundError:       true,
 		AfterNotFoundErrorSQLQueryDetails: []testdb.SQLQueryDetails{
 			{
-				Query:    regexp.QuoteMeta(`SELECT id, name, application_types, runtime_types, runtime_type_display_name, runtime_artifact_kind, leading_product_ids, supports_reset, tenant_id FROM public.formation_templates WHERE name = $1 AND tenant_id IS NULL`),
+				Query:    regexp.QuoteMeta(`SELECT id, name, application_types, runtime_types, runtime_type_display_name, runtime_artifact_kind, leading_product_ids, supports_reset, discovery_consumers, tenant_id FROM public.formation_templates WHERE name = $1 AND tenant_id IS NULL`),
 				Args:     []driver.Value{formationTemplateName},
 				IsSelect: true,
 				ValidRowsProvider: func() []*sqlmock.Rows {
-					return []*sqlmock.Rows{sqlmock.NewRows(fixColumns()).AddRow(formationTemplateEntity.ID, formationTemplateEntity.Name, formationTemplateEntity.ApplicationTypes, formationTemplateEntity.RuntimeTypes, formationTemplateEntity.RuntimeTypeDisplayName, formationTemplateEntity.RuntimeArtifactKind, formationTemplateEntity.LeadingProductIDs, formationTemplateEntityNullTenant.TenantID)}
+					return []*sqlmock.Rows{sqlmock.NewRows(fixColumns()).AddRow(formationTemplateEntity.ID, formationTemplateEntity.Name, formationTemplateEntity.ApplicationTypes, formationTemplateEntity.RuntimeTypes, formationTemplateEntity.RuntimeTypeDisplayName, formationTemplateEntity.RuntimeArtifactKind, formationTemplateEntity.LeadingProductIDs, formationTemplateEntity.SupportsReset, formationTemplateEntity.DiscoveryConsumers, formationTemplateEntityNullTenant.TenantID)}
 				},
 			},
 		},
@@ -89,11 +89,11 @@ func TestRepository_GetByNameAndTenant(t *testing.T) {
 		MethodName: "GetByNameAndTenant",
 		SQLQueryDetails: []testdb.SQLQueryDetails{
 			{
-				Query:    regexp.QuoteMeta(`SELECT id, name, application_types, runtime_types, runtime_type_display_name, runtime_artifact_kind, leading_product_ids, supports_reset, tenant_id FROM public.formation_templates WHERE name = $1 AND tenant_id IS NULL`),
+				Query:    regexp.QuoteMeta(`SELECT id, name, application_types, runtime_types, runtime_type_display_name, runtime_artifact_kind, leading_product_ids, supports_reset, discovery_consumers, tenant_id FROM public.formation_templates WHERE name = $1 AND tenant_id IS NULL`),
 				Args:     []driver.Value{formationTemplateName},
 				IsSelect: true,
 				ValidRowsProvider: func() []*sqlmock.Rows {
-					return []*sqlmock.Rows{sqlmock.NewRows(fixColumns()).AddRow(formationTemplateEntity.ID, formationTemplateEntity.Name, formationTemplateEntity.ApplicationTypes, formationTemplateEntity.RuntimeTypes, formationTemplateEntity.RuntimeTypeDisplayName, formationTemplateEntity.RuntimeArtifactKind, formationTemplateEntity.LeadingProductIDs, formationTemplateEntityNullTenant.TenantID)}
+					return []*sqlmock.Rows{sqlmock.NewRows(fixColumns()).AddRow(formationTemplateEntity.ID, formationTemplateEntity.Name, formationTemplateEntity.ApplicationTypes, formationTemplateEntity.RuntimeTypes, formationTemplateEntity.RuntimeTypeDisplayName, formationTemplateEntity.RuntimeArtifactKind, formationTemplateEntity.LeadingProductIDs, formationTemplateEntity.SupportsReset, formationTemplateEntity.DiscoveryConsumers, formationTemplateEntityNullTenant.TenantID)}
 				},
 				InvalidRowsProvider: func() []*sqlmock.Rows {
 					return []*sqlmock.Rows{sqlmock.NewRows(fixColumns())}
@@ -121,7 +121,7 @@ func TestRepository_Create(t *testing.T) {
 		SQLQueryDetails: []testdb.SQLQueryDetails{
 			{
 				Query:       `^INSERT INTO public.formation_templates \(.+\) VALUES \(.+\)$`,
-				Args:        []driver.Value{formationTemplateEntity.ID, formationTemplateEntity.Name, formationTemplateEntity.ApplicationTypes, formationTemplateEntity.RuntimeTypes, formationTemplateEntity.RuntimeTypeDisplayName, formationTemplateEntity.RuntimeArtifactKind, formationTemplateEntity.LeadingProductIDs, formationTemplateEntity.SupportsReset, formationTemplateEntity.TenantID},
+				Args:        []driver.Value{formationTemplateEntity.ID, formationTemplateEntity.Name, formationTemplateEntity.ApplicationTypes, formationTemplateEntity.RuntimeTypes, formationTemplateEntity.RuntimeTypeDisplayName, formationTemplateEntity.RuntimeArtifactKind, formationTemplateEntity.LeadingProductIDs, formationTemplateEntity.SupportsReset, formationTemplateEntity.DiscoveryConsumers, formationTemplateEntity.TenantID},
 				ValidResult: sqlmock.NewResult(-1, 1),
 			},
 		},
@@ -214,10 +214,10 @@ func TestRepository_List(t *testing.T) {
 		MethodName: "List",
 		SQLQueryDetails: []testdb.SQLQueryDetails{
 			{
-				Query:    regexp.QuoteMeta(`SELECT id, name, application_types, runtime_types, runtime_type_display_name, runtime_artifact_kind, leading_product_ids, supports_reset, tenant_id FROM public.formation_templates WHERE tenant_id IS NULL ORDER BY id LIMIT 3 OFFSET 0`),
+				Query:    regexp.QuoteMeta(`SELECT id, name, application_types, runtime_types, runtime_type_display_name, runtime_artifact_kind, leading_product_ids, supports_reset, discovery_consumers, tenant_id FROM public.formation_templates WHERE tenant_id IS NULL ORDER BY id LIMIT 3 OFFSET 0`),
 				IsSelect: true,
 				ValidRowsProvider: func() []*sqlmock.Rows {
-					return []*sqlmock.Rows{sqlmock.NewRows(fixColumns()).AddRow(formationTemplateEntity.ID, formationTemplateEntity.Name, formationTemplateEntity.ApplicationTypes, formationTemplateEntity.RuntimeTypes, formationTemplateEntity.RuntimeTypeDisplayName, formationTemplateEntity.RuntimeArtifactKind, formationTemplateEntity.LeadingProductIDs, formationTemplateEntityNullTenant.TenantID)}
+					return []*sqlmock.Rows{sqlmock.NewRows(fixColumns()).AddRow(formationTemplateEntity.ID, formationTemplateEntity.Name, formationTemplateEntity.ApplicationTypes, formationTemplateEntity.RuntimeTypes, formationTemplateEntity.RuntimeTypeDisplayName, formationTemplateEntity.RuntimeArtifactKind, formationTemplateEntity.LeadingProductIDs, formationTemplateEntity.SupportsReset, formationTemplateEntity.DiscoveryConsumers, formationTemplateEntityNullTenant.TenantID)}
 				},
 				InvalidRowsProvider: func() []*sqlmock.Rows {
 					return []*sqlmock.Rows{sqlmock.NewRows(fixColumns())}
@@ -259,11 +259,11 @@ func TestRepository_List(t *testing.T) {
 		MethodName: "List",
 		SQLQueryDetails: []testdb.SQLQueryDetails{
 			{
-				Query:    regexp.QuoteMeta(`SELECT id, name, application_types, runtime_types, runtime_type_display_name, runtime_artifact_kind, leading_product_ids, supports_reset, tenant_id FROM public.formation_templates WHERE (tenant_id IS NULL OR tenant_id = $1) ORDER BY id LIMIT 3 OFFSET 0`),
+				Query:    regexp.QuoteMeta(`SELECT id, name, application_types, runtime_types, runtime_type_display_name, runtime_artifact_kind, leading_product_ids, supports_reset, discovery_consumers, tenant_id FROM public.formation_templates WHERE (tenant_id IS NULL OR tenant_id = $1) ORDER BY id LIMIT 3 OFFSET 0`),
 				Args:     []driver.Value{testTenantID},
 				IsSelect: true,
 				ValidRowsProvider: func() []*sqlmock.Rows {
-					return []*sqlmock.Rows{sqlmock.NewRows(fixColumns()).AddRow(formationTemplateEntity.ID, formationTemplateEntity.Name, formationTemplateEntity.ApplicationTypes, formationTemplateEntity.RuntimeTypes, formationTemplateEntity.RuntimeTypeDisplayName, formationTemplateEntity.RuntimeArtifactKind, formationTemplateEntity.LeadingProductIDs, formationTemplateEntity.TenantID)}
+					return []*sqlmock.Rows{sqlmock.NewRows(fixColumns()).AddRow(formationTemplateEntity.ID, formationTemplateEntity.Name, formationTemplateEntity.ApplicationTypes, formationTemplateEntity.RuntimeTypes, formationTemplateEntity.RuntimeTypeDisplayName, formationTemplateEntity.RuntimeArtifactKind, formationTemplateEntity.LeadingProductIDs, formationTemplateEntity.SupportsReset, formationTemplateEntity.DiscoveryConsumers, formationTemplateEntity.TenantID)}
 				},
 				InvalidRowsProvider: func() []*sqlmock.Rows {
 					return []*sqlmock.Rows{sqlmock.NewRows(fixColumns())}
@@ -305,11 +305,11 @@ func TestRepository_List(t *testing.T) {
 		MethodName: "List",
 		SQLQueryDetails: []testdb.SQLQueryDetails{
 			{
-				Query:    regexp.QuoteMeta(`SELECT id, name, application_types, runtime_types, runtime_type_display_name, runtime_artifact_kind, leading_product_ids, supports_reset, tenant_id FROM public.formation_templates WHERE ((tenant_id IS NULL OR tenant_id = $1) AND name = $2) ORDER BY id LIMIT 3 OFFSET 0`),
+				Query:    regexp.QuoteMeta(`SELECT id, name, application_types, runtime_types, runtime_type_display_name, runtime_artifact_kind, leading_product_ids, supports_reset, discovery_consumers, tenant_id FROM public.formation_templates WHERE ((tenant_id IS NULL OR tenant_id = $1) AND name = $2) ORDER BY id LIMIT 3 OFFSET 0`),
 				Args:     []driver.Value{testTenantID, formationTemplateEntity.Name},
 				IsSelect: true,
 				ValidRowsProvider: func() []*sqlmock.Rows {
-					return []*sqlmock.Rows{sqlmock.NewRows(fixColumns()).AddRow(formationTemplateEntity.ID, formationTemplateEntity.Name, formationTemplateEntity.ApplicationTypes, formationTemplateEntity.RuntimeTypes, formationTemplateEntity.RuntimeTypeDisplayName, formationTemplateEntity.RuntimeArtifactKind, formationTemplateEntity.LeadingProductIDs, formationTemplateEntity.TenantID)}
+					return []*sqlmock.Rows{sqlmock.NewRows(fixColumns()).AddRow(formationTemplateEntity.ID, formationTemplateEntity.Name, formationTemplateEntity.ApplicationTypes, formationTemplateEntity.RuntimeTypes, formationTemplateEntity.RuntimeTypeDisplayName, formationTemplateEntity.RuntimeArtifactKind, formationTemplateEntity.LeadingProductIDs, formationTemplateEntity.SupportsReset, formationTemplateEntity.DiscoveryConsumers, formationTemplateEntity.TenantID)}
 				},
 				InvalidRowsProvider: func() []*sqlmock.Rows {
 					return []*sqlmock.Rows{sqlmock.NewRows(fixColumns())}
@@ -352,13 +352,13 @@ func TestRepository_List(t *testing.T) {
 }
 
 func TestRepository_Update(t *testing.T) {
-	updateStmtWithoutTenant := regexp.QuoteMeta(`UPDATE public.formation_templates SET name = ?, application_types = ?, runtime_types = ?, runtime_type_display_name = ?, runtime_artifact_kind = ?, leading_product_ids = ?, supports_reset = ? WHERE id = ?`)
+	updateStmtWithoutTenant := regexp.QuoteMeta(`UPDATE public.formation_templates SET name = ?, application_types = ?, runtime_types = ?, runtime_type_display_name = ?, runtime_artifact_kind = ?, leading_product_ids = ?, supports_reset = ?, discovery_consumers = ? WHERE id = ?`)
 	suiteWithoutTenant := testdb.RepoUpdateTestSuite{
 		Name: "Update Formation Template By ID without tenant",
 		SQLQueryDetails: []testdb.SQLQueryDetails{
 			{
 				Query:         updateStmtWithoutTenant,
-				Args:          []driver.Value{formationTemplateEntity.Name, formationTemplateEntity.ApplicationTypes, formationTemplateEntity.RuntimeTypes, formationTemplateEntity.RuntimeTypeDisplayName, formationTemplateEntity.RuntimeArtifactKind, formationTemplateEntity.LeadingProductIDs, formationTemplateEntity.SupportsReset, formationTemplateEntity.ID},
+				Args:          []driver.Value{formationTemplateEntity.Name, formationTemplateEntity.ApplicationTypes, formationTemplateEntity.RuntimeTypes, formationTemplateEntity.RuntimeTypeDisplayName, formationTemplateEntity.RuntimeArtifactKind, formationTemplateEntity.LeadingProductIDs, formationTemplateEntity.SupportsReset, formationTemplateEntity.DiscoveryConsumers, formationTemplateEntity.ID},
 				ValidResult:   sqlmock.NewResult(-1, 1),
 				InvalidResult: sqlmock.NewResult(-1, 0),
 			},
@@ -373,13 +373,13 @@ func TestRepository_Update(t *testing.T) {
 		IsGlobal:       true,
 	}
 
-	updateStmtWithTenant := regexp.QuoteMeta(`UPDATE public.formation_templates SET name = ?, application_types = ?, runtime_types = ?, runtime_type_display_name = ?, runtime_artifact_kind = ?, leading_product_ids = ?, supports_reset = ? WHERE id = ? AND tenant_id = ?`)
+	updateStmtWithTenant := regexp.QuoteMeta(`UPDATE public.formation_templates SET name = ?, application_types = ?, runtime_types = ?, runtime_type_display_name = ?, runtime_artifact_kind = ?, leading_product_ids = ?, supports_reset = ?, discovery_consumers = ? WHERE id = ? AND tenant_id = ?`)
 	suiteWithTenant := testdb.RepoUpdateTestSuite{
 		Name: "Update Formation Template By ID with tenant",
 		SQLQueryDetails: []testdb.SQLQueryDetails{
 			{
 				Query:         updateStmtWithTenant,
-				Args:          []driver.Value{formationTemplateEntity.Name, formationTemplateEntity.ApplicationTypes, formationTemplateEntity.RuntimeTypes, formationTemplateEntity.RuntimeTypeDisplayName, formationTemplateEntity.RuntimeArtifactKind, formationTemplateEntity.LeadingProductIDs, formationTemplateEntity.SupportsReset, formationTemplateEntity.ID, formationTemplateEntity.TenantID},
+				Args:          []driver.Value{formationTemplateEntity.Name, formationTemplateEntity.ApplicationTypes, formationTemplateEntity.RuntimeTypes, formationTemplateEntity.RuntimeTypeDisplayName, formationTemplateEntity.RuntimeArtifactKind, formationTemplateEntity.LeadingProductIDs, formationTemplateEntity.SupportsReset, formationTemplateEntity.DiscoveryConsumers, formationTemplateEntity.ID, formationTemplateEntity.TenantID},
 				ValidResult:   sqlmock.NewResult(-1, 1),
 				InvalidResult: sqlmock.NewResult(-1, 0),
 			},

--- a/components/director/internal/model/formation_template.go
+++ b/components/director/internal/model/formation_template.go
@@ -41,7 +41,7 @@ type FormationTemplateInput struct {
 	Webhooks               []*WebhookInput      `json:"webhooks"`
 	LeadingProductIDs      []string             `json:"leadingProductIDs"`
 	SupportsReset          bool                 `json:"supportsReset"`
-	DiscoveryConsumers      []string             `json:"discoveryConsumers"`
+	DiscoveryConsumers     []string             `json:"discoveryConsumers"`
 }
 
 // FormationTemplatePage missing godoc

--- a/components/director/internal/model/formation_template.go
+++ b/components/director/internal/model/formation_template.go
@@ -28,6 +28,7 @@ type FormationTemplate struct {
 	Webhooks               []*Webhook           `json:"webhooks"`
 	LeadingProductIDs      []string             `json:"leadingProductIDs"`
 	SupportsReset          bool                 `json:"supportsReset"`
+	DiscoveryConsumers     []string             `json:"discoveryConsumers"`
 }
 
 // FormationTemplateInput missing godoc
@@ -40,6 +41,7 @@ type FormationTemplateInput struct {
 	Webhooks               []*WebhookInput      `json:"webhooks"`
 	LeadingProductIDs      []string             `json:"leadingProductIDs"`
 	SupportsReset          bool                 `json:"supportsReset"`
+	DiscoveryConsumers      []string             `json:"discoveryConsumers"`
 }
 
 // FormationTemplatePage missing godoc

--- a/components/director/pkg/graphql/formation_template.go
+++ b/components/director/pkg/graphql/formation_template.go
@@ -11,6 +11,7 @@ type FormationTemplate struct {
 	Webhooks               []*Webhook    `json:"webhooks"`
 	LeadingProductIDs      []string      `json:"leadingProductIDs"`
 	SupportsReset          bool          `json:"supportsReset"`
+	DiscoveryConsumers     []string      `json:"discoveryConsumers"`
 }
 
 // FormationTemplateExt  is an extended types used by external API

--- a/components/director/pkg/graphql/formation_template_validation.go
+++ b/components/director/pkg/graphql/formation_template_validation.go
@@ -10,10 +10,19 @@ import (
 
 // Validate missing godoc
 func (i FormationTemplateInput) Validate() error {
+	subtypes := make([]interface{}, 0, len(i.RuntimeTypes)+len(i.ApplicationTypes))
+	for _, subtype := range i.RuntimeTypes {
+		subtypes = append(subtypes, subtype)
+	}
+	for _, subtype := range i.ApplicationTypes {
+		subtypes = append(subtypes, subtype)
+	}
+
 	fieldRules := []*validation.FieldRules{
 		validation.Field(&i.Name, validation.Required, validation.RuneLength(0, longStringLengthLimit)),
 		validation.Field(&i.ApplicationTypes, validation.Required, inputvalidation.Each(validation.Required, validation.RuneLength(0, longStringLengthLimit))),
 		validation.Field(&i.RuntimeTypes, inputvalidation.Each(validation.Required, validation.RuneLength(0, longStringLengthLimit))),
+		validation.Field(&i.DiscoveryConsumers, validation.Each(validation.Required, validation.In(subtypes...))),
 		validation.Field(&i.Webhooks, validation.By(webhooksRuleFunc)),
 	}
 

--- a/components/director/pkg/graphql/formation_template_validation_test.go
+++ b/components/director/pkg/graphql/formation_template_validation_test.go
@@ -237,6 +237,56 @@ func TestFormationTemplateInput_ValidateRuntimeTypes(t *testing.T) {
 	}
 }
 
+func TestFormationTemplateInput_ValidateDiscoveryConsumers(t *testing.T) {
+	testCases := []struct {
+		Name          string
+		Value         []string
+		ExpectedValid bool
+	}{
+		{
+			Name:          "Success",
+			Value:         []string{"some-runtime-type", "some-application-type"},
+			ExpectedValid: true,
+		},
+		{
+			Name:          "Non-existing type",
+			Value:         []string{"non-existing-type", "some-application-type"},
+			ExpectedValid: false,
+		},
+		{
+			Name:          "Empty slice",
+			Value:         []string{},
+			ExpectedValid: true,
+		},
+		{
+			Name:          "Nil slice",
+			Value:         nil,
+			ExpectedValid: true,
+		},
+		{
+			Name:          "Empty elements in slice",
+			Value:         []string{""},
+			ExpectedValid: false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.Name, func(t *testing.T) {
+			//GIVEN
+			formationTemplateInput := fixValidFormationTemplateInput()
+			formationTemplateInput.DiscoveryConsumers = testCase.Value
+			// WHEN
+			err := formationTemplateInput.Validate()
+			// THEN
+			if testCase.ExpectedValid {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+			}
+		})
+	}
+}
+
 func TestFormationTemplateInput_Validate_Webhooks(t *testing.T) {
 	webhookInput := fixValidWebhookInput(inputvalidationtest.ValidURL)
 	webhookInputWithInvalidOutputTemplate := fixValidWebhookInput(inputvalidationtest.ValidURL)

--- a/components/director/pkg/graphql/graphqlizer/fields.go
+++ b/components/director/pkg/graphql/graphqlizer/fields.go
@@ -188,6 +188,7 @@ func (fp *GqlFieldsProvider) ForFormationTemplate() string {
 		runtimeArtifactKind
         leadingProductIDs
         supportsReset
+		discoveryConsumers
         webhooks {%s}
 	`, fp.ForWebhooks())
 }
@@ -202,6 +203,8 @@ func (fp *GqlFieldsProvider) ForFormationTemplateWithConstraints() string {
 		runtimeTypeDisplayName	
 		runtimeArtifactKind
         leadingProductIDs
+        supportsReset
+		discoveryConsumers
         webhooks {%s}
 		formationConstraints {%s}
 	`, fp.ForWebhooks(), fp.ForFormationConstraint())

--- a/components/director/pkg/graphql/graphqlizer/graphqlizer.go
+++ b/components/director/pkg/graphql/graphqlizer/graphqlizer.go
@@ -731,6 +731,12 @@ func (g *Graphqlizer) FormationTemplateInputToGQL(in graphql.FormationTemplateIn
 				{{- if $i}}, {{- end}} {{ marshal $e }}
 			{{- end }} ],
 		{{- end}}
+		{{- if .DiscoveryConsumers }} 
+		discoveryConsumers: [
+			{{- range $i, $e := .DiscoveryConsumers }}
+				{{- if $i}}, {{- end}} {{ marshal $e }}
+			{{- end }} ],
+		{{- end}}
 		{{- if .Webhooks }}
 		webhooks: [
 			{{- range $i, $e := .Webhooks }}

--- a/components/director/pkg/graphql/models_gen.go
+++ b/components/director/pkg/graphql/models_gen.go
@@ -630,6 +630,7 @@ type FormationTemplateInput struct {
 	Webhooks               []*WebhookInput `json:"webhooks"`
 	LeadingProductIDs      []string        `json:"leadingProductIDs"`
 	SupportsReset          *bool           `json:"supportsReset"`
+	DiscoveryConsumers     []string        `json:"discoveryConsumers"`
 }
 
 type FormationTemplatePage struct {

--- a/components/director/pkg/graphql/schema.graphql
+++ b/components/director/pkg/graphql/schema.graphql
@@ -767,6 +767,7 @@ input FormationTemplateInput {
 	webhooks: [WebhookInput!]
 	leadingProductIDs: [String!]
 	supportsReset: Boolean
+	discoveryConsumers: [String!]
 }
 
 input IntegrationDependencyInput {
@@ -1382,6 +1383,7 @@ type FormationTemplate {
 	leadingProductIDs: [String!]
 	formationConstraints: [FormationConstraint!]
 	supportsReset: Boolean!
+	discoveryConsumers: [String!]
 }
 
 type FormationTemplatePage implements Pageable {

--- a/components/director/pkg/graphql/schema_gen.go
+++ b/components/director/pkg/graphql/schema_gen.go
@@ -437,6 +437,7 @@ type ComplexityRoot struct {
 
 	FormationTemplate struct {
 		ApplicationTypes       func(childComplexity int) int
+		DiscoveryConsumers     func(childComplexity int) int
 		FormationConstraints   func(childComplexity int) int
 		ID                     func(childComplexity int) int
 		LeadingProductIDs      func(childComplexity int) int
@@ -2827,6 +2828,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.FormationTemplate.ApplicationTypes(childComplexity), true
+
+	case "FormationTemplate.discoveryConsumers":
+		if e.complexity.FormationTemplate.DiscoveryConsumers == nil {
+			break
+		}
+
+		return e.complexity.FormationTemplate.DiscoveryConsumers(childComplexity), true
 
 	case "FormationTemplate.formationConstraints":
 		if e.complexity.FormationTemplate.FormationConstraints == nil {
@@ -6318,6 +6326,7 @@ input FormationTemplateInput {
 	webhooks: [WebhookInput!]
 	leadingProductIDs: [String!]
 	supportsReset: Boolean
+	discoveryConsumers: [String!]
 }
 
 input IntegrationDependencyInput {
@@ -6933,6 +6942,7 @@ type FormationTemplate {
 	leadingProductIDs: [String!]
 	formationConstraints: [FormationConstraint!]
 	supportsReset: Boolean!
+	discoveryConsumers: [String!]
 }
 
 type FormationTemplatePage implements Pageable {
@@ -19832,6 +19842,37 @@ func (ec *executionContext) _FormationTemplate_supportsReset(ctx context.Context
 	res := resTmp.(bool)
 	fc.Result = res
 	return ec.marshalNBoolean2bool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _FormationTemplate_discoveryConsumers(ctx context.Context, field graphql.CollectedField, obj *FormationTemplate) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:   "FormationTemplate",
+		Field:    field,
+		Args:     nil,
+		IsMethod: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.DiscoveryConsumers, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.([]string)
+	fc.Result = res
+	return ec.marshalOString2ᚕstringᚄ(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _FormationTemplatePage_data(ctx context.Context, field graphql.CollectedField, obj *FormationTemplatePage) (ret graphql.Marshaler) {
@@ -35884,6 +35925,12 @@ func (ec *executionContext) unmarshalInputFormationTemplateInput(ctx context.Con
 			if err != nil {
 				return it, err
 			}
+		case "discoveryConsumers":
+			var err error
+			it.DiscoveryConsumers, err = ec.unmarshalOString2ᚕstringᚄ(ctx, v)
+			if err != nil {
+				return it, err
+			}
 		}
 	}
 
@@ -38848,6 +38895,8 @@ func (ec *executionContext) _FormationTemplate(ctx context.Context, sel ast.Sele
 			if out.Values[i] == graphql.Null {
 				atomic.AddUint32(&invalids, 1)
 			}
+		case "discoveryConsumers":
+			out.Values[i] = ec._FormationTemplate_discoveryConsumers(ctx, field, obj)
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}

--- a/components/schema-migrator/migrations/director/20231228152252_add-discovery-consumers-allowlist.down.sql
+++ b/components/schema-migrator/migrations/director/20231228152252_add-discovery-consumers-allowlist.down.sql
@@ -3,7 +3,7 @@ BEGIN;
 ALTER TABLE formation_templates
     DROP COLUMN discovery_consumers;
 
-DROP INDEX discovery_consumers_gin
-DROP INDEX scenario_label_gin
+DROP INDEX discovery_consumers_gin;
+DROP INDEX scenario_label_gin;
 
 COMMIT;

--- a/components/schema-migrator/migrations/director/20231228152252_add-discovery-consumers-allowlist.down.sql
+++ b/components/schema-migrator/migrations/director/20231228152252_add-discovery-consumers-allowlist.down.sql
@@ -1,9 +1,9 @@
 BEGIN;
 
-ALTER TABLE formation_templates
-    DROP COLUMN discovery_consumers;
-
 DROP INDEX discovery_consumers_gin;
 DROP INDEX scenario_label_gin;
+
+ALTER TABLE formation_templates
+    DROP COLUMN discovery_consumers;
 
 COMMIT;

--- a/components/schema-migrator/migrations/director/20231228152252_add-discovery-consumers-allowlist.down.sql
+++ b/components/schema-migrator/migrations/director/20231228152252_add-discovery-consumers-allowlist.down.sql
@@ -1,0 +1,9 @@
+BEGIN;
+
+ALTER TABLE formation_templates
+    DROP COLUMN discovery_consumers;
+
+DROP INDEX discovery_consumers_gin
+DROP INDEX scenario_label_gin
+
+COMMIT;

--- a/components/schema-migrator/migrations/director/20231228152252_add-discovery-consumers-allowlist.up.sql
+++ b/components/schema-migrator/migrations/director/20231228152252_add-discovery-consumers-allowlist.up.sql
@@ -6,4 +6,7 @@ ALTER TABLE formation_templates
 CREATE INDEX discovery_consumers_gin ON formation_templates USING gin (discovery_consumers);
 CREATE INDEX scenario_label_gin ON labels USING gin (value) WHERE key = 'scenarios';
 
+-- Initial set of discovery consumers to ensure existing scenarios will continue working
+UPDATE formation_templates SET discovery_consumers = runtime_types;
+
 COMMIT;

--- a/components/schema-migrator/migrations/director/20231228152252_add-discovery-consumers-allowlist.up.sql
+++ b/components/schema-migrator/migrations/director/20231228152252_add-discovery-consumers-allowlist.up.sql
@@ -1,0 +1,9 @@
+BEGIN;
+
+ALTER TABLE formation_templates
+    ADD COLUMN discovery_consumers JSONB;
+
+CREATE INDEX discovery_consumers_gin ON formation_templates USING gin (discovery_consumers);
+CREATE INDEX scenario_label_gin ON labels USING gin (value) WHERE key = 'scenarios';
+
+COMMIT;

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/google/uuid v1.3.1
 	github.com/kyma-incubator/compass/components/connectivity-adapter v0.0.0-20231215122547-1bef112a2d63
 	github.com/kyma-incubator/compass/components/connector v0.0.0-20231215122547-1bef112a2d63
-	github.com/kyma-incubator/compass/components/director v0.0.0-20231215122547-1bef112a2d63
+	github.com/kyma-incubator/compass/components/director v0.0.0-20231228140541-bb3ad0739f49
 	github.com/kyma-incubator/compass/components/external-services-mock v0.0.0-20231215122547-1bef112a2d63
 	github.com/kyma-incubator/compass/components/gateway v0.0.0-20231215122547-1bef112a2d63
 	github.com/kyma-incubator/compass/components/operations-controller v0.0.0-20231215122547-1bef112a2d63

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -9,6 +9,8 @@ github.com/Masterminds/semver/v3 v3.2.0 h1:3MEsd0SM6jqZojhjLWWeBY+Kcjy9i6MQAeY7Y
 github.com/Masterminds/semver/v3 v3.2.0/go.mod h1:qvl/7zhW3nngYb5+80sSMF+FG2BjYrf8m9wsX0PNOMQ=
 github.com/Masterminds/sprig/v3 v3.2.3 h1:eL2fZNezLomi0uOLqjQoN6BfsDD+fyLtgbJMAj9n6YA=
 github.com/Masterminds/sprig/v3 v3.2.3/go.mod h1:rXcFaZ2zZbLRJv/xSysmlgIM1u11eBaRMhvYXJNkGuM=
+github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
+github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/agnivade/levenshtein v1.0.1/go.mod h1:CURSv5d9Uaml+FovSIICkLbAUZ9S4RqaHDIsdSBg7lM=
 github.com/agnivade/levenshtein v1.0.3/go.mod h1:4SFRZbbXWLF4MU1T9Qg0pGgH3Pjs+t6ie5efyrwRJXs=
 github.com/agnivade/levenshtein v1.1.1 h1:QY8M92nrzkmr798gCo3kmMyqXFzdQVpxLlGPRBij0P8=
@@ -135,6 +137,8 @@ github.com/kyma-incubator/compass/components/connector v0.0.0-20231215122547-1be
 github.com/kyma-incubator/compass/components/connector v0.0.0-20231215122547-1bef112a2d63/go.mod h1:QOp4KsvdWh71RljvfQcgPTX68TSmyV1VYaGcgxnerdQ=
 github.com/kyma-incubator/compass/components/director v0.0.0-20231215122547-1bef112a2d63 h1:cFwVa30cVSuzf5p3EgeGLxaLJb3quDbAjqLfrSk1L+U=
 github.com/kyma-incubator/compass/components/director v0.0.0-20231215122547-1bef112a2d63/go.mod h1:QyDLmcIjMEBG6e/8tBIy6niNw6EI3fNfLt+2pxze1V0=
+github.com/kyma-incubator/compass/components/director v0.0.0-20231228140541-bb3ad0739f49 h1:ADE2m5RK2Cwfe5lbUmDx3cjA7laDUAFbM82jIpuXF/4=
+github.com/kyma-incubator/compass/components/director v0.0.0-20231228140541-bb3ad0739f49/go.mod h1:Xh1BxMfdPpcCjtAwPzRsFUvUgZQNTsZAhGa9zE85ULU=
 github.com/kyma-incubator/compass/components/external-services-mock v0.0.0-20231215122547-1bef112a2d63 h1:HkvMwcaFp+xO6viz8/MHaz5GLQmZNdEaagwTJV1GXlg=
 github.com/kyma-incubator/compass/components/external-services-mock v0.0.0-20231215122547-1bef112a2d63/go.mod h1:BBsY0+5ZNFGPpSgZrgB87KxSxftCkNUJPKap8+cx5qA=
 github.com/kyma-incubator/compass/components/gateway v0.0.0-20231215122547-1bef112a2d63 h1:VfQVnFzjOsqHHDT/YwWvspEKPAOO3LtvQXfNUkYy0Jk=
@@ -219,6 +223,7 @@ github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/stoewer/go-strcase v1.2.0/go.mod h1:IBiWB2sKIp3wVVQ3Y035++gc+knqhUQag1KpM8ahLw8=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.5.0 h1:1zr/of2m5FGMsad5YfcqgdqdWrIhu+EBEJRhR1U7z/c=
+github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/testify v1.2.1/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=

--- a/tests/ord-service/tests/subscription_flow_test.go
+++ b/tests/ord-service/tests/subscription_flow_test.go
@@ -525,10 +525,10 @@ func TestConsumerProviderFlow(stdT *testing.T) {
 		var ftWithoutDiscoveryConsumers graphql.FormationTemplate // needed so the 'defer' can be above the formation template creation
 		defer fixtures.CleanupFormationTemplate(t, ctx, certSecuredGraphQLClient, &ftWithoutDiscoveryConsumers)
 		ftWithoutDiscoveryConsumers = fixtures.CreateFormationTemplate(stdT, ctx, certSecuredGraphQLClient, graphql.FormationTemplateInput{
-			Name:                   formationTmplName,
+			Name:                   secondFormationTmplName,
 			ApplicationTypes:       []string{string(applicationType), "SAP provider-app-template"},
 			RuntimeTypes:           []string{conf.SubscriptionProviderAppNameValue},
-			RuntimeTypeDisplayName: &formationTmplName,
+			RuntimeTypeDisplayName: &secondFormationTmplName,
 			RuntimeArtifactKind:    &artifactKind,
 		})
 

--- a/tests/ord-service/tests/subscription_flow_test.go
+++ b/tests/ord-service/tests/subscription_flow_test.go
@@ -170,7 +170,7 @@ func TestConsumerProviderFlow(stdT *testing.T) {
 		require.True(t, ok)
 		require.NotEmpty(t, saasAppLbl)
 
-		// Register application
+		// Register application directly in the tenant and don't add it to any formations and validate that this system won't be visible for the SaaS app calling as part of the formation.
 		app, err := fixtures.RegisterApplicationWithApplicationType(t, ctx, certSecuredGraphQLClient, "testingApp", conf.ApplicationTypeLabelKey, string(util.ApplicationTypeC4C), secondaryTenant)
 		defer fixtures.CleanupApplication(stdT, ctx, certSecuredGraphQLClient, secondaryTenant, &app)
 		require.NoError(stdT, err)
@@ -181,6 +181,12 @@ func TestConsumerProviderFlow(stdT *testing.T) {
 		defer fixtures.CleanupApplication(stdT, ctx, certSecuredGraphQLClient, subscriptionConsumerSubaccountID, &subaccountApp)
 		require.NoError(stdT, err)
 		require.NotEmpty(stdT, subaccountApp.ID)
+
+		// Register application directly in the tenant and add it to a formation that the caller is not discover consumer in and validate that this system won't be visible for the SaaS app calling as part of the formation.
+		appInAnotherFormation, err := fixtures.RegisterApplicationWithApplicationType(t, ctx, certSecuredGraphQLClient, "testingApp2", conf.ApplicationTypeLabelKey, string(util.ApplicationTypeC4C), secondaryTenant)
+		defer fixtures.CleanupApplication(stdT, ctx, certSecuredGraphQLClient, secondaryTenant, &appInAnotherFormation)
+		require.NoError(stdT, err)
+		require.NotEmpty(stdT, appInAnotherFormation.ID)
 
 		// Register consumer application
 		const localTenantID = "localTenantID"
@@ -200,11 +206,31 @@ func TestConsumerProviderFlow(stdT *testing.T) {
 
 		formationTmplName := "e2e-test-formation-template-name"
 		applicationType := util.ApplicationTypeC4C
+		artifactKind := graphql.ArtifactTypeSubscription
 
 		stdT.Logf("Creating formation template for the provider runtime type %q with name %q", conf.SubscriptionProviderAppNameValue, formationTmplName)
 		var ft graphql.FormationTemplate // needed so the 'defer' can be above the formation template creation
 		defer fixtures.CleanupFormationTemplate(t, ctx, certSecuredGraphQLClient, &ft)
-		ft = fixtures.CreateFormationTemplateWithoutInput(stdT, ctx, certSecuredGraphQLClient, formationTmplName, conf.SubscriptionProviderAppNameValue, []string{string(applicationType)}, graphql.ArtifactTypeSubscription)
+		ft = fixtures.CreateFormationTemplate(stdT, ctx, certSecuredGraphQLClient, graphql.FormationTemplateInput{
+			Name:                   formationTmplName,
+			ApplicationTypes:       []string{string(applicationType)},
+			RuntimeTypes:           []string{conf.SubscriptionProviderAppNameValue},
+			RuntimeTypeDisplayName: &formationTmplName,
+			RuntimeArtifactKind:    &artifactKind,
+			DiscoveryConsumers:     []string{string(applicationType), conf.SubscriptionProviderAppNameValue},
+		})
+
+		secondFormationTmplName := "e2e-test-formation-template-without-discovery-consumer"
+		stdT.Logf("Creating formation template with name %q, without discovery consumers configured", secondFormationTmplName)
+		var ftWithoutDiscoveryConsumers graphql.FormationTemplate // needed so the 'defer' can be above the formation template creation
+		defer fixtures.CleanupFormationTemplate(t, ctx, certSecuredGraphQLClient, &ftWithoutDiscoveryConsumers)
+		ftWithoutDiscoveryConsumers = fixtures.CreateFormationTemplate(stdT, ctx, certSecuredGraphQLClient, graphql.FormationTemplateInput{
+			Name:                   secondFormationTmplName,
+			ApplicationTypes:       []string{string(applicationType)},
+			RuntimeTypes:           []string{conf.SubscriptionProviderAppNameValue},
+			RuntimeTypeDisplayName: &secondFormationTmplName,
+			RuntimeArtifactKind:    &artifactKind,
+		})
 
 		consumerFormationName := "consumer-test-scenario"
 		stdT.Logf("Creating formation with name: %q from template with name: %q", consumerFormationName, formationTmplName)
@@ -222,6 +248,23 @@ func TestConsumerProviderFlow(stdT *testing.T) {
 		assignToFormation(stdT, ctx, subscriptionConsumerSubaccountID, "TENANT", consumerFormationName, secondaryTenant)
 		defer unassignFromFormation(stdT, ctx, subscriptionConsumerSubaccountID, "TENANT", consumerFormationName, secondaryTenant)
 		stdT.Logf("Successfully assigned tenant %s to formation %s", subscriptionConsumerSubaccountID, consumerFormationName)
+
+		noDiscoveryConsumptionFormationName := "no-discovery-consumption-scenario"
+		stdT.Logf("Creating formation with name: %q from template with name: %q", noDiscoveryConsumptionFormationName, secondFormationTmplName)
+		defer fixtures.DeleteFormationWithinTenant(stdT, ctx, certSecuredGraphQLClient, secondaryTenant, noDiscoveryConsumptionFormationName)
+		noDiscoveryConsumptionFormation := fixtures.CreateFormationFromTemplateWithinTenant(stdT, ctx, certSecuredGraphQLClient, secondaryTenant, noDiscoveryConsumptionFormationName, &secondFormationTmplName)
+		require.NotEmpty(t, noDiscoveryConsumptionFormation.ID)
+		stdT.Logf("Successfully created formation: %s", noDiscoveryConsumptionFormationName)
+
+		stdT.Logf("Assign application to formation %s", noDiscoveryConsumptionFormationName)
+		assignToFormation(stdT, ctx, appInAnotherFormation.ID, "APPLICATION", noDiscoveryConsumptionFormationName, secondaryTenant)
+		defer unassignFromFormation(stdT, ctx, appInAnotherFormation.ID, "APPLICATION", noDiscoveryConsumptionFormationName, secondaryTenant)
+		stdT.Logf("Successfully assigned application to formation %s", noDiscoveryConsumptionFormationName)
+
+		stdT.Logf("Assign tenant %s to formation %s...", subscriptionConsumerSubaccountID, noDiscoveryConsumptionFormationName)
+		assignToFormation(stdT, ctx, subscriptionConsumerSubaccountID, "TENANT", noDiscoveryConsumptionFormationName, secondaryTenant)
+		defer unassignFromFormation(stdT, ctx, subscriptionConsumerSubaccountID, "TENANT", noDiscoveryConsumptionFormationName, secondaryTenant)
+		stdT.Logf("Successfully assigned tenant %s to formation %s", subscriptionConsumerSubaccountID, noDiscoveryConsumptionFormationName)
 
 		selfRegLabelValue, ok := runtime.Labels[conf.SubscriptionConfig.SelfRegisterLabelKey].(string)
 		require.True(stdT, ok)
@@ -427,7 +470,7 @@ func TestConsumerProviderFlow(stdT *testing.T) {
 		require.True(t, ok)
 		require.NotEmpty(t, selfRegDistinguishValue)
 
-		// Register application
+		// Register application directly in the tenant and don't add it to any formations and validate that this system won't be visible for the SaaS app calling as part of the formation.
 		app, err := fixtures.RegisterApplicationWithApplicationType(t, ctx, certSecuredGraphQLClient, "testingApp", conf.ApplicationTypeLabelKey, string(util.ApplicationTypeC4C), secondaryTenant)
 		defer fixtures.CleanupApplication(stdT, ctx, certSecuredGraphQLClient, secondaryTenant, &app)
 		require.NoError(stdT, err)
@@ -438,6 +481,12 @@ func TestConsumerProviderFlow(stdT *testing.T) {
 		defer fixtures.CleanupApplication(stdT, ctx, certSecuredGraphQLClient, subscriptionConsumerSubaccountID, &subaccountApp)
 		require.NoError(stdT, err)
 		require.NotEmpty(stdT, subaccountApp.ID)
+
+		// Register application directly in the tenant and add it to a formation that the caller is not discover consumer in and validate that this system won't be visible for the SaaS app calling as part of the formation.
+		appInAnotherFormation, err := fixtures.RegisterApplicationWithApplicationType(t, ctx, certSecuredGraphQLClient, "testingApp2", conf.ApplicationTypeLabelKey, string(util.ApplicationTypeC4C), secondaryTenant)
+		defer fixtures.CleanupApplication(stdT, ctx, certSecuredGraphQLClient, secondaryTenant, &appInAnotherFormation)
+		require.NoError(stdT, err)
+		require.NotEmpty(stdT, appInAnotherFormation.ID)
 
 		// Register consumer application
 		const localTenantID = "localTenantID"
@@ -457,11 +506,31 @@ func TestConsumerProviderFlow(stdT *testing.T) {
 
 		formationTmplName := "e2e-test-formation-template-name"
 		applicationType := util.ApplicationTypeC4C
+		artifactKind := graphql.ArtifactTypeSubscription
 
 		stdT.Logf("Creating formation template for the provider application tempalаte type %q with name %q", conf.SubscriptionProviderAppNameValue, formationTmplName)
 		var ft graphql.FormationTemplate // needed so the 'defer' can be above the formation template creation
 		defer fixtures.CleanupFormationTemplate(t, ctx, certSecuredGraphQLClient, &ft)
-		ft = fixtures.CreateFormationTemplateWithoutInput(stdT, ctx, certSecuredGraphQLClient, formationTmplName, conf.SubscriptionProviderAppNameValue, []string{string(applicationType), "SAP provider-app-template"}, graphql.ArtifactTypeSubscription)
+		ft = fixtures.CreateFormationTemplate(stdT, ctx, certSecuredGraphQLClient, graphql.FormationTemplateInput{
+			Name:                   formationTmplName,
+			ApplicationTypes:       []string{string(applicationType), "SAP provider-app-template"},
+			RuntimeTypes:           []string{conf.SubscriptionProviderAppNameValue},
+			RuntimeTypeDisplayName: &formationTmplName,
+			RuntimeArtifactKind:    &artifactKind,
+			DiscoveryConsumers:     []string{string(applicationType), "SAP provider-app-template", conf.SubscriptionProviderAppNameValue},
+		})
+
+		secondFormationTmplName := "e2e-test-formation-template-without-discovery-consumer"
+		stdT.Logf("Creating formation template with name %q, without discovery consumers configured", secondFormationTmplName)
+		var ftWithoutDiscoveryConsumers graphql.FormationTemplate // needed so the 'defer' can be above the formation template creation
+		defer fixtures.CleanupFormationTemplate(t, ctx, certSecuredGraphQLClient, &ftWithoutDiscoveryConsumers)
+		ftWithoutDiscoveryConsumers = fixtures.CreateFormationTemplate(stdT, ctx, certSecuredGraphQLClient, graphql.FormationTemplateInput{
+			Name:                   formationTmplName,
+			ApplicationTypes:       []string{string(applicationType), "SAP provider-app-template"},
+			RuntimeTypes:           []string{conf.SubscriptionProviderAppNameValue},
+			RuntimeTypeDisplayName: &formationTmplName,
+			RuntimeArtifactKind:    &artifactKind,
+		})
 
 		consumerFormationName := "consumer-test-scenario"
 		stdT.Logf("Creating formation with name: %q from template with name: %q", consumerFormationName, formationTmplName)
@@ -474,6 +543,18 @@ func TestConsumerProviderFlow(stdT *testing.T) {
 		assignToFormation(stdT, ctx, consumerApp.ID, "APPLICATION", consumerFormationName, secondaryTenant)
 		defer unassignFromFormation(stdT, ctx, consumerApp.ID, "APPLICATION", consumerFormationName, secondaryTenant)
 		stdT.Logf("Successfully assigned application to formation %s", consumerFormationName)
+
+		noDiscoveryConsumptionFormationName := "no-discovery-consumption-scenario"
+		stdT.Logf("Creating formation with name: %q from template with name: %q", noDiscoveryConsumptionFormationName, secondFormationTmplName)
+		defer fixtures.DeleteFormationWithinTenant(stdT, ctx, certSecuredGraphQLClient, secondaryTenant, noDiscoveryConsumptionFormationName)
+		noDiscoveryConsumptionFormation := fixtures.CreateFormationFromTemplateWithinTenant(stdT, ctx, certSecuredGraphQLClient, secondaryTenant, noDiscoveryConsumptionFormationName, &secondFormationTmplName)
+		require.NotEmpty(t, noDiscoveryConsumptionFormation.ID)
+		stdT.Logf("Successfully created formation: %s", noDiscoveryConsumptionFormationName)
+
+		stdT.Logf("Assign application to formation %s", noDiscoveryConsumptionFormationName)
+		assignToFormation(stdT, ctx, appInAnotherFormation.ID, "APPLICATION", noDiscoveryConsumptionFormationName, secondaryTenant)
+		defer unassignFromFormation(stdT, ctx, appInAnotherFormation.ID, "APPLICATION", noDiscoveryConsumptionFormationName, secondaryTenant)
+		stdT.Logf("Successfully assigned application to formation %s", noDiscoveryConsumptionFormationName)
 
 		httpClient := &http.Client{
 			Timeout: 10 * time.Second,
@@ -544,6 +625,11 @@ func TestConsumerProviderFlow(stdT *testing.T) {
 		assignToFormation(stdT, ctx, providerApp.ID, "APPLICATION", consumerFormationName, secondaryTenant)
 		defer unassignFromFormation(stdT, ctx, providerApp.ID, "APPLICATION", consumerFormationName, secondaryTenant)
 		stdT.Logf("Successfully assigned application to formation %s", consumerFormationName)
+
+		stdT.Logf("Assign provider application with id %q to formation %s", providerApp.ID, noDiscoveryConsumptionFormationName)
+		assignToFormation(stdT, ctx, providerApp.ID, "APPLICATION", noDiscoveryConsumptionFormationName, secondaryTenant)
+		defer unassignFromFormation(stdT, ctx, providerApp.ID, "APPLICATION", noDiscoveryConsumptionFormationName, secondaryTenant)
+		stdT.Logf("Successfully assigned application to formation %s", noDiscoveryConsumptionFormationName)
 
 		// After successful subscription from above we call the director component with "double authentication(token + certificate)" in order to test claims validation is successful
 		consumerToken := token.GetUserToken(stdT, ctx, conf.ConsumerTokenURL+conf.TokenPath, conf.ProviderClientID, conf.ProviderClientSecret, conf.BasicUsername, conf.BasicPassword, claims.SubscriptionClaimKey)
@@ -685,7 +771,7 @@ func TestConsumerProviderFlow(stdT *testing.T) {
 		require.True(t, ok)
 		require.NotEmpty(t, saasAppLbl)
 
-		// Register application
+		// Register application directly in the tenant and don't add it to any formations and validate that this system won't be visible for the SaaS app calling as part of the formation.
 		app, err := fixtures.RegisterApplicationWithApplicationType(t, ctx, certSecuredGraphQLClient, "testingApp", conf.ApplicationTypeLabelKey, string(util.ApplicationTypeC4C), secondaryTenant)
 		defer fixtures.CleanupApplication(stdT, ctx, certSecuredGraphQLClient, secondaryTenant, &app)
 		require.NoError(stdT, err)
@@ -696,6 +782,12 @@ func TestConsumerProviderFlow(stdT *testing.T) {
 		defer fixtures.CleanupApplication(stdT, ctx, certSecuredGraphQLClient, subscriptionConsumerSubaccountID, &subaccountApp)
 		require.NoError(stdT, err)
 		require.NotEmpty(stdT, subaccountApp.ID)
+
+		// Register application directly in the tenant and add it to a formation that the caller is not discover consumer in and validate that this system won't be visible for the SaaS app calling as part of the formation.
+		appInAnotherFormation, err := fixtures.RegisterApplicationWithApplicationType(t, ctx, certSecuredGraphQLClient, "testingApp2", conf.ApplicationTypeLabelKey, string(util.ApplicationTypeC4C), secondaryTenant)
+		defer fixtures.CleanupApplication(stdT, ctx, certSecuredGraphQLClient, secondaryTenant, &appInAnotherFormation)
+		require.NoError(stdT, err)
+		require.NotEmpty(stdT, appInAnotherFormation.ID)
 
 		// Register consumer application
 		const localTenantID = "localTenantID"
@@ -715,11 +807,31 @@ func TestConsumerProviderFlow(stdT *testing.T) {
 
 		formationTmplName := "e2e-test-formation-template-name"
 		applicationType := util.ApplicationTypeC4C
+		artifactKind := graphql.ArtifactTypeSubscription
 
 		stdT.Logf("Creating formation template for the provider runtime type %q with name %q", conf.SubscriptionProviderAppNameValue, formationTmplName)
 		var ft graphql.FormationTemplate // needed so the 'defer' can be above the formation template creation
 		defer fixtures.CleanupFormationTemplate(t, ctx, certSecuredGraphQLClient, &ft)
-		ft = fixtures.CreateFormationTemplateWithoutInput(stdT, ctx, certSecuredGraphQLClient, formationTmplName, conf.SubscriptionProviderAppNameValue, []string{string(applicationType)}, graphql.ArtifactTypeSubscription)
+		ft = fixtures.CreateFormationTemplate(stdT, ctx, certSecuredGraphQLClient, graphql.FormationTemplateInput{
+			Name:                   formationTmplName,
+			ApplicationTypes:       []string{string(applicationType)},
+			RuntimeTypes:           []string{conf.SubscriptionProviderAppNameValue},
+			RuntimeTypeDisplayName: &formationTmplName,
+			RuntimeArtifactKind:    &artifactKind,
+			DiscoveryConsumers:     []string{string(applicationType), conf.SubscriptionProviderAppNameValue},
+		})
+
+		secondFormationTmplName := "e2e-test-formation-template-without-discovery-consumer"
+		stdT.Logf("Creating formation template with name %q, without discovery consumers configured", secondFormationTmplName)
+		var ftWithoutDiscoveryConsumers graphql.FormationTemplate // needed so the 'defer' can be above the formation template creation
+		defer fixtures.CleanupFormationTemplate(t, ctx, certSecuredGraphQLClient, &ftWithoutDiscoveryConsumers)
+		ftWithoutDiscoveryConsumers = fixtures.CreateFormationTemplate(stdT, ctx, certSecuredGraphQLClient, graphql.FormationTemplateInput{
+			Name:                   secondFormationTmplName,
+			ApplicationTypes:       []string{string(applicationType)},
+			RuntimeTypes:           []string{conf.SubscriptionProviderAppNameValue},
+			RuntimeTypeDisplayName: &secondFormationTmplName,
+			RuntimeArtifactKind:    &artifactKind,
+		})
 
 		consumerFormationName := "consumer-test-scenario"
 		stdT.Logf("Creating formation with name: %q from template with name: %q", consumerFormationName, formationTmplName)
@@ -737,6 +849,23 @@ func TestConsumerProviderFlow(stdT *testing.T) {
 		assignToFormation(stdT, ctx, subscriptionConsumerSubaccountID, "TENANT", consumerFormationName, secondaryTenant)
 		defer unassignFromFormation(stdT, ctx, subscriptionConsumerSubaccountID, "TENANT", consumerFormationName, secondaryTenant)
 		stdT.Logf("Successfully assigned tenant %s to formation %s", subscriptionConsumerSubaccountID, consumerFormationName)
+
+		noDiscoveryConsumptionFormationName := "no-discovery-consumption-scenario"
+		stdT.Logf("Creating formation with name: %q from template with name: %q", noDiscoveryConsumptionFormationName, secondFormationTmplName)
+		defer fixtures.DeleteFormationWithinTenant(stdT, ctx, certSecuredGraphQLClient, secondaryTenant, noDiscoveryConsumptionFormationName)
+		noDiscoveryConsumptionFormation := fixtures.CreateFormationFromTemplateWithinTenant(stdT, ctx, certSecuredGraphQLClient, secondaryTenant, noDiscoveryConsumptionFormationName, &secondFormationTmplName)
+		require.NotEmpty(t, noDiscoveryConsumptionFormation.ID)
+		stdT.Logf("Successfully created formation: %s", noDiscoveryConsumptionFormationName)
+
+		stdT.Logf("Assign application to formation %s", noDiscoveryConsumptionFormationName)
+		assignToFormation(stdT, ctx, appInAnotherFormation.ID, "APPLICATION", noDiscoveryConsumptionFormationName, secondaryTenant)
+		defer unassignFromFormation(stdT, ctx, appInAnotherFormation.ID, "APPLICATION", noDiscoveryConsumptionFormationName, secondaryTenant)
+		stdT.Logf("Successfully assigned application to formation %s", noDiscoveryConsumptionFormationName)
+
+		stdT.Logf("Assign tenant %s to formation %s...", subscriptionConsumerSubaccountID, noDiscoveryConsumptionFormationName)
+		assignToFormation(stdT, ctx, subscriptionConsumerSubaccountID, "TENANT", noDiscoveryConsumptionFormationName, secondaryTenant)
+		defer unassignFromFormation(stdT, ctx, subscriptionConsumerSubaccountID, "TENANT", noDiscoveryConsumptionFormationName, secondaryTenant)
+		stdT.Logf("Successfully assigned tenant %s to formation %s", subscriptionConsumerSubaccountID, noDiscoveryConsumptionFormationName)
 
 		selfRegLabelValue, ok := runtime.Labels[conf.SubscriptionConfig.SelfRegisterLabelKey].(string)
 		require.True(stdT, ok)

--- a/tests/ord-service/tests/subscription_flow_test.go
+++ b/tests/ord-service/tests/subscription_flow_test.go
@@ -728,6 +728,7 @@ func TestConsumerProviderFlow(stdT *testing.T) {
 		stdT.Log("Successfully fetched system with bundles and destinations")
 
 		unassignFromFormation(stdT, ctx, providerApp.ID, "APPLICATION", consumerFormationName, secondaryTenant)
+		unassignFromFormation(stdT, ctx, providerApp.ID, "APPLICATION", noDiscoveryConsumptionFormationName, secondaryTenant)
 		subscription.BuildAndExecuteUnsubscribeRequest(stdT, appTmpl.ID, appTmpl.Name, httpClient, conf.SubscriptionConfig.URL, apiPath, subscriptionToken, conf.SubscriptionConfig.PropagatedProviderSubaccountHeader, subscriptionConsumerSubaccountID, "", subscriptionProviderSubaccountID, conf.SubscriptionConfig.StandardFlow, conf.SubscriptionConfig.SubscriptionFlowHeaderKey)
 
 		stdT.Log("Validating no application is returned after successful unsubscription request...")


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:
- Add discovery consumers allowlist as a column of the formation template entity
- Add JSONB index to scenario labels for faster querying

**Related issue(s)**
- https://github.com/kyma-incubator/ord-service/pull/118

**Pull Request status**

- [x] Implementation
- [x] Unit tests
- [ ] Integration tests
- [x] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [ ] Mocks are regenerated, using the automated script
