### PR TITLE
[HOTFIX] Fix cost-object id trimming

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -173,8 +173,8 @@ global:
       version: "v20240313-05c805c2"
       name: compass-pairing-adapter
     director:
-      dir: prod/incubator/
-      version: "v20240313-05c805c2"
+      dir: dev/incubator/
+      version: "PR-3756"
       name: compass-director
     hydrator:
       dir: prod/incubator/
@@ -230,8 +230,8 @@ global:
       version: "v20230421-e8840c18"
       name: compass-console
     e2e_tests:
-      dir: prod/incubator/
-      version: "v20240313-05c805c2"
+      dir: dev/incubator/
+      version: "PR-3756"
       name: compass-e2e-tests
   isLocalEnv: false
   isForTesting: false

--- a/components/director/internal/domain/tenant/automock/business_tenant_mapping_converter.go
+++ b/components/director/internal/domain/tenant/automock/business_tenant_mapping_converter.go
@@ -3,6 +3,8 @@
 package automock
 
 import (
+	context "context"
+
 	graphql "github.com/kyma-incubator/compass/components/director/pkg/graphql"
 	mock "github.com/stretchr/testify/mock"
 
@@ -16,34 +18,54 @@ type BusinessTenantMappingConverter struct {
 	mock.Mock
 }
 
-// InputFromGraphQL provides a mock function with given fields: tnt
-func (_m *BusinessTenantMappingConverter) InputFromGraphQL(tnt graphql.BusinessTenantMappingInput) model.BusinessTenantMappingInput {
-	ret := _m.Called(tnt)
+// InputFromGraphQL provides a mock function with given fields: ctx, tnt, externalTenantToType, retrieveTenantTypeFn
+func (_m *BusinessTenantMappingConverter) InputFromGraphQL(ctx context.Context, tnt graphql.BusinessTenantMappingInput, externalTenantToType map[string]string, retrieveTenantTypeFn func(context.Context, string) (string, error)) (model.BusinessTenantMappingInput, error) {
+	ret := _m.Called(ctx, tnt, externalTenantToType, retrieveTenantTypeFn)
 
 	var r0 model.BusinessTenantMappingInput
-	if rf, ok := ret.Get(0).(func(graphql.BusinessTenantMappingInput) model.BusinessTenantMappingInput); ok {
-		r0 = rf(tnt)
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, graphql.BusinessTenantMappingInput, map[string]string, func(context.Context, string) (string, error)) (model.BusinessTenantMappingInput, error)); ok {
+		return rf(ctx, tnt, externalTenantToType, retrieveTenantTypeFn)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, graphql.BusinessTenantMappingInput, map[string]string, func(context.Context, string) (string, error)) model.BusinessTenantMappingInput); ok {
+		r0 = rf(ctx, tnt, externalTenantToType, retrieveTenantTypeFn)
 	} else {
 		r0 = ret.Get(0).(model.BusinessTenantMappingInput)
 	}
 
-	return r0
+	if rf, ok := ret.Get(1).(func(context.Context, graphql.BusinessTenantMappingInput, map[string]string, func(context.Context, string) (string, error)) error); ok {
+		r1 = rf(ctx, tnt, externalTenantToType, retrieveTenantTypeFn)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }
 
-// MultipleInputFromGraphQL provides a mock function with given fields: in
-func (_m *BusinessTenantMappingConverter) MultipleInputFromGraphQL(in []*graphql.BusinessTenantMappingInput) []model.BusinessTenantMappingInput {
-	ret := _m.Called(in)
+// MultipleInputFromGraphQL provides a mock function with given fields: ctx, in, retrieveTenantTypeFn
+func (_m *BusinessTenantMappingConverter) MultipleInputFromGraphQL(ctx context.Context, in []*graphql.BusinessTenantMappingInput, retrieveTenantTypeFn func(context.Context, string) (string, error)) ([]model.BusinessTenantMappingInput, error) {
+	ret := _m.Called(ctx, in, retrieveTenantTypeFn)
 
 	var r0 []model.BusinessTenantMappingInput
-	if rf, ok := ret.Get(0).(func([]*graphql.BusinessTenantMappingInput) []model.BusinessTenantMappingInput); ok {
-		r0 = rf(in)
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, []*graphql.BusinessTenantMappingInput, func(context.Context, string) (string, error)) ([]model.BusinessTenantMappingInput, error)); ok {
+		return rf(ctx, in, retrieveTenantTypeFn)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, []*graphql.BusinessTenantMappingInput, func(context.Context, string) (string, error)) []model.BusinessTenantMappingInput); ok {
+		r0 = rf(ctx, in, retrieveTenantTypeFn)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]model.BusinessTenantMappingInput)
 		}
 	}
 
