### PR TITLE
Use custom SQL query for listing tenants by paretn ID and tenant Type

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -170,8 +170,8 @@ global:
       version: "v20240123-eabe5df7"
       name: compass-pairing-adapter
     director:
-      dir: prod/incubator/
-      version: "v20240130-f291ccb7"
+      dir: dev/incubator/
+      version: "PR-3647"
       name: compass-director
     hydrator:
       dir: prod/incubator/

--- a/components/director/internal/domain/tenant/repository_test.go
+++ b/components/director/internal/domain/tenant/repository_test.go
@@ -1307,11 +1307,6 @@ func TestPgRepository_ListByParentAndType(t *testing.T) {
 			DBFN: func(t *testing.T) (*sqlx.DB, testdb.DBMock) {
 				db, dbMock := testdb.MockDatabase(t)
 
-				tenantByParentRowsToReturn := fixSQLTenantParentsRows([]sqlTenantParentsRow{
-					{tenantID: testID, parentID: testParentID},
-					{tenantID: testID2, parentID: testParentID},
-				})
-
 				rowsToReturn := fixSQLRowsWithComputedValues([]sqlRowWithComputedValues{
 					{sqlRow: sqlRow{id: testID, name: "name1", externalTenant: testExternal, typeRow: string(tenantEntity.Account), provider: "Compass", status: tenantEntity.Active}, initialized: boolToPtr(true)},
 					{sqlRow: sqlRow{id: testID2, name: "name2", externalTenant: testExternal, typeRow: string(tenantEntity.Account), provider: "Compass", status: tenantEntity.Active}, initialized: boolToPtr(true)},
@@ -1326,12 +1321,8 @@ func TestPgRepository_ListByParentAndType(t *testing.T) {
 					{tenantID: testID, parentID: testParentID},
 				})
 
-				dbMock.ExpectQuery(regexp.QuoteMeta(`SELECT tenant_id, parent_id FROM tenant_parents WHERE parent_id = $1`)).
-					WithArgs(testParentID).
-					WillReturnRows(tenantByParentRowsToReturn)
-
-				dbMock.ExpectQuery(regexp.QuoteMeta(`SELECT id, external_name, external_tenant, type, provider_name, status FROM public.business_tenant_mappings WHERE id IN ($1, $2) AND type = $3`)).
-					WithArgs(testID, testID2, tenantEntity.Account).
+				dbMock.ExpectQuery(regexp.QuoteMeta(`SELECT public.business_tenant_mappings.id, public.business_tenant_mappings.external_name, public.business_tenant_mappings.external_tenant, public.business_tenant_mappings.type, public.business_tenant_mappings.provider_name, public.business_tenant_mappings.status from public.business_tenant_mappings join tenant_parents on public.business_tenant_mappings.id = tenant_parents.tenant_id where tenant_parents.parent_id = $1 and public.business_tenant_mappings.type = $2`)).
+					WithArgs(testParentID, tenantEntity.Account).
 					WillReturnRows(rowsToReturn)
 
 				dbMock.ExpectQuery(regexp.QuoteMeta(`SELECT tenant_id, parent_id FROM tenant_parents WHERE tenant_id = $1`)).
@@ -1350,87 +1341,17 @@ func TestPgRepository_ListByParentAndType(t *testing.T) {
 			},
 		},
 		{
-			Name: "Error while listing parents",
-			ConverterFn: func() *automock.Converter {
-				tntModels := []*model.BusinessTenantMapping{
-					newModelBusinessTenantMappingWithParentAndType(testID, "name1", nil, nil, tenantEntity.Account),
-					newModelBusinessTenantMappingWithParentAndType(testID2, "name2", nil, nil, tenantEntity.Account),
-				}
-
-				tntEntities := []*tenantEntity.Entity{
-					newEntityBusinessTenantMappingWithComputedValues(testID, "name1", boolToPtr(true)),
-					newEntityBusinessTenantMappingWithComputedValues(testID2, "name2", boolToPtr(true)),
-				}
-
-				mockConverter := &automock.Converter{}
-				for i := 0; i < len(tntEntities); i++ {
-					mockConverter.On("FromEntity", tntEntities[i]).Return(tntModels[i]).Once()
-				}
-				return mockConverter
-			},
+			Name: "Error while listing tenants by parent and type",
 			DBFN: func(t *testing.T) (*sqlx.DB, testdb.DBMock) {
 				db, dbMock := testdb.MockDatabase(t)
 
-				tenantByParentRowsToReturn := fixSQLTenantParentsRows([]sqlTenantParentsRow{
-					{tenantID: testID, parentID: testParentID},
-					{tenantID: testID2, parentID: testParentID},
-				})
-
-				rowsToReturn := fixSQLRowsWithComputedValues([]sqlRowWithComputedValues{
-					{sqlRow: sqlRow{id: testID, name: "name1", externalTenant: testExternal, typeRow: string(tenantEntity.Account), provider: "Compass", status: tenantEntity.Active}, initialized: boolToPtr(true)},
-					{sqlRow: sqlRow{id: testID2, name: "name2", externalTenant: testExternal, typeRow: string(tenantEntity.Account), provider: "Compass", status: tenantEntity.Active}, initialized: boolToPtr(true)},
-				})
-
-				dbMock.ExpectQuery(regexp.QuoteMeta(`SELECT tenant_id, parent_id FROM tenant_parents WHERE parent_id = $1`)).
-					WithArgs(testParentID).
-					WillReturnRows(tenantByParentRowsToReturn)
-
-				dbMock.ExpectQuery(regexp.QuoteMeta(`SELECT id, external_name, external_tenant, type, provider_name, status FROM public.business_tenant_mappings WHERE id IN ($1, $2) AND type = $3`)).
-					WithArgs(testID, testID2, tenantEntity.Account).
-					WillReturnRows(rowsToReturn)
-
-				dbMock.ExpectQuery(regexp.QuoteMeta(`SELECT tenant_id, parent_id FROM tenant_parents WHERE tenant_id = $1`)).
-					WithArgs(testID).
+				dbMock.ExpectQuery(regexp.QuoteMeta(`SELECT public.business_tenant_mappings.id, public.business_tenant_mappings.external_name, public.business_tenant_mappings.external_tenant, public.business_tenant_mappings.type, public.business_tenant_mappings.provider_name, public.business_tenant_mappings.status from public.business_tenant_mappings join tenant_parents on public.business_tenant_mappings.id = tenant_parents.tenant_id where tenant_parents.parent_id = $1 and public.business_tenant_mappings.type = $2`)).
+					WithArgs(testParentID, tenantEntity.Account).
 					WillReturnError(testError)
 
 				return db, dbMock
 			},
-			ExpectedErrorMessage: fmt.Sprintf("while listing parent tenants for tenant with ID %s", testID),
-		},
-		{
-			Name: "Error while listing tenants by id",
-			DBFN: func(t *testing.T) (*sqlx.DB, testdb.DBMock) {
-				db, dbMock := testdb.MockDatabase(t)
-
-				tenantByParentRowsToReturn := fixSQLTenantParentsRows([]sqlTenantParentsRow{
-					{tenantID: testID, parentID: testParentID},
-					{tenantID: testID2, parentID: testParentID},
-				})
-
-				dbMock.ExpectQuery(regexp.QuoteMeta(`SELECT tenant_id, parent_id FROM tenant_parents WHERE parent_id = $1`)).
-					WithArgs(testParentID).
-					WillReturnRows(tenantByParentRowsToReturn)
-
-				dbMock.ExpectQuery(regexp.QuoteMeta(`SELECT id, external_name, external_tenant, type, provider_name, status FROM public.business_tenant_mappings WHERE id IN ($1, $2) AND type = $3`)).
-					WithArgs(testID, testID2, tenantEntity.Account).
-					WillReturnError(testError)
-
-				return db, dbMock
-			},
-			ExpectedErrorMessage: fmt.Sprintf("while listing tenants of type %s with ids %v", tenantEntity.Account, []string{testID, testID2}),
-		},
-		{
-			Name: "Error while listing tenant parent records",
-			DBFN: func(t *testing.T) (*sqlx.DB, testdb.DBMock) {
-				db, dbMock := testdb.MockDatabase(t)
-
-				dbMock.ExpectQuery(regexp.QuoteMeta(`SELECT tenant_id, parent_id FROM tenant_parents WHERE parent_id = $1`)).
-					WithArgs(testParentID).
-					WillReturnError(testError)
-
-				return db, dbMock
-			},
-			ExpectedErrorMessage: fmt.Sprintf("wlile listing tenant parent records for parent with id %s", testParentID),
+			ExpectedErrorMessage: fmt.Sprintf("while listing tenants of type %s with parent ID %s", tenantEntity.Account, testParentID),
 		},
 	}
 	for _, testCase := range testCases {

--- a/components/director/internal/domain/tenantparentmapping/repository.go
+++ b/components/director/internal/domain/tenantparentmapping/repository.go
@@ -11,13 +11,16 @@ import (
 )
 
 const (
-	tenantParentsTable = "tenant_parents"
-	tenantIDColumn     = "tenant_id"
-	parentIDColumn     = "parent_id"
+	// TenantParentsTable the name of the table containing parency relations
+	TenantParentsTable = "tenant_parents"
+	// TenantIDColumn the column containing the tenant ID
+	TenantIDColumn = "tenant_id"
+	// ParentIDColumn the column containing the parent ID
+	ParentIDColumn = "parent_id"
 )
 
 var (
-	tenantParentsSelectedColumns = []string{tenantIDColumn, parentIDColumn}
+	tenantParentsSelectedColumns = []string{TenantIDColumn, ParentIDColumn}
 )
 
 // TenantParent defines tenant parent record
@@ -73,10 +76,10 @@ type TenantParentRepository interface {
 // NewRepository returns a new entity responsible for repo-layer tenant operations. All of its methods require persistence.PersistenceOp it the provided context.
 func NewRepository() *pgRepository {
 	return &pgRepository{
-		listerGlobal:   repo.NewListerGlobal(resource.TenantParent, tenantParentsTable, tenantParentsSelectedColumns),
-		creatorGlobal:  repo.NewCreatorGlobal(resource.TenantParent, tenantParentsTable, tenantParentsSelectedColumns),
-		upserterGlobal: repo.NewUpserterGlobal(resource.TenantParent, tenantParentsTable, tenantParentsSelectedColumns, tenantParentsSelectedColumns, []string{}),
-		deleterGlobal:  repo.NewDeleterGlobal(resource.TenantParent, tenantParentsTable),
+		listerGlobal:   repo.NewListerGlobal(resource.TenantParent, TenantParentsTable, tenantParentsSelectedColumns),
+		creatorGlobal:  repo.NewCreatorGlobal(resource.TenantParent, TenantParentsTable, tenantParentsSelectedColumns),
+		upserterGlobal: repo.NewUpserterGlobal(resource.TenantParent, TenantParentsTable, tenantParentsSelectedColumns, tenantParentsSelectedColumns, []string{}),
+		deleterGlobal:  repo.NewDeleterGlobal(resource.TenantParent, TenantParentsTable),
 	}
 }
 
@@ -84,11 +87,11 @@ func NewRepository() *pgRepository {
 func (r *pgRepository) ListParents(ctx context.Context, tenantID string) ([]string, error) {
 	tenantParents := TenantParentCollection{}
 	conditions := repo.Conditions{
-		repo.NewEqualCondition(tenantIDColumn, tenantID),
+		repo.NewEqualCondition(TenantIDColumn, tenantID),
 	}
 
 	if err := r.listerGlobal.ListGlobal(ctx, &tenantParents, conditions...); err != nil {
-		log.C(ctx).Error(persistence.MapSQLError(ctx, err, resource.TenantParent, resource.List, "while listing tenant parent records from '%s' table", tenantParentsTable))
+		log.C(ctx).Error(persistence.MapSQLError(ctx, err, resource.TenantParent, resource.List, "while listing tenant parent records from '%s' table", TenantParentsTable))
 		return nil, err
 	}
 
@@ -99,7 +102,7 @@ func (r *pgRepository) ListParents(ctx context.Context, tenantID string) ([]stri
 func (r *pgRepository) ListByParent(ctx context.Context, parentID string) ([]string, error) {
 	tenantParents := TenantParentCollection{}
 	conditions := repo.Conditions{
-		repo.NewEqualCondition(parentIDColumn, parentID),
+		repo.NewEqualCondition(ParentIDColumn, parentID),
 	}
 
 	if err := r.listerGlobal.ListGlobal(ctx, &tenantParents, conditions...); err != nil {
@@ -134,8 +137,8 @@ func (r *pgRepository) UpsertMultiple(ctx context.Context, tenantID string, pare
 // Delete deletes the tenant parent mapping for tenantID and parentID
 func (r *pgRepository) Delete(ctx context.Context, tenantID string, parentID string) error {
 	if err := r.deleterGlobal.DeleteOneGlobal(ctx, repo.Conditions{
-		repo.NewEqualCondition(tenantIDColumn, tenantID),
-		repo.NewEqualCondition(parentIDColumn, parentID),
+		repo.NewEqualCondition(TenantIDColumn, tenantID),
+		repo.NewEqualCondition(ParentIDColumn, parentID),
 	}); err != nil {
 		log.C(ctx).Error(persistence.MapSQLError(ctx, err, resource.TenantParent, resource.Create, "while deleting tenant parent mapping for tenant with id %s and parent %s", tenantID, parentID))
 		return err


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

When listing tenants by parent ID and tenant Type we first list the IDs of all child tenants for `parent_id` and then filter them by type. The child tenant IDs fetched by the firs query are used in a IN clause in the second one. If the child tenant IDs are more than the maximum arguments count supported by SQL(~65 000) an error is returned.

Changes proposed in this pull request:
- Use custom SQL query joining the tenant_parents and business_tenant_mapping tables.

**Pull Request status**
<!-- Feel free to construct the checklist with whatever items seem most reasonable for your change. You could disassemble the Implementation part to even smaller separate checklist items if you're working on something big for example. But do make the effort to provide a checklist of some sort so that the core team as well as the community can have an idea about the progress of your Pull Request.
-->

- [X] Implementation
- [X] Unit tests
- [X] Integration tests
- [X] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [X] Mocks are regenerated, using the automated script
