### PR TITLE
Check if there are root tenants

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -171,7 +171,7 @@ global:
       name: compass-pairing-adapter
     director:
       dir: dev/incubator/
-      version: "PR-3618"
+      version: "PR-3622"
       name: compass-director
     hydrator:
       dir: dev/incubator/

--- a/components/director/internal/domain/tenant/fixtures_test.go
+++ b/components/director/internal/domain/tenant/fixtures_test.go
@@ -52,7 +52,17 @@ var (
 	tenantAccessTestTableColumns  = []string{"tenant_id", "id", "owner", "source"}
 	testTenantParentsTableColumns = []string{"tenant_id", "parent_id"}
 	testRootParents               = []*model.BusinessTenantMapping{{ID: testParentID}, {ID: testParentID2}}
-	tenantAccessInput             = graphql.TenantAccessInput{
+	tenantGAModel                 = &model.BusinessTenantMapping{
+		ID:             testInternal,
+		ExternalTenant: testExternal,
+		Type:           tenant.Account,
+	}
+	tenantFolderModel = &model.BusinessTenantMapping{
+		ID:             testInternal,
+		ExternalTenant: testExternal,
+		Type:           tenant.Folder,
+	}
+	tenantAccessInput = graphql.TenantAccessInput{
 		TenantID:     testExternal,
 		ResourceType: graphql.TenantAccessObjectTypeApplication,
 		ResourceID:   testID,
@@ -428,6 +438,6 @@ func fixDeleteTenantAccessesFromDirective() string {
 	return regexp.QuoteMeta(`
 DELETE FROM  `) + `(.+)` + regexp.QuoteMeta(` a 
 WHERE id IN ($1) AND source IN ($2, $3) AND NOT EXISTS
-		(SELECT 1 FROM tenant_applications ta WHERE ta.tenant_id = a.source AND ta.id = a.id);
+		(SELECT 1 FROM `) + `(.+)` + regexp.QuoteMeta(` ta WHERE ta.tenant_id = a.source AND ta.id = a.id);
 `)
 }

--- a/components/director/internal/domain/tenant/service.go
+++ b/components/director/internal/domain/tenant/service.go
@@ -270,17 +270,26 @@ func (s *service) DeleteTenantAccessForResourceRecursively(ctx context.Context, 
 		return errors.Wrapf(err, "while deleting tenant acccess for resource type %q with ID %q for tenant %q", string(resourceType), ta.ResourceID, ta.TenantID)
 	}
 
-	rootTenants, err := s.tenantMappingRepo.GetParentsRecursivelyByExternalTenant(ctx, tenantAccess.ExternalTenantID)
+	btm, err := s.tenantMappingRepo.GetByExternalTenant(ctx, tenantAccess.ExternalTenantID)
 	if err != nil {
 		return err
 	}
 
-	rootTenantIDs := make([]string, 0, len(rootTenants))
-	for _, rootTenant := range rootTenants {
-		rootTenantIDs = append(rootTenantIDs, rootTenant.ID)
+	if IsAtomTenant(btm.Type) {
+		rootTenants, err := s.tenantMappingRepo.GetParentsRecursivelyByExternalTenant(ctx, tenantAccess.ExternalTenantID)
+		if err != nil {
+			return err
+		}
+
+		rootTenantIDs := make([]string, 0, len(rootTenants))
+		for _, rootTenant := range rootTenants {
+			rootTenantIDs = append(rootTenantIDs, rootTenant.ID)
+		}
+
+		return repo.DeleteTenantAccessFromDirective(ctx, m2mTable, []string{tenantAccess.ResourceID}, rootTenantIDs)
 	}
 
-	return repo.DeleteTenantAccessFromDirective(ctx, m2mTable, []string{tenantAccess.ResourceID}, rootTenantIDs)
+	return nil
 }
 
 // GetTenantAccessForResource gets a tenant access record for the specified resource
@@ -623,4 +632,13 @@ func MoveBeforeIfShould(tenants []model.BusinessTenantMapping, parentTenantID, c
 		newTenants = append(newTenants, tenants[i])
 	}
 	return newTenants, true
+}
+
+// IsAtomTenant checks whether the tenant comes from atom
+func IsAtomTenant(tenantType tenantpkg.Type) bool {
+	if tenantType == tenantpkg.ResourceGroup || tenantType == tenantpkg.Folder || tenantType == tenantpkg.Organization {
+		return true
+	}
+
+	return false
 }

--- a/components/director/internal/domain/tenant/service_test.go
+++ b/components/director/internal/domain/tenant/service_test.go
@@ -1628,6 +1628,27 @@ func TestService_DeleteTenantAccessForResource(t *testing.T) {
 			Input: tenantAccessModel,
 		},
 		{
+			Name: "Success when removing tenant access for tenant without parents",
+			ConverterFn: func() *automock.BusinessTenantMappingConverter {
+				conv := &automock.BusinessTenantMappingConverter{}
+				conv.On("TenantAccessToEntity", tenantAccessModel).Return(tenantAccessEntity).Once()
+				return conv
+			},
+			TenantMappingRepoFn: func() *automock.TenantMappingRepository {
+				repo := &automock.TenantMappingRepository{}
+				repo.On("GetParentsRecursivelyByExternalTenant", mock.Anything, tenantAccessModel.ExternalTenantID).Return(nil, nil)
+				return repo
+			},
+			PersistenceFn: func() (*sqlx.DB, testdb.DBMock) {
+				db, dbMock := testdb.MockDatabase(t)
+				dbMock.ExpectExec(fixDeleteTenantAccessesQuery()).
+					WithArgs(testInternal, testInternal, testID, testID).
+					WillReturnResult(sqlmock.NewResult(1, 1))
+				return db, dbMock
+			},
+			Input: tenantAccessModel,
+		},
+		{
 			Name: "Error while deleting tenant access from directive",
 			ConverterFn: func() *automock.BusinessTenantMappingConverter {
 				conv := &automock.BusinessTenantMappingConverter{}

--- a/components/director/internal/domain/tenant/service_test.go
+++ b/components/director/internal/domain/tenant/service_test.go
@@ -1612,7 +1612,8 @@ func TestService_DeleteTenantAccessForResource(t *testing.T) {
 			},
 			TenantMappingRepoFn: func() *automock.TenantMappingRepository {
 				repo := &automock.TenantMappingRepository{}
-				repo.On("GetParentsRecursivelyByExternalTenant", mock.Anything, tenantAccessModel.ExternalTenantID).Return(testRootParents, nil)
+				repo.On("GetByExternalTenant", mock.Anything, tenantAccessModel.ExternalTenantID).Return(tenantFolderModel, nil).Once()
+				repo.On("GetParentsRecursivelyByExternalTenant", mock.Anything, tenantAccessModel.ExternalTenantID).Return(testRootParents, nil).Once()
 				return repo
 			},
 			PersistenceFn: func() (*sqlx.DB, testdb.DBMock) {
@@ -1636,7 +1637,29 @@ func TestService_DeleteTenantAccessForResource(t *testing.T) {
 			},
 			TenantMappingRepoFn: func() *automock.TenantMappingRepository {
 				repo := &automock.TenantMappingRepository{}
-				repo.On("GetParentsRecursivelyByExternalTenant", mock.Anything, tenantAccessModel.ExternalTenantID).Return(nil, nil)
+				repo.On("GetByExternalTenant", mock.Anything, tenantAccessModel.ExternalTenantID).Return(tenantFolderModel, nil).Once()
+				repo.On("GetParentsRecursivelyByExternalTenant", mock.Anything, tenantAccessModel.ExternalTenantID).Return(nil, nil).Once()
+				return repo
+			},
+			PersistenceFn: func() (*sqlx.DB, testdb.DBMock) {
+				db, dbMock := testdb.MockDatabase(t)
+				dbMock.ExpectExec(fixDeleteTenantAccessesQuery()).
+					WithArgs(testInternal, testInternal, testID, testID).
+					WillReturnResult(sqlmock.NewResult(1, 1))
+				return db, dbMock
+			},
+			Input: tenantAccessModel,
+		},
+		{
+			Name: "Success when tenant is not from atom - no directive tenant access records",
+			ConverterFn: func() *automock.BusinessTenantMappingConverter {
+				conv := &automock.BusinessTenantMappingConverter{}
+				conv.On("TenantAccessToEntity", tenantAccessModel).Return(tenantAccessEntity).Once()
+				return conv
+			},
+			TenantMappingRepoFn: func() *automock.TenantMappingRepository {
+				repo := &automock.TenantMappingRepository{}
+				repo.On("GetByExternalTenant", mock.Anything, tenantAccessModel.ExternalTenantID).Return(tenantGAModel, nil).Once()
 				return repo
 			},
 			PersistenceFn: func() (*sqlx.DB, testdb.DBMock) {
@@ -1657,7 +1680,8 @@ func TestService_DeleteTenantAccessForResource(t *testing.T) {
 			},
 			TenantMappingRepoFn: func() *automock.TenantMappingRepository {
 				repo := &automock.TenantMappingRepository{}
-				repo.On("GetParentsRecursivelyByExternalTenant", mock.Anything, tenantAccessModel.ExternalTenantID).Return(testRootParents, nil)
+				repo.On("GetByExternalTenant", mock.Anything, tenantAccessModel.ExternalTenantID).Return(tenantFolderModel, nil).Once()
+				repo.On("GetParentsRecursivelyByExternalTenant", mock.Anything, tenantAccessModel.ExternalTenantID).Return(testRootParents, nil).Once()
 				return repo
 			},
 			PersistenceFn: func() (*sqlx.DB, testdb.DBMock) {
@@ -1682,7 +1706,8 @@ func TestService_DeleteTenantAccessForResource(t *testing.T) {
 			},
 			TenantMappingRepoFn: func() *automock.TenantMappingRepository {
 				repo := &automock.TenantMappingRepository{}
-				repo.On("GetParentsRecursivelyByExternalTenant", mock.Anything, tenantAccessModel.ExternalTenantID).Return(nil, testError)
+				repo.On("GetByExternalTenant", mock.Anything, tenantAccessModel.ExternalTenantID).Return(tenantFolderModel, nil).Once()
+				repo.On("GetParentsRecursivelyByExternalTenant", mock.Anything, tenantAccessModel.ExternalTenantID).Return(nil, testError).Once()
 				return repo
 			},
 			PersistenceFn: func() (*sqlx.DB, testdb.DBMock) {

--- a/components/director/internal/repo/tenant_access_m2m.go
+++ b/components/director/internal/repo/tenant_access_m2m.go
@@ -99,7 +99,7 @@ WHERE act.%s
 FROM %s a
 WHERE %s
   AND %s
-  AND NOT EXISTS (SELECT 1 FROM tenant_applications ta WHERE ta.tenant_id = a.source AND ta.id = a.id);`
+  AND NOT EXISTS (SELECT 1 FROM %s ta WHERE ta.tenant_id = a.source AND ta.id = a.id);`
 
 	// DeleteTenantAccessGrantedByParentQuery is a delete SQL query that deletes tenant accesses based on given tenant id and source.
 	DeleteTenantAccessGrantedByParentQuery = `DELETE FROM %s WHERE tenant_id = ? AND source = ?`
@@ -240,7 +240,7 @@ func DeleteTenantAccessFromDirective(ctx context.Context, m2mTable string, resou
 		args = append(args, inArgs...)
 	}
 
-	deleteTenantAccessStmt := fmt.Sprintf(DeleteDirectiveAccess, m2mTable, inCondForResourceIDs.GetQueryPart(), inCondForRootTenantsIDs.GetQueryPart())
+	deleteTenantAccessStmt := fmt.Sprintf(DeleteDirectiveAccess, m2mTable, inCondForResourceIDs.GetQueryPart(), inCondForRootTenantsIDs.GetQueryPart(), m2mTable)
 	deleteTenantAccessStmt = sqlx.Rebind(sqlx.DOLLAR, deleteTenantAccessStmt)
 
 	log.C(ctx).Debugf("Executing DB query: %s", deleteTenantAccessStmt)

--- a/components/director/internal/repo/tenant_access_m2m.go
+++ b/components/director/internal/repo/tenant_access_m2m.go
@@ -213,6 +213,11 @@ func DeleteTenantAccessRecursively(ctx context.Context, m2mTable string, tenant 
 
 // DeleteTenantAccessFromDirective deletes all the accesses to the provided resource IDs created from the directive for which the root tenant no longer has access record
 func DeleteTenantAccessFromDirective(ctx context.Context, m2mTable string, resourceIDs, rootTenantIDs []string) error {
+	if len(rootTenantIDs) == 0 {
+		log.C(ctx).Info("There are no root tenants, nothing to delete")
+		return nil
+	}
+
 	log.C(ctx).Infof("Deleting tenant access records for %s with source in %s where the source no longer has access to the object", resourceIDs, rootTenantIDs)
 	if len(resourceIDs) == 0 {
 		return errors.New("resourceIDs cannot be empty")

--- a/components/director/pkg/applicationtenancy/directive.go
+++ b/components/director/pkg/applicationtenancy/directive.go
@@ -253,7 +253,7 @@ func (d *directive) handleNewApplicationCreation(ctx context.Context, resp inter
 
 	log.C(ctx).Debugf("Found a matching tenant in the database: %s", tntModel.ID)
 
-	if !isAtomTenant(tntModel.Type) {
+	if !tenant.IsAtomTenant(tntModel.Type) {
 		log.C(ctx).Infof("Tenant type is %s. Will not continue with tanancy synchronization", tntModel.Type)
 		return nil
 	}
@@ -265,12 +265,4 @@ func (d *directive) handleNewApplicationCreation(ctx context.Context, resp inter
 	}
 
 	return d.createTenantAccessForNewApplication(ctx, tntModel, entity.GetID())
-}
-
-func isAtomTenant(tenantType tenantpkg.Type) bool {
-	if tenantType == tenantpkg.ResourceGroup || tenantType == tenantpkg.Folder || tenantType == tenantpkg.Organization {
-		return true
-	}
-
-	return false
 }


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

When deleting tenant accesses for atom tenant there may be records created from the directive that have to be deleted. If deleting tenant access records for atom tenant  the root tenants for this tenant have to be found. Any access records whose sorce is one of those root tenants, but the root tenant itself no longer has acces over the referenced resource, should be deleted. When deleting tenant access records for non atom tenant there are no records created by the directive that should be deleted(the directive works from atom to non atom).

Changes proposed in this pull request:
- check if the tenat is from atom
- check if there are root tenant ids

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- ...

**Pull Request status**
<!-- Feel free to construct the checklist with whatever items seem most reasonable for your change. You could disassemble the Implementation part to even smaller separate checklist items if you're working on something big for example. But do make the effort to provide a checklist of some sort so that the core team as well as the community can have an idea about the progress of your Pull Request.
-->

- [x] Implementation
- [x] Unit tests
- [x] Integration tests
- [x] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [x] Mocks are regenerated, using the automated script
