### PR TITLE
[HOTFIX] Fix status report for self-referenced formation assignment

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -167,8 +167,8 @@ global:
       version: "v20240112-68df17f1"
       name: compass-pairing-adapter
     director:
-      dir: prod/incubator/
-      version: "v20240116-203cb8cb"
+      dir: dev/incubator/
+      version: "PR-3588"
       name: compass-director
     hydrator:
       dir: prod/incubator/

--- a/components/director/internal/formationmapping/handler.go
+++ b/components/director/internal/formationmapping/handler.go
@@ -393,8 +393,12 @@ func (h *Handler) processFormationUnassign(ctx context.Context, formation *model
 		return errors.Wrapf(err, "while unassigning object with type: %q and ID: %q", fa.SourceType, fa.Source)
 	}
 
-	if err = h.unassignObjectFromFormationWhenThereAreNoFormationAssignments(unassignCtx, fa, formation, fa.Target, fa.TargetType); err != nil {
-		return errors.Wrapf(err, "while unassigning object with type: %q and ID: %q", fa.TargetType, fa.Target)
+	// Skip second unassign from formation in case the formation assignment is self-referenced one,
+	// and if happened to be the last one. It will be handled above.
+	if fa.Source != fa.Target {
+		if err = h.unassignObjectFromFormationWhenThereAreNoFormationAssignments(unassignCtx, fa, formation, fa.Target, fa.TargetType); err != nil {
+			return errors.Wrapf(err, "while unassigning object with type: %q and ID: %q", fa.TargetType, fa.Target)
+		}
 	}
 
 	if err = unassignTx.Commit(); err != nil {


### PR DESCRIPTION
**Description**
In the case of self-referenced assignments the second unassign from scenario label will always fail, because the first one will have deleted it.

Changes proposed in this pull request:
- only unassign `Target` if it is different from `Source` 

**Related issue(s)**
- #3583
- #3284

**Pull Request status**
- [x] Implementation
- [x] [N/A] Unit tests
- [x] [N/A] Integration tests
- [x] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [x] [N/A] Mocks are regenerated, using the automated script
