### PR TITLE
Fix resynchronization when there is a participant without webhook but with error

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -175,7 +175,7 @@ global:
       name: compass-pairing-adapter
     director:
       dir: dev/incubator/
-      version: "PR-3794"
+      version: "PR-3802"
       name: compass-director
     hydrator:
       dir: dev/incubator/

--- a/components/director/internal/domain/formation/finalize_formation_test.go
+++ b/components/director/internal/domain/formation/finalize_formation_test.go
@@ -34,10 +34,10 @@ func TestServiceFinalizeDraftFormation(t *testing.T) {
 
 	allStates := model.ResynchronizableFormationAssignmentStates
 
-	fa1 := fixFormationAssignmentModelWithParameters("id1", FormationID, RuntimeID, ApplicationID, model.FormationAssignmentTypeRuntime, model.FormationAssignmentTypeApplication, model.InitialFormationState)
-	fa2 := fixFormationAssignmentModelWithParameters("id2", FormationID, RuntimeContextID, ApplicationID, model.FormationAssignmentTypeRuntimeContext, model.FormationAssignmentTypeApplication, model.CreateErrorFormationState)
-	fa3 := fixFormationAssignmentModelWithParameters("id3", FormationID, RuntimeID, RuntimeContextID, model.FormationAssignmentTypeRuntime, model.FormationAssignmentTypeRuntimeContext, model.DeletingFormationState)
-	fa4 := fixFormationAssignmentModelWithParameters("id4", FormationID, RuntimeContextID, RuntimeContextID, model.FormationAssignmentTypeRuntimeContext, model.FormationAssignmentTypeRuntimeContext, model.DeleteErrorFormationState)
+	fa1 := fixFormationAssignmentModelWithParameters("id1", FormationID, RuntimeID, ApplicationID, model.FormationAssignmentTypeRuntime, model.FormationAssignmentTypeApplication, model.InitialAssignmentState)
+	fa2 := fixFormationAssignmentModelWithParameters("id2", FormationID, RuntimeContextID, ApplicationID, model.FormationAssignmentTypeRuntimeContext, model.FormationAssignmentTypeApplication, model.CreateErrorAssignmentState)
+	fa3 := fixFormationAssignmentModelWithParameters("id3", FormationID, RuntimeID, RuntimeContextID, model.FormationAssignmentTypeRuntime, model.FormationAssignmentTypeRuntimeContext, model.DeletingAssignmentState)
+	fa4 := fixFormationAssignmentModelWithParameters("id4", FormationID, RuntimeContextID, RuntimeContextID, model.FormationAssignmentTypeRuntimeContext, model.FormationAssignmentTypeRuntimeContext, model.DeleteErrorAssignmentState)
 	formationAssignments := []*model.FormationAssignment{fa1, fa2, fa3, fa4}
 
 	formationAssignmentsInDeletingState := cloneFormationAssignments(formationAssignments)

--- a/components/director/internal/domain/formation/fixtures_test.go
+++ b/components/director/internal/domain/formation/fixtures_test.go
@@ -1450,7 +1450,7 @@ func fixFormationAssignmentModel(state string, configValue json.RawMessage) *mod
 	}
 }
 
