### PR TITLE
Ensure that configuration is provided to status reset API

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -175,7 +175,7 @@ global:
       name: compass-pairing-adapter
     director:
       dir: dev/incubator/
-      version: "PR-3791"
+      version: "PR-3794"
       name: compass-director
     hydrator:
       dir: dev/incubator/

--- a/components/director/internal/formationmapping/handler.go
+++ b/components/director/internal/formationmapping/handler.go
@@ -190,6 +190,12 @@ func (h *Handler) updateFormationAssignmentStatus(w http.ResponseWriter, r *http
 			return
 		}
 
+		if formationassignmentpkg.IsConfigEmpty(string(notificationStatusReport.Configuration)) {
+			errResp := errors.Errorf("Cannot reset formation assignment with source %q and target %q to state %s because provided configuration is empty. X-Request-Id: %s", fa.Source, fa.Target, assignmentReqBody.State, correlationID)
+			respondWithError(ctx, w, http.StatusBadRequest, errResp)
+			return
+		}
+
 		if fa.State != string(model.ReadyAssignmentState) {
 			errResp := errors.Errorf("Cannot reset formation assignment with source %q and target %q because assignment is not in %q state. X-Request-Id: %s", fa.Source, fa.Target, model.ReadyAssignmentState, correlationID)
 			respondWithError(ctx, w, http.StatusBadRequest, errResp)

--- a/components/director/internal/formationmapping/handler_test.go
+++ b/components/director/internal/formationmapping/handler_test.go
@@ -1620,6 +1620,25 @@ func TestHandler_ResetFormationAssignmentStatus(t *testing.T) {
 			expectedStatusCode: http.StatusBadRequest,
 		},
 		{
+			name:       "Fail when trying to reset assignment without configuration",
+			transactFn: txGen.ThatDoesntExpectCommit,
+			faServiceFn: func() *automock.FormationAssignmentService {
+				faSvc := &automock.FormationAssignmentService{}
+				faSvc.On("GetGlobalByIDAndFormationID", txtest.CtxWithDBMatcher(), testFormationAssignmentID, testFormationID).Return(faWithSourceAppAndTargetRuntime(model.InitialAssignmentState), nil).Once()
+				return faSvc
+			},
+			formationSvcFn: func() *automock.FormationService {
+				formationSvc := &automock.FormationService{}
+				formationSvc.On("Get", txtest.CtxWithDBMatcher(), testFormationID).Return(testFormationWithReadyState, nil).Once()
+				return formationSvc
+			},
+			reqBody: fm.FormationAssignmentRequestBody{
+				State: model.ReadyAssignmentState,
+			},
+			expectedStatusCode: http.StatusBadRequest,
+		},
+
+		{
 			name:       "Fail when failing to get reverse assignment",
 			transactFn: txGen.ThatDoesntExpectCommit,
 			faServiceFn: func() *automock.FormationAssignmentService {


### PR DESCRIPTION
**Description**
Currently when calling the formation status reset API, there is no validation that there is any configuration provided. If there is no configuration provided, the reverse assignment is stuck in `INITIAL`. Moreover, this does not semantically make sense, as the reset API sends a new configuration to the reverse assignment, but when no such configuration is provided is meaningless.

Changes proposed in this pull request:
- check that a configuration is provided in status reset API
- add unit test

**Related issue(s)**
- ...

**Pull Request status**
- [x] Implementation
- [x] Unit tests
- [x] [N/A] Integration tests
- [x] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [x] [N/A] Mocks are regenerated, using the automated script
