### PR TITLE
Insecure ClusterRoleBinding overrides

### DIFF
--- a/chart/compass/templates/jwks_cluster_binding.yaml
+++ b/chart/compass/templates/jwks_cluster_binding.yaml
@@ -1,3 +1,4 @@
+{{ if eq .Values.global.kubernetes.local true }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -10,3 +11,4 @@ subjects:
   - apiGroup: rbac.authorization.k8s.io
     kind: User
     name: system:anonymous
+{{- end }}

--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -683,6 +683,11 @@ global:
           - "x-vcap-request-id"
           - "x-broker-api-request-identity"
   kubernetes:
+    # Enable ClusterRoleBinding needed for local installation but unsafe on GKE
+    # It allows anonymous users to retrieve the JWKS of the K8S server used to create SA tokens
+    # Whenever this is running on GKE, there is a JWKS URL given by Google and is unneeded and unsafe
+    # Overriden to true in local compass overrides
+    local: false
     serviceAccountTokenIssuer: https://kubernetes.default.svc.cluster.local
     serviceAccountTokenJWKS: https://kubernetes.default.svc.cluster.local/openid/v1/jwks
   ingress:

--- a/installation/resources/compass-overrides-local.yaml
+++ b/installation/resources/compass-overrides-local.yaml
@@ -8,6 +8,11 @@ gateway:
       authMode: "oauth-mtls"
       enabled: true
 global:
+  kubernetes:
+    # Enable ClusterRoleBinding needed for local installation but unsafe on GKE
+    # It allows anonymous users to retrieve the JWKS of the K8S server used to create SA tokens
+    # Whenever this is running on GKE, there is a JWKS URL given by Google and is unneeded and unsafe
+    local: true
   isForTesting: true
   auditlog:
     skipSSLValidation: true


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
A security warning (one similiar to this one https://github.tools.sap/kyma/test-infra/issues/338) advised against the binding of unsecure Groups and Users. 

In our Helm templates we use the `system:anonymous` User to retrieve the JWKS in order to verify the token created by the Kubernetes server. However, this is only needed for a local installation, whenever GKE is used, a url is provided by Google

Changes proposed in this pull request:
- ClusterRoleBinding with insecure User is only used in local installation

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- https://github.tools.sap/kyma/test-infra/issues/338

**Pull Request status**
<!-- Feel free to construct the checklist with whatever items seem most reasonable for your change. You could disassemble the Implementation part to even smaller separate checklist items if you're working on something big for example. But do make the effort to provide a checklist of some sort so that the core team as well as the community can have an idea about the progress of your Pull Request.
-->

- [x] Implementation
- [ ] Unit tests
- [ ] Integration tests
- [ ] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [ ] Mocks are regenerated, using the automated script