-func fixFormationAssignmentModelWithParameters(id, formationID, source, target string, sourceType, targetType model.FormationAssignmentType, state model.FormationState) *model.FormationAssignment {
+func fixFormationAssignmentModelWithParameters(id, formationID, source, target string, sourceType, targetType model.FormationAssignmentType, state model.FormationAssignmentState) *model.FormationAssignment {
 	return &model.FormationAssignment{
 		ID:                            id,
 		FormationID:                   formationID,

--- a/components/director/internal/domain/formation/notifications_test.go
+++ b/components/director/internal/domain/formation/notifications_test.go
@@ -686,8 +686,8 @@ func Test_NotificationsService_SendNotification(t *testing.T) {
 
 	subtype := "subtype"
 
-	fa := fixFormationAssignmentModelWithParameters("id1", FormationID, RuntimeID, ApplicationID, model.FormationAssignmentTypeRuntime, model.FormationAssignmentTypeApplication, model.InitialFormationState)
-	reverseFa := fixFormationAssignmentModelWithParameters("id2", FormationID, ApplicationID, RuntimeID, model.FormationAssignmentTypeApplication, model.FormationAssignmentTypeRuntime, model.InitialFormationState)
+	fa := fixFormationAssignmentModelWithParameters("id1", FormationID, RuntimeID, ApplicationID, model.FormationAssignmentTypeRuntime, model.FormationAssignmentTypeApplication, model.InitialAssignmentState)
+	reverseFa := fixFormationAssignmentModelWithParameters("id2", FormationID, ApplicationID, RuntimeID, model.FormationAssignmentTypeApplication, model.FormationAssignmentTypeRuntime, model.InitialAssignmentState)
 
 	formationLifecycleTemplateInputWithCreateOperation := fixFormationLifecycleInput(model.CreateFormation, TntCustomerID, TntExternalID)
 	formationLifecycleTemplateInputWithDeleteOperation := fixFormationLifecycleInput(model.DeleteFormation, TntCustomerID, TntExternalID)

--- a/components/director/internal/domain/formation/service.go
+++ b/components/director/internal/domain/formation/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+
 	"github.com/kyma-incubator/compass/components/director/pkg/apperrors"
 	"github.com/kyma-incubator/compass/components/director/pkg/formationconstraint"
 	"github.com/kyma-incubator/compass/components/director/pkg/log"
@@ -1247,11 +1248,9 @@ func (s *service) resynchronizeFormationAssignmentNotifications(ctx context.Cont
 			}
 
 			faClone := fa.Clone()
-			if notificationForFA != nil {
-				if operation == model.UnassignFormation {
-					faClone.SetStateToDeleting()
-					formationassignment.ResetAssignmentConfigAndError(faClone)
-				}
+			if notificationForFA != nil && operation == model.UnassignFormation {
+				faClone.SetStateToDeleting()
+				formationassignment.ResetAssignmentConfigAndError(faClone)
 				if err := s.formationAssignmentService.Update(ctxWithTransact, faClone.ID, faClone); err != nil {
 					return errors.Wrapf(err, "while updating formation assignment with ID: '%s' to '%s' state", faClone.ID, faClone.State)
 				}

--- a/components/director/internal/domain/formation/service_test.go
+++ b/components/director/internal/domain/formation/service_test.go
@@ -3127,10 +3127,10 @@ func TestServiceResynchronizeFormationNotifications(t *testing.T) {
 		Version:    0,
 	}
 
-	fa1 := fixFormationAssignmentModelWithParameters("id1", FormationID, RuntimeID, ApplicationID, model.FormationAssignmentTypeRuntime, model.FormationAssignmentTypeApplication, model.InitialFormationState)
-	fa2 := fixFormationAssignmentModelWithParameters("id2", FormationID, RuntimeContextID, ApplicationID, model.FormationAssignmentTypeRuntimeContext, model.FormationAssignmentTypeApplication, model.CreateErrorFormationState)
-	fa3 := fixFormationAssignmentModelWithParameters("id3", FormationID, RuntimeID, RuntimeContextID, model.FormationAssignmentTypeRuntime, model.FormationAssignmentTypeRuntimeContext, model.DeletingFormationState)
-	fa4 := fixFormationAssignmentModelWithParameters("id4", FormationID, RuntimeContextID, RuntimeContextID, model.FormationAssignmentTypeRuntimeContext, model.FormationAssignmentTypeRuntimeContext, model.DeleteErrorFormationState)
+	fa1 := fixFormationAssignmentModelWithParameters("id1", FormationID, RuntimeID, ApplicationID, model.FormationAssignmentTypeRuntime, model.FormationAssignmentTypeApplication, model.InitialAssignmentState)
+	fa2 := fixFormationAssignmentModelWithParameters("id2", FormationID, RuntimeContextID, ApplicationID, model.FormationAssignmentTypeRuntimeContext, model.FormationAssignmentTypeApplication, model.CreateErrorAssignmentState)
+	fa4 := fixFormationAssignmentModelWithParameters("id4", FormationID, RuntimeContextID, RuntimeContextID, model.FormationAssignmentTypeRuntimeContext, model.FormationAssignmentTypeRuntimeContext, model.DeleteErrorAssignmentState)
+	fa3 := fixFormationAssignmentModelWithParameters("id3", FormationID, RuntimeID, RuntimeContextID, model.FormationAssignmentTypeRuntime, model.FormationAssignmentTypeRuntimeContext, model.DeletingAssignmentState)
 	formationAssignments := []*model.FormationAssignment{fa1, fa2, fa3, fa4}
 
 	formationAssignmentsInDeletingState := cloneFormationAssignments(formationAssignments)
@@ -3138,6 +3138,10 @@ func TestServiceResynchronizeFormationNotifications(t *testing.T) {
 
 	formationAssignmentsInInitialState := cloneFormationAssignments(formationAssignments)
 	setAssignmentsToState(model.InitialAssignmentState, formationAssignmentsInInitialState...)
+
+	formationAssignmentsInReadyAndOneCreateErrorStates := cloneFormationAssignments(formationAssignments)
+	setAssignmentsToState(model.ReadyAssignmentState, formationAssignmentsInReadyAndOneCreateErrorStates...)
+	formationAssignmentsInReadyAndOneCreateErrorStates[3].State = string(model.CreateErrorAssignmentState)
 
 	reverseAssignment := &model.FormationAssignment{
 		ID:          "id1",
@@ -3182,6 +3186,12 @@ func TestServiceResynchronizeFormationNotifications(t *testing.T) {
 	var formationAssignmentInitialPairs = make([]*formationassignment.AssignmentMappingPairWithOperation, 0, len(formationAssignments))
 	for i := range formationAssignmentsInInitialState {
 		formationAssignmentInitialPairs = append(formationAssignmentInitialPairs, fixFormationAssignmentPairWithNoReverseAssignment(notificationsForAssignments[i], formationAssignmentsInInitialState[i]))
+	}
+
+	var formationAssignmentReadyAndCreateErrorPairs = make([]*formationassignment.AssignmentMappingPairWithOperation, 0, len(formationAssignmentsInReadyAndOneCreateErrorStates))
+	for i := range formationAssignmentsInReadyAndOneCreateErrorStates {
+		formationAssignmentReadyAndCreateErrorPairs = append(formationAssignmentReadyAndCreateErrorPairs, fixFormationAssignmentPairWithNoReverseAssignment(nil, formationAssignmentsInReadyAndOneCreateErrorStates[i]))
+		formationAssignmentReadyAndCreateErrorPairs[i].Operation = model.AssignFormation
 	}
 
 	testSchema, err := labeldef.NewSchemaForFormations([]string{testScenario, testFormationName})
@@ -3247,6 +3257,45 @@ func TestServiceResynchronizeFormationNotifications(t *testing.T) {
 				svc.On("GenerateFormationAssignmentNotification", txtest.CtxWithDBMatcher(), formationAssignments[1], model.AssignFormation).Return(notificationsForAssignments[1], nil).Once()
 				svc.On("GenerateFormationAssignmentNotification", txtest.CtxWithDBMatcher(), formationAssignments[2], model.UnassignFormation).Return(notificationsForAssignments[2], nil).Once()
 				svc.On("GenerateFormationAssignmentNotification", txtest.CtxWithDBMatcher(), formationAssignments[3], model.UnassignFormation).Return(notificationsForAssignments[3], nil).Once()
+				return svc
+			},
+			FormationRepositoryFn: func() *automock.FormationRepository {
+				repo := &automock.FormationRepository{}
+				repo.On("Get", ctx, FormationID, TntInternalID).Return(testFormation, nil).Once()
+				return repo
+			},
+		},
+		{
+			Name:                 "success when resynchronization is successful and there is formation assignment in create error state and error but no webhook",
+			FormationAssignments: formationAssignmentsInReadyAndOneCreateErrorStates,
+			TxFn: func() (*persistenceautomock.PersistenceTx, *persistenceautomock.Transactioner) {
+				return txGen.ThatSucceedsMultipleTimes(2)
+			},
+			FormationAssignmentServiceFn: func() *automock.FormationAssignmentService {
+				svc := &automock.FormationAssignmentService{}
+				svc.On("GetAssignmentsForFormationWithStates", txtest.CtxWithDBMatcher(), TntInternalID, FormationID, allStates).Return(formationAssignmentsInReadyAndOneCreateErrorStates, nil).Once()
+
+				for _, fa := range formationAssignmentsInReadyAndOneCreateErrorStates {
+					svc.On("GetReverseBySourceAndTarget", txtest.CtxWithDBMatcher(), FormationID, fa.Source, fa.Target).Return(nil, apperrors.NewNotFoundError(resource.FormationAssignment, "")).Once()
+				}
+
+				svc.On("ProcessFormationAssignmentPair", txtest.CtxWithDBMatcher(), formationAssignmentReadyAndCreateErrorPairs[0]).Return(false, nil).Once()
+				svc.On("ProcessFormationAssignmentPair", txtest.CtxWithDBMatcher(), formationAssignmentReadyAndCreateErrorPairs[1]).Return(false, nil).Once()
+				svc.On("ProcessFormationAssignmentPair", txtest.CtxWithDBMatcher(), formationAssignmentReadyAndCreateErrorPairs[2]).Return(false, nil).Once()
+				svc.On("ProcessFormationAssignmentPair", txtest.CtxWithDBMatcher(), formationAssignmentReadyAndCreateErrorPairs[3]).Return(false, nil).Once()
+
+				svc.On("Update", txtest.CtxWithDBMatcher(), formationAssignmentsInReadyAndOneCreateErrorStates[0].ID, formationAssignmentsInInitialState[0]).Return(nil).Once()
+				svc.On("Update", txtest.CtxWithDBMatcher(), formationAssignmentsInReadyAndOneCreateErrorStates[1].ID, formationAssignmentsInInitialState[1]).Return(nil).Once()
+				svc.On("Update", txtest.CtxWithDBMatcher(), formationAssignmentsInReadyAndOneCreateErrorStates[2].ID, formationAssignmentsInInitialState[2]).Return(nil).Once()
+				svc.On("Update", txtest.CtxWithDBMatcher(), formationAssignmentsInReadyAndOneCreateErrorStates[3].ID, formationAssignmentsInInitialState[3]).Return(nil).Once()
+				return svc
+			},
+			FormationAssignmentNotificationServiceFN: func() *automock.FormationAssignmentNotificationsService {
+				svc := &automock.FormationAssignmentNotificationsService{}
+				svc.On("GenerateFormationAssignmentNotification", txtest.CtxWithDBMatcher(), formationAssignmentsInReadyAndOneCreateErrorStates[0], model.AssignFormation).Return(nil, nil).Once()
+				svc.On("GenerateFormationAssignmentNotification", txtest.CtxWithDBMatcher(), formationAssignmentsInReadyAndOneCreateErrorStates[1], model.AssignFormation).Return(nil, nil).Once()
+				svc.On("GenerateFormationAssignmentNotification", txtest.CtxWithDBMatcher(), formationAssignmentsInReadyAndOneCreateErrorStates[2], model.AssignFormation).Return(nil, nil).Once()
+				svc.On("GenerateFormationAssignmentNotification", txtest.CtxWithDBMatcher(), formationAssignmentsInReadyAndOneCreateErrorStates[3], model.AssignFormation).Return(nil, nil).Once()
 				return svc
 			},
 			FormationRepositoryFn: func() *automock.FormationRepository {

--- a/components/director/internal/domain/formationassignment/service.go
+++ b/components/director/internal/domain/formationassignment/service.go
@@ -3,7 +3,6 @@ package formationassignment
 import (
 	"context"
 	"encoding/json"
-
 	validation "github.com/go-ozzo/ozzo-validation/v4"
 	"github.com/hashicorp/go-multierror"
 	"github.com/kyma-incubator/compass/components/director/internal/domain/statusreport"
@@ -633,6 +632,10 @@ func (s *service) processFormationAssignmentsWithReverseNotification(ctx context
 
 	if assignmentReqMappingClone.Request == nil {
 		assignment.State = string(model.ReadyAssignmentState)
+		if mappingPair.Operation == model.AssignFormation {
+			// In case of error in the assignment we want to clear it
+			assignment.Error = nil
+		}
 		log.C(ctx).Infof("In the formation assignment mapping pair, assignment with ID: %q hasn't attached webhook request. Updating the formation assignment to %q state without sending notification", assignment.ID, assignment.State)
 		if err := s.Update(ctx, assignment.ID, assignment); err != nil {
 			return errors.Wrapf(err, "while updating formation assignment for formation with ID: %q with source: %q and target: %q", assignment.FormationID, assignment.Source, assignment.Target)

--- a/components/director/internal/domain/formationassignment/service.go
+++ b/components/director/internal/domain/formationassignment/service.go
@@ -3,6 +3,7 @@ package formationassignment
 import (
 	"context"
 	"encoding/json"
+
 	validation "github.com/go-ozzo/ozzo-validation/v4"
 	"github.com/hashicorp/go-multierror"
 	"github.com/kyma-incubator/compass/components/director/internal/domain/statusreport"

--- a/components/director/internal/domain/formationassignment/service_test.go
+++ b/components/director/internal/domain/formationassignment/service_test.go
@@ -2304,6 +2304,26 @@ func TestService_ProcessFormationAssignmentPair(t *testing.T) {
 			},
 		},
 		{
+			Name:    "Success: ready state assignment with error and no request",
+			Context: ctxWithTenant,
+			FormationAssignmentPairWithOperation: &formationassignment.AssignmentMappingPairWithOperation{
+				AssignmentMappingPair: &formationassignment.AssignmentMappingPair{
+					AssignmentReqMapping: &formationassignment.FormationAssignmentRequestMapping{
+						Request:             nil,
+						FormationAssignment: createErrorStateAssignment,
+					},
+					ReverseAssignmentReqMapping: nil,
+				},
+				Operation: model.AssignFormation,
+			},
+			FormationAssignmentRepo: func() *automock.FormationAssignmentRepository {
+				repo := &automock.FormationAssignmentRepository{}
+				repo.On("Exists", ctxWithTenant, TestID, TestTenantID).Return(true, nil).Once()
+				repo.On("Update", ctxWithTenant, readyStateAssignment).Return(nil).Once()
+				return repo
+			},
+		},
+		{
 			Name:    "Error when there is no request and update fails",
 			Context: ctxWithTenant,
 			FormationAssignmentPairWithOperation: &formationassignment.AssignmentMappingPairWithOperation{


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Currently, If we resynchronize formation in which there is a participant who doesn't have webhook but is in CREATE_ERROR state with some error in the database - the assignment will become READY but the error will not be deleted. This PR fixes that.

Changes proposed in this pull request:
- Fix resynchronize formation
- Add unit tests

**Pull Request status**
<!-- Feel free to construct the checklist with whatever items seem most reasonable for your change. You could disassemble the Implementation part to even smaller separate checklist items if you're working on something big for example. But do make the effort to provide a checklist of some sort so that the core team as well as the community can have an idea about the progress of your Pull Request.
-->

- [ ] Implementation
- [ ] Unit tests
- [ ] Integration tests
- [ ] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [ ] Mocks are regenerated, using the automated script
