### PR TITLE
Add indexes to operation table

### DIFF
--- a/components/schema-migrator/migrations/director/20240219121933_index-on-operations.down.sql
+++ b/components/schema-migrator/migrations/director/20240219121933_index-on-operations.down.sql
@@ -1,0 +1,8 @@
+BEGIN;
+
+DROP INDEX IF EXISTS operations_on_updated_at;
+DROP INDEX IF EXISTS operations_on_status;
+DROP INDEX IF EXISTS operations_on_priority;
+DROP INDEX IF EXISTS operations_on_op_type;
+
+COMMIT;

--- a/components/schema-migrator/migrations/director/20240219121933_index-on-operations.up.sql
+++ b/components/schema-migrator/migrations/director/20240219121933_index-on-operations.up.sql
@@ -1,0 +1,8 @@
+BEGIN;
+
+CREATE INDEX  operations_on_op_type ON operations (op_type);
+CREATE INDEX  operations_on_priority ON operations (priority DESC);
+CREATE INDEX  operations_on_status ON operations (status);
+CREATE INDEX  operations_on_updated_at ON operations (updated_at);
+
+COMMIT;


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:
- Add indexes to operation table

**Related issue(s)**
- Claiming an operation is called almost every second (actually 20 times per 5 seconds) and currently takes about 230ms to execute. Having those indexes is expected to speedup the query execution.

**Pull Request status**
- [x] Implementation
- [ ] Unit tests
- [ ] Integration tests
- [ ] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [ ] Mocks are regenerated, using the automated script
