### PR TITLE
Maintain lastUpdate property of ORD resources

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -168,7 +168,7 @@ global:
       name: compass-pairing-adapter
     director:
       dir: dev/incubator/
-      version: "PR-3571"
+      version: "PR-3576"
       name: compass-director
     hydrator:
       dir: dev/incubator/
@@ -204,7 +204,7 @@ global:
       name: compass-ord-service
     schema_migrator:
       dir: dev/incubator/
-      version: "PR-3531"
+      version: "PR-3576"
       name: compass-schema-migrator
     system_broker:
       dir: dev/incubator/

--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -200,7 +200,7 @@ global:
       name: compass-operations-controller
     ord_service:
       dir: dev/incubator/
-      version: "PR-119"
+      version: "PR-120"
       name: compass-ord-service
     schema_migrator:
       dir: dev/incubator/

--- a/components/director/internal/domain/bundle/converter.go
+++ b/components/director/internal/domain/bundle/converter.go
@@ -69,6 +69,7 @@ func (c *converter) ToEntity(in *model.Bundle) (*Entity, error) {
 		CorrelationIDs:                repo.NewNullableStringFromJSONRawMessage(in.CorrelationIDs),
 		Tags:                          repo.NewNullableStringFromJSONRawMessage(in.Tags),
 		DocumentationLabels:           repo.NewNullableStringFromJSONRawMessage(in.DocumentationLabels),
+		LastUpdate:                    repo.NewNullableString(in.LastUpdate),
 		BaseEntity: &repo.BaseEntity{
 			ID:        in.ID,
 			Ready:     in.Ready,
@@ -111,6 +112,7 @@ func (c *converter) FromEntity(entity *Entity) (*model.Bundle, error) {
 		CorrelationIDs:                 repo.JSONRawMessageFromNullableString(entity.CorrelationIDs),
 		Tags:                           repo.JSONRawMessageFromNullableString(entity.Tags),
 		DocumentationLabels:            repo.JSONRawMessageFromNullableString(entity.DocumentationLabels),
+		LastUpdate:                     repo.StringPtrFromNullableString(entity.LastUpdate),
 		BaseEntity: &model.BaseEntity{
 			ID:        entity.ID,
 			Ready:     entity.Ready,

--- a/components/director/internal/domain/bundle/entity.go
+++ b/components/director/internal/domain/bundle/entity.go
@@ -27,6 +27,7 @@ type Entity struct {
 	CorrelationIDs                sql.NullString `db:"correlation_ids"`
 	Tags                          sql.NullString `db:"tags"`
 	DocumentationLabels           sql.NullString `db:"documentation_labels"`
+	LastUpdate                    sql.NullString `db:"last_update"`
 	*repo.BaseEntity
 }
 

--- a/components/director/internal/domain/bundle/fixtures_test.go
+++ b/components/director/internal/domain/bundle/fixtures_test.go
@@ -188,6 +188,7 @@ const (
 	correlationIDs       = `["id1", "id2"]`
 	version              = "1.2.2"
 	resourceHash         = "123456"
+	lastUpdateTimestamp  = "2024-01-10T08:06:56.52Z"
 )
 
 func fixBundleModel(name, desc string) *model.Bundle {
@@ -215,6 +216,7 @@ func fixBundleModelWithAuth(id, name, desc string, auth *model.Auth) *model.Bund
 		Tags:                           json.RawMessage("[]"),
 		ResourceHash:                   str.Ptr(resourceHash),
 		DocumentationLabels:            json.RawMessage("[]"),
+		LastUpdate:                     str.Ptr(lastUpdateTimestamp),
 		BaseEntity: &model.BaseEntity{
 			ID:        id,
 			Ready:     true,
@@ -481,6 +483,7 @@ func fixEntityBundle(id, name, desc string) *bundle.Entity {
 		Tags:                          repo.NewValidNullableString("[]"),
 		ResourceHash:                  repo.NewValidNullableString(resourceHash),
 		DocumentationLabels:           repo.NewValidNullableString("[]"),
+		LastUpdate:                    repo.NewValidNullableString(lastUpdateTimestamp),
 		BaseEntity: &repo.BaseEntity{
 			ID:        id,
 			Ready:     true,
@@ -493,27 +496,27 @@ func fixEntityBundle(id, name, desc string) *bundle.Entity {
 }
 
 func fixBundleColumns() []string {
-	return []string{"id", "app_id", "app_template_version_id", "name", "description", "version", "instance_auth_request_json_schema", "default_instance_auth", "ord_id", "local_tenant_id", "short_description", "links", "labels", "credential_exchange_strategies", "ready", "created_at", "updated_at", "deleted_at", "error", "correlation_ids", "tags", "resource_hash", "documentation_labels"}
+	return []string{"id", "app_id", "app_template_version_id", "name", "description", "version", "instance_auth_request_json_schema", "default_instance_auth", "ord_id", "local_tenant_id", "short_description", "links", "labels", "credential_exchange_strategies", "ready", "created_at", "updated_at", "deleted_at", "error", "correlation_ids", "tags", "resource_hash", "documentation_labels", "last_update"}
 }
 
 func fixBundleRowWithAppID(id string) []driver.Value {
-	return []driver.Value{id, appID, repo.NewValidNullableString(""), "foo", "bar", version, fixSchema(), fixDefaultAuth(), ordID, localTenantID, str.Ptr("short_description"), repo.NewValidNullableString("[]"), repo.NewValidNullableString("[]"), repo.NewValidNullableString("[]"), true, fixedTimestamp, time.Time{}, time.Time{}, nil, repo.NewValidNullableString(correlationIDs), repo.NewValidNullableString("[]"), repo.NewValidNullableString(resourceHash), repo.NewValidNullableString("[]")}
+	return []driver.Value{id, appID, repo.NewValidNullableString(""), "foo", "bar", version, fixSchema(), fixDefaultAuth(), ordID, localTenantID, str.Ptr("short_description"), repo.NewValidNullableString("[]"), repo.NewValidNullableString("[]"), repo.NewValidNullableString("[]"), true, fixedTimestamp, time.Time{}, time.Time{}, nil, repo.NewValidNullableString(correlationIDs), repo.NewValidNullableString("[]"), repo.NewValidNullableString(resourceHash), repo.NewValidNullableString("[]"), repo.NewValidNullableString(lastUpdateTimestamp)}
 }
 
 func fixBundleRowWithAppTemplateVersionID(id string) []driver.Value {
-	return []driver.Value{id, repo.NewValidNullableString(""), appTemplateVersionID, "foo", "bar", version, fixSchema(), fixDefaultAuth(), ordID, localTenantID, str.Ptr("short_description"), repo.NewValidNullableString("[]"), repo.NewValidNullableString("[]"), repo.NewValidNullableString("[]"), true, fixedTimestamp, time.Time{}, time.Time{}, nil, repo.NewValidNullableString(correlationIDs), repo.NewValidNullableString("[]"), repo.NewValidNullableString(resourceHash), repo.NewValidNullableString("[]")}
+	return []driver.Value{id, repo.NewValidNullableString(""), appTemplateVersionID, "foo", "bar", version, fixSchema(), fixDefaultAuth(), ordID, localTenantID, str.Ptr("short_description"), repo.NewValidNullableString("[]"), repo.NewValidNullableString("[]"), repo.NewValidNullableString("[]"), true, fixedTimestamp, time.Time{}, time.Time{}, nil, repo.NewValidNullableString(correlationIDs), repo.NewValidNullableString("[]"), repo.NewValidNullableString(resourceHash), repo.NewValidNullableString("[]"), repo.NewValidNullableString(lastUpdateTimestamp)}
 }
 
 func fixBundleRowWithCustomAppID(id, applicationID string) []driver.Value {
-	return []driver.Value{id, applicationID, repo.NewValidNullableString(""), "foo", "bar", version, fixSchema(), fixDefaultAuth(), ordID, localTenantID, str.Ptr("short_description"), repo.NewValidNullableString("[]"), repo.NewValidNullableString("[]"), repo.NewValidNullableString("[]"), true, fixedTimestamp, time.Time{}, time.Time{}, nil, repo.NewValidNullableString(correlationIDs), repo.NewValidNullableString("[]"), repo.NewValidNullableString(resourceHash), repo.NewValidNullableString("[]")}
+	return []driver.Value{id, applicationID, repo.NewValidNullableString(""), "foo", "bar", version, fixSchema(), fixDefaultAuth(), ordID, localTenantID, str.Ptr("short_description"), repo.NewValidNullableString("[]"), repo.NewValidNullableString("[]"), repo.NewValidNullableString("[]"), true, fixedTimestamp, time.Time{}, time.Time{}, nil, repo.NewValidNullableString(correlationIDs), repo.NewValidNullableString("[]"), repo.NewValidNullableString(resourceHash), repo.NewValidNullableString("[]"), repo.NewValidNullableString(lastUpdateTimestamp)}
 }
 
 func fixBundleCreateArgsForApp(defAuth, schema string, bndl *model.Bundle) []driver.Value {
-	return []driver.Value{bundleID, appID, repo.NewValidNullableString(""), bndl.Name, bndl.Description, bndl.Version, schema, defAuth, ordID, bndl.LocalTenantID, bndl.ShortDescription, repo.NewNullableStringFromJSONRawMessage(bndl.Links), repo.NewNullableStringFromJSONRawMessage(bndl.Labels), repo.NewNullableStringFromJSONRawMessage(bndl.CredentialExchangeStrategies), bndl.Ready, bndl.CreatedAt, bndl.UpdatedAt, bndl.DeletedAt, bndl.Error, repo.NewNullableStringFromJSONRawMessage(bndl.CorrelationIDs), repo.NewNullableStringFromJSONRawMessage(bndl.Tags), bndl.ResourceHash, repo.NewNullableStringFromJSONRawMessage(bndl.DocumentationLabels)}
+	return []driver.Value{bundleID, appID, repo.NewValidNullableString(""), bndl.Name, bndl.Description, bndl.Version, schema, defAuth, ordID, bndl.LocalTenantID, bndl.ShortDescription, repo.NewNullableStringFromJSONRawMessage(bndl.Links), repo.NewNullableStringFromJSONRawMessage(bndl.Labels), repo.NewNullableStringFromJSONRawMessage(bndl.CredentialExchangeStrategies), bndl.Ready, bndl.CreatedAt, bndl.UpdatedAt, bndl.DeletedAt, bndl.Error, repo.NewNullableStringFromJSONRawMessage(bndl.CorrelationIDs), repo.NewNullableStringFromJSONRawMessage(bndl.Tags), bndl.ResourceHash, repo.NewNullableStringFromJSONRawMessage(bndl.DocumentationLabels), bndl.LastUpdate}
 }
 
 func fixBundleCreateArgsForAppTemplateVersion(defAuth, schema string, bndl *model.Bundle) []driver.Value {
-	return []driver.Value{bundleID, repo.NewValidNullableString(""), appTemplateVersionID, bndl.Name, bndl.Description, bndl.Version, schema, defAuth, ordID, bndl.LocalTenantID, bndl.ShortDescription, repo.NewNullableStringFromJSONRawMessage(bndl.Links), repo.NewNullableStringFromJSONRawMessage(bndl.Labels), repo.NewNullableStringFromJSONRawMessage(bndl.CredentialExchangeStrategies), bndl.Ready, bndl.CreatedAt, bndl.UpdatedAt, bndl.DeletedAt, bndl.Error, repo.NewNullableStringFromJSONRawMessage(bndl.CorrelationIDs), repo.NewNullableStringFromJSONRawMessage(bndl.Tags), bndl.ResourceHash, repo.NewNullableStringFromJSONRawMessage(bndl.DocumentationLabels)}
+	return []driver.Value{bundleID, repo.NewValidNullableString(""), appTemplateVersionID, bndl.Name, bndl.Description, bndl.Version, schema, defAuth, ordID, bndl.LocalTenantID, bndl.ShortDescription, repo.NewNullableStringFromJSONRawMessage(bndl.Links), repo.NewNullableStringFromJSONRawMessage(bndl.Labels), repo.NewNullableStringFromJSONRawMessage(bndl.CredentialExchangeStrategies), bndl.Ready, bndl.CreatedAt, bndl.UpdatedAt, bndl.DeletedAt, bndl.Error, repo.NewNullableStringFromJSONRawMessage(bndl.CorrelationIDs), repo.NewNullableStringFromJSONRawMessage(bndl.Tags), bndl.ResourceHash, repo.NewNullableStringFromJSONRawMessage(bndl.DocumentationLabels), bndl.LastUpdate}
 }
 
 func fixDefaultAuth() string {

--- a/components/director/internal/domain/bundle/repository.go
+++ b/components/director/internal/domain/bundle/repository.go
@@ -25,8 +25,8 @@ const (
 )
 
 var (
-	bundleColumns    = []string{"id", appIDColumn, "app_template_version_id", "name", "description", "version", "instance_auth_request_json_schema", "default_instance_auth", "ord_id", "local_tenant_id", "short_description", "links", "labels", "credential_exchange_strategies", "ready", "created_at", "updated_at", "deleted_at", "error", correlationIDs, "tags", "resource_hash", "documentation_labels"}
-	updatableColumns = []string{"name", "description", "version", "instance_auth_request_json_schema", "default_instance_auth", "ord_id", "local_tenant_id", "short_description", "links", "labels", "credential_exchange_strategies", "ready", "created_at", "updated_at", "deleted_at", "error", "correlation_ids", "tags", "resource_hash", "documentation_labels"}
+	bundleColumns    = []string{"id", appIDColumn, "app_template_version_id", "name", "description", "version", "instance_auth_request_json_schema", "default_instance_auth", "ord_id", "local_tenant_id", "short_description", "links", "labels", "credential_exchange_strategies", "ready", "created_at", "updated_at", "deleted_at", "error", correlationIDs, "tags", "resource_hash", "documentation_labels", "last_update"}
+	updatableColumns = []string{"name", "description", "version", "instance_auth_request_json_schema", "default_instance_auth", "ord_id", "local_tenant_id", "short_description", "links", "labels", "credential_exchange_strategies", "ready", "created_at", "updated_at", "deleted_at", "error", "correlation_ids", "tags", "resource_hash", "documentation_labels", "last_update"}
 	orderByColumns   = repo.OrderByParams{repo.NewAscOrderBy(appIDColumn), repo.NewAscOrderBy("id")}
 )
 

--- a/components/director/internal/domain/bundle/repository_test.go
+++ b/components/director/internal/domain/bundle/repository_test.go
@@ -99,7 +99,7 @@ func TestPgRepository_CreateGlobal(t *testing.T) {
 }
 
 func TestPgRepository_Update(t *testing.T) {
-	updateQuery := regexp.QuoteMeta(`UPDATE public.bundles SET name = ?, description = ?, version = ?, instance_auth_request_json_schema = ?, default_instance_auth = ?, ord_id = ?, local_tenant_id = ?, short_description = ?, links = ?, labels = ?, credential_exchange_strategies = ?, ready = ?, created_at = ?, updated_at = ?, deleted_at = ?, error = ?, correlation_ids = ?, tags = ?, resource_hash = ?, documentation_labels = ? WHERE id = ? AND (id IN (SELECT id FROM bundles_tenants WHERE tenant_id = ? AND owner = true))`)
+	updateQuery := regexp.QuoteMeta(`UPDATE public.bundles SET name = ?, description = ?, version = ?, instance_auth_request_json_schema = ?, default_instance_auth = ?, ord_id = ?, local_tenant_id = ?, short_description = ?, links = ?, labels = ?, credential_exchange_strategies = ?, ready = ?, created_at = ?, updated_at = ?, deleted_at = ?, error = ?, correlation_ids = ?, tags = ?, resource_hash = ?, documentation_labels = ?, last_update = ? WHERE id = ? AND (id IN (SELECT id FROM bundles_tenants WHERE tenant_id = ? AND owner = true))`)
 
 	var nilBundleMode *model.Bundle
 	bndl := fixBundleModel("foo", "update")
@@ -112,7 +112,7 @@ func TestPgRepository_Update(t *testing.T) {
 		SQLQueryDetails: []testdb.SQLQueryDetails{
 			{
 				Query:         updateQuery,
-				Args:          []driver.Value{entity.Name, entity.Description, entity.Version, entity.InstanceAuthRequestJSONSchema, entity.DefaultInstanceAuth, entity.OrdID, entity.LocalTenantID, entity.ShortDescription, entity.Links, entity.Labels, entity.CredentialExchangeStrategies, entity.Ready, entity.CreatedAt, entity.UpdatedAt, entity.DeletedAt, entity.Error, entity.CorrelationIDs, entity.Tags, entity.ResourceHash, entity.DocumentationLabels, entity.ID, tenantID},
+				Args:          []driver.Value{entity.Name, entity.Description, entity.Version, entity.InstanceAuthRequestJSONSchema, entity.DefaultInstanceAuth, entity.OrdID, entity.LocalTenantID, entity.ShortDescription, entity.Links, entity.Labels, entity.CredentialExchangeStrategies, entity.Ready, entity.CreatedAt, entity.UpdatedAt, entity.DeletedAt, entity.Error, entity.CorrelationIDs, entity.Tags, entity.ResourceHash, entity.DocumentationLabels, entity.LastUpdate, entity.ID, tenantID},
 				ValidResult:   sqlmock.NewResult(-1, 1),
 				InvalidResult: sqlmock.NewResult(-1, 0),
 			},
@@ -131,7 +131,7 @@ func TestPgRepository_Update(t *testing.T) {
 }
 
 func TestPgRepository_UpdateGlobal(t *testing.T) {
-	updateQuery := regexp.QuoteMeta(`UPDATE public.bundles SET name = ?, description = ?, version = ?, instance_auth_request_json_schema = ?, default_instance_auth = ?, ord_id = ?, local_tenant_id = ?, short_description = ?, links = ?, labels = ?, credential_exchange_strategies = ?, ready = ?, created_at = ?, updated_at = ?, deleted_at = ?, error = ?, correlation_ids = ?, tags = ?, resource_hash = ?, documentation_labels = ? WHERE id = ?`)
+	updateQuery := regexp.QuoteMeta(`UPDATE public.bundles SET name = ?, description = ?, version = ?, instance_auth_request_json_schema = ?, default_instance_auth = ?, ord_id = ?, local_tenant_id = ?, short_description = ?, links = ?, labels = ?, credential_exchange_strategies = ?, ready = ?, created_at = ?, updated_at = ?, deleted_at = ?, error = ?, correlation_ids = ?, tags = ?, resource_hash = ?, documentation_labels = ?, last_update = ? WHERE id = ?`)
 
 	var nilBundleMode *model.Bundle
 	bndl := fixBundleModel("foo", "update")
@@ -144,7 +144,7 @@ func TestPgRepository_UpdateGlobal(t *testing.T) {
 		SQLQueryDetails: []testdb.SQLQueryDetails{
 			{
 				Query:         updateQuery,
-				Args:          []driver.Value{entity.Name, entity.Description, entity.Version, entity.InstanceAuthRequestJSONSchema, entity.DefaultInstanceAuth, entity.OrdID, entity.LocalTenantID, entity.ShortDescription, entity.Links, entity.Labels, entity.CredentialExchangeStrategies, entity.Ready, entity.CreatedAt, entity.UpdatedAt, entity.DeletedAt, entity.Error, entity.CorrelationIDs, entity.Tags, entity.ResourceHash, entity.DocumentationLabels, entity.ID},
+				Args:          []driver.Value{entity.Name, entity.Description, entity.Version, entity.InstanceAuthRequestJSONSchema, entity.DefaultInstanceAuth, entity.OrdID, entity.LocalTenantID, entity.ShortDescription, entity.Links, entity.Labels, entity.CredentialExchangeStrategies, entity.Ready, entity.CreatedAt, entity.UpdatedAt, entity.DeletedAt, entity.Error, entity.CorrelationIDs, entity.Tags, entity.ResourceHash, entity.DocumentationLabels, entity.LastUpdate, entity.ID},
 				ValidResult:   sqlmock.NewResult(-1, 1),
 				InvalidResult: sqlmock.NewResult(-1, 0),
 			},
@@ -243,7 +243,7 @@ func TestPgRepository_GetByID(t *testing.T) {
 		Name: "Get Bundle",
 		SQLQueryDetails: []testdb.SQLQueryDetails{
 			{
-				Query:    regexp.QuoteMeta(`SELECT id, app_id, app_template_version_id, name, description, version, instance_auth_request_json_schema, default_instance_auth, ord_id, local_tenant_id, short_description, links, labels, credential_exchange_strategies, ready, created_at, updated_at, deleted_at, error, correlation_ids, tags, resource_hash, documentation_labels FROM public.bundles WHERE id = $1 AND (id IN (SELECT id FROM bundles_tenants WHERE tenant_id = $2))`),
+				Query:    regexp.QuoteMeta(`SELECT id, app_id, app_template_version_id, name, description, version, instance_auth_request_json_schema, default_instance_auth, ord_id, local_tenant_id, short_description, links, labels, credential_exchange_strategies, ready, created_at, updated_at, deleted_at, error, correlation_ids, tags, resource_hash, documentation_labels, last_update FROM public.bundles WHERE id = $1 AND (id IN (SELECT id FROM bundles_tenants WHERE tenant_id = $2))`),
 				Args:     []driver.Value{bundleID, tenantID},
 				IsSelect: true,
 				ValidRowsProvider: func() []*sqlmock.Rows {
@@ -278,7 +278,7 @@ func TestPgRepository_GetByIDGlobal(t *testing.T) {
 		Name: "Get Bundle Global",
 		SQLQueryDetails: []testdb.SQLQueryDetails{
 			{
-				Query:    regexp.QuoteMeta(`SELECT id, app_id, app_template_version_id, name, description, version, instance_auth_request_json_schema, default_instance_auth, ord_id, local_tenant_id, short_description, links, labels, credential_exchange_strategies, ready, created_at, updated_at, deleted_at, error, correlation_ids, tags, resource_hash, documentation_labels FROM public.bundles WHERE id = $1`),
+				Query:    regexp.QuoteMeta(`SELECT id, app_id, app_template_version_id, name, description, version, instance_auth_request_json_schema, default_instance_auth, ord_id, local_tenant_id, short_description, links, labels, credential_exchange_strategies, ready, created_at, updated_at, deleted_at, error, correlation_ids, tags, resource_hash, documentation_labels, last_update FROM public.bundles WHERE id = $1`),
 				Args:     []driver.Value{bundleID},
 				IsSelect: true,
 				ValidRowsProvider: func() []*sqlmock.Rows {
@@ -314,7 +314,7 @@ func TestPgRepository_GetForApplication(t *testing.T) {
 		Name: "Get Bundle For Application",
 		SQLQueryDetails: []testdb.SQLQueryDetails{
 			{
-				Query:    regexp.QuoteMeta(`SELECT id, app_id, app_template_version_id, name, description, version, instance_auth_request_json_schema, default_instance_auth, ord_id, local_tenant_id, short_description, links, labels, credential_exchange_strategies, ready, created_at, updated_at, deleted_at, error, correlation_ids, tags, resource_hash, documentation_labels FROM public.bundles WHERE id = $1 AND app_id = $2 AND (id IN (SELECT id FROM bundles_tenants WHERE tenant_id = $3))`),
+				Query:    regexp.QuoteMeta(`SELECT id, app_id, app_template_version_id, name, description, version, instance_auth_request_json_schema, default_instance_auth, ord_id, local_tenant_id, short_description, links, labels, credential_exchange_strategies, ready, created_at, updated_at, deleted_at, error, correlation_ids, tags, resource_hash, documentation_labels, last_update FROM public.bundles WHERE id = $1 AND app_id = $2 AND (id IN (SELECT id FROM bundles_tenants WHERE tenant_id = $3))`),
 				Args:     []driver.Value{bundleID, appID, tenantID},
 				IsSelect: true,
 				ValidRowsProvider: func() []*sqlmock.Rows {
@@ -368,11 +368,11 @@ func TestPgRepository_ListByApplicationIDs(t *testing.T) {
 		Name: "List Bundles for multiple Applications with paging",
 		SQLQueryDetails: []testdb.SQLQueryDetails{
 			{
-				Query: regexp.QuoteMeta(`(SELECT id, app_id, app_template_version_id, name, description, version, instance_auth_request_json_schema, default_instance_auth, ord_id, local_tenant_id, short_description, links, labels, credential_exchange_strategies, ready, created_at, updated_at, deleted_at, error, correlation_ids, tags, resource_hash, documentation_labels FROM public.bundles WHERE (id IN (SELECT id FROM bundles_tenants WHERE tenant_id = $1)) AND app_id = $2 ORDER BY app_id ASC, id ASC LIMIT $3 OFFSET $4)
+				Query: regexp.QuoteMeta(`(SELECT id, app_id, app_template_version_id, name, description, version, instance_auth_request_json_schema, default_instance_auth, ord_id, local_tenant_id, short_description, links, labels, credential_exchange_strategies, ready, created_at, updated_at, deleted_at, error, correlation_ids, tags, resource_hash, documentation_labels, last_update FROM public.bundles WHERE (id IN (SELECT id FROM bundles_tenants WHERE tenant_id = $1)) AND app_id = $2 ORDER BY app_id ASC, id ASC LIMIT $3 OFFSET $4)
 												UNION
-												(SELECT id, app_id, app_template_version_id, name, description, version, instance_auth_request_json_schema, default_instance_auth, ord_id, local_tenant_id, short_description, links, labels, credential_exchange_strategies, ready, created_at, updated_at, deleted_at, error, correlation_ids, tags, resource_hash, documentation_labels FROM public.bundles WHERE (id IN (SELECT id FROM bundles_tenants WHERE tenant_id = $5)) AND app_id = $6 ORDER BY app_id ASC, id ASC LIMIT $7 OFFSET $8)
+												(SELECT id, app_id, app_template_version_id, name, description, version, instance_auth_request_json_schema, default_instance_auth, ord_id, local_tenant_id, short_description, links, labels, credential_exchange_strategies, ready, created_at, updated_at, deleted_at, error, correlation_ids, tags, resource_hash, documentation_labels, last_update FROM public.bundles WHERE (id IN (SELECT id FROM bundles_tenants WHERE tenant_id = $5)) AND app_id = $6 ORDER BY app_id ASC, id ASC LIMIT $7 OFFSET $8)
 												UNION
-												(SELECT id, app_id, app_template_version_id, name, description, version, instance_auth_request_json_schema, default_instance_auth, ord_id, local_tenant_id, short_description, links, labels, credential_exchange_strategies, ready, created_at, updated_at, deleted_at, error, correlation_ids, tags, resource_hash, documentation_labels FROM public.bundles WHERE (id IN (SELECT id FROM bundles_tenants WHERE tenant_id = $9)) AND app_id = $10 ORDER BY app_id ASC, id ASC LIMIT $11 OFFSET $12)`),
+												(SELECT id, app_id, app_template_version_id, name, description, version, instance_auth_request_json_schema, default_instance_auth, ord_id, local_tenant_id, short_description, links, labels, credential_exchange_strategies, ready, created_at, updated_at, deleted_at, error, correlation_ids, tags, resource_hash, documentation_labels, last_update FROM public.bundles WHERE (id IN (SELECT id FROM bundles_tenants WHERE tenant_id = $9)) AND app_id = $10 ORDER BY app_id ASC, id ASC LIMIT $11 OFFSET $12)`),
 
 				Args:     []driver.Value{tenantID, emptyPageAppID, pageSize, 0, tenantID, onePageAppID, pageSize, 0, tenantID, multiplePagesAppID, pageSize, 0},
 				IsSelect: true,
@@ -457,7 +457,7 @@ func TestPgRepository_ListByResourceIDNoPaging(t *testing.T) {
 		Name: "List Bundles No Paging",
 		SQLQueryDetails: []testdb.SQLQueryDetails{
 			{
-				Query:    regexp.QuoteMeta(`SELECT id, app_id, app_template_version_id, name, description, version, instance_auth_request_json_schema, default_instance_auth, ord_id, local_tenant_id, short_description, links, labels, credential_exchange_strategies, ready, created_at, updated_at, deleted_at, error, correlation_ids, tags, resource_hash, documentation_labels FROM public.bundles WHERE app_id = $1 AND (id IN (SELECT id FROM bundles_tenants WHERE tenant_id = $2)) FOR UPDATE`),
+				Query:    regexp.QuoteMeta(`SELECT id, app_id, app_template_version_id, name, description, version, instance_auth_request_json_schema, default_instance_auth, ord_id, local_tenant_id, short_description, links, labels, credential_exchange_strategies, ready, created_at, updated_at, deleted_at, error, correlation_ids, tags, resource_hash, documentation_labels, last_update FROM public.bundles WHERE app_id = $1 AND (id IN (SELECT id FROM bundles_tenants WHERE tenant_id = $2)) FOR UPDATE`),
 				Args:     []driver.Value{appID, tenantID},
 				IsSelect: true,
 				ValidRowsProvider: func() []*sqlmock.Rows {
@@ -483,7 +483,7 @@ func TestPgRepository_ListByResourceIDNoPaging(t *testing.T) {
 		Name: "List Bundles No Paging",
 		SQLQueryDetails: []testdb.SQLQueryDetails{
 			{
-				Query:    regexp.QuoteMeta(`SELECT id, app_id, app_template_version_id, name, description, version, instance_auth_request_json_schema, default_instance_auth, ord_id, local_tenant_id, short_description, links, labels, credential_exchange_strategies, ready, created_at, updated_at, deleted_at, error, correlation_ids, tags, resource_hash, documentation_labels FROM public.bundles WHERE app_template_version_id = $1 FOR UPDATE`),
+				Query:    regexp.QuoteMeta(`SELECT id, app_id, app_template_version_id, name, description, version, instance_auth_request_json_schema, default_instance_auth, ord_id, local_tenant_id, short_description, links, labels, credential_exchange_strategies, ready, created_at, updated_at, deleted_at, error, correlation_ids, tags, resource_hash, documentation_labels, last_update FROM public.bundles WHERE app_template_version_id = $1 FOR UPDATE`),
 				Args:     []driver.Value{appTemplateVersionID},
 				IsSelect: true,
 				ValidRowsProvider: func() []*sqlmock.Rows {
@@ -525,7 +525,7 @@ func TestPgRepository_ListByDestination(t *testing.T) {
 			{
 				Query: regexp.QuoteMeta(`SELECT id, app_id, app_template_version_id, name, description, version, instance_auth_request_json_schema, 
 					default_instance_auth, ord_id, local_tenant_id, short_description, links, labels, credential_exchange_strategies,
-					ready, created_at, updated_at, deleted_at, error, correlation_ids, tags, resource_hash, documentation_labels FROM 
+					ready, created_at, updated_at, deleted_at, error, correlation_ids, tags, resource_hash, documentation_labels, last_update FROM 
 					public.bundles WHERE app_id IN (
 						SELECT id
 						FROM public.applications
@@ -573,7 +573,7 @@ func TestPgRepository_ListByDestination(t *testing.T) {
 			{
 				Query: regexp.QuoteMeta(`SELECT id, app_id, app_template_version_id, name, description, version, instance_auth_request_json_schema,
 					default_instance_auth, ord_id, local_tenant_id, short_description, links, labels, credential_exchange_strategies,
-					ready, created_at, updated_at, deleted_at, error, correlation_ids, tags, resource_hash, documentation_labels FROM
+					ready, created_at, updated_at, deleted_at, error, correlation_ids, tags, resource_hash, documentation_labels, last_update FROM
 					public.bundles WHERE app_id IN (
 						SELECT DISTINCT pa.id as id
 						FROM public.applications pa JOIN labels l ON pa.id=l.app_id

--- a/components/director/internal/domain/integrationdependency/resolver.go
+++ b/components/director/internal/domain/integrationdependency/resolver.go
@@ -3,6 +3,7 @@ package integrationdependency
 import (
 	"context"
 	"fmt"
+
 	"github.com/kyma-incubator/compass/components/director/internal/model"
 	"github.com/kyma-incubator/compass/components/director/pkg/graphql"
 	"github.com/kyma-incubator/compass/components/director/pkg/log"

--- a/components/director/internal/model/api.go
+++ b/components/director/internal/model/api.go
@@ -110,7 +110,7 @@ type APIDefinitionInput struct {
 	DocumentationLabels                     json.RawMessage               `json:"documentationLabels"`
 	CorrelationIDs                          json.RawMessage               `json:"correlationIds,omitempty"`
 	Direction                               *string                       `json:"direction"`
-	LastUpdate                              *string                       `json:"lastUpdate"`
+	LastUpdate                              *string                       `json:"lastUpdate" hash:"ignore"`
 	DeprecationDate                         *string                       `json:"deprecationDate"`
 	Responsible                             *string                       `json:"responsible"`
 	Usage                                   *string                       `json:"usage"`

--- a/components/director/internal/model/bundle.go
+++ b/components/director/internal/model/bundle.go
@@ -29,6 +29,7 @@ type Bundle struct {
 	CorrelationIDs                 json.RawMessage
 	Tags                           json.RawMessage
 	DocumentationLabels            json.RawMessage
+	LastUpdate                     *string
 	*BaseEntity
 }
 
@@ -82,6 +83,7 @@ type BundleCreateInput struct {
 	CorrelationIDs                 json.RawMessage         `json:"correlationIds"`
 	Tags                           json.RawMessage         `json:"tags"`
 	DocumentationLabels            json.RawMessage         `json:"documentationLabels"`
+	LastUpdate                     *string                 `json:"lastUpdate" hash:"ignore"`
 }
 
 // BundleUpdateInput missing godoc
@@ -100,6 +102,7 @@ type BundleUpdateInput struct {
 	CorrelationIDs                 json.RawMessage
 	Tags                           json.RawMessage
 	DocumentationLabels            json.RawMessage
+	LastUpdate                     *string
 }
 
 // BundlePage missing godoc
@@ -139,6 +142,7 @@ func (i *BundleCreateInput) ToBundle(id string, resourceType resource.Type, reso
 		CorrelationIDs:                 i.CorrelationIDs,
 		Tags:                           i.Tags,
 		DocumentationLabels:            i.DocumentationLabels,
+		LastUpdate:                     i.LastUpdate,
 		BaseEntity: &BaseEntity{
 			ID:    id,
 			Ready: true,

--- a/components/director/internal/model/data_product.go
+++ b/components/director/internal/model/data_product.go
@@ -62,7 +62,7 @@ type DataProductInput struct {
 	ShortDescription    *string         `json:"shortDescription,omitempty"`
 	Description         *string         `json:"description"`
 	OrdPackageID        *string         `json:"partOfPackage"`
-	LastUpdate          *string         `json:"lastUpdate,omitempty"`
+	LastUpdate          *string         `json:"lastUpdate,omitempty" hash:"ignore"`
 	Visibility          *string         `json:"visibility"`
 	ReleaseStatus       *string         `json:"releaseStatus"`
 	Disabled            *bool           `json:"disabled"`

--- a/components/director/internal/model/entitytype.go
+++ b/components/director/internal/model/entitytype.go
@@ -73,7 +73,7 @@ type EntityTypeInput struct {
 	Visibility          string          `json:"visibility"`
 	Links               json.RawMessage `json:"links,omitempty"`
 	PartOfProducts      json.RawMessage `json:"partOfProducts,omitempty"`
-	LastUpdate          *string         `json:"lastUpdate,omitempty"`
+	LastUpdate          *string         `json:"lastUpdate,omitempty" hash:"ignore"`
 	PolicyLevel         *string         `json:"policyLevel,omitempty"`
 	CustomPolicyLevel   *string         `json:"customPolicyLevel,omitempty"`
 	ReleaseStatus       string          `json:"releaseStatus"`

--- a/components/director/internal/model/eventapi.go
+++ b/components/director/internal/model/eventapi.go
@@ -108,7 +108,7 @@ type EventDefinitionInput struct {
 	EntityTypeMappings                      []*EntityTypeMappingInput     `json:"entityTypeMappings"`
 	DocumentationLabels                     json.RawMessage               `json:"documentationLabels"`
 	CorrelationIDs                          json.RawMessage               `json:"correlationIds,omitempty"`
-	LastUpdate                              *string                       `json:"lastUpdate"`
+	LastUpdate                              *string                       `json:"lastUpdate" hash:"ignore"`
 	DeprecationDate                         *string                       `json:"deprecationDate"`
 	Responsible                             *string                       `json:"responsible"`
 	*VersionInput                           `hash:"ignore"`

--- a/components/director/internal/model/integration_dependency.go
+++ b/components/director/internal/model/integration_dependency.go
@@ -51,7 +51,7 @@ type IntegrationDependencyInput struct {
 	ShortDescription               *string         `json:"shortDescription,omitempty"`
 	Description                    *string         `json:"description,omitempty"`
 	OrdPackageID                   *string         `json:"partOfPackage"`
-	LastUpdate                     *string         `json:"lastUpdate,omitempty"`
+	LastUpdate                     *string         `json:"lastUpdate,omitempty" hash:"ignore"`
 	Visibility                     string          `json:"visibility"`
 	ReleaseStatus                  *string         `json:"releaseStatus"`
 	SunsetDate                     *string         `json:"sunsetDate,omitempty"`

--- a/components/director/internal/open_resource_discovery/processor/api.go
+++ b/components/director/internal/open_resource_discovery/processor/api.go
@@ -2,8 +2,9 @@ package processor
 
 import (
 	"context"
-	"github.com/kyma-incubator/compass/components/director/pkg/log"
 	"time"
+
+	"github.com/kyma-incubator/compass/components/director/pkg/log"
 
 	"github.com/kyma-incubator/compass/components/director/internal/domain/tenant"
 	"github.com/kyma-incubator/compass/components/director/internal/model"

--- a/components/director/internal/open_resource_discovery/processor/capability.go
+++ b/components/director/internal/open_resource_discovery/processor/capability.go
@@ -5,10 +5,12 @@ import (
 
 	"github.com/kyma-incubator/compass/components/director/internal/domain/tenant"
 	"github.com/kyma-incubator/compass/components/director/internal/model"
+	"github.com/kyma-incubator/compass/components/director/pkg/log"
 	"github.com/kyma-incubator/compass/components/director/pkg/persistence"
 	"github.com/kyma-incubator/compass/components/director/pkg/resource"
 	"github.com/kyma-incubator/compass/components/director/pkg/str"
 	"github.com/pkg/errors"
+	"time"
 )
 
 // CapabilityService is responsible for the service-layer Capability operations.
@@ -130,6 +132,9 @@ func (cp *CapabilityProcessor) resyncCapability(ctx context.Context, resourceTyp
 	}
 
 	if !isCapabilityFound {
+		currentTime := time.Now().Format(time.RFC3339)
+		capability.LastUpdate = &currentTime
+
 		capabilityID, err := cp.capabilitySvc.Create(ctx, resourceType, resourceID, packageID, capability, nil, capabilityHash)
 		if err != nil {
 			return nil, err
@@ -143,7 +148,15 @@ func (cp *CapabilityProcessor) resyncCapability(ctx context.Context, resourceTyp
 		return fetchRequests, nil
 	}
 
-	err := cp.capabilitySvc.Update(ctx, resourceType, capabilitiesFromDB[i].ID, packageID, capability, capabilityHash)
+	log.C(ctx).Infof("Calculate the newest lastUpdate time for Capability")
+	newestLastUpdateTime, err := NewestLastUpdateTimestamp(capability.LastUpdate, capabilitiesFromDB[i].LastUpdate, capabilitiesFromDB[i].ResourceHash, capabilityHash)
+	if err != nil {
+		return nil, errors.Wrap(err, "error while calculating the newest lastUpdate time for Capability")
+	}
+
+	capability.LastUpdate = newestLastUpdateTime
+
+	err = cp.capabilitySvc.Update(ctx, resourceType, capabilitiesFromDB[i].ID, packageID, capability, capabilityHash)
 	if err != nil {
 		return nil, err
 	}

--- a/components/director/internal/open_resource_discovery/processor/capability.go
+++ b/components/director/internal/open_resource_discovery/processor/capability.go
@@ -3,6 +3,8 @@ package processor
 import (
 	"context"
 
+	"time"
+
 	"github.com/kyma-incubator/compass/components/director/internal/domain/tenant"
 	"github.com/kyma-incubator/compass/components/director/internal/model"
 	"github.com/kyma-incubator/compass/components/director/pkg/log"
@@ -10,7 +12,6 @@ import (
 	"github.com/kyma-incubator/compass/components/director/pkg/resource"
 	"github.com/kyma-incubator/compass/components/director/pkg/str"
 	"github.com/pkg/errors"
-	"time"
 )
 
 // CapabilityService is responsible for the service-layer Capability operations.

--- a/components/director/internal/open_resource_discovery/processor/capability_test.go
+++ b/components/director/internal/open_resource_discovery/processor/capability_test.go
@@ -3,6 +3,7 @@ package processor_test
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/kyma-incubator/compass/components/director/pkg/str"
 
@@ -37,7 +38,7 @@ func TestCapabilityProcessor_Process(t *testing.T) {
 		fixCapabilityInput(),
 	}
 
-	resourceHashes := map[string]uint64{ordID: uint64ResourceHash}
+	resourceHashes := map[string]uint64{capabilityORDID: uint64ResourceHash}
 
 	testCases := []struct {
 		Name                       string
@@ -79,7 +80,7 @@ func TestCapabilityProcessor_Process(t *testing.T) {
 			CapabilitySvcFn: func() *automock.CapabilityService {
 				capabilitySvc := &automock.CapabilityService{}
 				capabilitySvc.On("ListByApplicationID", txtest.CtxWithDBMatcher(), appID).Return(fixCapabilities, nil).Twice()
-				capabilitySvc.On("Update", txtest.CtxWithDBMatcher(), resource.Application, fixCapabilities[0].ID, str.Ptr(packageID1), *fixCapabilityInputs[0], emptyHash).Return(nil).Once()
+				capabilitySvc.On("Update", txtest.CtxWithDBMatcher(), resource.Application, fixCapabilities[0].ID, str.Ptr(packageID1), *fixCapabilityInputs[0], uint64ResourceHash).Return(nil).Once()
 				return capabilitySvc
 			},
 			SpecSvcFn: func() *automock.SpecService {
@@ -106,7 +107,7 @@ func TestCapabilityProcessor_Process(t *testing.T) {
 				capabilitySvc := &automock.CapabilityService{}
 				capabilitySvc.On("ListByApplicationID", txtest.CtxWithDBMatcher(), appID).Return(fixCapabilitiesNoNewerLastUpdate(), nil).Once()
 				capabilitySvc.On("ListByApplicationID", txtest.CtxWithDBMatcher(), appID).Return(fixCapabilities, nil).Once()
-				capabilitySvc.On("Update", txtest.CtxWithDBMatcher(), resource.Application, fixCapabilities[0].ID, str.Ptr(packageID1), *fixCapabilityInputs[0], emptyHash).Return(nil).Once()
+				capabilitySvc.On("Update", txtest.CtxWithDBMatcher(), resource.Application, fixCapabilities[0].ID, str.Ptr(packageID1), *fixCapabilityInputs[0], uint64ResourceHash).Return(nil).Once()
 				return capabilitySvc
 			},
 			SpecSvcFn: func() *automock.SpecService {
@@ -131,7 +132,12 @@ func TestCapabilityProcessor_Process(t *testing.T) {
 			CapabilitySvcFn: func() *automock.CapabilityService {
 				apiSvc := &automock.CapabilityService{}
 				apiSvc.On("ListByApplicationID", txtest.CtxWithDBMatcher(), appID).Return(fixCapabilities2, nil).Twice()
-				apiSvc.On("Create", txtest.CtxWithDBMatcher(), resource.Application, appID, str.Ptr(packageID1), *fixCapabilityInputs[0], nilSpecInputSlice, emptyHash).Return(capabilityID, nil).Once()
+
+				// set to time.Now, because on Create the lastUpdate is set to current time
+				currentTime := time.Now().Format(time.RFC3339)
+				fixCapabilityInputs[0].LastUpdate = &currentTime
+
+				apiSvc.On("Create", txtest.CtxWithDBMatcher(), resource.Application, appID, str.Ptr(packageID1), *fixCapabilityInputs[0], nilSpecInputSlice, uint64ResourceHash).Return(capabilityID, nil).Once()
 				return apiSvc
 			},
 			SpecSvcFn: func() *automock.SpecService {
@@ -226,7 +232,7 @@ func TestCapabilityProcessor_Process(t *testing.T) {
 			CapabilitySvcFn: func() *automock.CapabilityService {
 				capabilitySvc := &automock.CapabilityService{}
 				capabilitySvc.On("ListByApplicationID", txtest.CtxWithDBMatcher(), appID).Return(fixCapabilities, nil).Once()
-				capabilitySvc.On("Update", txtest.CtxWithDBMatcher(), resource.Application, fixCapabilities[0].ID, str.Ptr(packageID1), *fixCapabilityInputs[0], emptyHash).Return(testErr).Once()
+				capabilitySvc.On("Update", txtest.CtxWithDBMatcher(), resource.Application, fixCapabilities[0].ID, str.Ptr(packageID1), *fixCapabilityInputs[0], uint64ResourceHash).Return(testErr).Once()
 				return capabilitySvc
 			},
 			InputResource:       resource.Application,
@@ -248,7 +254,12 @@ func TestCapabilityProcessor_Process(t *testing.T) {
 			CapabilitySvcFn: func() *automock.CapabilityService {
 				capabilitySvc := &automock.CapabilityService{}
 				capabilitySvc.On("ListByApplicationID", txtest.CtxWithDBMatcher(), appID).Return(fixCapabilities2, nil).Once()
-				capabilitySvc.On("Create", txtest.CtxWithDBMatcher(), resource.Application, appID, nilString, *fixCapabilityInputs[0], nilSpecInputSlice, emptyHash).Return("", testErr).Once()
+
+				// set to time.Now, because on Create the lastUpdate is set to current time
+				currentTime := time.Now().Format(time.RFC3339)
+				fixCapabilityInputs[0].LastUpdate = &currentTime
+
+				capabilitySvc.On("Create", txtest.CtxWithDBMatcher(), resource.Application, appID, nilString, *fixCapabilityInputs[0], nilSpecInputSlice, uint64ResourceHash).Return("", testErr).Once()
 				return capabilitySvc
 			},
 			InputResource:       resource.Application,
@@ -270,7 +281,12 @@ func TestCapabilityProcessor_Process(t *testing.T) {
 			CapabilitySvcFn: func() *automock.CapabilityService {
 				capabilitySvc := &automock.CapabilityService{}
 				capabilitySvc.On("ListByApplicationID", txtest.CtxWithDBMatcher(), appID).Return(fixCapabilities2, nil).Once()
-				capabilitySvc.On("Create", txtest.CtxWithDBMatcher(), resource.Application, appID, nilString, *fixCapabilityInputs[0], nilSpecInputSlice, emptyHash).Return(capabilityID, nil).Once()
+
+				// set to time.Now, because on Create the lastUpdate is set to current time
+				currentTime := time.Now().Format(time.RFC3339)
+				fixCapabilityInputs[0].LastUpdate = &currentTime
+
+				capabilitySvc.On("Create", txtest.CtxWithDBMatcher(), resource.Application, appID, nilString, *fixCapabilityInputs[0], nilSpecInputSlice, uint64ResourceHash).Return(capabilityID, nil).Once()
 				return capabilitySvc
 			},
 			SpecSvcFn: func() *automock.SpecService {
@@ -300,7 +316,7 @@ func TestCapabilityProcessor_Process(t *testing.T) {
 			CapabilitySvcFn: func() *automock.CapabilityService {
 				capabilitySvc := &automock.CapabilityService{}
 				capabilitySvc.On("ListByApplicationID", txtest.CtxWithDBMatcher(), appID).Return(fixCapabilities, nil).Once()
-				capabilitySvc.On("Update", txtest.CtxWithDBMatcher(), resource.Application, fixCapabilities[0].ID, str.Ptr(packageID1), *fixCapabilityInputs[0], emptyHash).Return(nil).Once()
+				capabilitySvc.On("Update", txtest.CtxWithDBMatcher(), resource.Application, fixCapabilities[0].ID, str.Ptr(packageID1), *fixCapabilityInputs[0], uint64ResourceHash).Return(nil).Once()
 				return capabilitySvc
 			},
 			SpecSvcFn: func() *automock.SpecService {
@@ -327,7 +343,10 @@ func TestCapabilityProcessor_Process(t *testing.T) {
 			CapabilitySvcFn: func() *automock.CapabilityService {
 				capabilitySvc := &automock.CapabilityService{}
 				capabilitySvc.On("ListByApplicationID", txtest.CtxWithDBMatcher(), appID).Return(fixCapabilitiesNoNewerLastUpdate(), nil).Once()
-				capabilitySvc.On("Update", txtest.CtxWithDBMatcher(), resource.Application, fixCapabilities[0].ID, str.Ptr(packageID1), *fixCapabilityInputs[0], emptyHash).Return(nil).Once()
+				fixCapabilityInputs := []*model.CapabilityInput{
+					fixCapabilityInput(),
+				}
+				capabilitySvc.On("Update", txtest.CtxWithDBMatcher(), resource.Application, fixCapabilities[0].ID, str.Ptr(packageID1), *fixCapabilityInputs[0], uint64ResourceHash).Return(nil).Once()
 				return capabilitySvc
 			},
 			SpecSvcFn: func() *automock.SpecService {
@@ -339,7 +358,9 @@ func TestCapabilityProcessor_Process(t *testing.T) {
 			InputResource:       resource.Application,
 			InputResourceID:     appID,
 			InputPackagesFromDB: fixPackages(),
-			CapabilityInput:     fixCapabilityInputs,
+			CapabilityInput: []*model.CapabilityInput{
+				fixCapabilityInput(),
+			},
 			InputResourceHashes: resourceHashes,
 			ExpectedErr:         testErr,
 		},
@@ -355,7 +376,10 @@ func TestCapabilityProcessor_Process(t *testing.T) {
 			CapabilitySvcFn: func() *automock.CapabilityService {
 				capabilitySvc := &automock.CapabilityService{}
 				capabilitySvc.On("ListByApplicationTemplateVersionID", txtest.CtxWithDBMatcher(), appTemplateVersionID).Return(fixCapabilitiesNoNewerLastUpdate(), nil).Once()
-				capabilitySvc.On("Update", txtest.CtxWithDBMatcher(), resource.ApplicationTemplateVersion, fixCapabilities[0].ID, str.Ptr(packageID1), *fixCapabilityInputs[0], emptyHash).Return(nil).Once()
+				fixCapabilityInputs := []*model.CapabilityInput{
+					fixCapabilityInput(),
+				}
+				capabilitySvc.On("Update", txtest.CtxWithDBMatcher(), resource.ApplicationTemplateVersion, fixCapabilities[0].ID, str.Ptr(packageID1), *fixCapabilityInputs[0], uint64ResourceHash).Return(nil).Once()
 				return capabilitySvc
 			},
 			SpecSvcFn: func() *automock.SpecService {
@@ -367,7 +391,9 @@ func TestCapabilityProcessor_Process(t *testing.T) {
 			InputResource:       resource.ApplicationTemplateVersion,
 			InputResourceID:     appTemplateVersionID,
 			InputPackagesFromDB: fixPackages(),
-			CapabilityInput:     fixCapabilityInputs,
+			CapabilityInput: []*model.CapabilityInput{
+				fixCapabilityInput(),
+			},
 			InputResourceHashes: resourceHashes,
 			ExpectedErr:         testErr,
 		},
@@ -381,7 +407,7 @@ func TestCapabilityProcessor_Process(t *testing.T) {
 				fixCapabilityInputs[0].OrdPackageID = str.Ptr(packageORDID2)
 				capabilitySvc.On("ListByApplicationID", txtest.CtxWithDBMatcher(), appID).Return(fixCapabilities, nil).Once()
 				capabilitySvc.On("ListByApplicationID", txtest.CtxWithDBMatcher(), appID).Return(fixUpdatedCapabilities, nil).Once()
-				capabilitySvc.On("Update", txtest.CtxWithDBMatcher(), resource.Application, fixCapabilities[0].ID, str.Ptr(packageID2), *fixCapabilityInputs[0], emptyHash).Return(nil).Once()
+				capabilitySvc.On("Update", txtest.CtxWithDBMatcher(), resource.Application, fixCapabilities[0].ID, str.Ptr(packageID2), *fixCapabilityInputs[0], uint64ResourceHash).Return(nil).Once()
 				return capabilitySvc
 			},
 			SpecSvcFn: func() *automock.SpecService {

--- a/components/director/internal/open_resource_discovery/processor/common.go
+++ b/components/director/internal/open_resource_discovery/processor/common.go
@@ -2,7 +2,6 @@ package processor
 
 import (
 	"context"
-	"fmt"
 	"strconv"
 	"time"
 
@@ -57,14 +56,10 @@ func NewestLastUpdateTimestamp(lastUpdateValueFromDoc, lastUpdateValueFromDB, ha
 		return nil, err
 	}
 
-	fmt.Println(*newestLastUpdateTime, "after compare")
-
 	var hashIsEqual bool
 	if hashFromDB != nil {
 		hashIsEqual = cmp.Equal(*hashFromDB, strconv.FormatUint(hashFromDoc, 10))
 	}
-
-	fmt.Println(hashIsEqual, "HASH IS EQUAL")
 
 	if !hashIsEqual {
 		currentTime := time.Now().Format(time.RFC3339)

--- a/components/director/internal/open_resource_discovery/processor/common.go
+++ b/components/director/internal/open_resource_discovery/processor/common.go
@@ -2,11 +2,12 @@ package processor
 
 import (
 	"context"
+	"strconv"
+	"time"
+
 	"github.com/google/go-cmp/cmp"
 	"github.com/kyma-incubator/compass/components/director/pkg/str"
 	"github.com/pkg/errors"
-	"strconv"
-	"time"
 
 	"github.com/kyma-incubator/compass/components/director/pkg/log"
 )
@@ -48,6 +49,7 @@ func checkIfShouldFetchSpecs(lastUpdateValueFromDoc, lastUpdateValueFromDB *stri
 	return lastUpdateTimeFromDoc.After(lastUpdateTimeFromDB), nil
 }
 
+// NewestLastUpdateTimestamp returns the newest lastUpdate timestamp comparing the lastUpdate from doc and db
 func NewestLastUpdateTimestamp(lastUpdateValueFromDoc, lastUpdateValueFromDB, hashFromDB *string, hashFromDoc uint64) (*string, error) {
 	newestLastUpdateTime, err := compareLastUpdateFromDocAndDB(lastUpdateValueFromDoc, lastUpdateValueFromDB)
 	if err != nil {

--- a/components/director/internal/open_resource_discovery/processor/common.go
+++ b/components/director/internal/open_resource_discovery/processor/common.go
@@ -2,6 +2,11 @@ package processor
 
 import (
 	"context"
+	"github.com/google/go-cmp/cmp"
+	"github.com/kyma-incubator/compass/components/director/pkg/str"
+	"github.com/pkg/errors"
+	"strconv"
+	"time"
 
 	"github.com/kyma-incubator/compass/components/director/pkg/log"
 )
@@ -23,4 +28,73 @@ func addFieldToLogger(ctx context.Context, fieldName, fieldValue string) context
 	logger := log.LoggerFromContext(ctx)
 	logger = logger.WithField(fieldName, fieldValue)
 	return log.ContextWithLogger(ctx, logger)
+}
+
+func checkIfShouldFetchSpecs(lastUpdateValueFromDoc, lastUpdateValueFromDB *string) (bool, error) {
+	if lastUpdateValueFromDoc == nil || lastUpdateValueFromDB == nil {
+		return true, nil
+	}
+
+	lastUpdateTimeFromDoc, err := time.Parse(time.RFC3339, str.PtrStrToStr(lastUpdateValueFromDoc))
+	if err != nil {
+		return false, err
+	}
+
+	lastUpdateTimeFromDB, err := time.Parse(time.RFC3339, str.PtrStrToStr(lastUpdateValueFromDB))
+	if err != nil {
+		return false, err
+	}
+
+	return lastUpdateTimeFromDoc.After(lastUpdateTimeFromDB), nil
+}
+
+func NewestLastUpdateTimestamp(lastUpdateValueFromDoc, lastUpdateValueFromDB, hashFromDB *string, hashFromDoc uint64) (*string, error) {
+	newestLastUpdateTime, err := compareLastUpdateFromDocAndDB(lastUpdateValueFromDoc, lastUpdateValueFromDB)
+	if err != nil {
+		return nil, err
+	}
+
+	var hashIsEqual bool
+	if hashFromDB != nil {
+		hashIsEqual = cmp.Equal(*hashFromDB, strconv.FormatUint(hashFromDoc, 10))
+	}
+
+	if !hashIsEqual {
+		currentTime := time.Now().Format(time.RFC3339)
+		newestLastUpdateTime = &currentTime
+	}
+
+	return newestLastUpdateTime, nil
+}
+
+func compareLastUpdateFromDocAndDB(lastUpdateValueFromDoc, lastUpdateValueFromDB *string) (*string, error) {
+	if lastUpdateValueFromDoc == nil {
+		if lastUpdateValueFromDB == nil {
+			currentTime := time.Now().Format(time.RFC3339)
+			return &currentTime, nil
+		}
+		return lastUpdateValueFromDB, nil
+	}
+
+	if lastUpdateValueFromDB == nil {
+		return lastUpdateValueFromDoc, nil
+	}
+
+	newestLastUpdateTime := lastUpdateValueFromDB
+
+	lastUpdateTimeFromDoc, err := time.Parse(time.RFC3339, str.PtrStrToStr(lastUpdateValueFromDoc))
+	if err != nil {
+		return nil, errors.Wrap(err, "error while parsing lastUpdate timestamp from document")
+	}
+
+	lastUpdateTimeFromDB, err := time.Parse(time.RFC3339, str.PtrStrToStr(lastUpdateValueFromDB))
+	if err != nil {
+		return nil, errors.Wrap(err, "error while parsing lastUpdate timestamp from db")
+	}
+
+	if lastUpdateTimeFromDoc.After(lastUpdateTimeFromDB) {
+		newestLastUpdateTime = lastUpdateValueFromDoc
+	}
+
+	return newestLastUpdateTime, nil
 }

--- a/components/director/internal/open_resource_discovery/processor/common.go
+++ b/components/director/internal/open_resource_discovery/processor/common.go
@@ -2,6 +2,7 @@ package processor
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 	"time"
 
@@ -56,10 +57,14 @@ func NewestLastUpdateTimestamp(lastUpdateValueFromDoc, lastUpdateValueFromDB, ha
 		return nil, err
 	}
 
+	fmt.Println(*newestLastUpdateTime, "after compare")
+
 	var hashIsEqual bool
 	if hashFromDB != nil {
 		hashIsEqual = cmp.Equal(*hashFromDB, strconv.FormatUint(hashFromDoc, 10))
 	}
+
+	fmt.Println(hashIsEqual, "HASH IS EQUAL")
 
 	if !hashIsEqual {
 		currentTime := time.Now().Format(time.RFC3339)

--- a/components/director/internal/open_resource_discovery/processor/data_product.go
+++ b/components/director/internal/open_resource_discovery/processor/data_product.go
@@ -2,8 +2,9 @@ package processor
 
 import (
 	"context"
-	"github.com/kyma-incubator/compass/components/director/pkg/log"
 	"time"
+
+	"github.com/kyma-incubator/compass/components/director/pkg/log"
 
 	"github.com/kyma-incubator/compass/components/director/internal/model"
 	"github.com/kyma-incubator/compass/components/director/pkg/persistence"

--- a/components/director/internal/open_resource_discovery/processor/data_product_test.go
+++ b/components/director/internal/open_resource_discovery/processor/data_product_test.go
@@ -2,7 +2,9 @@ package processor_test
 
 import (
 	"context"
+	"strconv"
 	"testing"
+	"time"
 
 	"github.com/kyma-incubator/compass/components/director/internal/model"
 	ord "github.com/kyma-incubator/compass/components/director/internal/open_resource_discovery"
@@ -39,6 +41,9 @@ func TestDataProductProcessor_Process(t *testing.T) {
 	resourceHashes := map[string]uint64{
 		dataProductORDID1: hashDataProduct,
 	}
+
+	uintHashDataProduct := strconv.FormatUint(hashDataProduct, 10)
+	dataProductModel[0].ResourceHash = &uintHashDataProduct
 
 	dataProductInputs := []*model.DataProductInput{
 		fixDataProductInputModel(dataProductORDID1),
@@ -101,6 +106,11 @@ func TestDataProductProcessor_Process(t *testing.T) {
 			DataProductSvcFn: func() *automock.DataProductService {
 				dataProductSvc := &automock.DataProductService{}
 				dataProductSvc.On("ListByApplicationID", txtest.CtxWithDBMatcher(), appID).Return([]*model.DataProduct{}, nil).Once()
+
+				// set to time.Now, because on Create the lastUpdate is set to current time
+				currentTime := time.Now().Format(time.RFC3339)
+				dataProductInputs[0].LastUpdate = &currentTime
+
 				dataProductSvc.On("Create", txtest.CtxWithDBMatcher(), resource.Application, appID, str.Ptr(packageID1), *dataProductInputs[0], mock.Anything).Return(dataProductID, nil).Once()
 				dataProductSvc.On("ListByApplicationID", txtest.CtxWithDBMatcher(), appID).Return(dataProductModel, nil).Once()
 				return dataProductSvc
@@ -186,6 +196,11 @@ func TestDataProductProcessor_Process(t *testing.T) {
 			DataProductSvcFn: func() *automock.DataProductService {
 				dataProductSvc := &automock.DataProductService{}
 				dataProductSvc.On("ListByApplicationID", txtest.CtxWithDBMatcher(), appID).Return(dataProductModel, nil).Once()
+
+				// set to time.Now, because on Create the lastUpdate is set to current time
+				currentTime := time.Now().Format(time.RFC3339)
+				dataProductCreateInputs[0].LastUpdate = &currentTime
+
 				dataProductSvc.On("Create", txtest.CtxWithDBMatcher(), resource.Application, appID, str.Ptr(packageID1), *dataProductCreateInputs[0], mock.Anything).Return("", testErr).Once()
 				return dataProductSvc
 			},

--- a/components/director/internal/open_resource_discovery/processor/entity_type.go
+++ b/components/director/internal/open_resource_discovery/processor/entity_type.go
@@ -2,6 +2,8 @@ package processor
 
 import (
 	"context"
+	"github.com/kyma-incubator/compass/components/director/pkg/log"
+	"time"
 
 	"github.com/kyma-incubator/compass/components/director/internal/model"
 	"github.com/kyma-incubator/compass/components/director/pkg/persistence"
@@ -107,12 +109,22 @@ func (ep *EntityTypeProcessor) resyncEntityType(ctx context.Context, resourceTyp
 	}
 
 	if !isEntityTypeFound {
+		currentTime := time.Now().Format(time.RFC3339)
+		entityType.LastUpdate = &currentTime
+
 		_, err := ep.entityTypeSvc.Create(ctx, resourceType, resourceID, packageID, entityType, entityTypeHash)
 		if err != nil {
 			return err
 		}
 	} else {
-		err := ep.entityTypeSvc.Update(ctx, resourceType, entityTypesFromDB[i].ID, packageID, entityType, entityTypeHash)
+		log.C(ctx).Infof("Calculate the newest lastUpdate time for Entity Type")
+		newestLastUpdateTime, err := NewestLastUpdateTimestamp(entityType.LastUpdate, entityTypesFromDB[i].LastUpdate, entityTypesFromDB[i].ResourceHash, entityTypeHash)
+		if err != nil {
+			return errors.Wrap(err, "error while calculating the newest lastUpdate time for Entity Type")
+		}
+
+		entityType.LastUpdate = newestLastUpdateTime
+		err = ep.entityTypeSvc.Update(ctx, resourceType, entityTypesFromDB[i].ID, packageID, entityType, entityTypeHash)
 		if err != nil {
 			return err
 		}

--- a/components/director/internal/open_resource_discovery/processor/entity_type.go
+++ b/components/director/internal/open_resource_discovery/processor/entity_type.go
@@ -2,8 +2,9 @@ package processor
 
 import (
 	"context"
-	"github.com/kyma-incubator/compass/components/director/pkg/log"
 	"time"
+
+	"github.com/kyma-incubator/compass/components/director/pkg/log"
 
 	"github.com/kyma-incubator/compass/components/director/internal/model"
 	"github.com/kyma-incubator/compass/components/director/pkg/persistence"

--- a/components/director/internal/open_resource_discovery/processor/entity_type_test.go
+++ b/components/director/internal/open_resource_discovery/processor/entity_type_test.go
@@ -3,6 +3,7 @@ package processor_test
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/kyma-incubator/compass/components/director/internal/model"
 	"github.com/kyma-incubator/compass/components/director/internal/open_resource_discovery/processor"
@@ -73,6 +74,11 @@ func TestEntityTypeProcessor_Process(t *testing.T) {
 				entityTypeSvc := &automock.EntityTypeService{}
 				entityTypeSvc.On("ListByApplicationID", txtest.CtxWithDBMatcher(), appID).Return(emptyEntityTypeModels, nil).Once()
 				entityTypeSvc.On("ListByApplicationID", txtest.CtxWithDBMatcher(), appID).Return(entityTypeModels, nil).Once()
+
+				// set to time.Now, because on Create the lastUpdate is set to current time
+				currentTime := time.Now().Format(time.RFC3339)
+				entityTypeInputs[0].LastUpdate = &currentTime
+
 				entityTypeSvc.On("Create", txtest.CtxWithDBMatcher(), resource.Application, appID, packageID1, *entityTypeInputs[0], uint64ResourceHash).Return(entityTypeID, nil).Once()
 				return entityTypeSvc
 			},
@@ -108,6 +114,11 @@ func TestEntityTypeProcessor_Process(t *testing.T) {
 				entityTypeSvc := &automock.EntityTypeService{}
 				entityTypeSvc.On("ListByApplicationTemplateVersionID", txtest.CtxWithDBMatcher(), appTemplateVersionID).Return(emptyEntityTypeModels, nil).Once()
 				entityTypeSvc.On("ListByApplicationTemplateVersionID", txtest.CtxWithDBMatcher(), appTemplateVersionID).Return(entityTypeModels, nil).Once()
+
+				// set to time.Now, because on Create the lastUpdate is set to current time
+				currentTime := time.Now().Format(time.RFC3339)
+				entityTypeInputs[0].LastUpdate = &currentTime
+
 				entityTypeSvc.On("Create", txtest.CtxWithDBMatcher(), resource.ApplicationTemplateVersion, appTemplateVersionID, packageID1, *entityTypeInputs[0], uint64ResourceHash).Return(entityTypeID, nil).Once()
 				return entityTypeSvc
 			},

--- a/components/director/internal/open_resource_discovery/processor/event.go
+++ b/components/director/internal/open_resource_discovery/processor/event.go
@@ -2,8 +2,9 @@ package processor
 
 import (
 	"context"
-	"github.com/kyma-incubator/compass/components/director/pkg/log"
 	"time"
+
+	"github.com/kyma-incubator/compass/components/director/pkg/log"
 
 	"github.com/kyma-incubator/compass/components/director/internal/domain/tenant"
 	"github.com/kyma-incubator/compass/components/director/internal/model"

--- a/components/director/internal/open_resource_discovery/processor/event.go
+++ b/components/director/internal/open_resource_discovery/processor/event.go
@@ -2,6 +2,8 @@ package processor
 
 import (
 	"context"
+	"github.com/kyma-incubator/compass/components/director/pkg/log"
+	"time"
 
 	"github.com/kyma-incubator/compass/components/director/internal/domain/tenant"
 	"github.com/kyma-incubator/compass/components/director/internal/model"
@@ -141,6 +143,9 @@ func (ep *EventProcessor) resyncEvent(ctx context.Context, resourceType resource
 	}
 
 	if !isEventFound {
+		currentTime := time.Now().Format(time.RFC3339)
+		event.LastUpdate = &currentTime
+
 		eventID, err := ep.eventSvc.Create(ctx, resourceType, resourceID, nil, packageID, event, nil, bundleIDsFromBundleReference, eventHash, defaultConsumptionBundleID)
 		if err != nil {
 			return nil, err
@@ -152,7 +157,16 @@ func (ep *EventProcessor) resyncEvent(ctx context.Context, resourceType resource
 
 		return ep.createSpecs(ctx, model.EventSpecReference, eventID, specs, resourceType)
 	}
-	err := ep.resyncEntityTypeMappings(ctx, resource.EventDefinition, eventsFromDB[i].ID, event.EntityTypeMappings)
+
+	log.C(ctx).Infof("Calculate the newest lastUpdate time for Event")
+	newestLastUpdateTime, err := NewestLastUpdateTimestamp(event.LastUpdate, eventsFromDB[i].LastUpdate, eventsFromDB[i].ResourceHash, eventHash)
+	if err != nil {
+		return nil, errors.Wrap(err, "error while calculating the newest lastUpdate time for Event")
+	}
+
+	event.LastUpdate = newestLastUpdateTime
+
+	err = ep.resyncEntityTypeMappings(ctx, resource.EventDefinition, eventsFromDB[i].ID, event.EntityTypeMappings)
 	if err != nil {
 		return nil, err
 	}

--- a/components/director/internal/open_resource_discovery/processor/event.go
+++ b/components/director/internal/open_resource_discovery/processor/event.go
@@ -2,7 +2,6 @@ package processor
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/kyma-incubator/compass/components/director/pkg/log"
@@ -54,8 +53,6 @@ func (ep *EventProcessor) Process(ctx context.Context, resourceType resource.Typ
 	if err != nil {
 		return nil, nil, err
 	}
-
-	fmt.Println(len(packagesFromDB))
 
 	fetchRequests := make([]*OrdFetchRequest, 0)
 	for _, event := range events {
@@ -133,10 +130,9 @@ func (ep *EventProcessor) resyncEvent(ctx context.Context, resourceType resource
 			}
 		}
 	}
-	fmt.Println(len(packagesFromDB))
+
 	var packageID *string
 	if i, found := searchInSlice(len(packagesFromDB), func(i int) bool {
-		fmt.Println(packagesFromDB[i].OrdID, *event.OrdPackageID)
 		return equalStrings(&packagesFromDB[i].OrdID, event.OrdPackageID)
 	}); found {
 		packageID = &packagesFromDB[i].ID

--- a/components/director/internal/open_resource_discovery/processor/event.go
+++ b/components/director/internal/open_resource_discovery/processor/event.go
@@ -2,6 +2,7 @@ package processor
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/kyma-incubator/compass/components/director/pkg/log"
@@ -53,6 +54,8 @@ func (ep *EventProcessor) Process(ctx context.Context, resourceType resource.Typ
 	if err != nil {
 		return nil, nil, err
 	}
+
+	fmt.Println(len(packagesFromDB))
 
 	fetchRequests := make([]*OrdFetchRequest, 0)
 	for _, event := range events {
@@ -130,9 +133,10 @@ func (ep *EventProcessor) resyncEvent(ctx context.Context, resourceType resource
 			}
 		}
 	}
-
+	fmt.Println(len(packagesFromDB))
 	var packageID *string
 	if i, found := searchInSlice(len(packagesFromDB), func(i int) bool {
+		fmt.Println(packagesFromDB[i].OrdID, *event.OrdPackageID)
 		return equalStrings(&packagesFromDB[i].OrdID, event.OrdPackageID)
 	}); found {
 		packageID = &packagesFromDB[i].ID

--- a/components/director/internal/open_resource_discovery/processor/event_test.go
+++ b/components/director/internal/open_resource_discovery/processor/event_test.go
@@ -3,6 +3,7 @@ package processor_test
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/kyma-incubator/compass/components/director/internal/domain/tenant"
 	"github.com/kyma-incubator/compass/components/director/internal/model"
@@ -51,7 +52,7 @@ func TestEventProcessor_Process(t *testing.T) {
 		return entityTypeMappingSvc
 	}
 
-	resourceHashes := map[string]uint64{ordID: uint64ResourceHash}
+	resourceHashes := map[string]uint64{eventORDID: uint64ResourceHash}
 
 	testCases := []struct {
 		Name                       string
@@ -98,7 +99,7 @@ func TestEventProcessor_Process(t *testing.T) {
 			EventSvcFn: func() *automock.EventService {
 				eventSvc := &automock.EventService{}
 				eventSvc.On("ListByApplicationID", txtest.CtxWithDBMatcher(), appID).Return(fixEventDef, nil).Twice()
-				eventSvc.On("UpdateInManyBundles", txtest.CtxWithDBMatcher(), resource.Application, fixEventDef[0].ID, str.Ptr(packageID1), *fixEventInputs[0], nilSpecInput, []string{}, []string{}, []string{}, emptyHash, "").Return(nil).Once()
+				eventSvc.On("UpdateInManyBundles", txtest.CtxWithDBMatcher(), resource.Application, fixEventDef[0].ID, str.Ptr(packageID1), *fixEventInputs[0], nilSpecInput, []string{}, []string{}, []string{}, uint64ResourceHash, "").Return(nil).Once()
 
 				return eventSvc
 			},
@@ -129,7 +130,7 @@ func TestEventProcessor_Process(t *testing.T) {
 				eventSvc := &automock.EventService{}
 				eventSvc.On("ListByApplicationID", txtest.CtxWithDBMatcher(), appID).Return(fixEventsNoNewerLastUpdate(), nil).Once()
 				eventSvc.On("ListByApplicationID", txtest.CtxWithDBMatcher(), appID).Return(fixEventDef, nil).Once()
-				eventSvc.On("UpdateInManyBundles", txtest.CtxWithDBMatcher(), resource.Application, fixEventDef[0].ID, str.Ptr(packageID1), *fixEventInputs[0], nilSpecInput, []string{}, []string{}, []string{}, emptyHash, "").Return(nil).Once()
+				eventSvc.On("UpdateInManyBundles", txtest.CtxWithDBMatcher(), resource.Application, fixEventDef[0].ID, str.Ptr(packageID1), *fixEventInputs[0], nilSpecInput, []string{}, []string{}, []string{}, uint64ResourceHash, "").Return(nil).Once()
 				return eventSvc
 			},
 			EntityTypeMappingSvcFn: successfulEntityTypeMapping,
@@ -157,7 +158,12 @@ func TestEventProcessor_Process(t *testing.T) {
 			EventSvcFn: func() *automock.EventService {
 				eventSvc := &automock.EventService{}
 				eventSvc.On("ListByApplicationID", txtest.CtxWithDBMatcher(), appID).Return(fixEventDef2, nil).Twice()
-				eventSvc.On("Create", txtest.CtxWithDBMatcher(), resource.Application, appID, nilString, str.Ptr(packageID1), *fixEventInputs[0], nilSpecInputSlice, []string{}, emptyHash, "").Return(eventID, nil).Once()
+
+				// set to time.Now, because on Create the lastUpdate is set to current time
+				currentTime := time.Now().Format(time.RFC3339)
+				fixEventInputs[0].LastUpdate = &currentTime
+
+				eventSvc.On("Create", txtest.CtxWithDBMatcher(), resource.Application, appID, nilString, str.Ptr(packageID1), *fixEventInputs[0], nilSpecInputSlice, []string{}, uint64ResourceHash, "").Return(eventID, nil).Once()
 				return eventSvc
 			},
 			EntityTypeMappingSvcFn: func() *automock.EntityTypeMappingService {
@@ -263,7 +269,7 @@ func TestEventProcessor_Process(t *testing.T) {
 			EventSvcFn: func() *automock.EventService {
 				eventSvc := &automock.EventService{}
 				eventSvc.On("ListByApplicationID", txtest.CtxWithDBMatcher(), appID).Return(fixEventDef, nil).Once()
-				eventSvc.On("UpdateInManyBundles", txtest.CtxWithDBMatcher(), resource.Application, fixEventDef[0].ID, str.Ptr(packageID1), *fixEventInputs[0], nilSpecInput, []string{}, []string{}, []string{}, emptyHash, "").Return(testErr).Once()
+				eventSvc.On("UpdateInManyBundles", txtest.CtxWithDBMatcher(), resource.Application, fixEventDef[0].ID, str.Ptr(packageID1), *fixEventInputs[0], nilSpecInput, []string{}, []string{}, []string{}, uint64ResourceHash, "").Return(testErr).Once()
 				return eventSvc
 			},
 			EntityTypeMappingSvcFn: func() *automock.EntityTypeMappingService {
@@ -293,7 +299,12 @@ func TestEventProcessor_Process(t *testing.T) {
 			EventSvcFn: func() *automock.EventService {
 				eventSvc := &automock.EventService{}
 				eventSvc.On("ListByApplicationID", txtest.CtxWithDBMatcher(), appID).Return(fixEventDef2, nil).Once()
-				eventSvc.On("Create", txtest.CtxWithDBMatcher(), resource.Application, appID, nilString, nilString, *fixEventInputs[0], nilSpecInputSlice, []string{}, emptyHash, "").Return("", testErr).Once()
+
+				// set to time.Now, because on Create the lastUpdate is set to current time
+				currentTime := time.Now().Format(time.RFC3339)
+				fixEventInputs[0].LastUpdate = &currentTime
+
+				eventSvc.On("Create", txtest.CtxWithDBMatcher(), resource.Application, appID, nilString, nilString, *fixEventInputs[0], nilSpecInputSlice, []string{}, uint64ResourceHash, "").Return("", testErr).Once()
 				return eventSvc
 			},
 			InputResource:       resource.Application,
@@ -316,7 +327,12 @@ func TestEventProcessor_Process(t *testing.T) {
 			EventSvcFn: func() *automock.EventService {
 				eventSvc := &automock.EventService{}
 				eventSvc.On("ListByApplicationID", txtest.CtxWithDBMatcher(), appID).Return(fixEventDef2, nil).Once()
-				eventSvc.On("Create", txtest.CtxWithDBMatcher(), resource.Application, appID, nilString, nilString, *fixEventInputs[0], nilSpecInputSlice, []string{}, emptyHash, "").Return(eventID, nil).Once()
+
+				// set to time.Now, because on Create the lastUpdate is set to current time
+				currentTime := time.Now().Format(time.RFC3339)
+				fixEventInputs[0].LastUpdate = &currentTime
+
+				eventSvc.On("Create", txtest.CtxWithDBMatcher(), resource.Application, appID, nilString, nilString, *fixEventInputs[0], nilSpecInputSlice, []string{}, uint64ResourceHash, "").Return(eventID, nil).Once()
 				return eventSvc
 			},
 			EntityTypeMappingSvcFn: func() *automock.EntityTypeMappingService {
@@ -344,7 +360,12 @@ func TestEventProcessor_Process(t *testing.T) {
 			EventSvcFn: func() *automock.EventService {
 				eventSvc := &automock.EventService{}
 				eventSvc.On("ListByApplicationID", txtest.CtxWithDBMatcher(), appID).Return(fixEventDef2, nil).Once()
-				eventSvc.On("Create", txtest.CtxWithDBMatcher(), resource.Application, appID, nilString, nilString, *fixEventInputs[0], nilSpecInputSlice, []string{}, emptyHash, "").Return(eventID, nil).Once()
+
+				// set to time.Now, because on Create the lastUpdate is set to current time
+				currentTime := time.Now().Format(time.RFC3339)
+				fixEventInputs[0].LastUpdate = &currentTime
+
+				eventSvc.On("Create", txtest.CtxWithDBMatcher(), resource.Application, appID, nilString, nilString, *fixEventInputs[0], nilSpecInputSlice, []string{}, uint64ResourceHash, "").Return(eventID, nil).Once()
 				return eventSvc
 			},
 			EntityTypeMappingSvcFn: func() *automock.EntityTypeMappingService {
@@ -373,7 +394,12 @@ func TestEventProcessor_Process(t *testing.T) {
 			EventSvcFn: func() *automock.EventService {
 				eventSvc := &automock.EventService{}
 				eventSvc.On("ListByApplicationID", txtest.CtxWithDBMatcher(), appID).Return(fixEventDef2, nil).Once()
-				eventSvc.On("Create", txtest.CtxWithDBMatcher(), resource.Application, appID, nilString, nilString, *fixEventInputs[0], nilSpecInputSlice, []string{}, emptyHash, "").Return(eventID, nil).Once()
+
+				// set to time.Now, because on Create the lastUpdate is set to current time
+				currentTime := time.Now().Format(time.RFC3339)
+				fixEventInputs[0].LastUpdate = &currentTime
+
+				eventSvc.On("Create", txtest.CtxWithDBMatcher(), resource.Application, appID, nilString, nilString, *fixEventInputs[0], nilSpecInputSlice, []string{}, uint64ResourceHash, "").Return(eventID, nil).Once()
 				return eventSvc
 			},
 			EntityTypeMappingSvcFn: func() *automock.EntityTypeMappingService {
@@ -402,7 +428,12 @@ func TestEventProcessor_Process(t *testing.T) {
 			EventSvcFn: func() *automock.EventService {
 				eventSvc := &automock.EventService{}
 				eventSvc.On("ListByApplicationID", txtest.CtxWithDBMatcher(), appID).Return(fixEventDef2, nil).Once()
-				eventSvc.On("Create", txtest.CtxWithDBMatcher(), resource.Application, appID, nilString, nilString, *fixEventInputs[0], nilSpecInputSlice, []string{}, emptyHash, "").Return(eventID, nil).Once()
+
+				// set to time.Now, because on Create the lastUpdate is set to current time
+				currentTime := time.Now().Format(time.RFC3339)
+				fixEventInputs[0].LastUpdate = &currentTime
+
+				eventSvc.On("Create", txtest.CtxWithDBMatcher(), resource.Application, appID, nilString, nilString, *fixEventInputs[0], nilSpecInputSlice, []string{}, uint64ResourceHash, "").Return(eventID, nil).Once()
 				return eventSvc
 			},
 			EntityTypeMappingSvcFn: func() *automock.EntityTypeMappingService {
@@ -439,7 +470,7 @@ func TestEventProcessor_Process(t *testing.T) {
 			EventSvcFn: func() *automock.EventService {
 				eventSvc := &automock.EventService{}
 				eventSvc.On("ListByApplicationID", txtest.CtxWithDBMatcher(), appID).Return(fixEventDef, nil).Once()
-				eventSvc.On("UpdateInManyBundles", txtest.CtxWithDBMatcher(), resource.Application, fixEventDef[0].ID, str.Ptr(packageID1), *fixEventInputs[0], nilSpecInput, []string{}, []string{}, []string{}, emptyHash, "").Return(nil).Once()
+				eventSvc.On("UpdateInManyBundles", txtest.CtxWithDBMatcher(), resource.Application, fixEventDef[0].ID, str.Ptr(packageID1), *fixEventInputs[0], nilSpecInput, []string{}, []string{}, []string{}, uint64ResourceHash, "").Return(nil).Once()
 				return eventSvc
 			},
 			EntityTypeMappingSvcFn: successfulEntityTypeMapping,
@@ -469,7 +500,10 @@ func TestEventProcessor_Process(t *testing.T) {
 			EventSvcFn: func() *automock.EventService {
 				eventSvc := &automock.EventService{}
 				eventSvc.On("ListByApplicationID", txtest.CtxWithDBMatcher(), appID).Return(fixEventsNoNewerLastUpdate(), nil).Once()
-				eventSvc.On("UpdateInManyBundles", txtest.CtxWithDBMatcher(), resource.Application, fixEventDef[0].ID, str.Ptr(packageID1), *fixEventInputs[0], nilSpecInput, []string{}, []string{}, []string{}, emptyHash, "").Return(nil).Once()
+				fixEventInputs = []*model.EventDefinitionInput{
+					fixEventInput(),
+				}
+				eventSvc.On("UpdateInManyBundles", txtest.CtxWithDBMatcher(), resource.Application, fixEventDef[0].ID, str.Ptr(packageID1), *fixEventInputs[0], nilSpecInput, []string{}, []string{}, []string{}, uint64ResourceHash, "").Return(nil).Once()
 				return eventSvc
 			},
 			EntityTypeMappingSvcFn: successfulEntityTypeMapping,
@@ -484,7 +518,9 @@ func TestEventProcessor_Process(t *testing.T) {
 			InputResourceID:     appID,
 			InputBundlesFromDB:  fixEmptyBundles(),
 			InputPackagesFromDB: fixPackages(),
-			EventInput:          fixEventInputs,
+			EventInput: []*model.EventDefinitionInput{
+				fixEventInput(),
+			},
 			InputResourceHashes: resourceHashes,
 			ExpectedErr:         testErr,
 		},
@@ -500,7 +536,10 @@ func TestEventProcessor_Process(t *testing.T) {
 			EventSvcFn: func() *automock.EventService {
 				eventSvc := &automock.EventService{}
 				eventSvc.On("ListByApplicationTemplateVersionID", txtest.CtxWithDBMatcher(), appTemplateVersionID).Return(fixEventsNoNewerLastUpdate(), nil).Once()
-				eventSvc.On("UpdateInManyBundles", txtest.CtxWithDBMatcher(), resource.ApplicationTemplateVersion, fixEventDef[0].ID, str.Ptr(packageID1), *fixEventInputs[0], nilSpecInput, []string{}, []string{}, []string{}, emptyHash, "").Return(nil).Once()
+				fixEventInputs = []*model.EventDefinitionInput{
+					fixEventInput(),
+				}
+				eventSvc.On("UpdateInManyBundles", txtest.CtxWithDBMatcher(), resource.ApplicationTemplateVersion, fixEventDef[0].ID, str.Ptr(packageID1), *fixEventInputs[0], nilSpecInput, []string{}, []string{}, []string{}, uint64ResourceHash, "").Return(nil).Once()
 				return eventSvc
 			},
 			EntityTypeMappingSvcFn: successfulEntityTypeMapping,
@@ -515,7 +554,9 @@ func TestEventProcessor_Process(t *testing.T) {
 			InputResourceID:     appTemplateVersionID,
 			InputBundlesFromDB:  fixEmptyBundles(),
 			InputPackagesFromDB: fixPackages(),
-			EventInput:          fixEventInputs,
+			EventInput: []*model.EventDefinitionInput{
+				fixEventInput(),
+			},
 			InputResourceHashes: resourceHashes,
 			ExpectedErr:         testErr,
 		},
@@ -526,10 +567,10 @@ func TestEventProcessor_Process(t *testing.T) {
 			},
 			EventSvcFn: func() *automock.EventService {
 				eventSvc := &automock.EventService{}
-				fixEventInputs[0].OrdPackageID = str.Ptr(packageORDID2)
 				eventSvc.On("ListByApplicationID", txtest.CtxWithDBMatcher(), appID).Return(fixEventDef, nil).Once()
 				eventSvc.On("ListByApplicationID", txtest.CtxWithDBMatcher(), appID).Return(fixUpdatedEventDef, nil).Once()
-				eventSvc.On("UpdateInManyBundles", txtest.CtxWithDBMatcher(), resource.Application, fixEventDef[0].ID, str.Ptr(packageID2), *fixEventInputs[0], nilSpecInput, []string{}, []string{}, []string{}, emptyHash, "").Return(nil).Once()
+
+				eventSvc.On("UpdateInManyBundles", txtest.CtxWithDBMatcher(), resource.Application, fixEventDef[0].ID, str.Ptr(packageID2), *fixEventInputsWithNewPkg()[0], nilSpecInput, []string{}, []string{}, []string{}, uint64ResourceHash, "").Return(nil).Once()
 
 				return eventSvc
 			},
@@ -546,7 +587,7 @@ func TestEventProcessor_Process(t *testing.T) {
 			InputResourceID:            appID,
 			InputBundlesFromDB:         fixEmptyBundles(),
 			InputPackagesFromDB:        fixPackages(),
-			EventInput:                 fixEventInputs,
+			EventInput:                 fixEventInputsWithNewPkg(),
 			InputResourceHashes:        resourceHashes,
 			ExpectedEventDefOutput:     fixUpdatedEventDef,
 			ExpectedFetchRequestOutput: []*processor.OrdFetchRequest{{FetchRequest: nil, RefObjectOrdID: eventORDID}},

--- a/components/director/internal/open_resource_discovery/processor/fixtures_test.go
+++ b/components/director/internal/open_resource_discovery/processor/fixtures_test.go
@@ -463,6 +463,7 @@ func fixAPI(id string, ordID *string) *model.APIDefinition {
 			Value: "2.1.3",
 		},
 		DocumentationLabels: json.RawMessage(documentLabels),
+		ResourceHash:        str.Ptr(resourceHash),
 		BaseEntity: &model.BaseEntity{
 			ID:    id,
 			Ready: true,

--- a/components/director/internal/open_resource_discovery/processor/fixtures_test.go
+++ b/components/director/internal/open_resource_discovery/processor/fixtures_test.go
@@ -282,6 +282,7 @@ func fixEntityTypeModel(entityTypeID string) *model.EntityType {
 		Tags:                         json.RawMessage(tags),
 		Labels:                       json.RawMessage(labels),
 		DocumentationLabels:          json.RawMessage(documentationLabels),
+		LastUpdate:                   str.Ptr("2023-01-25T15:47:04+00:00"),
 		Version:                      fixVersionModel(versionValue, versionDeprecated, versionDeprecatedSince, versionForRemoval),
 		ResourceHash:                 &resourceHash,
 	}
@@ -311,6 +312,7 @@ func fixEntityTypeInputModel() *model.EntityTypeInput {
 		Tags:                json.RawMessage(tags),
 		Labels:              json.RawMessage(labels),
 		DocumentationLabels: json.RawMessage(documentationLabels),
+		LastUpdate:          str.Ptr("2023-01-25T15:47:04+00:00"),
 	}
 }
 
@@ -324,6 +326,7 @@ func fixIntegrationDependencyModel(integrationDependencyID, integrationDependenc
 		ApplicationID:                &appID,
 		ApplicationTemplateVersionID: &appTemplateVersionID,
 		PackageID:                    str.Ptr(packageORDID1),
+		LastUpdate:                   str.Ptr("2023-01-25T15:47:04+00:00"),
 	}
 }
 
@@ -337,6 +340,7 @@ func fixIntegrationDependencyInputModel(integrationDependencyORDID string) *mode
 				Mandatory: &mandatoryTrue,
 			},
 		},
+		LastUpdate: str.Ptr("2023-01-25T15:47:04+00:00"),
 	}
 }
 
@@ -350,6 +354,7 @@ func fixDataProductModel(dataProductID, dataProductORDID string) *model.DataProd
 		ApplicationID:                &appID,
 		ApplicationTemplateVersionID: &appTemplateVersionID,
 		PackageID:                    str.Ptr(packageID1),
+		LastUpdate:                   str.Ptr("2023-01-25T15:47:04+00:00"),
 	}
 }
 
@@ -359,6 +364,7 @@ func fixDataProductInputModel(dataProductORDID string) *model.DataProductInput {
 		OrdPackageID: str.Ptr(packageORDID1),
 		Title:        "Data Product title",
 		Visibility:   str.Ptr("public"),
+		LastUpdate:   str.Ptr("2023-01-25T15:47:04+00:00"),
 	}
 }
 
@@ -579,6 +585,7 @@ func fixEvent(id string, ordID *string) *model.EventDefinition {
 		Version: &model.Version{
 			Value: "2.1.3",
 		},
+		ResourceHash: str.Ptr(resourceHash),
 		BaseEntity: &model.BaseEntity{
 			ID:    id,
 			Ready: true,
@@ -609,6 +616,7 @@ func fixCapability(id string, ordID *string) *model.Capability {
 			Value: "2.1.3",
 		},
 		DocumentationLabels: json.RawMessage(documentLabels),
+		ResourceHash:        str.Ptr(resourceHash),
 		BaseEntity: &model.BaseEntity{
 			ID:    id,
 			Ready: true,
@@ -675,6 +683,15 @@ func fixCapabilitiesNoNewerLastUpdate() []*model.Capability {
 	return []*model.Capability{
 		capability,
 	}
+}
+
+func fixEventInputsWithNewPkg() []*model.EventDefinitionInput {
+	events := []*model.EventDefinitionInput{
+		fixEventInput(),
+	}
+	events[0].OrdPackageID = str.Ptr(packageORDID2)
+
+	return events
 }
 
 func fixEventInput() *model.EventDefinitionInput {

--- a/components/director/internal/open_resource_discovery/processor/integration_dependency.go
+++ b/components/director/internal/open_resource_discovery/processor/integration_dependency.go
@@ -2,6 +2,7 @@ package processor
 
 import (
 	"context"
+
 	"github.com/kyma-incubator/compass/components/director/internal/model"
 	"github.com/kyma-incubator/compass/components/director/pkg/log"
 	"github.com/kyma-incubator/compass/components/director/pkg/persistence"

--- a/components/director/internal/open_resource_discovery/processor/integration_dependency_test.go
+++ b/components/director/internal/open_resource_discovery/processor/integration_dependency_test.go
@@ -2,6 +2,7 @@ package processor_test
 
 import (
 	"context"
+	"strconv"
 	"testing"
 
 	"github.com/kyma-incubator/compass/components/director/pkg/str"
@@ -43,6 +44,9 @@ func TestIntegrationDependencyProcessor_Process(t *testing.T) {
 	resourceHashes := map[string]uint64{
 		integrationDependencyORDID: hashIntegrationDependency,
 	}
+
+	uintHashDataProduct := strconv.FormatUint(hashIntegrationDependency, 10)
+	integrationDependencyModel[0].ResourceHash = &uintHashDataProduct
 
 	integrationDependencyInputs := []*model.IntegrationDependencyInput{
 		fixIntegrationDependencyInputModel(integrationDependencyORDID),

--- a/components/director/internal/open_resource_discovery/service_test.go
+++ b/components/director/internal/open_resource_discovery/service_test.go
@@ -195,7 +195,7 @@ func TestService_Processing(t *testing.T) {
 		bundlesSvc.On("ListByApplicationIDNoPaging", txtest.CtxWithDBMatcher(), appID).Return(nil, nil).Once()
 		currentTime := time.Now().Format(time.RFC3339)
 		sanitizedDocForProxy.ConsumptionBundles[0].LastUpdate = &currentTime
-		bundlesSvc.On("CreateBundle", txtest.CtxWithDBMatcher(), resource.Application, appID, *sanitizedDocForProxy.ConsumptionBundles[0], mock.Anything).Return("", nil).Once()
+		bundlesSvc.On("CreateBundle", txtest.CtxWithDBMatcher(), resource.Application, appID, mock.Anything, mock.Anything).Return("", nil).Once()
 		bundlesSvc.On("ListByApplicationIDNoPaging", txtest.CtxWithDBMatcher(), appID).Return(fixBundles(), nil).Once()
 		return bundlesSvc
 	}
@@ -222,9 +222,7 @@ func TestService_Processing(t *testing.T) {
 		bundlesSvc := &automock.BundleService{}
 		bundlesSvc.On("ListByApplicationIDNoPaging", txtest.CtxWithDBMatcher(), appID).Return(nil, nil).Once()
 		bundlesSvc.On("ListByApplicationIDNoPaging", txtest.CtxWithDBMatcher(), appID).Return(nil, nil).Once()
-		currentTime := time.Now().Format(time.RFC3339)
-		sanitizedDoc.ConsumptionBundles[0].LastUpdate = &currentTime
-		bundlesSvc.On("CreateBundle", txtest.CtxWithDBMatcher(), resource.Application, appID, *sanitizedDoc.ConsumptionBundles[0], mock.Anything).Return("", nil).Once()
+		bundlesSvc.On("CreateBundle", txtest.CtxWithDBMatcher(), resource.Application, appID, mock.Anything, mock.Anything).Return("", nil).Once()
 		bundlesSvc.On("ListByApplicationIDNoPaging", txtest.CtxWithDBMatcher(), appID).Return(fixBundles(), nil).Once()
 		return bundlesSvc
 	}
@@ -233,9 +231,7 @@ func TestService_Processing(t *testing.T) {
 		bundlesSvc := &automock.BundleService{}
 		bundlesSvc.On("ListByApplicationTemplateVersionIDNoPaging", txtest.CtxWithDBMatcher(), appTemplateVersionID).Return(nil, nil).Once()
 		bundlesSvc.On("ListByApplicationTemplateVersionIDNoPaging", txtest.CtxWithDBMatcher(), appTemplateVersionID).Return(nil, nil).Once()
-		currentTime := time.Now().Format(time.RFC3339)
-		sanitizedStaticDoc.ConsumptionBundles[0].LastUpdate = &currentTime
-		bundlesSvc.On("CreateBundle", txtest.CtxWithDBMatcher(), resource.ApplicationTemplateVersion, appTemplateVersionID, *sanitizedStaticDoc.ConsumptionBundles[0], mock.Anything).Return("", nil).Once()
+		bundlesSvc.On("CreateBundle", txtest.CtxWithDBMatcher(), resource.ApplicationTemplateVersion, appTemplateVersionID, mock.Anything, mock.Anything).Return("", nil).Once()
 		bundlesSvc.On("ListByApplicationTemplateVersionIDNoPaging", txtest.CtxWithDBMatcher(), appTemplateVersionID).Return(fixBundles(), nil).Once()
 		return bundlesSvc
 	}
@@ -2283,7 +2279,7 @@ func TestService_Processing(t *testing.T) {
 				bundlesSvc := &automock.BundleService{}
 				bundlesSvc.On("ListByApplicationIDNoPaging", txtest.CtxWithDBMatcher(), appID).Return(nil, nil).Once()
 				bundlesSvc.On("ListByApplicationIDNoPaging", txtest.CtxWithDBMatcher(), appID).Return(nil, nil).Once()
-				bundlesSvc.On("CreateBundle", txtest.CtxWithDBMatcher(), resource.Application, appID, *sanitizedDoc.ConsumptionBundles[0], mock.Anything).Return("", testErr).Once()
+				bundlesSvc.On("CreateBundle", txtest.CtxWithDBMatcher(), resource.Application, appID, mock.Anything, mock.Anything).Return("", testErr).Once()
 				return bundlesSvc
 			},
 			clientFn:                   successfulClientFetch,

--- a/components/director/internal/open_resource_discovery/service_test.go
+++ b/components/director/internal/open_resource_discovery/service_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/kyma-incubator/compass/components/director/internal/open_resource_discovery/processor"
 
@@ -192,6 +193,8 @@ func TestService_Processing(t *testing.T) {
 		bundlesSvc := &automock.BundleService{}
 		bundlesSvc.On("ListByApplicationIDNoPaging", txtest.CtxWithDBMatcher(), appID).Return(nil, nil).Once()
 		bundlesSvc.On("ListByApplicationIDNoPaging", txtest.CtxWithDBMatcher(), appID).Return(nil, nil).Once()
+		currentTime := time.Now().Format(time.RFC3339)
+		sanitizedDocForProxy.ConsumptionBundles[0].LastUpdate = &currentTime
 		bundlesSvc.On("CreateBundle", txtest.CtxWithDBMatcher(), resource.Application, appID, *sanitizedDocForProxy.ConsumptionBundles[0], mock.Anything).Return("", nil).Once()
 		bundlesSvc.On("ListByApplicationIDNoPaging", txtest.CtxWithDBMatcher(), appID).Return(fixBundles(), nil).Once()
 		return bundlesSvc
@@ -219,6 +222,8 @@ func TestService_Processing(t *testing.T) {
 		bundlesSvc := &automock.BundleService{}
 		bundlesSvc.On("ListByApplicationIDNoPaging", txtest.CtxWithDBMatcher(), appID).Return(nil, nil).Once()
 		bundlesSvc.On("ListByApplicationIDNoPaging", txtest.CtxWithDBMatcher(), appID).Return(nil, nil).Once()
+		currentTime := time.Now().Format(time.RFC3339)
+		sanitizedDoc.ConsumptionBundles[0].LastUpdate = &currentTime
 		bundlesSvc.On("CreateBundle", txtest.CtxWithDBMatcher(), resource.Application, appID, *sanitizedDoc.ConsumptionBundles[0], mock.Anything).Return("", nil).Once()
 		bundlesSvc.On("ListByApplicationIDNoPaging", txtest.CtxWithDBMatcher(), appID).Return(fixBundles(), nil).Once()
 		return bundlesSvc
@@ -228,6 +233,8 @@ func TestService_Processing(t *testing.T) {
 		bundlesSvc := &automock.BundleService{}
 		bundlesSvc.On("ListByApplicationTemplateVersionIDNoPaging", txtest.CtxWithDBMatcher(), appTemplateVersionID).Return(nil, nil).Once()
 		bundlesSvc.On("ListByApplicationTemplateVersionIDNoPaging", txtest.CtxWithDBMatcher(), appTemplateVersionID).Return(nil, nil).Once()
+		currentTime := time.Now().Format(time.RFC3339)
+		sanitizedStaticDoc.ConsumptionBundles[0].LastUpdate = &currentTime
 		bundlesSvc.On("CreateBundle", txtest.CtxWithDBMatcher(), resource.ApplicationTemplateVersion, appTemplateVersionID, *sanitizedStaticDoc.ConsumptionBundles[0], mock.Anything).Return("", nil).Once()
 		bundlesSvc.On("ListByApplicationTemplateVersionIDNoPaging", txtest.CtxWithDBMatcher(), appTemplateVersionID).Return(fixBundles(), nil).Once()
 		return bundlesSvc

--- a/components/schema-migrator/migrations/director/20240110153859_add-lastUpdate-to-bundle.down.sql
+++ b/components/schema-migrator/migrations/director/20240110153859_add-lastUpdate-to-bundle.down.sql
@@ -1,0 +1,52 @@
+BEGIN;
+DROP VIEW IF EXISTS tenants_bundles;
+
+-- Alter table - remove `last_update` from Consumption Bundle
+ALTER TABLE bundles
+    DROP COLUMN last_update;
+
+CREATE OR REPLACE VIEW tenants_bundles
+            (tenant_id, formation_id, id, app_id, name, description, version, instance_auth_request_json_schema,
+             default_instance_auth, ord_id, local_tenant_id, short_description, links, labels, tags,
+             credential_exchange_strategies, ready, created_at, updated_at, deleted_at, error, correlation_ids,
+             resource_hash)
+AS
+SELECT DISTINCT t_apps.tenant_id,
+                t_apps.formation_id,
+                b.id,
+                b.app_id,
+                b.name,
+                b.description,
+                b.version,
+                b.instance_auth_request_json_schema,
+                b.default_instance_auth,
+                b.ord_id,
+                b.local_tenant_id,
+                b.short_description,
+                b.links,
+                b.labels,
+                b.tags,
+                b.credential_exchange_strategies,
+                b.ready,
+                b.created_at,
+                b.updated_at,
+                b.deleted_at,
+                b.error,
+                b.correlation_ids,
+                b.resource_hash
+FROM bundles b
+         JOIN (SELECT a1.id,
+                      a1.tenant_id,
+                      'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'::uuid AS formation_id
+               FROM tenant_applications a1
+               UNION ALL
+               SELECT apps_subaccounts.id,
+                      apps_subaccounts.tenant_id,
+                      apps_subaccounts.formation_id
+               FROM apps_subaccounts
+               UNION ALL
+               SELECT apps_subaccounts.id,
+                      apps_subaccounts.tenant_id,
+                      'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'::uuid AS formation_id
+               FROM apps_subaccounts) t_apps ON b.app_id = t_apps.id;
+COMMIT;

--- a/components/schema-migrator/migrations/director/20240110153859_add-lastUpdate-to-bundle.down.sql
+++ b/components/schema-migrator/migrations/director/20240110153859_add-lastUpdate-to-bundle.down.sql
@@ -40,10 +40,10 @@ FROM bundles b
                       'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'::uuid AS formation_id
                FROM tenant_applications a1
                UNION ALL
-               SELECT apps_subaccounts.id,
-                      apps_subaccounts.tenant_id,
-                      apps_subaccounts.formation_id
-               FROM apps_subaccounts
+               SELECT af.app_id,
+                      'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'::uuid AS tenant_id,
+                       af.formation_id
+               FROM apps_formations_id af
                UNION ALL
                SELECT apps_subaccounts.id,
                       apps_subaccounts.tenant_id,

--- a/components/schema-migrator/migrations/director/20240110153859_add-lastUpdate-to-bundle.up.sql
+++ b/components/schema-migrator/migrations/director/20240110153859_add-lastUpdate-to-bundle.up.sql
@@ -1,0 +1,55 @@
+BEGIN;
+DROP VIEW IF EXISTS tenants_bundles;
+
+-- Alter table - add column lastUpdate to Consumption Bundle
+ALTER TABLE bundles
+    ADD COLUMN last_update VARCHAR(256);
+
+CREATE OR REPLACE VIEW tenants_bundles
+            (tenant_id, formation_id, id, app_id, name, description, version, instance_auth_request_json_schema,
+             default_instance_auth, ord_id, local_tenant_id, short_description, links, labels, tags,
+             credential_exchange_strategies, ready, created_at, updated_at, deleted_at, error, correlation_ids, last_update,
+             resource_hash)
+AS
+SELECT DISTINCT t_apps.tenant_id,
+                t_apps.formation_id,
+                b.id,
+                b.app_id,
+                b.name,
+                b.description,
+                b.version,
+                b.instance_auth_request_json_schema,
+                b.default_instance_auth,
+                b.ord_id,
+                b.local_tenant_id,
+                b.short_description,
+                b.links,
+                b.labels,
+                b.tags,
+                b.credential_exchange_strategies,
+                b.ready,
+                b.created_at,
+                b.updated_at,
+                b.deleted_at,
+                b.error,
+                b.correlation_ids,
+                b.last_update,
+                b.resource_hash
+FROM bundles b
+         JOIN (SELECT a1.id,
+                      a1.tenant_id,
+                      'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'::uuid AS formation_id
+               FROM tenant_applications a1
+               UNION ALL
+               SELECT apps_subaccounts.id,
+                      apps_subaccounts.tenant_id,
+                      apps_subaccounts.formation_id
+               FROM apps_subaccounts
+               UNION ALL
+               SELECT apps_subaccounts.id,
+                      apps_subaccounts.tenant_id,
+                      'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'::uuid AS formation_id
+               FROM apps_subaccounts) t_apps ON b.app_id = t_apps.id;
+
+
+COMMIT;

--- a/components/schema-migrator/migrations/director/20240110153859_add-lastUpdate-to-bundle.up.sql
+++ b/components/schema-migrator/migrations/director/20240110153859_add-lastUpdate-to-bundle.up.sql
@@ -41,10 +41,10 @@ FROM bundles b
                       'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'::uuid AS formation_id
                FROM tenant_applications a1
                UNION ALL
-               SELECT apps_subaccounts.id,
-                      apps_subaccounts.tenant_id,
-                      apps_subaccounts.formation_id
-               FROM apps_subaccounts
+               SELECT af.app_id,
+                      'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'::uuid AS tenant_id,
+                       af.formation_id
+               FROM apps_formations_id af
                UNION ALL
                SELECT apps_subaccounts.id,
                       apps_subaccounts.tenant_id,


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
ORD resources have the `lastUpdate` field for saving the information about the time when the resources (or its resource definitions if it has such) have changed since the last aggregation. The lastUpdate is not always maintained by the ORD providers, so UCL now will set the right timestamp regarding the state of the resources.

Resources that have the property `lastUpdate` in the ORD spec - API, Event, Consumption Bundle, Capability, Integration Dependency, Entity Type, Data Product.

Changes proposed in this pull request:
- set `lastUpdate` to time.Now when creating the resource (on aggregation when the resource is not present in the DB)
- find the newest value for the `lastUpdate` comparing its value in the document and in the db
- exclude the `lastUpdate` field from the hash of the resources
- if the hash of the resource has changed, set the `lastUpdate` to time.Now
- add `lastUpdate` field to Consumption bundle
- adapt unit tests
- add migration for altering the bundles table

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- https://github.com/kyma-incubator/ord-service/pull/120

**Pull Request status**
<!-- Feel free to construct the checklist with whatever items seem most reasonable for your change. You could disassemble the Implementation part to even smaller separate checklist items if you're working on something big for example. But do make the effort to provide a checklist of some sort so that the core team as well as the community can have an idea about the progress of your Pull Request.
-->

- [x] Implementation
- [x] Unit tests
- [ ] Integration tests
- [x] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [ ] Mocks are regenerated, using the automated script
