### PR TITLE
Fix Instance Creator e2e test flapping on real env

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -190,7 +190,7 @@ global:
       name: compass-kyma-adapter
     instance_creator:
       dir: dev/incubator/
-      version: "PR-3714"
+      version: "PR-3760"
       name: compass-instance-creator
     default_tenant_mapping_handler:
       dir: dev/incubator/
@@ -231,7 +231,7 @@ global:
       name: compass-console
     e2e_tests:
       dir: dev/incubator/
-      version: "PR-3757"
+      version: "PR-3760"
       name: compass-e2e-tests
   isLocalEnv: false
   isForTesting: false

--- a/components/instance-creator/internal/handler/handler.go
+++ b/components/instance-creator/internal/handler/handler.go
@@ -378,7 +378,7 @@ func (i *InstanceCreatorHandler) handleUnassign(ctx context.Context, reqBody *te
 		return
 	}
 	defer func() {
-		log.C(ctx).Debug("Closing a DB connection for instance creation...")
+		log.C(ctx).Debug("Closing a DB connection for instance deletion...")
 		if err := connection.Close(); err != nil {
 			log.C(ctx).WithError(err).Error("Error while closing the database connection")
 		}
@@ -392,7 +392,7 @@ func (i *InstanceCreatorHandler) handleUnassign(ctx context.Context, reqBody *te
 	// This lock prevents multiple unassign operations to execute simultaneously
 	locked, err := advisoryLocker.TryLock(ctx, assignmentID+reqBody.Context.Operation)
 	if err != nil {
-		i.reportToUCLWithError(ctx, statusAPIURL, createErrorState, errors.Wrap(err, "while trying to acquire postgres advisory lock in the beginning of instance creation"))
+		i.reportToUCLWithError(ctx, statusAPIURL, createErrorState, errors.Wrap(err, "while trying to acquire postgres advisory lock in the beginning of instance deletion"))
 		return
 	}
 	if !locked {
@@ -409,7 +409,7 @@ func (i *InstanceCreatorHandler) handleUnassign(ctx context.Context, reqBody *te
 	log.C(ctx).Debugf("Locking an advisory lock with assignmentID %q...", assignmentID)
 	// This lock prevents unassign and assign operations to execute simultaneously
 	if err := advisoryLocker.Lock(ctx, assignmentID); err != nil {
-		i.reportToUCLWithError(ctx, statusAPIURL, createErrorState, errors.Wrap(err, "while trying to acquire postgres advisory lock in the beginning of instance creation"))
+		i.reportToUCLWithError(ctx, statusAPIURL, createErrorState, errors.Wrap(err, "while trying to acquire postgres advisory lock in the beginning of instance deletion"))
 		return
 	}
 	defer func() {

--- a/tests/instance-creator/tests/instance_creator_test.go
+++ b/tests/instance-creator/tests/instance_creator_test.go
@@ -42,6 +42,9 @@ const (
 
 	uriKey      = "uri"
 	usernameKey = "username"
+
+	eventuallyTimeoutForInstances = 60 * time.Second
+	eventuallyTickForInstances    = 2 * time.Second
 )
 
 var (
@@ -324,7 +327,9 @@ func TestInstanceCreator(t *testing.T) {
 			return assertExactConfig(t, expectedConfig, actualConfig)
 		}
 
-		asserterWithCustomConfigMatcher := asserters.NewFormationAssignmentsAsyncCustomConfigMatcherAsserter(configMatcher, expectedAssignments, 4, certSecuredGraphQLClient, tnt)
+		asserterWithCustomConfigMatcher := asserters.NewFormationAssignmentsAsyncCustomConfigMatcherAsserter(configMatcher, expectedAssignments, 4, certSecuredGraphQLClient, tnt).
+			WithTimeout(eventuallyTimeoutForInstances).
+			WithTick(eventuallyTickForInstances)
 		statusAsserter = asserters.NewFormationStatusAsserter(tnt, certSecuredGraphQLClient)
 		op = operations.NewAssignAppToFormationOperation(app1ID, tnt).WithAsserters(asserterWithCustomConfigMatcher, statusAsserter).Operation()
 		defer op.Cleanup(t, ctx, certSecuredGraphQLClient)

--- a/tests/instance-creator/tests/instance_creator_test.go
+++ b/tests/instance-creator/tests/instance_creator_test.go
@@ -337,7 +337,9 @@ func TestInstanceCreator(t *testing.T) {
 
 		t.Logf("Unassign Application 1 from formation: %s", formationName)
 		expectationsBuilder = mock_data.NewFAExpectationsBuilder().WithParticipant(app2ID)
-		faAsserter := asserters.NewFormationAssignmentAsyncAsserter(expectationsBuilder.GetExpectations(), expectationsBuilder.GetExpectedAssignmentsCount(), certSecuredGraphQLClient, tnt)
+		faAsserter := asserters.NewFormationAssignmentAsyncAsserter(expectationsBuilder.GetExpectations(), expectationsBuilder.GetExpectedAssignmentsCount(), certSecuredGraphQLClient, tnt).
+			WithTimeout(eventuallyTimeoutForInstances).
+			WithTick(eventuallyTickForInstances)
 		statusAsserter = asserters.NewFormationStatusAsserter(tnt, certSecuredGraphQLClient)
 		unassignNotificationsAsserter := asserters.NewUnassignNotificationsAsserter(1, app1ID, app2ID, subscriptionConsumerTenantID, appNamespace, appRegion, tnt, emptyParentCustomerID, "", conf.ExternalServicesMockMtlsSecuredURL, certSecuredHTTPClient)
 		op = operations.NewUnassignAppToFormationOperationGlobal(app1ID).WithAsserters(faAsserter, statusAsserter, unassignNotificationsAsserter).Operation()

--- a/tests/pkg/notifications/asserters/formation_assigments_async_custom_config_matcher.go
+++ b/tests/pkg/notifications/asserters/formation_assigments_async_custom_config_matcher.go
@@ -37,10 +37,12 @@ func (a *FormationAssignmentsAsyncCustomConfigMatcherAsserter) AssertExpectation
 	a.assertFormationAssignmentsAsynchronouslyWithEventually(t, ctx, a.certSecuredGraphQLClient, a.tenantID, formationID, a.expectedAssignmentsCount, a.expectations, a.configMatcher)
 }
 
-func (a *FormationAssignmentsAsyncCustomConfigMatcherAsserter) WithTimeout(timeout time.Duration) {
+func (a *FormationAssignmentsAsyncCustomConfigMatcherAsserter) WithTimeout(timeout time.Duration) *FormationAssignmentsAsyncCustomConfigMatcherAsserter {
 	a.timeout = timeout
+	return a
 }
 
-func (a *FormationAssignmentsAsyncCustomConfigMatcherAsserter) WithTick(tick time.Duration) {
+func (a *FormationAssignmentsAsyncCustomConfigMatcherAsserter) WithTick(tick time.Duration) *FormationAssignmentsAsyncCustomConfigMatcherAsserter {
 	a.tick = tick
+	return a
 }


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Currently, Instance Creator e2e test flaps on real env, because the test does not wait enough for the instances to be created and times out.

Changes proposed in this pull request:
- Bump the time which the test waits for the instances

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- https://github.com/kyma-incubator/compass/pull/3636

**Pull Request status**
<!-- Feel free to construct the checklist with whatever items seem most reasonable for your change. You could disassemble the Implementation part to even smaller separate checklist items if you're working on something big for example. But do make the effort to provide a checklist of some sort so that the core team as well as the community can have an idea about the progress of your Pull Request.
-->

- [ ] Implementation
- [ ] Unit tests
- [ ] Integration tests
- [ ] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [ ] Mocks are regenerated, using the automated script
