### PR TITLE
Fix formation assignment state in notification payload

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -168,7 +168,7 @@ global:
       name: compass-pairing-adapter
     director:
       dir: dev/incubator/
-      version: "PR-3572"
+      version: "PR-3575"
       name: compass-director
     hydrator:
       dir: dev/incubator/
@@ -225,7 +225,7 @@ global:
       name: compass-console
     e2e_tests:
       dir: dev/incubator/
-      version: "PR-3572"
+      version: "PR-3575"
       name: compass-e2e-tests
   isLocalEnv: false
   isForTesting: false

--- a/components/director/pkg/webhook/application_tenant_mapping.go
+++ b/components/director/pkg/webhook/application_tenant_mapping.go
@@ -62,7 +62,7 @@ func (rd *ApplicationTenantMappingInput) SetAssignment(assignment *model.Formati
 		SourceType:  assignment.SourceType,
 		Target:      assignment.Target,
 		TargetType:  assignment.TargetType,
-		State:       assignment.State,
+		State:       assignment.GetNotificationState(),
 		Value:       str.StringifyJSONRawMessage(assignment.Value),
 		Error:       str.StringifyJSONRawMessage(assignment.Error),
 	}
@@ -78,7 +78,7 @@ func (rd *ApplicationTenantMappingInput) SetReverseAssignment(reverseAssignment 
 		SourceType:  reverseAssignment.SourceType,
 		Target:      reverseAssignment.Target,
 		TargetType:  reverseAssignment.TargetType,
-		State:       reverseAssignment.State,
+		State:       reverseAssignment.GetNotificationState(),
 		Value:       str.StringifyJSONRawMessage(reverseAssignment.Value),
 		Error:       str.StringifyJSONRawMessage(reverseAssignment.Error),
 	}

--- a/components/director/pkg/webhook/formation_configuration_change.go
+++ b/components/director/pkg/webhook/formation_configuration_change.go
@@ -134,7 +134,7 @@ func (rd *FormationConfigurationChangeInput) SetAssignment(assignment *model.For
 		SourceType:  assignment.SourceType,
 		Target:      assignment.Target,
 		TargetType:  assignment.TargetType,
-		State:       assignment.State,
+		State:       assignment.GetNotificationState(),
 		Value:       str.StringifyJSONRawMessage(assignment.Value),
 		Error:       str.StringifyJSONRawMessage(assignment.Error),
 	}
@@ -150,7 +150,7 @@ func (rd *FormationConfigurationChangeInput) SetReverseAssignment(reverseAssignm
 		SourceType:  reverseAssignment.SourceType,
 		Target:      reverseAssignment.Target,
 		TargetType:  reverseAssignment.TargetType,
-		State:       reverseAssignment.State,
+		State:       reverseAssignment.GetNotificationState(),
 		Value:       str.StringifyJSONRawMessage(reverseAssignment.Value),
 		Error:       str.StringifyJSONRawMessage(reverseAssignment.Error),
 	}

