### PR TITLE
[Improvement] Improve formation assignment asserters logs

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -231,7 +231,7 @@ global:
       name: compass-console
     e2e_tests:
       dir: dev/incubator/
-      version: "PR-3767"
+      version: "PR-3772"
       name: compass-e2e-tests
   isLocalEnv: false
   isForTesting: false

--- a/tests/director/tests/notifications/fixtures_test.go
+++ b/tests/director/tests/notifications/fixtures_test.go
@@ -99,7 +99,7 @@ func assertFormationAssignmentsAsynchronouslyWithEventually(t *testing.T, ctx co
 		assignmentsPage := fixtures.ListFormationAssignments(t, ctx, certSecuredGraphQLClient, tenantID, listFormationAssignmentsRequest)
 		if expectedAssignmentsCount != assignmentsPage.TotalCount {
 			tOnce.Logf("The expected assignments count: %d didn't match the actual: %d", expectedAssignmentsCount, assignmentsPage.TotalCount)
-			tOnce.Logf("The expected assignments are: %s", *jsonutils.MarshalJSON(t, assignmentsPage))
+			tOnce.Logf("The actual assignments are: %s", *jsonutils.MarshalJSON(t, assignmentsPage))
 			return
 		}
 		tOnce.Logf("There is/are: %d assignment(s), assert them with the expected ones...", assignmentsPage.TotalCount)
@@ -109,28 +109,28 @@ func assertFormationAssignmentsAsynchronouslyWithEventually(t *testing.T, ctx co
 			sourceAssignmentsExpectations, ok := expectedAssignments[assignment.Source]
 			if !ok {
 				tOnce.Logf("Could not find expectations for assignment with ID: %q and source ID: %q", assignment.ID, assignment.Source)
-				tOnce.Logf("The expected assignments are: %s", *jsonutils.MarshalJSON(t, assignmentsPage))
+				tOnce.Logf("The actual assignments are: %s", *jsonutils.MarshalJSON(t, assignmentsPage))
 				return
 			}
 			assignmentExpectation, ok := sourceAssignmentsExpectations[assignment.Target]
 			if !ok {
 				tOnce.Logf("Could not find expectations for assignment with ID: %q, source ID: %q and target ID: %q", assignment.ID, assignment.Source, assignment.Target)
-				tOnce.Logf("The expected assignments are: %s", *jsonutils.MarshalJSON(t, assignmentsPage))
+				tOnce.Logf("The actual assignments are: %s", *jsonutils.MarshalJSON(t, assignmentsPage))
 				return
 			}
 			if assignmentExpectation.State != assignment.State {
 				tOnce.Logf("The expected assignment state: %s doesn't match the actual: %s for assignment ID: %s", assignmentExpectation.State, assignment.State, assignment.ID)
-				tOnce.Logf("The expected assignments are: %s", *jsonutils.MarshalJSON(t, assignmentsPage))
+				tOnce.Logf("The actual assignments are: %s", *jsonutils.MarshalJSON(t, assignmentsPage))
 				return
 			}
 			if isEqual := jsonutils.AssertJSONStringEquality(tOnce, assignmentExpectation.Error, assignment.Error); !isEqual {
 				tOnce.Logf("The expected assignment state: %s doesn't match the actual: %s for assignment ID: %s", str.PtrStrToStr(assignmentExpectation.Error), str.PtrStrToStr(assignment.Error), assignment.ID)
-				tOnce.Logf("The expected assignments are: %s", *jsonutils.MarshalJSON(t, assignmentsPage))
+				tOnce.Logf("The actual assignments are: %s", *jsonutils.MarshalJSON(t, assignmentsPage))
 				return
 			}
 			if isEqual := jsonutils.AssertJSONStringEquality(tOnce, assignmentExpectation.Config, assignment.Configuration); !isEqual {
 				tOnce.Logf("The expected assignment config: %s doesn't match the actual: %s for assignment ID: %s", str.PtrStrToStr(assignmentExpectation.Config), str.PtrStrToStr(assignment.Configuration), assignment.ID)
-				tOnce.Logf("The expected assignments are: %s", *jsonutils.MarshalJSON(t, assignmentsPage))
+				tOnce.Logf("The actual assignments are: %s", *jsonutils.MarshalJSON(t, assignmentsPage))
 				return
 			}
 		}

--- a/tests/director/tests/notifications/fixtures_test.go
+++ b/tests/director/tests/notifications/fixtures_test.go
@@ -98,7 +98,8 @@ func assertFormationAssignmentsAsynchronouslyWithEventually(t *testing.T, ctx co
 		listFormationAssignmentsRequest := fixtures.FixListFormationAssignmentRequest(formationID, 200)
 		assignmentsPage := fixtures.ListFormationAssignments(t, ctx, certSecuredGraphQLClient, tenantID, listFormationAssignmentsRequest)
 		if expectedAssignmentsCount != assignmentsPage.TotalCount {
-			t.Logf("The expected assignments count: %d didn't match the actual: %d", expectedAssignmentsCount, assignmentsPage.TotalCount)
+			tOnce.Logf("The expected assignments count: %d didn't match the actual: %d", expectedAssignmentsCount, assignmentsPage.TotalCount)
+			tOnce.Logf("The expected assignments are: %s", *jsonutils.MarshalJSON(t, assignmentsPage))
 			return
 		}
 		tOnce.Logf("There is/are: %d assignment(s), assert them with the expected ones...", assignmentsPage.TotalCount)
@@ -108,23 +109,28 @@ func assertFormationAssignmentsAsynchronouslyWithEventually(t *testing.T, ctx co
 			sourceAssignmentsExpectations, ok := expectedAssignments[assignment.Source]
 			if !ok {
 				tOnce.Logf("Could not find expectations for assignment with ID: %q and source ID: %q", assignment.ID, assignment.Source)
+				tOnce.Logf("The expected assignments are: %s", *jsonutils.MarshalJSON(t, assignmentsPage))
 				return
 			}
 			assignmentExpectation, ok := sourceAssignmentsExpectations[assignment.Target]
 			if !ok {
 				tOnce.Logf("Could not find expectations for assignment with ID: %q, source ID: %q and target ID: %q", assignment.ID, assignment.Source, assignment.Target)
+				tOnce.Logf("The expected assignments are: %s", *jsonutils.MarshalJSON(t, assignmentsPage))
 				return
 			}
 			if assignmentExpectation.State != assignment.State {
 				tOnce.Logf("The expected assignment state: %s doesn't match the actual: %s for assignment ID: %s", assignmentExpectation.State, assignment.State, assignment.ID)
+				tOnce.Logf("The expected assignments are: %s", *jsonutils.MarshalJSON(t, assignmentsPage))
 				return
 			}
 			if isEqual := jsonutils.AssertJSONStringEquality(tOnce, assignmentExpectation.Error, assignment.Error); !isEqual {
 				tOnce.Logf("The expected assignment state: %s doesn't match the actual: %s for assignment ID: %s", str.PtrStrToStr(assignmentExpectation.Error), str.PtrStrToStr(assignment.Error), assignment.ID)
+				tOnce.Logf("The expected assignments are: %s", *jsonutils.MarshalJSON(t, assignmentsPage))
 				return
 			}
 			if isEqual := jsonutils.AssertJSONStringEquality(tOnce, assignmentExpectation.Config, assignment.Configuration); !isEqual {
 				tOnce.Logf("The expected assignment config: %s doesn't match the actual: %s for assignment ID: %s", str.PtrStrToStr(assignmentExpectation.Config), str.PtrStrToStr(assignment.Configuration), assignment.ID)
+				tOnce.Logf("The expected assignments are: %s", *jsonutils.MarshalJSON(t, assignmentsPage))
 				return
 			}
 		}

--- a/tests/pkg/notifications/asserters/formation_assignments_async.go
+++ b/tests/pkg/notifications/asserters/formation_assignments_async.go
@@ -26,8 +26,8 @@ var exactJSONConfigMatcher = func(t require.TestingT, expectedConfig, actualConf
 type FormationAssignmentsAsyncAsserter struct {
 	FormationAssignmentsAsserter
 	formationName string
-	timeout time.Duration
-	tick    time.Duration
+	timeout       time.Duration
+	tick          time.Duration
 }
 
 func NewFormationAssignmentAsyncAsserter(expectations map[string]map[string]fixtures.AssignmentState, expectedAssignmentsCount int, certSecuredGraphQLClient *graphql.Client, tenantID string) *FormationAssignmentsAsyncAsserter {
@@ -49,23 +49,23 @@ func (a *FormationAssignmentsAsyncAsserter) AssertExpectations(t *testing.T, ctx
 	if a.formationName != "" {
 		formation := fixtures.GetFormationByName(t, ctx, a.certSecuredGraphQLClient, a.formationName, a.tenantID)
 		formationID = formation.ID
-	}else {
+	} else {
 		formationID = ctx.Value(context_keys.FormationIDKey).(string)
 	}
 	a.assertFormationAssignmentsAsynchronouslyWithEventually(t, ctx, a.certSecuredGraphQLClient, a.tenantID, formationID, a.expectedAssignmentsCount, a.expectations, exactJSONConfigMatcher)
 }
 
-func (a *FormationAssignmentsAsyncAsserter) WithFormationName(formationName string)  *FormationAssignmentsAsyncAsserter{
+func (a *FormationAssignmentsAsyncAsserter) WithFormationName(formationName string) *FormationAssignmentsAsyncAsserter {
 	a.formationName = formationName
 	return a
 }
 
-func (a *FormationAssignmentsAsyncAsserter) WithTimeout(timeout time.Duration)  *FormationAssignmentsAsyncAsserter{
+func (a *FormationAssignmentsAsyncAsserter) WithTimeout(timeout time.Duration) *FormationAssignmentsAsyncAsserter {
 	a.timeout = timeout
 	return a
 }
 
-func (a *FormationAssignmentsAsyncAsserter) WithTick(tick time.Duration)  *FormationAssignmentsAsyncAsserter{
+func (a *FormationAssignmentsAsyncAsserter) WithTick(tick time.Duration) *FormationAssignmentsAsyncAsserter {
 	a.tick = tick
 	return a
 }
@@ -73,12 +73,14 @@ func (a *FormationAssignmentsAsyncAsserter) WithTick(tick time.Duration)  *Forma
 func (a *FormationAssignmentsAsyncAsserter) assertFormationAssignmentsAsynchronouslyWithEventually(t *testing.T, ctx context.Context, certSecuredGraphQLClient *graphql.Client, tenantID, formationID string, expectedAssignmentsCount int, expectedAssignments map[string]map[string]fixtures.AssignmentState, configMatcher func(t require.TestingT, expectedConfig, actualConfig *string) bool) {
 	t.Logf("Asserting formation assignments with eventually...")
 	tOnce := testingx.NewOnceLogger(t)
+
 	require.Eventually(t, func() (isOkay bool) {
 		tOnce.Logf("Getting formation assignments...")
 		listFormationAssignmentsRequest := fixtures.FixListFormationAssignmentRequest(formationID, 200)
 		assignmentsPage := fixtures.ListFormationAssignments(tOnce, ctx, certSecuredGraphQLClient, tenantID, listFormationAssignmentsRequest)
 		if expectedAssignmentsCount != assignmentsPage.TotalCount {
 			tOnce.Logf("The expected assignments count: %d didn't match the actual: %d", expectedAssignmentsCount, assignmentsPage.TotalCount)
+			tOnce.Logf("The expected assignments are: %s", *json.MarshalJSON(t, assignmentsPage))
 			return
 		}
 		tOnce.Logf("There is/are: %d assignment(s), assert them with the expected ones...", assignmentsPage.TotalCount)
@@ -88,23 +90,28 @@ func (a *FormationAssignmentsAsyncAsserter) assertFormationAssignmentsAsynchrono
 			sourceAssignmentsExpectations, ok := expectedAssignments[assignment.Source]
 			if !ok {
 				tOnce.Logf("Could not find expectations for assignment with ID: %q and source ID: %q", assignment.ID, assignment.Source)
+				tOnce.Logf("The expected assignments are: %s", *json.MarshalJSON(t, assignmentsPage))
 				return
 			}
 			assignmentExpectation, ok := sourceAssignmentsExpectations[assignment.Target]
 			if !ok {
 				tOnce.Logf("Could not find expectations for assignment with ID: %q, source ID: %q and target ID: %q", assignment.ID, assignment.Source, assignment.Target)
+				tOnce.Logf("The expected assignments are: %s", *json.MarshalJSON(t, assignmentsPage))
 				return
 			}
 			if assignmentExpectation.State != assignment.State {
 				tOnce.Logf("The expected assignment state: %s doesn't match the actual: %s for assignment ID: %s", assignmentExpectation.State, assignment.State, assignment.ID)
+				tOnce.Logf("The expected assignments are: %s", *json.MarshalJSON(t, assignmentsPage))
 				return
 			}
 			if isEqual := json.AssertJSONStringEquality(tOnce, assignmentExpectation.Error, assignment.Error); !isEqual {
 				tOnce.Logf("The expected assignment state: %s doesn't match the actual: %s for assignment ID: %s", str.PtrStrToStr(assignmentExpectation.Error), str.PtrStrToStr(assignment.Error), assignment.ID)
+				tOnce.Logf("The expected assignments are: %s", *json.MarshalJSON(t, assignmentsPage))
 				return
 			}
 			if isEqual := configMatcher(t, assignmentExpectation.Config, assignment.Configuration); !isEqual {
 				tOnce.Logf("The expected assignment config: %s doesn't match the actual: %s for assignment ID: %s", str.PtrStrToStr(assignmentExpectation.Config), str.PtrStrToStr(assignment.Configuration), assignment.ID)
+				tOnce.Logf("The expected assignments are: %s", *json.MarshalJSON(t, assignmentsPage))
 				return
 			}
 		}

--- a/tests/pkg/notifications/asserters/formation_assignments_async.go
+++ b/tests/pkg/notifications/asserters/formation_assignments_async.go
@@ -80,7 +80,7 @@ func (a *FormationAssignmentsAsyncAsserter) assertFormationAssignmentsAsynchrono
 		assignmentsPage := fixtures.ListFormationAssignments(tOnce, ctx, certSecuredGraphQLClient, tenantID, listFormationAssignmentsRequest)
 		if expectedAssignmentsCount != assignmentsPage.TotalCount {
 			tOnce.Logf("The expected assignments count: %d didn't match the actual: %d", expectedAssignmentsCount, assignmentsPage.TotalCount)
-			tOnce.Logf("The expected assignments are: %s", *json.MarshalJSON(t, assignmentsPage))
+			tOnce.Logf("The actual assignments are: %s", *json.MarshalJSON(t, assignmentsPage))
 			return
 		}
 		tOnce.Logf("There is/are: %d assignment(s), assert them with the expected ones...", assignmentsPage.TotalCount)
@@ -90,28 +90,28 @@ func (a *FormationAssignmentsAsyncAsserter) assertFormationAssignmentsAsynchrono
 			sourceAssignmentsExpectations, ok := expectedAssignments[assignment.Source]
 			if !ok {
 				tOnce.Logf("Could not find expectations for assignment with ID: %q and source ID: %q", assignment.ID, assignment.Source)
-				tOnce.Logf("The expected assignments are: %s", *json.MarshalJSON(t, assignmentsPage))
+				tOnce.Logf("The actual assignments are: %s", *json.MarshalJSON(t, assignmentsPage))
 				return
 			}
 			assignmentExpectation, ok := sourceAssignmentsExpectations[assignment.Target]
 			if !ok {
 				tOnce.Logf("Could not find expectations for assignment with ID: %q, source ID: %q and target ID: %q", assignment.ID, assignment.Source, assignment.Target)
-				tOnce.Logf("The expected assignments are: %s", *json.MarshalJSON(t, assignmentsPage))
+				tOnce.Logf("The actual assignments are: %s", *json.MarshalJSON(t, assignmentsPage))
 				return
 			}
 			if assignmentExpectation.State != assignment.State {
 				tOnce.Logf("The expected assignment state: %s doesn't match the actual: %s for assignment ID: %s", assignmentExpectation.State, assignment.State, assignment.ID)
-				tOnce.Logf("The expected assignments are: %s", *json.MarshalJSON(t, assignmentsPage))
+				tOnce.Logf("The actual assignments are: %s", *json.MarshalJSON(t, assignmentsPage))
 				return
 			}
 			if isEqual := json.AssertJSONStringEquality(tOnce, assignmentExpectation.Error, assignment.Error); !isEqual {
 				tOnce.Logf("The expected assignment state: %s doesn't match the actual: %s for assignment ID: %s", str.PtrStrToStr(assignmentExpectation.Error), str.PtrStrToStr(assignment.Error), assignment.ID)
-				tOnce.Logf("The expected assignments are: %s", *json.MarshalJSON(t, assignmentsPage))
+				tOnce.Logf("The actual assignments are: %s", *json.MarshalJSON(t, assignmentsPage))
 				return
 			}
 			if isEqual := configMatcher(t, assignmentExpectation.Config, assignment.Configuration); !isEqual {
 				tOnce.Logf("The expected assignment config: %s doesn't match the actual: %s for assignment ID: %s", str.PtrStrToStr(assignmentExpectation.Config), str.PtrStrToStr(assignment.Configuration), assignment.ID)
-				tOnce.Logf("The expected assignments are: %s", *json.MarshalJSON(t, assignmentsPage))
+				tOnce.Logf("The actual assignments are: %s", *json.MarshalJSON(t, assignmentsPage))
 				return
 			}
 		}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Currently, when an e2e test(which includes asserting the formation assignments) fails there are no logs of what the actual assignments are and it is difficult to debug such errors/flappings.

Changes proposed in this pull request:
- Enhance the logs in the e2e tests

**Pull Request status**
<!-- Feel free to construct the checklist with whatever items seem most reasonable for your change. You could disassemble the Implementation part to even smaller separate checklist items if you're working on something big for example. But do make the effort to provide a checklist of some sort so that the core team as well as the community can have an idea about the progress of your Pull Request.
-->

- [ ] Implementation
- [ ] Unit tests
- [ ] Integration tests
- [ ] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [ ] Mocks are regenerated, using the automated script
