### PR TITLE
Handle empty config in instance creator asynchronous flow control operator

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -174,7 +174,7 @@ global:
       name: compass-pairing-adapter
     director:
       dir: dev/incubator/
-      version: "PR-3659"
+      version: "PR-3667"
       name: compass-director
     hydrator:
       dir: dev/incubator/

--- a/components/director/internal/domain/formationconstraint/operators/asynchronous_flow_control_operator.go
+++ b/components/director/internal/domain/formationconstraint/operators/asynchronous_flow_control_operator.go
@@ -70,7 +70,7 @@ func (e *ConstraintEngine) AsynchronousFlowControlOperator(ctx context.Context, 
 			return false, err
 		}
 		if ri.Operation == model.AssignFormation {
-			if statusReport.State == string(model.ReadyAssignmentState) {
+			if statusReport.State == string(model.ReadyAssignmentState) && !isNotificationStatusReportConfigEmpty(statusReport) {
 				var assignmentConfig Configuration
 				if err = json.Unmarshal(statusReport.Configuration, &assignmentConfig); err != nil {
 					return false, errors.Wrapf(err, "while unmarshalling tenant mapping response configuration for assignment with ID: %q", formationAssignment.ID)

--- a/components/director/internal/domain/formationconstraint/operators/asynchronous_flow_control_operator_test.go
+++ b/components/director/internal/domain/formationconstraint/operators/asynchronous_flow_control_operator_test.go
@@ -87,7 +87,7 @@ func TestConstraintOperators_AsynchronousFlowControlOperator(t *testing.T) {
 		},
 		// Assign during PreStatusReturned
 		{
-			Name:                             "Success when transitioning to READY state with inbound credentials",
+			Name:                             "Error when formation assignment config is invalid",
 			Input:                            inputForNotificationStatusReturnedAssign,
 			Assignment:                       fixFormationAssignmentWithState(model.InitialAssignmentState),
 			ReverseAssignment:                fixFormationAssignmentWithState(model.InitialAssignmentState),
@@ -95,6 +95,16 @@ func TestConstraintOperators_AsynchronousFlowControlOperator(t *testing.T) {
 			StatusReport:                     fixNotificationStatusReportWithStateAndConfig(string(model.ReadyAssignmentState), invalidFAConfig),
 			ExpectedStatusReportState:        string(model.ConfigPendingAssignmentState),
 			ExpectedErrorMsg:                 "while unmarshalling tenant mapping response configuration for assignment with ID:",
+		},
+		{
+			Name:                             "Success when transitioning to READY state with no configuration",
+			Input:                            inputForNotificationStatusReturnedAssign,
+			Assignment:                       fixFormationAssignmentWithState(model.InitialAssignmentState),
+			ReverseAssignment:                fixFormationAssignmentWithState(model.InitialAssignmentState),
+			ExpectedFormationAssignmentState: string(model.InitialAssignmentState),
+			StatusReport:                     fixNotificationStatusReportWithStateAndConfig(string(model.ReadyAssignmentState), emptyConfig),
+			ExpectedStatusReportState:        string(model.ReadyAssignmentState),
+			ExpectedResult:                   true,
 		},
 		{
 			Name:                             "Success when transitioning to READY state with inbound credentials",

--- a/components/director/internal/domain/formationconstraint/operators/destination_creator_operator.go
+++ b/components/director/internal/domain/formationconstraint/operators/destination_creator_operator.go
@@ -227,18 +227,6 @@ func (e *ConstraintEngine) DestinationCreator(ctx context.Context, input Operato
 	return true, nil
 }
 
-func isConfigEmpty(config string) bool {
-	return config == "" || config == "{}" || config == "\"\"" || config == "null"
-}
-
-func isFormationAssignmentConfigEmpty(assignment *model.FormationAssignment) bool {
-	return assignment != nil && isConfigEmpty(string(assignment.Value))
-}
-
-func isNotificationStatusReportConfigEmpty(notificationStatusReport *statusreport.NotificationStatusReport) bool {
-	return notificationStatusReport != nil && isConfigEmpty(string(notificationStatusReport.Configuration))
-}
-
 // Destination Creator Operator types
 
 // Configuration represents a formation assignment (or reverse formation assignment) configuration

--- a/components/director/internal/domain/formationconstraint/operators/fixtures_test.go
+++ b/components/director/internal/domain/formationconstraint/operators/fixtures_test.go
@@ -117,6 +117,7 @@ var (
 
 // Destination Creator variables
 var (
+	emptyConfig                  = json.RawMessage("{}")
 	invalidFAConfig              = json.RawMessage("invalid-Destination-config")
 	configWithDifferentStructure = json.RawMessage(testJSONConfig)
 	destsConfigValueRawJSON      = json.RawMessage(

--- a/components/director/internal/domain/formationconstraint/operators/utils.go
+++ b/components/director/internal/domain/formationconstraint/operators/utils.go
@@ -18,6 +18,18 @@ import (
 // reqBodyNameRegex is a regex defined by the destination creator API specifying what destination names are allowed
 var reqBodyNameRegex = "[a-zA-Z0-9_-]{1,64}"
 
+func isConfigEmpty(config string) bool {
+	return config == "" || config == "{}" || config == "\"\"" || config == "null"
+}
+
+func isFormationAssignmentConfigEmpty(assignment *model.FormationAssignment) bool {
+	return assignment != nil && isConfigEmpty(string(assignment.Value))
+}
+
+func isNotificationStatusReportConfigEmpty(notificationStatusReport *statusreport.NotificationStatusReport) bool {
+	return notificationStatusReport != nil && isConfigEmpty(string(notificationStatusReport.Configuration))
+}
+
 // RetrieveFormationAssignmentPointer converts the provided memory address in form of an integer back to the model.FormationAssignment pointer structure
 // It's important the provided memory address to stores information about model.FormationAssignment entity, otherwise the result could be very abnormal
 func RetrieveFormationAssignmentPointer(ctx context.Context, joinPointDetailsAssignmentMemoryAddress uintptr) (*model.FormationAssignment, error) {


### PR DESCRIPTION
**Description**
Currently when there is no configuration in the flow control operator, it throws an error while unmarshallling.

Changes proposed in this pull request:
- only Unmarshal configuration when it is not empty

**Related issue(s)**
- #3531

**Pull Request status**
<!-- Feel free to construct the checklist with whatever items seem most reasonable for your change. You could disassemble the Implementation part to even smaller separate checklist items if you're working on something big for example. But do make the effort to provide a checklist of some sort so that the core team as well as the community can have an idea about the progress of your Pull Request.
-->

- [x] Implementation
- [x] Unit tests
- [x] [N/A] Integration tests
- [x] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [x] [N/A] Mocks are regenerated, using the automated script
