### PR TITLE
Use correct tenant for calling subscription API in System Field Discovery Engine flow

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -174,7 +174,7 @@ global:
       name: compass-pairing-adapter
     director:
       dir: dev/incubator/
-      version: "PR-3693"
+      version: "PR-3696"
       name: compass-director
     hydrator:
       dir: dev/incubator/

--- a/components/director/internal/domain/subscription/service.go
+++ b/components/director/internal/domain/subscription/service.go
@@ -505,7 +505,7 @@ func (s *service) createApplicationFromTemplate(ctx context.Context, appTemplate
 			if !ok {
 				log.C(ctx).Infof("%s label for Application Template with ID %s is not a boolean", webhookprocessor.SystemFieldDiscoveryLabelKey, appTemplate.ID)
 			} else {
-				appCreateInputModel.Webhooks, systemFieldDiscoveryLabelIsTrue = s.systemFieldDiscoveryEngine.EnrichApplicationWebhookIfNeeded(ctx, appCreateInputModel, systemFieldDiscoveryValue, region, subscribedSubaccountID, appTemplate.Name, subscribedAppName)
+				appCreateInputModel.Webhooks, systemFieldDiscoveryLabelIsTrue = s.systemFieldDiscoveryEngine.EnrichApplicationWebhookIfNeeded(ctx, appCreateInputModel, systemFieldDiscoveryValue, region, consumerTenantID, appTemplate.Name, subscribedAppName)
 			}
 		}
 	}

