### PR TITLE
Fix TestFormationNotificationsForDraftFormationWithInitialConfig e2e test tenancy

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -175,7 +175,7 @@ global:
       name: compass-pairing-adapter
     director:
       dir: dev/incubator/
-      version: "PR-3782"
+      version: "PR-3789"
       name: compass-director
     hydrator:
       dir: dev/incubator/

--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -232,7 +232,7 @@ global:
       name: compass-console
     e2e_tests:
       dir: dev/incubator/
-      version: "PR-3782"
+      version: "PR-3789"
       name: compass-e2e-tests
   isLocalEnv: false
   isForTesting: false

--- a/components/director/internal/formationmapping/auth_middleware.go
+++ b/components/director/internal/formationmapping/auth_middleware.go
@@ -362,7 +362,7 @@ func (a *Authenticator) isFormationAssignmentAuthorized(ctx context.Context, for
 
 		if consumerType == consumer.User { // call with external token
 			if tntFromToken != fa.TenantID {
-				return false, http.StatusInternalServerError, errors.Errorf("external tenant from token with ID %q is not allowed to update formation assignment in tenant %q", tntFromToken, fa.TenantID)
+				return false, http.StatusInternalServerError, errors.Errorf("internal tenant from token with ID %q is not allowed to update formation assignment in tenant %q", tntFromToken, fa.TenantID)
 			}
 			if err := tx.Commit(); err != nil {
 				return false, http.StatusInternalServerError, errors.Wrap(err, "while closing database transaction")

--- a/tests/director/tests/notifications/status_api_external_call_test.go
+++ b/tests/director/tests/notifications/status_api_external_call_test.go
@@ -13,7 +13,6 @@ import (
 	mock_data "github.com/kyma-incubator/compass/tests/pkg/notifications/expectations-builders"
 	"github.com/kyma-incubator/compass/tests/pkg/notifications/operations"
 	resource_providers "github.com/kyma-incubator/compass/tests/pkg/notifications/resource-providers"
-	"github.com/kyma-incubator/compass/tests/pkg/tenant"
 	"github.com/kyma-incubator/compass/tests/pkg/token"
 	"github.com/stretchr/testify/require"
 )
@@ -26,7 +25,7 @@ func TestFormationNotificationsForDraftFormationWithInitialConfig(t *testing.T) 
 
 	ctx := context.Background()
 
-	tnt := tenant.TestTenants.GetIDByName(t, tenant.ApplicationsForRuntimeTenantName)
+	tnt := conf.TestConsumerAccountID
 
 	appName := "testAsyncApp"
 	appType := "async-app-type-1"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
We are using the wrong tenant in TestFormationNotificationsForDraftFormationWithInitialConfig e2e test on real env.

Changes proposed in this pull request:
- Fix TestFormationNotificationsForDraftFormationWithInitialConfig e2e test tenancy

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- https://github.com/kyma-incubator/compass/pull/3782

**Pull Request status**
<!-- Feel free to construct the checklist with whatever items seem most reasonable for your change. You could disassemble the Implementation part to even smaller separate checklist items if you're working on something big for example. But do make the effort to provide a checklist of some sort so that the core team as well as the community can have an idea about the progress of your Pull Request.
-->

- [ ] Implementation
- [ ] Unit tests
- [ ] Integration tests
- [ ] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [ ] Mocks are regenerated, using the automated script
