### PR TITLE
Fix formationTemplate gql query not found error

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -175,7 +175,7 @@ global:
       name: compass-pairing-adapter
     director:
       dir: dev/incubator/
-      version: "PR-3789"
+      version: "PR-3791"
       name: compass-director
     hydrator:
       dir: dev/incubator/

--- a/components/director/internal/domain/formationtemplate/resolver.go
+++ b/components/director/internal/domain/formationtemplate/resolver.go
@@ -140,9 +140,6 @@ func (r *Resolver) FormationTemplate(ctx context.Context, id string) (*graphql.F
 
 	formationTemplate, err := r.formationTemplateSvc.Get(ctx, id)
 	if err != nil {
-		if apperrors.IsNotFoundError(err) {
-			return nil, tx.Commit()
-		}
 		return nil, err
 	}
 

--- a/components/director/internal/domain/formationtemplate/resolver_test.go
+++ b/components/director/internal/domain/formationtemplate/resolver_test.go
@@ -71,7 +71,7 @@ func TestResolver_FormationTemplate(t *testing.T) {
 		},
 		{
 			Name: "Returns nil when formation template not found",
-			TxFn: txGen.ThatSucceeds,
+			TxFn: txGen.ThatDoesntExpectCommit,
 			FormationTemplateService: func() *automock.FormationTemplateService {
 				svc := &automock.FormationTemplateService{}
 				svc.On("Get", txtest.CtxWithDBMatcher(), testID).Return(nil, apperrors.NewNotFoundError(resource.FormationTemplate, testID))
@@ -80,7 +80,7 @@ func TestResolver_FormationTemplate(t *testing.T) {
 			},
 			FormationTemplateConverter: UnusedFormationTemplateConverter,
 			ExpectedOutput:             nil,
-			ExpectedError:              nil,
+			ExpectedError:              apperrors.NewNotFoundError(resource.FormationTemplate, testID),
 		},
 		{
 			Name: "Returns error when failing on the committing of a transaction",

--- a/components/director/internal/domain/formationtemplate/resolver_test.go
+++ b/components/director/internal/domain/formationtemplate/resolver_test.go
@@ -70,7 +70,7 @@ func TestResolver_FormationTemplate(t *testing.T) {
 			ExpectedError:              testErr,
 		},
 		{
-			Name: "Returns nil when formation template not found",
+			Name: "Returns error when formation template not found",
 			TxFn: txGen.ThatDoesntExpectCommit,
 			FormationTemplateService: func() *automock.FormationTemplateService {
 				svc := &automock.FormationTemplateService{}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Currently, when you fetch formationTemplate by ID which does not exist it returns null instead of Not Found error which is misleading.

Changes proposed in this pull request:
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- ...

**Pull Request status**
<!-- Feel free to construct the checklist with whatever items seem most reasonable for your change. You could disassemble the Implementation part to even smaller separate checklist items if you're working on something big for example. But do make the effort to provide a checklist of some sort so that the core team as well as the community can have an idea about the progress of your Pull Request.
-->

- [ ] Implementation
- [ ] Unit tests
- [ ] Integration tests
- [ ] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [ ] Mocks are regenerated, using the automated script