--- a/components/director/internal/domain/subscription/service_test.go
+++ b/components/director/internal/domain/subscription/service_test.go
@@ -1266,7 +1266,7 @@ func TestSubscribeTenantToApplication(t *testing.T) {
 				newWebhooks := modelAppCreateInputWithLabels.Webhooks
 				newWebhooks = append(newWebhooks, &model.WebhookInput{
 					Type: model.WebhookTypeSystemFieldDiscovery})
-				systemFieldDiscoveryEngine.On("EnrichApplicationWebhookIfNeeded", ctxWithTenantMatcher(subaccountTenantInternalID), modelAppCreateInputWithLabels, systemFieldDiscoveryLabelIsTrue, tenantRegionWithPrefix, subaccountTenantExtID, modelAppTemplate.Name, subscriptionAppName).Return(newWebhooks, true).Once()
+				systemFieldDiscoveryEngine.On("EnrichApplicationWebhookIfNeeded", ctxWithTenantMatcher(subaccountTenantInternalID), modelAppCreateInputWithLabels, systemFieldDiscoveryLabelIsTrue, tenantRegionWithPrefix, consumerTenantID, modelAppTemplate.Name, subscriptionAppName).Return(newWebhooks, true).Once()
 				systemFieldDiscoveryEngine.On("CreateLabelForApplicationWebhook", ctxWithTenantMatcher(subaccountTenantInternalID), appTmplID).Return(nil).Once()
 
 				return systemFieldDiscoveryEngine
@@ -1316,7 +1316,7 @@ func TestSubscribeTenantToApplication(t *testing.T) {
 				newWebhooks := modelAppCreateInputWithLabels.Webhooks
 				newWebhooks = append(newWebhooks, &model.WebhookInput{
 					Type: model.WebhookTypeSystemFieldDiscovery})
-				systemFieldDiscoveryEngine.On("EnrichApplicationWebhookIfNeeded", ctxWithTenantMatcher(subaccountTenantInternalID), modelAppCreateInputWithLabels, systemFieldDiscoveryLabelIsTrue, tenantRegionWithPrefix, subaccountTenantExtID, modelAppTemplate.Name, subscriptionAppName).Return(newWebhooks, true).Once()
+				systemFieldDiscoveryEngine.On("EnrichApplicationWebhookIfNeeded", ctxWithTenantMatcher(subaccountTenantInternalID), modelAppCreateInputWithLabels, systemFieldDiscoveryLabelIsTrue, tenantRegionWithPrefix, consumerTenantID, modelAppTemplate.Name, subscriptionAppName).Return(newWebhooks, true).Once()
 				systemFieldDiscoveryEngine.On("CreateLabelForApplicationWebhook", ctxWithTenantMatcher(subaccountTenantInternalID), appTmplID).Return(nil).Once()
 
 				return systemFieldDiscoveryEngine
@@ -1574,7 +1574,7 @@ func TestSubscribeTenantToApplication(t *testing.T) {
 				newWebhooks := modelAppCreateInputWithLabels.Webhooks
 				newWebhooks = append(newWebhooks, &model.WebhookInput{
 					Type: model.WebhookTypeSystemFieldDiscovery})
-				systemFieldDiscoveryEngine.On("EnrichApplicationWebhookIfNeeded", ctxWithTenantMatcher(subaccountTenantInternalID), modelAppCreateInputWithLabels, systemFieldDiscoveryLabelIsTrue, tenantRegionWithPrefix, subaccountTenantExtID, modelAppTemplate.Name, subscriptionAppName).Return(newWebhooks, true).Once()
+				systemFieldDiscoveryEngine.On("EnrichApplicationWebhookIfNeeded", ctxWithTenantMatcher(subaccountTenantInternalID), modelAppCreateInputWithLabels, systemFieldDiscoveryLabelIsTrue, tenantRegionWithPrefix, consumerTenantID, modelAppTemplate.Name, subscriptionAppName).Return(newWebhooks, true).Once()
 				systemFieldDiscoveryEngine.On("CreateLabelForApplicationWebhook", ctxWithTenantMatcher(subaccountTenantInternalID), appTmplID).Return(nil).Once()
 
 				return systemFieldDiscoveryEngine
@@ -1839,7 +1839,7 @@ func TestSubscribeTenantToApplication(t *testing.T) {
 				newWebhooks := modelAppCreateInputWithLabels.Webhooks
 				newWebhooks = append(newWebhooks, &model.WebhookInput{
 					Type: model.WebhookTypeSystemFieldDiscovery})
-				systemFieldDiscoveryEngine.On("EnrichApplicationWebhookIfNeeded", ctxWithTenantMatcher(subaccountTenantInternalID), modelAppCreateInputWithLabels, systemFieldDiscoveryLabelIsTrue, tenantRegionWithPrefix, subaccountTenantExtID, modelAppTemplate.Name, subscriptionAppName).Return(newWebhooks, true).Once()
+				systemFieldDiscoveryEngine.On("EnrichApplicationWebhookIfNeeded", ctxWithTenantMatcher(subaccountTenantInternalID), modelAppCreateInputWithLabels, systemFieldDiscoveryLabelIsTrue, tenantRegionWithPrefix, consumerTenantID, modelAppTemplate.Name, subscriptionAppName).Return(newWebhooks, true).Once()
 				systemFieldDiscoveryEngine.AssertNotCalled(t, "CreateLabelForApplicationWebhook")
 
 				return systemFieldDiscoveryEngine
@@ -1894,7 +1894,7 @@ func TestSubscribeTenantToApplication(t *testing.T) {
 				newWebhooks := modelAppCreateInputWithLabels.Webhooks
 				newWebhooks = append(newWebhooks, &model.WebhookInput{
 					Type: model.WebhookTypeSystemFieldDiscovery})
-				systemFieldDiscoveryEngine.On("EnrichApplicationWebhookIfNeeded", ctxWithTenantMatcher(subaccountTenantInternalID), modelAppCreateInputWithLabels, systemFieldDiscoveryLabelIsTrue, tenantRegionWithPrefix, subaccountTenantExtID, modelAppTemplate.Name, subscriptionAppName).Return(newWebhooks, true).Once()
+				systemFieldDiscoveryEngine.On("EnrichApplicationWebhookIfNeeded", ctxWithTenantMatcher(subaccountTenantInternalID), modelAppCreateInputWithLabels, systemFieldDiscoveryLabelIsTrue, tenantRegionWithPrefix, consumerTenantID, modelAppTemplate.Name, subscriptionAppName).Return(newWebhooks, true).Once()
 				systemFieldDiscoveryEngine.On("CreateLabelForApplicationWebhook", ctxWithTenantMatcher(subaccountTenantInternalID), appTmplID).Return(testError).Once()
 
 				return systemFieldDiscoveryEngine

--- a/components/director/internal/system-field-discovery-engine/system_field_discovery_engine.go
+++ b/components/director/internal/system-field-discovery-engine/system_field_discovery_engine.go
@@ -54,7 +54,7 @@ func NewSystemFieldDiscoveryEngine(cfg config.SystemFieldDiscoveryEngineConfig, 
 }
 
 // EnrichApplicationWebhookIfNeeded enriches application webhook input with webhook of type 'SYSTEM_FIELD_DISCOVERY' if needed
-func (s *systemFieldDiscoveryEngine) EnrichApplicationWebhookIfNeeded(ctx context.Context, appCreateInputModel model.ApplicationRegisterInput, systemFieldDiscovery bool, region, subaccountID, appTemplateName, appName string) ([]*model.WebhookInput, bool) {
+func (s *systemFieldDiscoveryEngine) EnrichApplicationWebhookIfNeeded(ctx context.Context, appCreateInputModel model.ApplicationRegisterInput, systemFieldDiscovery bool, region, tenantID, appTemplateName, appName string) ([]*model.WebhookInput, bool) {
 	if _, regionExists := s.cfg.RegionToSaasRegConfig[region]; !regionExists {
 		log.C(ctx).Warnf("Region %q is not present into the saas reg configuration for application with name %q", region, appName)
 		return appCreateInputModel.Webhooks, false
@@ -62,7 +62,7 @@ func (s *systemFieldDiscoveryEngine) EnrichApplicationWebhookIfNeeded(ctx contex
 
 	if systemFieldDiscovery {
 		log.C(ctx).Infof("Application Template with name %q has label systemFieldDiscovery with value %t and region %q is present into the configuration. Enriching the application with name %q with webhook of type %q", appTemplateName, systemFieldDiscovery, region, appName, model.WebhookTypeSystemFieldDiscovery)
-		appCreateInputModel.Webhooks = s.enrichWithWebhook(appCreateInputModel.Webhooks, region, subaccountID)
+		appCreateInputModel.Webhooks = s.enrichWithWebhook(appCreateInputModel.Webhooks, region, tenantID)
 		log.C(ctx).Infof("Successfully enriched Application with name %q with webhook of type %q", appName, model.WebhookTypeSystemFieldDiscovery)
 	}
 
@@ -95,10 +95,10 @@ func (s *systemFieldDiscoveryEngine) CreateLabelForApplicationWebhook(ctx contex
 	return nil
 }
 
-func (s *systemFieldDiscoveryEngine) enrichWithWebhook(modelInputWebhooks []*model.WebhookInput, region, subaccountID string) []*model.WebhookInput {
+func (s *systemFieldDiscoveryEngine) enrichWithWebhook(modelInputWebhooks []*model.WebhookInput, region, tenantID string) []*model.WebhookInput {
 	modelInputWebhooks = append(modelInputWebhooks, &model.WebhookInput{
 		Type: model.WebhookTypeSystemFieldDiscovery,
-		URL:  str.Ptr(fmt.Sprintf("%s/saas-manager/v1/service/subscriptions?includeIndirectSubscriptions=true&tenantId=%s", s.cfg.RegionToSaasRegConfig[region].SaasRegistryURL, subaccountID)),
+		URL:  str.Ptr(fmt.Sprintf("%s/saas-manager/v1/service/subscriptions?includeIndirectSubscriptions=true&tenantId=%s", s.cfg.RegionToSaasRegConfig[region].SaasRegistryURL, tenantID)),
 		Auth: &model.AuthInput{
 			Credential: &model.CredentialDataInput{
 				Oauth: &model.OAuthCredentialDataInput{


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Consumer subaccount ID should be used instead of subaccount ID property for calling subscriptions API.
In most cases the properties match,  but there are corner cases in which they are not the same and the proper one which to be used must be the consumer tenant ID.

Changes proposed in this pull request:
- Change the tenant ID which is passed.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- ...

**Pull Request status**
<!-- Feel free to construct the checklist with whatever items seem most reasonable for your change. You could disassemble the Implementation part to even smaller separate checklist items if you're working on something big for example. But do make the effort to provide a checklist of some sort so that the core team as well as the community can have an idea about the progress of your Pull Request.
-->

- [x] Implementation
- [x] Unit tests
- [ ] Integration tests
- [x] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [ ] Mocks are regenerated, using the automated script
