### PR TITLE
Fix status API external token authenticator

### DIFF
--- a/chart/compass/charts/gateway/templates/oathkeeper-rules.yaml
+++ b/chart/compass/charts/gateway/templates/oathkeeper-rules.yaml
@@ -497,7 +497,7 @@ spec:
   - handler: hydrator
     config:
       api:
-        url: "http://{{ $.Values.global.hydrator.host }}:{{ $.Values.global.hydrator.port }}{{ $.Values.global.hydrator.prefix}}/authn-mapping/{{ .Values.global.director.formationMappingAsyncStatusApi.authentication.name }}"
+        url: "http://{{ $.Values.global.hydrator.host }}:{{ $.Values.global.hydrator.port }}{{ $.Values.global.hydrator.prefix}}/authn-mapping/{{ .Values.global.director.formationMappingAsyncStatusApi.authentication.hydratorAuthenticator.name }}"
         retry:
           give_up_after: {{ default "6s" .Values.global.director.formationMappingAsyncStatusApi.authentication.retry.give_up_after }}
           max_delay: {{ default "2000ms" .Values.global.director.formationMappingAsyncStatusApi.authentication.retry.max_delay }}

--- a/chart/compass/charts/hydrator/templates/deployment.yaml
+++ b/chart/compass/charts/hydrator/templates/deployment.yaml
@@ -94,12 +94,14 @@ spec:
               value: {{ $config.authenticator.checkSuffix | quote }}
             {{- end }}
             {{- end }}
-            - name: APP_{{ .Values.global.director.formationMappingAsyncStatusApi.authentication.name }}_AUTHENTICATOR_TRUSTED_ISSUERS
+            {{- if eq .Values.global.director.formationMappingAsyncStatusApi.authentication.hydratorAuthenticator.enabled true }}
+            - name: APP_{{ .Values.global.director.formationMappingAsyncStatusApi.authentication.hydratorAuthenticator.name }}_AUTHENTICATOR_TRUSTED_ISSUERS
               value: {{ .Values.global.director.formationMappingAsyncStatusApi.authentication.trusted_issuers | quote }}
-            - name: APP_{{ .Values.global.director.formationMappingAsyncStatusApi.authentication.name }}_AUTHENTICATOR_ATTRIBUTES
+            - name: APP_{{ .Values.global.director.formationMappingAsyncStatusApi.authentication.hydratorAuthenticator.name }}_AUTHENTICATOR_ATTRIBUTES
               value: {{ .Values.global.director.formationMappingAsyncStatusApi.authentication.attributes | quote }}
-            - name: APP_{{ .Values.global.director.formationMappingAsyncStatusApi.authentication.name }}_AUTHENTICATOR_CHECK_CLIENT_ID_SUFFIX
+            - name: APP_{{ .Values.global.director.formationMappingAsyncStatusApi.authentication.hydratorAuthenticator.name }}_AUTHENTICATOR_CHECK_CLIENT_ID_SUFFIX
               value: {{ .Values.global.director.formationMappingAsyncStatusApi.authentication.checkSuffix | quote }}
+            {{- end }}
             - name: APP_CSR_SUBJECT_COUNTRY
               value: {{ .Values.deployment.args.csrSubject.country | quote }}
             - name: APP_CSR_SUBJECT_ORGANIZATION

--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -287,6 +287,9 @@ global:
       formationPath: "/{ucl-formation-id}/status"
       authentication:
         name: "external-token-status"
+        hydratorAuthenticator:
+          name: "external-token"
+          enabled: false
         gatewayHost: "compass-gateway-external-token"
         trusted_issuers: '[{"domain_url": "compass-system.svc.cluster.local:8080", "scope_prefixes": ["prefix.", "prefix2."], "protocol": "http", "region": "eu-1"}]'
         attributes: '{"uniqueAttribute": { "key": "unique-attr-authenticator-key", "value": "unique-attr-authenticator-value" }, "tenants": [{ "key": "ext_attr.subaccountid", "priority": 1 },{ "key": "ext_attr.globalaccountid", "priority": 2 }], "identity": { "key": "user_name" }, "clientid": { "key": "client_id" } }'

--- a/installation/resources/compass-overrides-local.yaml
+++ b/installation/resources/compass-overrides-local.yaml
@@ -28,6 +28,10 @@ global:
       manage: true
   domainName: "local.kyma.dev"
   director:
+    formationMappingAsyncStatusApi:
+      authentication:
+        hydratorAuthenticator:
+          enabled: true
     subscription:
       subscriptionProviderLabelKey: "subscriptionProviderId"
     ordWebhookMappings: '[{ "OrdUrlPath": "/.well-known/open-resource-discovery", "Type": "SAP temp1", "PpmsProductVersions": ["12345"], "SubdomainSuffix": "" }, { "ProxyURL": "http://compass-external-services-mock.compass-system.svc.cluster.local:8090", "ProxyHeaderTemplate": "{\"target_host\": [\"{{.Application.BaseURL}}\"] }", "OrdUrlPath": "/proxy", "SubdomainSuffix": "-api", "Type": "SAP Proxy Template" }]'


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Currently, the `TestFormationNotificationsForDraftFormationWithInitialConfig` e2e test fails on real env because the ory rule hydrator authenticator is pointing to a local authenticator. This PR fixes that.

Changes proposed in this pull request:
- Fix status API external token authenticator env vars

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- https://github.com/kyma-incubator/compass/pull/3782

**Pull Request status**
<!-- Feel free to construct the checklist with whatever items seem most reasonable for your change. You could disassemble the Implementation part to even smaller separate checklist items if you're working on something big for example. But do make the effort to provide a checklist of some sort so that the core team as well as the community can have an idea about the progress of your Pull Request.
-->

- [ ] Implementation
- [ ] Unit tests
- [ ] Integration tests
- [ ] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [ ] Mocks are regenerated, using the automated script
