### PR TITLE
Allow horizontally scaling SaaS Application Providers to onboard to UCL

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -174,7 +174,7 @@ global:
       name: compass-pairing-adapter
     director:
       dir: dev/incubator/
-      version: "PR-3731"
+      version: "PR-3767"
       name: compass-director
     hydrator:
       dir: dev/incubator/
@@ -231,7 +231,7 @@ global:
       name: compass-console
     e2e_tests:
       dir: dev/incubator/
-      version: "PR-3731"
+      version: "PR-3767"
       name: compass-e2e-tests
   isLocalEnv: false
   isForTesting: false

--- a/components/director/internal/domain/apptemplate/service.go
+++ b/components/director/internal/domain/apptemplate/service.go
@@ -494,7 +494,7 @@ func validatePlaceholderValue(placeholder model.ApplicationTemplatePlaceholder, 
 	return nil
 }
 
-func enrichWithApplicationTypeLabel(applicationInputJSON, applicationType string) (string, error) {
+func enrichWithApplicationTypeLabel(applicationInputJSON, appTemplateInputName string) (string, error) {
 	var appInput map[string]interface{}
 
 	if err := json.Unmarshal([]byte(applicationInputJSON), &appInput); err != nil {
@@ -508,21 +508,14 @@ func enrichWithApplicationTypeLabel(applicationInputJSON, applicationType string
 			return "", fmt.Errorf("app input json labels are type %T instead of map[string]interface{}. %v", labelsMap, labels)
 		}
 
-		if appType, ok := labelsMap[applicationTypeLabelKey]; ok {
-			appTypeValue, ok := appType.(string)
-			if !ok {
-				return "", fmt.Errorf("%q label value must be string", applicationTypeLabelKey)
-			}
-			if applicationType != otherSystemType && appTypeValue != applicationType {
-				return "", fmt.Errorf("%q label value does not match the application template name", applicationTypeLabelKey)
-			}
+		if _, exists := labelsMap[applicationTypeLabelKey]; exists {
 			return applicationInputJSON, nil
 		}
 
-		labelsMap[applicationTypeLabelKey] = applicationType
+		labelsMap[applicationTypeLabelKey] = appTemplateInputName
 		appInput[labelsKey] = labelsMap
 	} else {
-		appInput[labelsKey] = map[string]interface{}{applicationTypeLabelKey: applicationType}
+		appInput[labelsKey] = map[string]interface{}{applicationTypeLabelKey: appTemplateInputName}
 	}
 
 	inputJSON, err := json.Marshal(appInput)

--- a/components/director/internal/domain/apptemplate/service_test.go
+++ b/components/director/internal/domain/apptemplate/service_test.go
@@ -194,29 +194,6 @@ func TestService_Create(t *testing.T) {
 			ExpectedError:     errors.New("app input json labels are type map[string]interface {} instead of map[string]interface{}"),
 		},
 		{
-			Name: "Error when checking application type label - application type is not string",
-			Input: func() *model.ApplicationTemplateInput {
-				appInputJSON := `{"name":"foo","providerName":"compass","description":"Lorem ipsum","labels":{"applicationType":123,"test":["val","val2"]},"healthCheckURL":"https://foo.bar","webhooks":[{"type":"","url":"webhook1.foo.bar","auth":null},{"type":"","url":"webhook2.foo.bar","auth":null}],"integrationSystemID":"iiiiiiiii-iiii-iiii-iiii-iiiiiiiiiiii"}`
-				return fixModelAppTemplateInput(testName, appInputJSON)
-			},
-			AppTemplateRepoFn: UnusedAppTemplateRepo,
-			WebhookRepoFn:     UnusedWebhookRepo,
-			LabelUpsertSvcFn:  UnusedLabelUpsertSvc,
-			LabelRepoFn:       UnusedLabelRepo,
-			ExpectedError:     errors.New("\"applicationType\" label value must be string"),
-		},
-		{
-			Name: "Error when checking application type label - application type does not match the application template name",
-			Input: func() *model.ApplicationTemplateInput {
-				return fixModelAppTemplateInput(testName, fmt.Sprintf(appInputJSONWithAppTypeLabelString, "random-name"))
-			},
-			AppTemplateRepoFn: UnusedAppTemplateRepo,
-			WebhookRepoFn:     UnusedWebhookRepo,
-			LabelUpsertSvcFn:  UnusedLabelUpsertSvc,
-			LabelRepoFn:       UnusedLabelRepo,
-			ExpectedError:     errors.New("\"applicationType\" label value does not match the application template name"),
-		},
-		{
 			Name: "No error when checking application type label - application type does not match the application template name",
 			Input: func() *model.ApplicationTemplateInput {
 				return fixModelAppTemplateInput(testNameOtherSystemType, fmt.Sprintf(appInputJSONWithAppTypeLabelString, "random-name"))
@@ -1522,54 +1499,6 @@ func TestService_Update(t *testing.T) {
 			AppRepoFn:     UnusedAppRepo,
 			UIDService:    UnusedUIDService,
 			ExpectedError: errors.New("app input json labels are type map[string]interface {} instead of map[string]interface{}"),
-		},
-		{
-			Name: "Error when func enriching app input json with applicationType label - application type is not string",
-			Input: func() *model.ApplicationTemplateUpdateInput {
-				appInputJSON := `{"name":"foo","providerName":"compass","description":"Lorem ipsum","labels":{"applicationType":123,"test":["val","val2"]},"healthCheckURL":"https://foo.bar","webhooks":[{"type":"","url":"webhook1.foo.bar","auth":null},{"type":"","url":"webhook2.foo.bar","auth":null}],"integrationSystemID":"iiiiiiiii-iiii-iiii-iiii-iiiiiiiiiiii"}`
-				return fixModelAppTemplateUpdateInput(testName, appInputJSON)
-			},
-			InputOverride: true,
-			TimeSvcFn:     UnusedTimeService,
-			AppTemplateRepoFn: func() *automock.ApplicationTemplateRepository {
-				appTemplateRepo := &automock.ApplicationTemplateRepository{}
-				appTemplateRepo.On("Get", ctx, modelAppTemplate.ID).Return(modelAppTemplate, nil).Once()
-				return appTemplateRepo
-			},
-			WebhookRepoFn:    UnusedWebhookRepo,
-			LabelUpsertSvcFn: UnusedLabelUpsertSvc,
-			LabelRepoFn: func() *automock.LabelRepository {
-				labelRepo := &automock.LabelRepository{}
-				labelRepo.On("GetByKey", ctx, "", model.AppTemplateLabelableObject, modelAppTemplate.ID, "region").Return(&model.Label{Value: "eu-1"}, nil).Once()
-				return labelRepo
-			},
-			AppRepoFn:     UnusedAppRepo,
-			UIDService:    UnusedUIDService,
-			ExpectedError: errors.New("\"applicationType\" label value must be string"),
-		},
-		{
-			Name: "Error when func enriching app input json with applicationType label - application type value does not match the application template name",
-			Input: func() *model.ApplicationTemplateUpdateInput {
-				appInputJSON := `{"name":"foo","providerName":"compass","description":"Lorem ipsum","labels":{"applicationType":"random-text","test":["val","val2"]},"healthCheckURL":"https://foo.bar","webhooks":[{"type":"","url":"webhook1.foo.bar","auth":null},{"type":"","url":"webhook2.foo.bar","auth":null}],"integrationSystemID":"iiiiiiiii-iiii-iiii-iiii-iiiiiiiiiiii"}`
-				return fixModelAppTemplateUpdateInput(testName, appInputJSON)
-			},
-			InputOverride: true,
-			TimeSvcFn:     UnusedTimeService,
-			AppTemplateRepoFn: func() *automock.ApplicationTemplateRepository {
-				appTemplateRepo := &automock.ApplicationTemplateRepository{}
-				appTemplateRepo.On("Get", ctx, modelAppTemplate.ID).Return(modelAppTemplate, nil).Once()
-				return appTemplateRepo
-			},
-			WebhookRepoFn:    UnusedWebhookRepo,
-			LabelUpsertSvcFn: UnusedLabelUpsertSvc,
-			LabelRepoFn: func() *automock.LabelRepository {
-				labelRepo := &automock.LabelRepository{}
-				labelRepo.On("GetByKey", ctx, "", model.AppTemplateLabelableObject, modelAppTemplate.ID, "region").Return(&model.Label{Value: "eu-1"}, nil).Once()
-				return labelRepo
-			},
-			AppRepoFn:     UnusedAppRepo,
-			UIDService:    UnusedUIDService,
-			ExpectedError: errors.New("\"applicationType\" label value does not match the application template name"),
 		},
 		{
 			Name: "No error in func enriching app input json with applicationType label when application type value does not match the application template name for Other System Type",


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
When SaaS Application Providers have multiple SaaS Applications on the same region we want to be able to represent them as different application templates, but when creating a subscription the `system type` field in the Cockpit must be the same regardless of which SaaS Application the subscription was made. That means we want to soften to option to have different application templates with the same `applicationType` label value.


Changes proposed in this pull request:
- Allow different application templates to have the same `applicationType` label value
- Remove unit tests that are not up to date with this change
- Introduce E2E test
- Adjust old E2E tests

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- ...

**Pull Request status**
<!-- Feel free to construct the checklist with whatever items seem most reasonable for your change. You could disassemble the Implementation part to even smaller separate checklist items if you're working on something big for example. But do make the effort to provide a checklist of some sort so that the core team as well as the community can have an idea about the progress of your Pull Request.
-->

- [x] Implementation
- [x] Unit tests
- [x] Integration tests
- [x] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [ ] Mocks are regenerated, using the automated script
