### PR TITLE
Fix unstable notification lifecycle test

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -225,7 +225,7 @@ global:
       name: compass-console
     e2e_tests:
       dir: dev/incubator/
-      version: "PR-3564"
+      version: "PR-3568"
       name: compass-e2e-tests
   isLocalEnv: false
   isForTesting: false


### PR DESCRIPTION
**Description**
Currently we rely that the two assign operations done in the test are done fast enough, that the formation lifecycle response happens after they have finished. Sometimes in PR executions it is too slow, and that causes the test to fail.

The approach used to fix this is to make it so that the e2e test webhook points to an endpoint that does not respond at all, and when we assign, we change it to a webhook that actually responds and trigger it via resync.

Changes proposed in this pull request:
- test asynchronous lifecycle notifications with tenant mapping notification resync, rather than relying that the assign operations will have passed before the status report for creating the application responds

**Related issue(s)**
- #3545

**Pull Request status**
- [x] [N/A] Implementation
- [x] [N/A] Unit tests
- [x] Integration tests
- [x] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [x] [N/A] Mocks are regenerated, using the automated script
