### PR TITLE
Expose labels management to GQL API for IntDep

### DIFF
--- a/components/director/internal/domain/integrationdependency/converter.go
+++ b/components/director/internal/domain/integrationdependency/converter.go
@@ -1,6 +1,8 @@
 package integrationdependency
 
 import (
+	"encoding/json"
+
 	"github.com/kyma-incubator/compass/components/director/internal/domain/version"
 	"github.com/kyma-incubator/compass/components/director/internal/model"
 	"github.com/kyma-incubator/compass/components/director/internal/repo"
@@ -135,6 +137,13 @@ func (c *converter) ToGraphQL(in *model.IntegrationDependency, aspects []*model.
 		return nil, err
 	}
 
+	var labels *graphql.Labels
+	if in.Labels != nil {
+		if err := json.Unmarshal(in.Labels, &labels); err != nil {
+			return nil, err
+		}
+	}
+
 	return &graphql.IntegrationDependency{
 		Name:          in.Title,
 		Description:   in.Description,
@@ -145,6 +154,7 @@ func (c *converter) ToGraphQL(in *model.IntegrationDependency, aspects []*model.
 		Mandatory:     in.Mandatory,
 		Aspects:       gqlAspects,
 		Version:       c.version.ToGraphQL(in.Version),
+		Labels:        labels,
 		BaseEntity: &graphql.BaseEntity{
 			ID:        in.ID,
 			Ready:     in.Ready,
@@ -167,6 +177,14 @@ func (c *converter) InputFromGraphQL(in *graphql.IntegrationDependencyInput) (*m
 		return nil, err
 	}
 
+	var labels []byte
+	if in.Labels != nil {
+		labels, err = json.Marshal(in.Labels)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	return &model.IntegrationDependencyInput{
 		Title:         in.Name,
 		Description:   in.Description,
@@ -177,5 +195,6 @@ func (c *converter) InputFromGraphQL(in *graphql.IntegrationDependencyInput) (*m
 		Mandatory:     in.Mandatory,
 		Aspects:       aspects,
 		VersionInput:  c.version.InputFromGraphQL(in.Version),
+		Labels:        labels,
 	}, nil
 }

--- a/components/director/internal/domain/integrationdependency/fixtures_test.go
+++ b/components/director/internal/domain/integrationdependency/fixtures_test.go
@@ -31,6 +31,7 @@ const (
 	sunsetDate              = "2022-01-08T15:47:04+00:00"
 	lastUpdate              = "2022-01-08T15:47:04+00:00"
 	resourceHash            = "123456"
+	defaultLabelsRaw        = `{"displayName":"bar","test":["val","val2"]}`
 )
 
 var (
@@ -45,6 +46,13 @@ var (
 	versionDeprecatedSince   = "v1.0"
 	versionForRemoval        = false
 	testErr                  = errors.New("test error")
+	defaultLabelsModel       = graphql.Labels{
+		"displayName": "bar",
+		"test": []interface{}{
+			"val",
+			"val2",
+		},
+	}
 )
 
 func fixIntegrationDependencyModel(integrationDependencyID string) *model.IntegrationDependency {
@@ -75,7 +83,7 @@ func fixIntegrationDependencyModel(integrationDependencyID string) *model.Integr
 		Mandatory:                      &mandatory,
 		Links:                          json.RawMessage("[]"),
 		Tags:                           json.RawMessage("[]"),
-		Labels:                         json.RawMessage("[]"),
+		Labels:                         json.RawMessage(defaultLabelsRaw),
 		DocumentationLabels:            json.RawMessage("[]"),
 		ResourceHash:                   str.Ptr(resourceHash),
 		Version: &model.Version{
@@ -103,6 +111,7 @@ func fixGQLIntegrationDependency(id string) *graphql.IntegrationDependency {
 			DeprecatedSince: &versionDeprecatedSince,
 			ForRemoval:      &versionForRemoval,
 		},
+		Labels: &defaultLabelsModel,
 		BaseEntity: &graphql.BaseEntity{
 			ID:        id,
 			Ready:     true,
@@ -142,7 +151,7 @@ func fixIntegrationDependencyEntity(integrationDependencyID, appID string) *inte
 		Mandatory:                      repo.NewValidNullableBool(mandatory),
 		Links:                          repo.NewValidNullableString("[]"),
 		Tags:                           repo.NewValidNullableString("[]"),
-		Labels:                         repo.NewValidNullableString("[]"),
+		Labels:                         repo.NewValidNullableString(defaultLabelsRaw),
 		DocumentationLabels:            repo.NewValidNullableString("[]"),
 		ResourceHash:                   repo.NewValidNullableString(resourceHash),
 		Version: version.Version{
@@ -323,7 +332,7 @@ func fixIntegrationDependenciesColumns() []string {
 func fixIntegrationDependenciesRow(id, appID string) []driver.Value {
 	return []driver.Value{id, ready, fixedTimestamp, time.Time{}, time.Time{}, nil, appID, repo.NewValidNullableString(appTemplateVersionID), ordID, localTenantID,
 		repo.NewNullableStringFromJSONRawMessage(json.RawMessage("[]")), title, repo.NewValidNullableString(shortDescription), repo.NewValidNullableString(description), packageID, publicVisibility,
-		repo.NewValidNullableString(lastUpdate), releaseStatus, repo.NewValidNullableString(sunsetDate), repo.NewNullableStringFromJSONRawMessage(json.RawMessage("[]")), repo.NewNullableBool(&mandatory), repo.NewNullableStringFromJSONRawMessage(json.RawMessage("[]")), repo.NewNullableStringFromJSONRawMessage(json.RawMessage("[]")), repo.NewNullableStringFromJSONRawMessage(json.RawMessage("[]")), repo.NewNullableStringFromJSONRawMessage(json.RawMessage("[]")),
+		repo.NewValidNullableString(lastUpdate), releaseStatus, repo.NewValidNullableString(sunsetDate), repo.NewNullableStringFromJSONRawMessage(json.RawMessage("[]")), repo.NewNullableBool(&mandatory), repo.NewNullableStringFromJSONRawMessage(json.RawMessage("[]")), repo.NewNullableStringFromJSONRawMessage(json.RawMessage("[]")), repo.NewNullableStringFromJSONRawMessage(json.RawMessage("[]")), repo.NewNullableStringFromJSONRawMessage(json.RawMessage(defaultLabelsRaw)),
 		repo.NewNullableStringFromJSONRawMessage(json.RawMessage("[]")), repo.NewValidNullableString(resourceHash), repo.NewNullableString(&versionValue), repo.NewNullableBool(&versionDeprecated), repo.NewNullableString(&versionDeprecatedSince), repo.NewNullableBool(&versionForRemoval)}
 }
 

--- a/components/director/pkg/graphql/integration_dependency.go
+++ b/components/director/pkg/graphql/integration_dependency.go
@@ -11,6 +11,7 @@ type IntegrationDependency struct {
 	Mandatory     *bool     `json:"mandatory"`
 	Aspects       []*Aspect `json:"aspects"`
 	Version       *Version  `json:"version"`
+	Labels        *Labels   `json:"labels"`
 	*BaseEntity
 }
 

--- a/components/director/pkg/graphql/models_gen.go
+++ b/components/director/pkg/graphql/models_gen.go
@@ -671,6 +671,7 @@ type IntegrationDependencyInput struct {
 	Mandatory     *bool          `json:"mandatory,omitempty"`
 	Aspects       []*AspectInput `json:"aspects,omitempty"`
 	Version       *VersionInput  `json:"version,omitempty"`
+	Labels        Labels         `json:"labels,omitempty"`
 }
 
 type IntegrationDependencyPage struct {

--- a/components/director/pkg/graphql/schema.graphql
+++ b/components/director/pkg/graphql/schema.graphql
@@ -786,6 +786,7 @@ input IntegrationDependencyInput {
 	mandatory: Boolean
 	aspects: [AspectInput!]
 	version: VersionInput
+	labels: Labels
 }
 
 input IntegrationSystemInput {
@@ -1437,6 +1438,7 @@ type IntegrationDependency {
 	mandatory: Boolean
 	aspects: [Aspect!]
 	version: Version
+	labels: Labels
 	created_at: Timestamp
 	updated_at: Timestamp
 	deleted_at: Timestamp

--- a/components/director/pkg/graphql/schema_gen.go
+++ b/components/director/pkg/graphql/schema_gen.go
@@ -494,6 +494,7 @@ type ComplexityRoot struct {
 		Description   func(childComplexity int) int
 		Error         func(childComplexity int) int
 		ID            func(childComplexity int) int
+		Labels        func(childComplexity int) int
 		Mandatory     func(childComplexity int) int
 		Name          func(childComplexity int) int
 		OrdID         func(childComplexity int) int
@@ -3114,6 +3115,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.IntegrationDependency.ID(childComplexity), true
+
+	case "IntegrationDependency.labels":
+		if e.complexity.IntegrationDependency.Labels == nil {
+			break
+		}
+
+		return e.complexity.IntegrationDependency.Labels(childComplexity), true
 
 	case "IntegrationDependency.mandatory":
 		if e.complexity.IntegrationDependency.Mandatory == nil {
@@ -23390,6 +23398,47 @@ func (ec *executionContext) fieldContext_IntegrationDependency_version(ctx conte
 	return fc, nil
 }
 
+func (ec *executionContext) _IntegrationDependency_labels(ctx context.Context, field graphql.CollectedField, obj *IntegrationDependency) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_IntegrationDependency_labels(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Labels, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(Labels)
+	fc.Result = res
+	return ec.marshalOLabels2githubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋdirectorᚋpkgᚋgraphqlᚐLabels(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_IntegrationDependency_labels(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "IntegrationDependency",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Labels does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _IntegrationDependency_created_at(ctx context.Context, field graphql.CollectedField, obj *IntegrationDependency) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_IntegrationDependency_created_at(ctx, field)
 	if err != nil {
@@ -23613,6 +23662,8 @@ func (ec *executionContext) fieldContext_IntegrationDependencyPage_data(ctx cont
 				return ec.fieldContext_IntegrationDependency_aspects(ctx, field)
 			case "version":
 				return ec.fieldContext_IntegrationDependency_version(ctx, field)
+			case "labels":
+				return ec.fieldContext_IntegrationDependency_labels(ctx, field)
 			case "created_at":
 				return ec.fieldContext_IntegrationDependency_created_at(ctx, field)
 			case "updated_at":
@@ -27327,6 +27378,8 @@ func (ec *executionContext) fieldContext_Mutation_addIntegrationDependencyToAppl
 				return ec.fieldContext_IntegrationDependency_aspects(ctx, field)
 			case "version":
 				return ec.fieldContext_IntegrationDependency_version(ctx, field)
+			case "labels":
+				return ec.fieldContext_IntegrationDependency_labels(ctx, field)
 			case "created_at":
 				return ec.fieldContext_IntegrationDependency_created_at(ctx, field)
 			case "updated_at":
@@ -27436,6 +27489,8 @@ func (ec *executionContext) fieldContext_Mutation_deleteIntegrationDependency(ct
 				return ec.fieldContext_IntegrationDependency_aspects(ctx, field)
 			case "version":
 				return ec.fieldContext_IntegrationDependency_version(ctx, field)
+			case "labels":
+				return ec.fieldContext_IntegrationDependency_labels(ctx, field)
 			case "created_at":
 				return ec.fieldContext_IntegrationDependency_created_at(ctx, field)
 			case "updated_at":
@@ -45780,7 +45835,7 @@ func (ec *executionContext) unmarshalInputIntegrationDependencyInput(ctx context
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"name", "description", "ordID", "partOfPackage", "visibility", "releaseStatus", "mandatory", "aspects", "version"}
+	fieldsInOrder := [...]string{"name", "description", "ordID", "partOfPackage", "visibility", "releaseStatus", "mandatory", "aspects", "version", "labels"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -45850,6 +45905,13 @@ func (ec *executionContext) unmarshalInputIntegrationDependencyInput(ctx context
 				return it, err
 			}
 			it.Version = data
+		case "labels":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("labels"))
+			data, err := ec.unmarshalOLabels2githubᚗcomᚋkymaᚑincubatorᚋcompassᚋcomponentsᚋdirectorᚋpkgᚋgraphqlᚐLabels(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Labels = data
 		}
 	}
 
@@ -50478,6 +50540,8 @@ func (ec *executionContext) _IntegrationDependency(ctx context.Context, sel ast.
 			out.Values[i] = ec._IntegrationDependency_aspects(ctx, field, obj)
 		case "version":
 			out.Values[i] = ec._IntegrationDependency_version(ctx, field, obj)
+		case "labels":
+			out.Values[i] = ec._IntegrationDependency_labels(ctx, field, obj)
 		case "created_at":
 			out.Values[i] = ec._IntegrationDependency_created_at(ctx, field, obj)
 		case "updated_at":


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:
- Expose labels management to GQL API for Integration Dependencies

**Pull Request status**
- [x] Implementation
- [x] Unit tests
- [ ] Integration tests
- [ ] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [ ] Mocks are regenerated, using the automated script