-	return r0
+	if rf, ok := ret.Get(1).(func(context.Context, []*graphql.BusinessTenantMappingInput, func(context.Context, string) (string, error)) error); ok {
+		r1 = rf(ctx, in, retrieveTenantTypeFn)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }
 
 // MultipleToGraphQL provides a mock function with given fields: in

--- a/components/director/internal/domain/tenant/converter.go
+++ b/components/director/internal/domain/tenant/converter.go
@@ -1,6 +1,8 @@
 package tenant
 
 import (
+	"context"
+
 	"github.com/kyma-incubator/compass/components/director/internal/model"
 	"github.com/kyma-incubator/compass/components/director/internal/repo"
 	"github.com/kyma-incubator/compass/components/director/pkg/graphql"
@@ -82,26 +84,52 @@ func (c *converter) ToGraphQLInput(in model.BusinessTenantMappingInput) graphql.
 	}
 }
 
-func (c *converter) MultipleInputFromGraphQL(in []*graphql.BusinessTenantMappingInput) []model.BusinessTenantMappingInput {
+func (c *converter) MultipleInputFromGraphQL(ctx context.Context, in []*graphql.BusinessTenantMappingInput, retrieveTenantTypeFn func(ctx context.Context, t string) (string, error)) ([]model.BusinessTenantMappingInput, error) {
+	externalTenantToType := make(map[string]string)
+	for _, tnt := range in {
+		externalTenantToType[tnt.ExternalTenant] = tnt.Type
+	}
+
 	res := make([]model.BusinessTenantMappingInput, 0, len(in))
 
 	for _, tnt := range in {
 		if tnt != nil {
-			res = append(res, c.InputFromGraphQL(*tnt))
+			btm, err := c.InputFromGraphQL(ctx, *tnt, externalTenantToType, retrieveTenantTypeFn)
+			if err != nil {
+				return nil, err
+			}
+			res = append(res, btm)
 		}
 	}
 
-	return res
+	return res, nil
 }
 
-func (c *converter) InputFromGraphQL(tnt graphql.BusinessTenantMappingInput) model.BusinessTenantMappingInput {
+func (c *converter) InputFromGraphQL(ctx context.Context, tnt graphql.BusinessTenantMappingInput, externalTenantToType map[string]string, retrieveTenantTypeFn func(ctx context.Context, t string) (string, error)) (model.BusinessTenantMappingInput, error) {
 	externalTenant := tnt.ExternalTenant
 	trimmedParents := pointerStringsToStrings(tnt.Parents)
 
 	switch tnt.Type {
 	case tenant.TypeToStr(tenant.Customer):
 		externalTenant = tenant.TrimCustomerIDLeadingZeros(tnt.ExternalTenant)
-	case tenant.TypeToStr(tenant.Account), tenant.TypeToStr(tenant.Organization):
+	case tenant.TypeToStr(tenant.Account):
+		trimmedParents = make([]string, 0, len(tnt.Parents))
+		for _, parent := range tnt.Parents {
+			if parent != nil && str.PtrStrToStr(parent) != "" {
+				parentType, err := c.getTenantType(ctx, externalTenantToType, *parent, retrieveTenantTypeFn)
+				if err != nil {
+					return model.BusinessTenantMappingInput{}, err
+				}
+
+				if parentType == tenant.TypeToStr(tenant.Customer) {
+					trimmedParent := tenant.TrimCustomerIDLeadingZeros(*parent)
+					trimmedParents = append(trimmedParents, trimmedParent)
+				} else {
+					trimmedParents = append(trimmedParents, *parent)
+				}
+			}
+		}
+	case tenant.TypeToStr(tenant.Organization):
 		trimmedParents = make([]string, 0, len(tnt.Parents))
 		for _, parent := range tnt.Parents {
 			if parent != nil {
@@ -128,7 +156,21 @@ func (c *converter) InputFromGraphQL(tnt graphql.BusinessTenantMappingInput) mod
 		CustomerID:     customerID,
 		CostObjectType: tnt.CostObjectType,
 		CostObjectID:   tnt.CostObjectID,
+	}, nil
+}
+
+func (c *converter) getTenantType(ctx context.Context, externalTenantToType map[string]string, externalTenant string, retrieveTenantTypeFn func(ctx context.Context, t string) (string, error)) (string, error) {
+	tenantType, ok := externalTenantToType[externalTenant]
+	if ok {
+		return tenantType, nil
 	}
+
+	tenantType, err := retrieveTenantTypeFn(ctx, externalTenant)
+	if err != nil {
+		return "", errors.Wrapf(err, "while retrieving tenant type for tenant %q", externalTenant)
+	}
+
+	return tenantType, nil
 }
 
 // MultipleToGraphQL converts all the provided model.BusinessTenantMapping service-layer representations of a tenant to the GraphQL-layer representations graphql.Tenant.

--- a/components/director/internal/domain/tenant/resolver_test.go
+++ b/components/director/internal/domain/tenant/resolver_test.go
@@ -727,7 +727,7 @@ func TestResolver_Write(t *testing.T) {
 			},
 			TenantConvFn: func() *automock.BusinessTenantMappingConverter {
 				TenantConv := &automock.BusinessTenantMappingConverter{}
-				TenantConv.On("MultipleInputFromGraphQL", tenantsToUpsertGQL).Return(tenantsToUpsertModel).Once()
+				TenantConv.On("MultipleInputFromGraphQL", mock.Anything, tenantsToUpsertGQL, mock.Anything).Return(tenantsToUpsertModel, nil).Once()
 				return TenantConv
 			},
 			TenantsInput:   tenantsToUpsertGQL,
@@ -753,7 +753,20 @@ func TestResolver_Write(t *testing.T) {
 			},
 			TenantConvFn: func() *automock.BusinessTenantMappingConverter {
 				TenantConv := &automock.BusinessTenantMappingConverter{}
-				TenantConv.On("MultipleInputFromGraphQL", tenantsToUpsertGQL).Return(tenantsToUpsertModel).Once()
+				TenantConv.On("MultipleInputFromGraphQL", mock.Anything, tenantsToUpsertGQL, mock.Anything).Return(tenantsToUpsertModel, nil).Once()
+				return TenantConv
+			},
+			TenantsInput:   tenantsToUpsertGQL,
+			ExpectedError:  testError,
+			ExpectedResult: nil,
+		},
+		{
+			Name:        "Returns error when converting multiple input from graphql",
+			TxFn:        txGen.ThatDoesntExpectCommit,
+			TenantSvcFn: unusedTenantService,
+			TenantConvFn: func() *automock.BusinessTenantMappingConverter {
+				TenantConv := &automock.BusinessTenantMappingConverter{}
+				TenantConv.On("MultipleInputFromGraphQL", mock.Anything, tenantsToUpsertGQL, mock.Anything).Return(nil, testError).Once()
 				return TenantConv
 			},
 			TenantsInput:   tenantsToUpsertGQL,
@@ -770,7 +783,7 @@ func TestResolver_Write(t *testing.T) {
 			},
 			TenantConvFn: func() *automock.BusinessTenantMappingConverter {
 				TenantConv := &automock.BusinessTenantMappingConverter{}
-				TenantConv.On("MultipleInputFromGraphQL", tenantsToUpsertGQL).Return(tenantsToUpsertModel).Once()
+				TenantConv.On("MultipleInputFromGraphQL", mock.Anything, tenantsToUpsertGQL, mock.Anything).Return(tenantsToUpsertModel, nil).Once()
 				return TenantConv
 			},
 			TenantsInput:   tenantsToUpsertGQL,
@@ -853,7 +866,7 @@ func TestResolver_WriteSingle(t *testing.T) {
 			},
 			TenantConvFn: func() *automock.BusinessTenantMappingConverter {
 				tenantConv := &automock.BusinessTenantMappingConverter{}
-				tenantConv.On("InputFromGraphQL", tenantToUpsertGQL).Return(tenantToUpsertModel).Once()
+				tenantConv.On("InputFromGraphQL", mock.Anything, tenantToUpsertGQL, map[string]string{}, mock.Anything).Return(tenantToUpsertModel, nil).Once()
 				return tenantConv
 			},
 			TenantsInput:   tenantToUpsertGQL,
@@ -879,7 +892,20 @@ func TestResolver_WriteSingle(t *testing.T) {
 			},
 			TenantConvFn: func() *automock.BusinessTenantMappingConverter {
 				tenantConv := &automock.BusinessTenantMappingConverter{}
-				tenantConv.On("InputFromGraphQL", tenantToUpsertGQL).Return(tenantToUpsertModel).Once()
+				tenantConv.On("InputFromGraphQL", mock.Anything, tenantToUpsertGQL, map[string]string{}, mock.Anything).Return(tenantToUpsertModel, nil).Once()
+				return tenantConv
+			},
+			TenantsInput:   tenantToUpsertGQL,
+			ExpectedError:  testError,
+			ExpectedResult: "",
+		},
+		{
+			Name:        "Error when converting input from graphql",
+			TxFn:        txGen.ThatDoesntExpectCommit,
+			TenantSvcFn: unusedTenantService,
+			TenantConvFn: func() *automock.BusinessTenantMappingConverter {
+				tenantConv := &automock.BusinessTenantMappingConverter{}
+				tenantConv.On("InputFromGraphQL", mock.Anything, tenantToUpsertGQL, map[string]string{}, mock.Anything).Return(model.BusinessTenantMappingInput{}, testError).Once()
 				return tenantConv
 			},
 			TenantsInput:   tenantToUpsertGQL,
@@ -896,7 +922,7 @@ func TestResolver_WriteSingle(t *testing.T) {
 			},
 			TenantConvFn: func() *automock.BusinessTenantMappingConverter {
 				tenantConv := &automock.BusinessTenantMappingConverter{}
-				tenantConv.On("InputFromGraphQL", tenantToUpsertGQL).Return(tenantToUpsertModel).Once()
+				tenantConv.On("InputFromGraphQL", mock.Anything, tenantToUpsertGQL, map[string]string{}, mock.Anything).Return(tenantToUpsertModel, nil).Once()
 				return tenantConv
 			},
 			TenantsInput:   tenantToUpsertGQL,
@@ -1027,28 +1053,24 @@ func TestResolver_Update(t *testing.T) {
 	tenantParent := ""
 	tenantInternalID := "internal"
 
-	tenantsToUpdateGQL := []*graphql.BusinessTenantMappingInput{
-		{
-			Name:           testName,
-			ExternalTenant: testExternal,
-			Parents:        []*string{str.Ptr(tenantParent)},
-			Subdomain:      str.Ptr(testSubdomain),
-			Region:         str.Ptr(testRegion),
-			Type:           string(tnt.Account),
-			Provider:       testProvider,
-		},
+	tenantToUpdateGQL := graphql.BusinessTenantMappingInput{
+		Name:           testName,
+		ExternalTenant: testExternal,
+		Parents:        []*string{str.Ptr(tenantParent)},
+		Subdomain:      str.Ptr(testSubdomain),
+		Region:         str.Ptr(testRegion),
+		Type:           string(tnt.Account),
+		Provider:       testProvider,
 	}
 
-	tenantsToUpdateModel := []model.BusinessTenantMappingInput{
-		{
-			Name:           testName,
-			ExternalTenant: testExternal,
-			Parents:        []string{tenantParent},
-			Subdomain:      testSubdomain,
-			Region:         testRegion,
-			Type:           string(tnt.Account),
-			Provider:       testProvider,
-		},
+	tenantToUpdateModel := model.BusinessTenantMappingInput{
+		Name:           testName,
+		ExternalTenant: testExternal,
+		Parents:        []string{tenantParent},
+		Subdomain:      testSubdomain,
+		Region:         testRegion,
+		Type:           string(tnt.Account),
+		Provider:       testProvider,
 	}
 
 	expectedTenantModel := &model.BusinessTenantMapping{
@@ -1087,17 +1109,17 @@ func TestResolver_Update(t *testing.T) {
 			TxFn: txGen.ThatSucceeds,
 			TenantSvcFn: func() *automock.BusinessTenantMappingService {
 				TenantSvc := &automock.BusinessTenantMappingService{}
-				TenantSvc.On("GetTenantByExternalID", txtest.CtxWithDBMatcher(), tenantsToUpdateGQL[0].ExternalTenant).Return(expectedTenantModel, nil).Once()
-				TenantSvc.On("Update", txtest.CtxWithDBMatcher(), tenantInternalID, tenantsToUpdateModel[0]).Return(nil).Once()
+				TenantSvc.On("GetTenantByExternalID", txtest.CtxWithDBMatcher(), tenantToUpdateGQL.ExternalTenant).Return(expectedTenantModel, nil).Once()
+				TenantSvc.On("Update", txtest.CtxWithDBMatcher(), tenantInternalID, tenantToUpdateModel).Return(nil).Once()
 				return TenantSvc
 			},
 			TenantConvFn: func() *automock.BusinessTenantMappingConverter {
 				conv := &automock.BusinessTenantMappingConverter{}
-				conv.On("MultipleInputFromGraphQL", tenantsToUpdateGQL).Return(tenantsToUpdateModel)
+				conv.On("InputFromGraphQL", mock.Anything, tenantToUpdateGQL, map[string]string{}, mock.Anything).Return(tenantToUpdateModel, nil).Once()
 				conv.On("ToGraphQL", expectedTenantModel).Return(expectedTenantGQL)
 				return conv
 			},
-			TenantInput:    *tenantsToUpdateGQL[0],
+			TenantInput:    tenantToUpdateGQL,
 			IDInput:        tenantInternalID,
 			ExpectedError:  nil,
 			ExpectedResult: expectedTenantGQL,
@@ -1107,7 +1129,7 @@ func TestResolver_Update(t *testing.T) {
 			TxFn:           txGen.ThatFailsOnBegin,
 			TenantSvcFn:    unusedTenantService,
 			TenantConvFn:   unusedTenantConverter,
-			TenantInput:    *tenantsToUpdateGQL[0],
+			TenantInput:    tenantToUpdateGQL,
 			IDInput:        tenantInternalID,
 			ExpectedError:  testError,
 			ExpectedResult: nil,
@@ -1117,15 +1139,15 @@ func TestResolver_Update(t *testing.T) {
 			TxFn: txGen.ThatDoesntExpectCommit,
 			TenantSvcFn: func() *automock.BusinessTenantMappingService {
 				TenantSvc := &automock.BusinessTenantMappingService{}
-				TenantSvc.On("Update", txtest.CtxWithDBMatcher(), tenantInternalID, tenantsToUpdateModel[0]).Return(testError).Once()
+				TenantSvc.On("Update", txtest.CtxWithDBMatcher(), tenantInternalID, tenantToUpdateModel).Return(testError).Once()
 				return TenantSvc
 			},
 			TenantConvFn: func() *automock.BusinessTenantMappingConverter {
 				conv := &automock.BusinessTenantMappingConverter{}
-				conv.On("MultipleInputFromGraphQL", tenantsToUpdateGQL).Return(tenantsToUpdateModel)
+				conv.On("InputFromGraphQL", mock.Anything, tenantToUpdateGQL, map[string]string{}, mock.Anything).Return(tenantToUpdateModel, nil).Once()
 				return conv
 			},
-			TenantInput:    *tenantsToUpdateGQL[0],
+			TenantInput:    tenantToUpdateGQL,
 			IDInput:        tenantInternalID,
 			ExpectedError:  testError,
 			ExpectedResult: nil,
@@ -1135,16 +1157,30 @@ func TestResolver_Update(t *testing.T) {
 			TxFn: txGen.ThatDoesntExpectCommit,
 			TenantSvcFn: func() *automock.BusinessTenantMappingService {
 				TenantSvc := &automock.BusinessTenantMappingService{}
-				TenantSvc.On("GetTenantByExternalID", txtest.CtxWithDBMatcher(), tenantsToUpdateGQL[0].ExternalTenant).Return(nil, testError).Once()
-				TenantSvc.On("Update", txtest.CtxWithDBMatcher(), tenantInternalID, tenantsToUpdateModel[0]).Return(nil).Once()
+				TenantSvc.On("GetTenantByExternalID", txtest.CtxWithDBMatcher(), tenantToUpdateGQL.ExternalTenant).Return(nil, testError).Once()
+				TenantSvc.On("Update", txtest.CtxWithDBMatcher(), tenantInternalID, tenantToUpdateModel).Return(nil).Once()
 				return TenantSvc
 			},
 			TenantConvFn: func() *automock.BusinessTenantMappingConverter {
 				conv := &automock.BusinessTenantMappingConverter{}
-				conv.On("MultipleInputFromGraphQL", tenantsToUpdateGQL).Return(tenantsToUpdateModel)
+				conv.On("InputFromGraphQL", mock.Anything, tenantToUpdateGQL, map[string]string{}, mock.Anything).Return(tenantToUpdateModel, nil).Once()
 				return conv
 			},
-			TenantInput:    *tenantsToUpdateGQL[0],
+			TenantInput:    tenantToUpdateGQL,
+			IDInput:        tenantInternalID,
+			ExpectedError:  testError,
+			ExpectedResult: nil,
+		},
+		{
+			Name:        "Returns error when converting input from graphql",
+			TxFn:        txGen.ThatDoesntExpectCommit,
+			TenantSvcFn: unusedTenantService,
+			TenantConvFn: func() *automock.BusinessTenantMappingConverter {
+				conv := &automock.BusinessTenantMappingConverter{}
+				conv.On("InputFromGraphQL", mock.Anything, tenantToUpdateGQL, map[string]string{}, mock.Anything).Return(model.BusinessTenantMappingInput{}, testError).Once()
+				return conv
+			},
+			TenantInput:    tenantToUpdateGQL,
 			IDInput:        tenantInternalID,
 			ExpectedError:  testError,
 			ExpectedResult: nil,
@@ -1154,16 +1190,16 @@ func TestResolver_Update(t *testing.T) {
 			TxFn: txGen.ThatFailsOnCommit,
 			TenantSvcFn: func() *automock.BusinessTenantMappingService {
 				TenantSvc := &automock.BusinessTenantMappingService{}
-				TenantSvc.On("GetTenantByExternalID", txtest.CtxWithDBMatcher(), tenantsToUpdateGQL[0].ExternalTenant).Return(expectedTenantModel, nil).Once()
-				TenantSvc.On("Update", txtest.CtxWithDBMatcher(), tenantInternalID, tenantsToUpdateModel[0]).Return(nil).Once()
+				TenantSvc.On("GetTenantByExternalID", txtest.CtxWithDBMatcher(), tenantToUpdateGQL.ExternalTenant).Return(expectedTenantModel, nil).Once()
+				TenantSvc.On("Update", txtest.CtxWithDBMatcher(), tenantInternalID, tenantToUpdateModel).Return(nil).Once()
 				return TenantSvc
 			},
 			TenantConvFn: func() *automock.BusinessTenantMappingConverter {
 				conv := &automock.BusinessTenantMappingConverter{}
-				conv.On("MultipleInputFromGraphQL", tenantsToUpdateGQL).Return(tenantsToUpdateModel)
+				conv.On("InputFromGraphQL", mock.Anything, tenantToUpdateGQL, map[string]string{}, mock.Anything).Return(tenantToUpdateModel, nil).Once()
 				return conv
 			},
-			TenantInput:    *tenantsToUpdateGQL[0],
+			TenantInput:    tenantToUpdateGQL,
 			IDInput:        tenantInternalID,
 			ExpectedError:  testError,
 			ExpectedResult: nil,

--- a/components/director/internal/tenantfetchersvc/provisioner.go
+++ b/components/director/internal/tenantfetchersvc/provisioner.go
@@ -3,6 +3,8 @@ package tenantfetchersvc
 import (
 	"context"
 
+	"github.com/kyma-incubator/compass/components/director/pkg/log"
+
 	"github.com/kyma-incubator/compass/components/director/pkg/graphql"
 
 	"github.com/kyma-incubator/compass/components/director/internal/model"
@@ -75,16 +77,17 @@ func NewTenantProvisioner(directorClient DirectorGraphQLClient, tenantConverter 
 
 // ProvisionTenants provisions tenants according to their type
 func (p *provisioner) ProvisionTenants(ctx context.Context, request *TenantSubscriptionRequest) error {
-	tenantsToCreateGQL := p.converter.MultipleInputToGraphQLInput(p.tenantsFromRequest(*request))
+	tenantsToCreateGQL := p.converter.MultipleInputToGraphQLInput(p.tenantsFromRequest(ctx, *request))
 	return p.gqlClient.WriteTenants(ctx, tenantsToCreateGQL)
 }
 
-func (p *provisioner) tenantsFromRequest(request TenantSubscriptionRequest) []model.BusinessTenantMappingInput {
+func (p *provisioner) tenantsFromRequest(ctx context.Context, request TenantSubscriptionRequest) []model.BusinessTenantMappingInput {
 	tenants := make([]model.BusinessTenantMappingInput, 0, 3)
 	customerID := request.CustomerTenantID
 	accountID := request.AccountTenantID
 	costObjectID := request.CostObjectTenantID
 
+	log.C(ctx).Debugf("Tenants retrieved from the subscription request. Customer id %q,account id %q, cost-object id %q", customerID, accountID, costObjectID)
 	var licenseType *string
 
 	if len(request.SubscriptionLcenseType) > 0 {

--- a/tests/director/tests/tenants_api_test.go
+++ b/tests/director/tests/tenants_api_test.go
@@ -656,6 +656,150 @@ func TestWriteTenantsTenantAccess(t *testing.T) {
 	assertions.AssertApplication(t, in, app)
 }
 
+func TestWriteTenantsCostObjectAsParentWithLeadingZeros(t *testing.T) {
+	testProvider := "e2e-test-provider"
+	testLicenseType := "LICENSETYPE"
+
+	costObjectName := "cost-object"
+	costObjectExternalTenant := "0123"
+	costObjectSubdomain := "cost-object-subdomain"
+
+	accountExternalTenant := "account-external-tenant"
+	accountName := "account-name"
+	accountSubdomain := "account-subdomain"
+
+	region := "local"
+
+	tenants := []graphql.BusinessTenantMappingInput{
+		{
+			Name:           costObjectName,
+			ExternalTenant: costObjectExternalTenant,
+			Parents:        nil,
+			Subdomain:      &costObjectSubdomain,
+			Region:         &region,
+			Type:           string(tenant.CostObject),
+			Provider:       testProvider,
+			LicenseType:    &testLicenseType,
+		},
+		{
+			Name:           accountName,
+			ExternalTenant: accountExternalTenant,
+			Parents:        []*string{&costObjectExternalTenant},
+			Subdomain:      &accountSubdomain,
+			Region:         &region,
+			Type:           string(tenant.Account),
+			Provider:       testProvider,
+			LicenseType:    &testLicenseType,
+		},
+	}
+	err := fixtures.WriteTenants(t, ctx, directorInternalGQLClient, tenants)
+	assert.NoError(t, err)
+	defer func() { // cleanup tenants
+		err := fixtures.DeleteTenants(t, ctx, directorInternalGQLClient, tenants)
+		assert.NoError(t, err)
+		log.D().Info("Successfully cleanup tenants")
+	}()
+
+	var actualCostObject graphql.Tenant
+	getTenant := fixtures.FixTenantRequest(costObjectExternalTenant)
+	t.Logf("Query tenant for external tenant: %q", costObjectExternalTenant)
+
+	err = testctx.Tc.RunOperation(ctx, certSecuredGraphQLClient, getTenant, &actualCostObject)
+	require.NoError(t, err)
+	require.Equal(t, costObjectExternalTenant, actualCostObject.ID)
+	require.Equal(t, costObjectName, *actualCostObject.Name)
+	require.Equal(t, string(tenant.CostObject), actualCostObject.Type)
+
+	var actualAccountTenant graphql.Tenant
+	getTenant = fixtures.FixTenantRequest(accountExternalTenant)
+	t.Logf("Query tenant for external tenant: %q", accountExternalTenant)
+
+	err = testctx.Tc.RunOperation(ctx, certSecuredGraphQLClient, getTenant, &actualAccountTenant)
+	require.NoError(t, err)
+	require.Equal(t, accountExternalTenant, actualAccountTenant.ID)
+	require.Equal(t, accountName, *actualAccountTenant.Name)
+	require.Equal(t, string(tenant.Account), actualAccountTenant.Type)
+	require.True(t, slices.Contains(actualAccountTenant.Parents, actualCostObject.InternalID))
+}
+
+func TestWriteTenantsCostObjectAsParentWithLeadingZerosRetrievedFromDB(t *testing.T) {
+	testProvider := "e2e-test-provider"
+	testLicenseType := "LICENSETYPE"
+
+	costObjectName := "cost-object"
+	costObjectExternalTenant := "0123"
+	costObjectSubdomain := "cost-object-subdomain"
+
+	accountExternalTenant := "account-external-tenant"
+	accountName := "account-name"
+	accountSubdomain := "account-subdomain"
+
+	region := "local"
+
+	costObject := []graphql.BusinessTenantMappingInput{
+		{
+			Name:           costObjectName,
+			ExternalTenant: costObjectExternalTenant,
+			Parents:        nil,
+			Subdomain:      &costObjectSubdomain,
+			Region:         &region,
+			Type:           string(tenant.CostObject),
+			Provider:       testProvider,
+			LicenseType:    &testLicenseType,
+		},
+	}
+
+	err := fixtures.WriteTenants(t, ctx, directorInternalGQLClient, costObject)
+	assert.NoError(t, err)
+	defer func() { // cleanup tenants
+		err := fixtures.DeleteTenants(t, ctx, directorInternalGQLClient, costObject)
+		assert.NoError(t, err)
+		log.D().Info("Successfully cleanup tenants")
+	}()
+
+	var actualCostObject graphql.Tenant
+	getTenant := fixtures.FixTenantRequest(costObjectExternalTenant)
+	t.Logf("Query tenant for external tenant: %q", costObjectExternalTenant)
+
+	err = testctx.Tc.RunOperation(ctx, certSecuredGraphQLClient, getTenant, &actualCostObject)
+	require.NoError(t, err)
+	require.Equal(t, costObjectExternalTenant, actualCostObject.ID)
+	require.Equal(t, costObjectName, *actualCostObject.Name)
+	require.Equal(t, string(tenant.CostObject), actualCostObject.Type)
+
+	account := []graphql.BusinessTenantMappingInput{
+		{
+			Name:           accountName,
+			ExternalTenant: accountExternalTenant,
+			Parents:        []*string{&costObjectExternalTenant},
+			Subdomain:      &accountSubdomain,
+			Region:         &region,
+			Type:           string(tenant.Account),
+			Provider:       testProvider,
+			LicenseType:    &testLicenseType,
+		},
+	}
+
+	err = fixtures.WriteTenants(t, ctx, directorInternalGQLClient, account)
+	assert.NoError(t, err)
+	defer func() { // cleanup tenants
+		err := fixtures.DeleteTenants(t, ctx, directorInternalGQLClient, account)
+		assert.NoError(t, err)
+		log.D().Info("Successfully cleanup tenants")
+	}()
+
+	var actualAccountTenant graphql.Tenant
+	getTenant = fixtures.FixTenantRequest(accountExternalTenant)
+	t.Logf("Query tenant for external tenant: %q", accountExternalTenant)
+
+	err = testctx.Tc.RunOperation(ctx, certSecuredGraphQLClient, getTenant, &actualAccountTenant)
+	require.NoError(t, err)
+	require.Equal(t, accountExternalTenant, actualAccountTenant.ID)
+	require.Equal(t, accountName, *actualAccountTenant.Name)
+	require.Equal(t, string(tenant.Account), actualAccountTenant.Type)
+	require.True(t, slices.Contains(actualAccountTenant.Parents, actualCostObject.InternalID))
+}
+
 func TestTenantParentUpdateWithCostObject(t *testing.T) {
 	// GIVEN
 	isolatedAccount := tenant.TestTenants.GetIDByName(t, tenant.TestIsolatedAccountName)


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:
- When creating an Account tenant with a parent of type 'cost-object,' the cost-object ID must not be trimmed.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- ...

**Pull Request status**
<!-- Feel free to construct the checklist with whatever items seem most reasonable for your change. You could disassemble the Implementation part to even smaller separate checklist items if you're working on something big for example. But do make the effort to provide a checklist of some sort so that the core team as well as the community can have an idea about the progress of your Pull Request.
-->

- [x] Implementation
- [x] Unit tests
- [x] Integration tests
- [x] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [ ] Mocks are regenerated, using the automated script
