### PR TITLE
Extend error checks

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -174,7 +174,7 @@ global:
       name: compass-pairing-adapter
     director:
       dir: dev/incubator/
-      version: "PR-3667"
+      version: "PR-3672"
       name: compass-director
     hydrator:
       dir: dev/incubator/

--- a/components/director/internal/domain/formation/fixtures_test.go
+++ b/components/director/internal/domain/formation/fixtures_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/kyma-incubator/compass/components/director/pkg/resource"
+
 	dataloader "github.com/kyma-incubator/compass/components/director/internal/dataloaders"
 	"github.com/kyma-incubator/compass/components/director/pkg/apperrors"
 
@@ -115,6 +117,7 @@ var (
 	emptyCtx          = context.Background()
 	testErr           = errors.New("Test error")
 	unauthorizedError = apperrors.NewUnauthorizedError(apperrors.ShouldBeOwnerMsg)
+	notFoundError     = apperrors.NewNotFoundError(resource.FormationAssignment, FormationAssignmentID)
 
 	formationModelWithoutError = fixFormationModelWithoutError()
 	modelFormation             = model.Formation{

--- a/components/director/internal/domain/formation/notifications.go
+++ b/components/director/internal/domain/formation/notifications.go
@@ -258,25 +258,25 @@ func (ns *notificationsService) updateLastNotificationSentTimestamp(ctx context.
 	if fa == nil && f != nil {
 		log.C(ctx).Infof("Updating the last notification sent timestamp for formation with ID: %s", f.ID)
 		f.SetLastNotificationSentTimestamp(time.Now())
-		if updateErr := ns.formationRepo.Update(ctx, f); updateErr != nil {
-			if webhookNotificationReq.GetOperation() == model.DeleteFormation && apperrors.IsUnauthorizedError(updateErr) { // the not found error is disguised behind the unauthorized error
+		if err := ns.formationRepo.Update(ctx, f); err != nil {
+			if webhookNotificationReq.GetOperation() == model.DeleteFormation && (apperrors.IsNotFoundError(err) || apperrors.IsUnauthorizedError(err)) { // the not found error is disguised behind the unauthorized error in case of update
 				return nil
 			}
-			return errors.Wrapf(updateErr, "while updating last notification sent timestamp for formation with ID: %s", f.ID)
+			return errors.Wrapf(err, "while updating last notification sent timestamp for formation with ID: %s", f.ID)
 		}
 	}
 
 	if fa != nil {
 		log.C(ctx).Infof("Updating the last notification sent timestamp for formation assignment with ID: %s", fa.ID)
 		fa.SetLastNotificationSentTimestamp(time.Now())
-		if updateErr := ns.formationAssignmentRepo.Update(ctx, fa); updateErr != nil {
+		if err := ns.formationAssignmentRepo.Update(ctx, fa); err != nil {
 			// That covers the case when we send two unassign notifications to one participant
 			// and the response of the first notification is returned and processed, which deletes the formation assignment,
 			// while the second notification still hasn't been sent.
-			if webhookNotificationReq.GetOperation() == model.UnassignFormation && apperrors.IsUnauthorizedError(updateErr) { // the not found error is disguised behind the unauthorized error
+			if webhookNotificationReq.GetOperation() == model.UnassignFormation && (apperrors.IsNotFoundError(err) || apperrors.IsUnauthorizedError(err)) { // the not found error is disguised behind the unauthorized error in case of update
 				return nil
 			}
-			return errors.Wrapf(updateErr, "while updating last notification sent timestamp for formation assignment with ID: %s", fa.ID)
+			return errors.Wrapf(err, "while updating last notification sent timestamp for formation assignment with ID: %s", fa.ID)
 		}
 	}
 

--- a/components/director/internal/domain/formation/notifications_test.go
+++ b/components/director/internal/domain/formation/notifications_test.go
@@ -829,6 +829,26 @@ func Test_NotificationsService_SendNotification(t *testing.T) {
 			WebhookRequest: faRequestExtWithUnassignOperation,
 		},
 		{
+			Name: "Success when updating formation assignment last notification sent timestamp and not found error is returned",
+			WebhookClientFN: func() *automock.WebhookClient {
+				client := &automock.WebhookClient{}
+				client.On("Do", ctx, faRequestExtWithUnassignOperation).Return(nil, nil)
+				return client
+			},
+			ConstraintEngine: func() *automock.ConstraintEngine {
+				engine := &automock.ConstraintEngine{}
+				engine.On("EnforceConstraints", ctx, formationconstraint.PreSendNotification, preSendNotificationJoinPointDetailsForAssignmentWithUnassignOperation, FormationTemplateID).Return(nil).Once()
+				engine.On("EnforceConstraints", ctx, formationconstraint.PostSendNotification, postSendNotificationJoinPointDetailsForAssignmentWithUnassignOperation, FormationTemplateID).Return(nil).Once()
+				return engine
+			},
+			FormationAssignmentRepo: func() *automock.FormationAssignmentRepository {
+				faRepo := &automock.FormationAssignmentRepository{}
+				faRepo.On("Update", ctx, fa).Return(notFoundError).Once()
+				return faRepo
+			},
+			WebhookRequest: faRequestExtWithUnassignOperation,
+		},
+		{
 			Name: "Error when updating formation last notification sent timestamp fail",
 			WebhookClientFN: func() *automock.WebhookClient {
 				client := &automock.WebhookClient{}
@@ -864,6 +884,26 @@ func Test_NotificationsService_SendNotification(t *testing.T) {
 			FormationRepo: func() *automock.FormationRepository {
 				formationRepo := &automock.FormationRepository{}
 				formationRepo.On("Update", ctx, formationModel).Return(unauthorizedError).Once()
+				return formationRepo
+			},
+			WebhookRequest: deleteFormationRequestExt,
+		},
+		{
+			Name: "Success when updating formation last notification sent timestamp and not found error is returned",
+			WebhookClientFN: func() *automock.WebhookClient {
+				client := &automock.WebhookClient{}
+				client.On("Do", ctx, deleteFormationRequestExt).Return(nil, nil)
+				return client
+			},
+			ConstraintEngine: func() *automock.ConstraintEngine {
+				engine := &automock.ConstraintEngine{}
+				engine.On("EnforceConstraints", ctx, formationconstraint.PreSendNotification, preSendNotificationJoinPointDetailsForDeleteFormation, FormationTemplateID).Return(nil).Once()
+				engine.On("EnforceConstraints", ctx, formationconstraint.PostSendNotification, postSendNotificationJoinPointDetailsForDeleteFormation, FormationTemplateID).Return(nil).Once()
+				return engine
+			},
+			FormationRepo: func() *automock.FormationRepository {
+				formationRepo := &automock.FormationRepository{}
+				formationRepo.On("Update", ctx, formationModel).Return(notFoundError).Once()
 				return formationRepo
 			},
 			WebhookRequest: deleteFormationRequestExt,

--- a/components/director/internal/domain/formation/service.go
+++ b/components/director/internal/domain/formation/service.go
@@ -1529,7 +1529,7 @@ func (s *service) SetFormationToErrorState(ctx context.Context, formation *model
 	formation.Error = marshaledErr
 
 	if err := s.formationRepository.Update(ctx, formation); err != nil {
-		if state == model.DeleteErrorFormationState && apperrors.IsNotFoundError(err) && apperrors.IsUnauthorizedError(err) { // the not found error is disguised behind the unauthorized error in case of update
+		if state == model.DeleteErrorFormationState && (apperrors.IsNotFoundError(err) || apperrors.IsUnauthorizedError(err)) { // the not found error is disguised behind the unauthorized error in case of update
 			return nil
 		}
 		return err
@@ -1874,7 +1874,7 @@ func (s *service) processFormationNotifications(ctx context.Context, formation *
 		}
 		log.C(ctx).Infof("Updating formation with ID: %q and name: %q to: %q state and waiting for the receiver to report the status on the status API...", formation.ID, formation.Name, formation.State)
 		if err = s.formationRepository.Update(ctx, formation); err != nil {
-			if errorState == model.DeleteErrorFormationState && apperrors.IsNotFoundError(err) && apperrors.IsUnauthorizedError(err) { // the not found error is disguised behind the unauthorized error in case of update
+			if errorState == model.DeleteErrorFormationState && (apperrors.IsNotFoundError(err) || apperrors.IsUnauthorizedError(err)) { // the not found error is disguised behind the unauthorized error in case of update
 				return nil
 			}
 

--- a/components/director/internal/domain/formation/service.go
+++ b/components/director/internal/domain/formation/service.go
@@ -1529,7 +1529,7 @@ func (s *service) SetFormationToErrorState(ctx context.Context, formation *model
 	formation.Error = marshaledErr
 
 	if err := s.formationRepository.Update(ctx, formation); err != nil {
-		if state == model.DeleteErrorFormationState && apperrors.IsUnauthorizedError(err) { // the not found error is disguised behind the unauthorized error
+		if state == model.DeleteErrorFormationState && apperrors.IsNotFoundError(err) && apperrors.IsUnauthorizedError(err) { // the not found error is disguised behind the unauthorized error in case of update
 			return nil
 		}
 		return err
@@ -1874,7 +1874,7 @@ func (s *service) processFormationNotifications(ctx context.Context, formation *
 		}
 		log.C(ctx).Infof("Updating formation with ID: %q and name: %q to: %q state and waiting for the receiver to report the status on the status API...", formation.ID, formation.Name, formation.State)
 		if err = s.formationRepository.Update(ctx, formation); err != nil {
-			if errorState == model.DeleteErrorFormationState && apperrors.IsUnauthorizedError(err) { // the not found error is disguised behind the unauthorized error
+			if errorState == model.DeleteErrorFormationState && apperrors.IsNotFoundError(err) && apperrors.IsUnauthorizedError(err) { // the not found error is disguised behind the unauthorized error in case of update
 				return nil
 			}
 

--- a/components/director/internal/domain/formation/status_service.go
+++ b/components/director/internal/domain/formation/status_service.go
@@ -47,7 +47,7 @@ func (s *formationStatusService) UpdateWithConstraints(ctx context.Context, form
 	}
 
 	if err := s.formationRepository.Update(ctx, formation); err != nil {
-		if operation == model.DeleteFormation && apperrors.IsUnauthorizedError(err) { // the not found error is disguised behind the unauthorized error
+		if operation == model.DeleteFormation && apperrors.IsNotFoundError(err) && apperrors.IsUnauthorizedError(err) { // the not found error is disguised behind the unauthorized error in case of update
 			return nil
 		}
 		log.C(ctx).Errorf("An error occurred while updating formation with ID: %q", formation.ID)

--- a/components/director/internal/domain/formation/status_service.go
+++ b/components/director/internal/domain/formation/status_service.go
@@ -47,7 +47,7 @@ func (s *formationStatusService) UpdateWithConstraints(ctx context.Context, form
 	}
 
 	if err := s.formationRepository.Update(ctx, formation); err != nil {
-		if operation == model.DeleteFormation && apperrors.IsNotFoundError(err) && apperrors.IsUnauthorizedError(err) { // the not found error is disguised behind the unauthorized error in case of update
+		if operation == model.DeleteFormation && (apperrors.IsNotFoundError(err) || apperrors.IsUnauthorizedError(err)) { // the not found error is disguised behind the unauthorized error in case of update
 			return nil
 		}
 		log.C(ctx).Errorf("An error occurred while updating formation with ID: %q", formation.ID)


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
In the linked PR below we suppress not found error disguised as unauthorized error in case of update. However, during update operations we also execute get operation(s) which return not found error that we miss to handle.

Changes proposed in this pull request:
- Ignore not found error when updating formation/formation assignment entity and not found error is received

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- https://github.com/kyma-incubator/compass/pull/3643

**Pull Request status**
<!-- Feel free to construct the checklist with whatever items seem most reasonable for your change. You could disassemble the Implementation part to even smaller separate checklist items if you're working on something big for example. But do make the effort to provide a checklist of some sort so that the core team as well as the community can have an idea about the progress of your Pull Request.
-->

- [x] Implementation
- [x] Unit tests
- [ ] Integration tests
- [x] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [ ] Mocks are regenerated, using the automated script