--- a/tests/director/tests/notifications/application_only_notifications_new_format_test.go
+++ b/tests/director/tests/notifications/application_only_notifications_new_format_test.go
@@ -974,7 +974,7 @@ func TestFormationNotificationsWithApplicationOnlyParticipantsNewFormat(t *testi
 		notificationCountAsyncAsserter := asserters.NewNotificationsCountAsyncAsserter(1, unassignOperation, localTenantID, conf.ExternalServicesMockMtlsSecuredURL, certSecuredHTTPClient)
 		notificationsUnassignAsserter := asserters.NewUnassignNotificationsAsserter(1, localTenantID, app2ID, localTenantID, appNamespace, appRegion, tnt, tntParentCustomer, "", conf.ExternalServicesMockMtlsSecuredURL, certSecuredHTTPClient)
 		notificationCountRedirectNotificationAsyncAsserter := asserters.NewNotificationsCountAsyncAsserter(1, unassignOperation, redirectedTntID, conf.ExternalServicesMockMtlsSecuredURL, certSecuredHTTPClient)
-		notificationsUnassignRedirectedAsserter := asserters.NewUnassignNotificationsAsserter(1, redirectedTntID, app2ID, localTenantID, appNamespace, appRegion, tnt, tntParentCustomer, "", conf.ExternalServicesMockMtlsSecuredURL, certSecuredHTTPClient)
+		notificationsUnassignRedirectedAsserter := asserters.NewUnassignNotificationsAsserter(1, redirectedTntID, app2ID, localTenantID, appNamespace, appRegion, tnt, tntParentCustomer, "", conf.ExternalServicesMockMtlsSecuredURL, certSecuredHTTPClient).WithState(deletingAssignmentState)
 		op = operations.NewUnassignAppToFormationOperation(app2ID, tnt).WithAsserters(faAsserter, statusAsserter, notificationCountAsyncAsserter, notificationsUnassignAsserter, notificationCountRedirectNotificationAsyncAsserter, notificationsUnassignRedirectedAsserter).Operation()
 		defer op.Cleanup(t, ctx, certSecuredGraphQLClient)
 		op.Execute(t, ctx, certSecuredGraphQLClient)

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/google/uuid v1.3.1
 	github.com/kyma-incubator/compass/components/connectivity-adapter v0.0.0-20240103071758-92efbd94b916
 	github.com/kyma-incubator/compass/components/connector v0.0.0-20240103071758-92efbd94b916
-	github.com/kyma-incubator/compass/components/director v0.0.0-20240103150409-a616d7becc02
+	github.com/kyma-incubator/compass/components/director v0.0.0-20240110140728-7f8fb848e925
 	github.com/kyma-incubator/compass/components/external-services-mock v0.0.0-20240103071758-92efbd94b916
 	github.com/kyma-incubator/compass/components/gateway v0.0.0-20240103071758-92efbd94b916
 	github.com/kyma-incubator/compass/components/operations-controller v0.0.0-20240103071758-92efbd94b916

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -135,6 +135,8 @@ github.com/kyma-incubator/compass/components/connector v0.0.0-20240103071758-92e
 github.com/kyma-incubator/compass/components/connector v0.0.0-20240103071758-92efbd94b916/go.mod h1:vkGBt3PRRROx3TP9Zm/ifa8rqwIe3Kkln+Bw0u4D0A0=
 github.com/kyma-incubator/compass/components/director v0.0.0-20240103150409-a616d7becc02 h1:r7iMxX3Vzf0LaNTan8YbkdeaTA4XBVSAuFE1UnMp+2c=
 github.com/kyma-incubator/compass/components/director v0.0.0-20240103150409-a616d7becc02/go.mod h1:W27oolzjiXHsC36OxElTUnn5ycSkGyyjPfcteqBCWNE=
+github.com/kyma-incubator/compass/components/director v0.0.0-20240110140728-7f8fb848e925 h1:pTnvMgLHYh9Ts2q7cmyPikYwr/QKgvdds/zFJIf1WI4=
+github.com/kyma-incubator/compass/components/director v0.0.0-20240110140728-7f8fb848e925/go.mod h1:W27oolzjiXHsC36OxElTUnn5ycSkGyyjPfcteqBCWNE=
 github.com/kyma-incubator/compass/components/external-services-mock v0.0.0-20240103071758-92efbd94b916 h1:+9qwGhnCFYZ++oihBXLUqqyzKhwzuAuD/OR9tcUEjHI=
 github.com/kyma-incubator/compass/components/external-services-mock v0.0.0-20240103071758-92efbd94b916/go.mod h1:n9dFKNggl07D4ldZD2gla8JH5Jm0sJMrrp1WXESIw4o=
 github.com/kyma-incubator/compass/components/gateway v0.0.0-20240103071758-92efbd94b916 h1:KPGnOHhAT5gYN9w1iuAEqhW8QB862rNXwk4aCMhxO4c=

--- a/tests/pkg/notifications/asserters/formation_assignments_async.go
+++ b/tests/pkg/notifications/asserters/formation_assignments_async.go
@@ -58,7 +58,7 @@ func (a *FormationAssignmentsAsyncAsserter) assertFormationAssignmentsAsynchrono
 	require.Eventually(t, func() (isOkay bool) {
 		tOnce.Logf("Getting formation assignments...")
 		listFormationAssignmentsRequest := fixtures.FixListFormationAssignmentRequest(formationID, 200)
-		assignmentsPage := fixtures.ListFormationAssignments(t, ctx, certSecuredGraphQLClient, tenantID, listFormationAssignmentsRequest)
+		assignmentsPage := fixtures.ListFormationAssignments(tOnce, ctx, certSecuredGraphQLClient, tenantID, listFormationAssignmentsRequest)
 		if expectedAssignmentsCount != assignmentsPage.TotalCount {
 			tOnce.Logf("The expected assignments count: %d didn't match the actual: %d", expectedAssignmentsCount, assignmentsPage.TotalCount)
 			return

--- a/tests/pkg/notifications/asserters/notifications_unassign.go
+++ b/tests/pkg/notifications/asserters/notifications_unassign.go
@@ -12,6 +12,7 @@ import (
 
 type UnassignNotificationsAsserter struct {
 	op                                 string
+	state                              *string
 	expectedNotificationsCountForOp    int
 	targetObjectID                     string
 	sourceObjectID                     string
@@ -42,6 +43,11 @@ func NewUnassignNotificationsAsserter(expectedNotificationsCountForOp int, targe
 	}
 }
 
+func (a *UnassignNotificationsAsserter) WithState(state string) *UnassignNotificationsAsserter {
+	a.state = &state
+	return a
+}
+
 func (a *UnassignNotificationsAsserter) AssertExpectations(t *testing.T, ctx context.Context) {
 	formationID := ctx.Value(context_keys.FormationIDKey).(string)
 	body := getNotificationsFromExternalSvcMock(t, a.client, a.externalServicesMockMtlsSecuredURL)
@@ -52,7 +58,7 @@ func (a *UnassignNotificationsAsserter) AssertExpectations(t *testing.T, ctx con
 		op := notification.Get("Operation").String()
 		if op == a.op {
 			notificationsFoundCount++
-			err := verifyFormationAssignmentNotification(t, notification, unassignOperation, formationID, a.sourceObjectID, a.localTenantID, a.appNamespace, a.region, a.config, a.tenant, a.tenantParentCustomer, false)
+			err := verifyFormationAssignmentNotification(t, notification, unassignOperation, formationID, a.sourceObjectID, a.localTenantID, a.appNamespace, a.region, a.config, a.tenant, a.tenantParentCustomer, false, a.state)
 			require.NoError(t, err)
 		}
 	}


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:
- change instance creator states in notification payload to regular states
- add a check in e2e tests that the notification is with the regular state

**Related issue(s)**
- #3531

**Pull Request status**
- [x] Implementation
- [x] [N/A] Unit tests
- [x] Integration tests
- [x] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [x] [N/A] Mocks are regenerated, using the automated script
