### PR TITLE
Adjust System Field Discovery Engine e2e test to work and for real env

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -231,7 +231,7 @@ global:
       name: compass-console
     e2e_tests:
       dir: dev/incubator/
-      version: "PR-3700"
+      version: "PR-3729"
       name: compass-e2e-tests
   isLocalEnv: false
   isForTesting: false

--- a/tests/director/tests/application/application_templates_subscription_test.go
+++ b/tests/director/tests/application/application_templates_subscription_test.go
@@ -538,14 +538,14 @@ func TestSubscriptionApplicationTemplateFlowWithSystemFieldDiscoveryLabel(baseT 
 					return false
 				}
 
-				if appPageExt.Data[0].BaseURL != nil && appPageExt.Data[0].Ready == true {
-					t.Log("application webhook was executed. Base URL was updated successfully. Application ready state was set to true.")
+				if appPageExt.Data[0].BaseURL != nil {
+					t.Log("application webhook was executed and base URL was updated successfully")
 					return true
 				}
 
-				t.Log("application webhook was executed, but application base URL or application state were not updated")
+				t.Log("application webhook was executed, but application base URL was not updated")
 				return false
-			}, timeout, checkInterval, "Waiting for application base URL and application state to be updated.")
+			}, timeout, checkInterval, "Waiting for application base URL to be updated.")
 		})
 	})
 }

--- a/tests/director/tests/application/application_templates_subscription_test.go
+++ b/tests/director/tests/application/application_templates_subscription_test.go
@@ -543,9 +543,9 @@ func TestSubscriptionApplicationTemplateFlowWithSystemFieldDiscoveryLabel(baseT 
 					return true
 				}
 
-				t.Log("application webhook was executed, but application base URL was not updated")
+				t.Log("application webhook was executed, but application base URL or application state were not updated")
 				return false
-			}, timeout, checkInterval, "Waiting for application base URL to be updated.")
+			}, timeout, checkInterval, "Waiting for application base URL and application state to be updated.")
 		})
 	})
 }

--- a/tests/director/tests/application/application_templates_subscription_test.go
+++ b/tests/director/tests/application/application_templates_subscription_test.go
@@ -487,6 +487,9 @@ func TestSubscriptionApplicationTemplateFlowWithSystemFieldDiscoveryLabel(baseT 
 		for i := range appTemplateInput.Placeholders {
 			appTemplateInput.Placeholders[i].JSONPath = str.Ptr(fmt.Sprintf("$.%s", conf.SubscriptionProviderAppNameProperty))
 		}
+
+		// explicit set BaseURL to nil
+		appTemplateInput.ApplicationInput.BaseURL = nil
 		// label to trigger the system field discovery engine
 		appTemplateInput.Labels["systemFieldDiscovery"] = true
 
@@ -527,9 +530,6 @@ func TestSubscriptionApplicationTemplateFlowWithSystemFieldDiscoveryLabel(baseT 
 			assertApplicationFromSubscription(t, appPageExt, appTmpl.ID, 1)
 			require.NotEmpty(t, appPageExt.Data[0].Webhooks)
 
-			// this value is from external svc mock
-			expectedURL := "https://new-url.com"
-
 			require.Eventually(t, func() bool {
 				appPageExt = fixtures.GetApplicationPageExt(t, ctx, certSecuredGraphQLClient, subscriptionConsumerSubaccountID)
 				// webhooks with types - configuration changed and system field discovery
@@ -538,8 +538,8 @@ func TestSubscriptionApplicationTemplateFlowWithSystemFieldDiscoveryLabel(baseT 
 					return false
 				}
 
-				if appPageExt.Data[0].BaseURL != nil && *appPageExt.Data[0].BaseURL == expectedURL {
-					t.Log("application webhook was executed and base URL was updated successfully")
+				if appPageExt.Data[0].BaseURL != nil && appPageExt.Data[0].Ready == true {
+					t.Log("application webhook was executed. Base URL was updated successfully. Application ready state was set to true.")
 					return true
 				}
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
When executing System Field Discovery webhook on real env we are calling an external subscription API, which returns a different application base URL.


Changes proposed in this pull request:
- Adjust system field discovery engine e2e test to work for real env

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- ...

**Pull Request status**
<!-- Feel free to construct the checklist with whatever items seem most reasonable for your change. You could disassemble the Implementation part to even smaller separate checklist items if you're working on something big for example. But do make the effort to provide a checklist of some sort so that the core team as well as the community can have an idea about the progress of your Pull Request.
-->

- [ ] Implementation
- [ ] Unit tests
- [x] Integration tests
- [x] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [ ] Mocks are regenerated, using the automated script
