### PR TITLE
Add env var for instance creator region in e2e test

### DIFF
--- a/chart/compass/templates/tests/instance-creator/instance-creator-test.yaml
+++ b/chart/compass/templates/tests/instance-creator/instance-creator-test.yaml
@@ -63,6 +63,8 @@ spec:
               value: {{ .Values.global.tests.selfRegistration.region }}
             - name: APP_SELF_REG_REGION2
               value: {{ .Values.global.tests.selfRegistration.region2 }}
+            - name: APP_INSTANCE_CREATOR_REGION
+              value: {{ .Values.global.tests.instanceCreator.region }}
             - name: APP_SKIP_SSL_VALIDATION
               value: "{{ .Values.global.tests.http.client.skipSSLValidation }}"
             - name: TEST_EXTERNAL_CERT_CN

--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -231,7 +231,7 @@ global:
       name: compass-console
     e2e_tests:
       dir: dev/incubator/
-      version: "PR-3754"
+      version: "PR-3757"
       name: compass-e2e-tests
   isLocalEnv: false
   isForTesting: false

--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -1336,6 +1336,8 @@ global:
     selfRegistration:
       region: "eu-1"
       region2: "eu-2"
+    instanceCreator:
+      region: "eu-1"
     destination:
       consumerSubdomain: "compass-external-services-mock"
       consumerSubdomainMtls: "compass-external-services-mock-sap-mtls"

--- a/tests/instance-creator/tests/config.go
+++ b/tests/instance-creator/tests/config.go
@@ -30,5 +30,6 @@ type InstanceCreatorConfig struct {
 	GlobalSubaccountIDLabelKey          string        `envconfig:"APP_GLOBAL_SUBACCOUNT_ID_LABEL_KEY"`
 	SubscriptionProviderAppNameProperty string        `envconfig:"APP_TENANT_PROVIDER_SUBSCRIPTION_PROVIDER_APP_NAME_PROPERTY"`
 	CertSubjectMappingResyncInterval    time.Duration `envconfig:"APP_CERT_SUBJECT_MAPPING_RESYNC_INTERVAL"`
+	InstanceCreatorRegion               string        `envconfig:"APP_INSTANCE_CREATOR_REGION,default=eu-1"`
 	SkipSSLValidation                   bool          `envconfig:"default=false"`
 }

--- a/tests/instance-creator/tests/instance_creator_test.go
+++ b/tests/instance-creator/tests/instance_creator_test.go
@@ -118,7 +118,7 @@ func TestInstanceCreator(t *testing.T) {
 
 	namePlaceholder := "name"
 	displayNamePlaceholder := "display-name"
-	appRegion := "eu-1"
+	appRegion := conf.InstanceCreatorRegion
 	appNamespace := "compass.test"
 	localTenantID := "local-tenant-id"
 	applicationType1 := "app-type-1"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Currently, the instance creator e2e test is failing on real env because the region in the test is hardcoded "eu-1" and this region does not exist on real env.
With this PR I'm adding an environment variable for this region which on real environment will be the real region.

Changes proposed in this pull request:
- Add env var for instance creator region

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- https://github.com/kyma-incubator/compass/pull/3636

**Pull Request status**
<!-- Feel free to construct the checklist with whatever items seem most reasonable for your change. You could disassemble the Implementation part to even smaller separate checklist items if you're working on something big for example. But do make the effort to provide a checklist of some sort so that the core team as well as the community can have an idea about the progress of your Pull Request.
-->

- [ ] Implementation
- [ ] Unit tests
- [ ] Integration tests
- [ ] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [ ] Mocks are regenerated, using the automated script
