### PR TITLE
Encode the OData query parameters of the URL in ORD Service e2e tests

### DIFF
--- a/tests/instance-creator/tests/config.go
+++ b/tests/instance-creator/tests/config.go
@@ -1,12 +1,13 @@
 package tests
 
 import (
+	"time"
+
 	directorcfg "github.com/kyma-incubator/compass/components/director/pkg/config"
 	"github.com/kyma-incubator/compass/components/director/pkg/credloader"
 	"github.com/kyma-incubator/compass/tests/pkg/certs/certprovider"
 	"github.com/kyma-incubator/compass/tests/pkg/config"
 	"github.com/kyma-incubator/compass/tests/pkg/subscription"
-	"time"
 )
 
 type InstanceCreatorConfig struct {

--- a/tests/ord-service/tests/api_test.go
+++ b/tests/ord-service/tests/api_test.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 	urlpkg "net/url"
 	"strings"
 	"testing"
@@ -164,19 +165,35 @@ func TestORDService(t *testing.T) {
 	extIssuerCertHttpClient := CreateHttpClientWithCert(providerClientKey, providerRawCertChain, conf.SkipSSLValidation)
 
 	t.Run("401 when requests to ORD Service are unsecured", func(t *testing.T) {
-		makeRequestWithStatusExpect(t, unsecuredHttpClient, conf.ORDServiceURL+"/$metadata?$format=json", http.StatusUnauthorized)
+		params := url.Values{}
+		params.Add("$format", "json")
+
+		serviceURL := conf.ORDServiceURL + "/$metadata?" + params.Encode()
+		makeRequestWithStatusExpect(t, unsecuredHttpClient, serviceURL, http.StatusUnauthorized)
 	})
 
 	t.Run("400 when requests to ORD Service do not have tenant header", func(t *testing.T) {
-		makeRequestWithStatusExpect(t, intSystemHttpClient, conf.ORDServiceURL+"/consumptionBundles?$format=json", http.StatusBadRequest)
+		params := url.Values{}
+		params.Add("$format", "json")
+
+		serviceURL := conf.ORDServiceURL + "/consumptionBundles?" + params.Encode()
+		makeRequestWithStatusExpect(t, intSystemHttpClient, serviceURL, http.StatusBadRequest)
 	})
 
 	t.Run("400 when requests to ORD Service have wrong tenant header", func(t *testing.T) {
-		request.MakeRequestWithHeadersAndStatusExpect(t, intSystemHttpClient, conf.ORDServiceURL+"/consumptionBundles?$format=json", map[string][]string{tenantHeader: {" "}}, http.StatusBadRequest, conf.ORDServiceDefaultResponseType)
+		params := url.Values{}
+		params.Add("$format", "json")
+
+		serviceURL := conf.ORDServiceURL + "/consumptionBundles?" + params.Encode()
+		request.MakeRequestWithHeadersAndStatusExpect(t, intSystemHttpClient, serviceURL, map[string][]string{tenantHeader: {" "}}, http.StatusBadRequest, conf.ORDServiceDefaultResponseType)
 	})
 
 	t.Run("400 when requests to ORD Service api specification do not have tenant header", func(t *testing.T) {
-		respBody := makeRequestWithHeaders(t, intSystemHttpClient, conf.ORDServiceURL+"/apis?$format=json", map[string][]string{tenantHeader: {defaultTestTenant}})
+		params := url.Values{}
+		params.Add("$format", "json")
+
+		serviceURL := conf.ORDServiceURL + "/apis?" + params.Encode()
+		respBody := makeRequestWithHeaders(t, intSystemHttpClient, serviceURL, map[string][]string{tenantHeader: {defaultTestTenant}})
 		require.Equal(t, len(appInput.Bundles[0].APIDefinitions), len(gjson.Get(respBody, "value").Array()))
 
 		specs := gjson.Get(respBody, fmt.Sprintf("value.%d.resourceDefinitions", 0)).Array()
@@ -187,7 +204,11 @@ func TestORDService(t *testing.T) {
 	})
 
 	t.Run("400 when requests to ORD Service event specification do not have tenant header", func(t *testing.T) {
-		respBody := makeRequestWithHeaders(t, intSystemHttpClient, conf.ORDServiceURL+"/events?$format=json", map[string][]string{tenantHeader: {defaultTestTenant}})
+		params := url.Values{}
+		params.Add("$format", "json")
+
+		serviceURL := conf.ORDServiceURL + "/events?" + params.Encode()
+		respBody := makeRequestWithHeaders(t, intSystemHttpClient, serviceURL, map[string][]string{tenantHeader: {defaultTestTenant}})
 		require.Equal(t, len(appInput.Bundles[0].EventDefinitions), len(gjson.Get(respBody, "value").Array()))
 
 		specs := gjson.Get(respBody, fmt.Sprintf("value.%d.resourceDefinitions", 0)).Array()
@@ -198,7 +219,11 @@ func TestORDService(t *testing.T) {
 	})
 
 	t.Run("400 when requests to ORD Service api specification have wrong tenant header", func(t *testing.T) {
-		respBody := makeRequestWithHeaders(t, intSystemHttpClient, conf.ORDServiceURL+"/apis?$format=json", map[string][]string{tenantHeader: {defaultTestTenant}})
+		params := url.Values{}
+		params.Add("$format", "json")
+
+		serviceURL := conf.ORDServiceURL + "/apis?" + params.Encode()
+		respBody := makeRequestWithHeaders(t, intSystemHttpClient, serviceURL, map[string][]string{tenantHeader: {defaultTestTenant}})
 		require.Equal(t, len(appInput.Bundles[0].APIDefinitions), len(gjson.Get(respBody, "value").Array()))
 
 		specs := gjson.Get(respBody, fmt.Sprintf("value.%d.resourceDefinitions", 0)).Array()
@@ -209,7 +234,11 @@ func TestORDService(t *testing.T) {
 	})
 
 	t.Run("400 when requests to ORD Service event specification have wrong tenant header", func(t *testing.T) {
-		respBody := makeRequestWithHeaders(t, intSystemHttpClient, conf.ORDServiceURL+"/events?$format=json", map[string][]string{tenantHeader: {defaultTestTenant}})
+		params := url.Values{}
+		params.Add("$format", "json")
+
+		serviceURL := conf.ORDServiceURL + "/events?" + params.Encode()
+		respBody := makeRequestWithHeaders(t, intSystemHttpClient, serviceURL, map[string][]string{tenantHeader: {defaultTestTenant}})
 		require.Equal(t, len(appInput.Bundles[0].EventDefinitions), len(gjson.Get(respBody, "value").Array()))
 
 		specs := gjson.Get(respBody, fmt.Sprintf("value.%d.resourceDefinitions", 0)).Array()
@@ -228,14 +257,23 @@ func TestORDService(t *testing.T) {
 	})
 
 	t.Run("Requesting Packages returns empty", func(t *testing.T) {
-		respBody := makeRequestWithHeaders(t, intSystemHttpClient, fmt.Sprintf("%s/packages?$expand=apis,events&$format=json", conf.ORDServiceURL), map[string][]string{tenantHeader: {defaultTestTenant}})
+		params := url.Values{}
+		params.Add("$expand", "apis,events")
+		params.Add("$format", "json")
+
+		serviceURL := conf.ORDServiceURL + "/packages?" + params.Encode()
+		respBody := makeRequestWithHeaders(t, intSystemHttpClient, serviceURL, map[string][]string{tenantHeader: {defaultTestTenant}})
 		require.Equal(t, 0, len(gjson.Get(respBody, "value").Array()))
 	})
 
 	t.Run("Requesting filtering of Bundles that do not have only ODATA APIs", func(t *testing.T) {
-		escapedFilterValue := urlpkg.PathEscape("apis/any(d:d/apiProtocol ne 'odata-v2')")
+		params := url.Values{}
+		params.Add("$filter", "apis/any(d:d/apiProtocol ne 'odata-v2')")
+		params.Add("$expand", "apis")
+		params.Add("$format", "json")
 
-		respBody := makeRequestWithHeaders(t, intSystemHttpClient, fmt.Sprintf("%s/consumptionBundles?$filter=%s&$expand=apis&$format=json", conf.ORDServiceURL, escapedFilterValue), map[string][]string{tenantHeader: {tenantAPIProtocolFiltering}})
+		serviceURL := conf.ORDServiceURL + "/consumptionBundles?" + strings.ReplaceAll(params.Encode(), "+", "%20")
+		respBody := makeRequestWithHeaders(t, intSystemHttpClient, serviceURL, map[string][]string{tenantHeader: {tenantAPIProtocolFiltering}})
 
 		require.Equal(t, len(appInputAPIProtocolFiltering.Bundles)-1, len(gjson.Get(respBody, "value").Array()))
 		require.Equal(t, appInputAPIProtocolFiltering.Bundles[0].Name, gjson.Get(respBody, "value.0.title").String())
@@ -257,9 +295,13 @@ func TestORDService(t *testing.T) {
 	})
 
 	t.Run("Requesting filtering of Bundles that have only ODATA APIs", func(t *testing.T) {
-		escapedFilterValue := urlpkg.PathEscape("apis/all(d:d/apiProtocol eq 'odata-v2')")
+		params := url.Values{}
+		params.Add("$filter", "apis/all(d:d/apiProtocol eq 'odata-v2')")
+		params.Add("$expand", "apis")
+		params.Add("$format", "json")
 
-		respBody := makeRequestWithHeaders(t, intSystemHttpClient, fmt.Sprintf("%s/consumptionBundles?$filter=%s&$expand=apis&$format=json", conf.ORDServiceURL, escapedFilterValue), map[string][]string{tenantHeader: {tenantAPIProtocolFiltering}})
+		serviceURL := conf.ORDServiceURL + "/consumptionBundles?" + strings.ReplaceAll(params.Encode(), "+", "%20")
+		respBody := makeRequestWithHeaders(t, intSystemHttpClient, serviceURL, map[string][]string{tenantHeader: {tenantAPIProtocolFiltering}})
 
 		require.Equal(t, len(appInputAPIProtocolFiltering.Bundles)-1, len(gjson.Get(respBody, "value").Array()))
 		require.Equal(t, appInputAPIProtocolFiltering.Bundles[1].Name, gjson.Get(respBody, "value.0.title").String())
@@ -282,7 +324,11 @@ func TestORDService(t *testing.T) {
 
 	for _, resource := range []string{"vendors", "tombstones", "products"} { // This tests assert integrity between ORD Service JPA model and our Database model
 		t.Run(fmt.Sprintf("Requesting %s", resource), func(t *testing.T) {
-			respBody := makeRequestWithHeaders(t, intSystemHttpClient, fmt.Sprintf("%s/%s?$format=json", conf.ORDServiceURL, resource), map[string][]string{tenantHeader: {defaultTestTenant}})
+			params := url.Values{}
+			params.Add("$format", "json")
+
+			serviceURL := fmt.Sprintf("%s/%s?", conf.ORDServiceURL, resource) + params.Encode()
+			respBody := makeRequestWithHeaders(t, intSystemHttpClient, serviceURL, map[string][]string{tenantHeader: {defaultTestTenant}})
 			require.True(t, gjson.Get(respBody, "value").Exists())
 		})
 	}
@@ -297,7 +343,10 @@ func TestORDService(t *testing.T) {
 	fixtures.AssignFormationWithTenantObjectType(t, ctx, certSecuredGraphQLClient, formationInput, subTenantID, tenantFilteringTenant)
 
 	// assert no system instances are visible without formation
-	respBody := makeRequestWithHeaders(t, intSystemHttpClient, conf.ORDServiceURL+"/systemInstances?$format=json", map[string][]string{tenantHeader: {subTenantID}})
+	params := url.Values{}
+	params.Add("$format", "json")
+
+	respBody := makeRequestWithHeadersAndQueryParams(t, intSystemHttpClient, conf.ORDServiceURL+"/systemInstances?", map[string][]string{tenantHeader: {subTenantID}}, params)
 	require.Equal(t, 0, len(gjson.Get(respBody, "value").Array()))
 
 	// assign application to scenario
@@ -352,7 +401,10 @@ func TestORDService(t *testing.T) {
 	} {
 
 		t.Run(fmt.Sprintf("Requesting System Instances for tenant %s returns them as expected", testData.msg), func(t *testing.T) {
-			respBody := makeRequestWithHeaders(t, testData.client, testData.url+"/systemInstances?$format=json", testData.headers)
+			params := url.Values{}
+			params.Add("$format", "json")
+
+			respBody := makeRequestWithHeadersAndQueryParams(t, testData.client, testData.url+"/systemInstances?", testData.headers, params)
 
 			require.Equal(t, 1, len(gjson.Get(respBody, "value").Array()))
 			require.Equal(t, testData.appInput.Name, gjson.Get(respBody, "value.0.title").String())
@@ -360,7 +412,11 @@ func TestORDService(t *testing.T) {
 		})
 
 		t.Run(fmt.Sprintf("Requesting System Instances with apis for tenant %s returns them as expected", testData.msg), func(t *testing.T) {
-			respBody := makeRequestWithHeaders(t, testData.client, testData.url+"/systemInstances?$expand=apis&$format=json", testData.headers)
+			params := url.Values{}
+			params.Add("$expand", "apis")
+			params.Add("$format", "json")
+
+			respBody := makeRequestWithHeadersAndQueryParams(t, testData.client, testData.url+"/systemInstances?", testData.headers, params)
 			require.Equal(t, 1, len(gjson.Get(respBody, "value").Array()))
 			require.Equal(t, testData.appInput.Name, gjson.Get(respBody, "value.0.title").String())
 			require.Equal(t, *testData.appInput.Description, gjson.Get(respBody, "value.0.description").String())
@@ -369,7 +425,11 @@ func TestORDService(t *testing.T) {
 		})
 
 		t.Run(fmt.Sprintf("Requesting System Instances with events for tenant %s returns them as expected", testData.msg), func(t *testing.T) {
-			respBody := makeRequestWithHeaders(t, testData.client, testData.url+"/systemInstances?$expand=events&$format=json", testData.headers)
+			params := url.Values{}
+			params.Add("$expand", "events")
+			params.Add("$format", "json")
+
+			respBody := makeRequestWithHeadersAndQueryParams(t, testData.client, testData.url+"/systemInstances?", testData.headers, params)
 			require.Equal(t, 1, len(gjson.Get(respBody, "value").Array()))
 			require.Equal(t, testData.appInput.Name, gjson.Get(respBody, "value.0.title").String())
 			require.Equal(t, *testData.appInput.Description, gjson.Get(respBody, "value.0.description").String())
@@ -378,7 +438,10 @@ func TestORDService(t *testing.T) {
 		})
 
 		t.Run(fmt.Sprintf("Requesting Bundles for tenant %s returns them as expected", testData.msg), func(t *testing.T) {
-			respBody := makeRequestWithHeaders(t, testData.client, testData.url+"/consumptionBundles?$format=json", testData.headers)
+			params := url.Values{}
+			params.Add("$format", "json")
+
+			respBody := makeRequestWithHeadersAndQueryParams(t, testData.client, testData.url+"/consumptionBundles?", testData.headers, params)
 
 			require.Equal(t, len(testData.appInput.Bundles), len(gjson.Get(respBody, "value").Array()))
 			require.Equal(t, testData.appInput.Bundles[0].Name, gjson.Get(respBody, "value.0.title").String())
@@ -386,13 +449,19 @@ func TestORDService(t *testing.T) {
 		})
 
 		t.Run(fmt.Sprintf("Requesting APIs and their specs for tenant %s returns them as expected", testData.msg), func(t *testing.T) {
-			respBody := makeRequestWithHeaders(t, testData.client, testData.url+"/apis?$format=json", testData.headers)
+			params := url.Values{}
+			params.Add("$format", "json")
+
+			respBody := makeRequestWithHeadersAndQueryParams(t, testData.client, testData.url+"/apis?", testData.headers, params)
 
 			assertEqualAPIDefinitions(t, testData.appInput.Bundles[0].APIDefinitions, gjson.Get(respBody, "value").String(), testData.apisMap, testData.client, testData.headers)
 		})
 
 		t.Run(fmt.Sprintf("Requesting Events and their specs for tenant %s returns them as expected", testData.msg), func(t *testing.T) {
-			respBody := makeRequestWithHeaders(t, testData.client, testData.url+"/events?$format=json", testData.headers)
+			params := url.Values{}
+			params.Add("$format", "json")
+
+			respBody := makeRequestWithHeadersAndQueryParams(t, testData.client, testData.url+"/events?", testData.headers, params)
 
 			assertEqualEventDefinitions(t, testData.appInput.Bundles[0].EventDefinitions, gjson.Get(respBody, "value").String(), testData.eventsMap, testData.client, testData.headers)
 		})
@@ -400,11 +469,20 @@ func TestORDService(t *testing.T) {
 		// Paging:
 		t.Run(fmt.Sprintf("Requesting paging of Bundles for tenant %s returns them as expected", testData.msg), func(t *testing.T) {
 			totalCount := len(testData.appInput.Bundles)
+			params := url.Values{}
+			params.Add("$top", "10")
+			params.Add("$skip", "0")
+			params.Add("$format", "json")
 
-			respBody := makeRequestWithHeaders(t, testData.client, testData.url+"/consumptionBundles?$top=10&$skip=0&$format=json", testData.headers)
+			respBody := makeRequestWithHeadersAndQueryParams(t, testData.client, testData.url+"/consumptionBundles?", testData.headers, params)
 			require.Equal(t, totalCount, len(gjson.Get(respBody, "value").Array()))
 
-			respBody = makeRequestWithHeaders(t, testData.client, fmt.Sprintf("%s/consumptionBundles?$top=10&$skip=%d&$format=json", testData.url, totalCount), testData.headers)
+			params = url.Values{}
+			params.Add("$top", "10")
+			params.Add("$skip", fmt.Sprintf("%d", totalCount))
+			params.Add("$format", "json")
+
+			respBody = makeRequestWithHeadersAndQueryParams(t, testData.client, testData.url+"/consumptionBundles?", testData.headers, params)
 			require.Equal(t, 0, len(gjson.Get(respBody, "value").Array()))
 		})
 
@@ -442,12 +520,16 @@ func TestORDService(t *testing.T) {
 		t.Run(fmt.Sprintf("Requesting filtering of Bundles for tenant %s returns them as expected", testData.msg), func(t *testing.T) {
 			bndlName := testData.appInput.Bundles[0].Name
 
-			escapedFilterValue := urlpkg.PathEscape(fmt.Sprintf("title eq '%s'", bndlName))
-			respBody := makeRequestWithHeaders(t, testData.client, fmt.Sprintf("%s/consumptionBundles?$filter=(%s)&$format=json", testData.url, escapedFilterValue), testData.headers)
+			params := urlpkg.Values{}
+			params.Add("$filter", fmt.Sprintf("(title eq '%s')", bndlName))
+			params.Add("$format", "json")
+			serviceURL := testData.url + "/consumptionBundles?" + strings.ReplaceAll(params.Encode(), "+", "%20")
+			respBody := makeRequestWithHeaders(t, testData.client, serviceURL, testData.headers)
 			require.Equal(t, 1, len(gjson.Get(respBody, "value").Array()))
 
-			escapedFilterValue = urlpkg.PathEscape(fmt.Sprintf("title ne '%s'", bndlName))
-			respBody = makeRequestWithHeaders(t, testData.client, fmt.Sprintf("%s/consumptionBundles?$filter=(%s)&$format=json", testData.url, escapedFilterValue), testData.headers)
+			params.Set("$filter", fmt.Sprintf("(title ne '%s')", bndlName))
+			serviceURL = testData.url + "/consumptionBundles?" + strings.ReplaceAll(params.Encode(), "+", "%20")
+			respBody = makeRequestWithHeaders(t, testData.client, serviceURL, testData.headers)
 			require.Equal(t, 0, len(gjson.Get(respBody, "value").Array()))
 		})
 
@@ -455,12 +537,17 @@ func TestORDService(t *testing.T) {
 			totalCount := len(testData.appInput.Bundles[0].APIDefinitions)
 			apiName := testData.appInput.Bundles[0].APIDefinitions[0].Name
 
-			escapedFilterValue := urlpkg.PathEscape(fmt.Sprintf("title eq '%s'", apiName))
-			respBody := makeRequestWithHeaders(t, testData.client, fmt.Sprintf("%s/consumptionBundles?$expand=apis($filter=(%s))&$format=json", testData.url, escapedFilterValue), testData.headers)
+			params := urlpkg.Values{}
+
+			params.Add("$expand", fmt.Sprintf("apis($filter=(title eq '%s'))", apiName))
+			params.Add("$format", "json")
+			serviceURL := testData.url + "/consumptionBundles?" + strings.ReplaceAll(params.Encode(), "+", "%20")
+			respBody := makeRequestWithHeaders(t, testData.client, serviceURL, testData.headers)
 			require.Equal(t, 1, len(gjson.Get(respBody, "value").Array()))
 
-			escapedFilterValue = urlpkg.PathEscape(fmt.Sprintf("title ne '%s'", apiName))
-			respBody = makeRequestWithHeaders(t, testData.client, fmt.Sprintf("%s/consumptionBundles?$expand=apis($filter=(%s))&$format=json", testData.url, escapedFilterValue), testData.headers)
+			params.Set("$expand", fmt.Sprintf("apis($filter=(title ne '%s'))", apiName))
+			serviceURL = testData.url + "/consumptionBundles?" + strings.ReplaceAll(params.Encode(), "+", "%20")
+			respBody = makeRequestWithHeaders(t, testData.client, serviceURL, testData.headers)
 			require.Equal(t, totalCount-1, len(gjson.Get(respBody, "value.0.apis").Array()))
 		})
 
@@ -468,25 +555,37 @@ func TestORDService(t *testing.T) {
 			totalCount := len(testData.appInput.Bundles[0].EventDefinitions)
 			eventName := testData.appInput.Bundles[0].EventDefinitions[0].Name
 
-			escapedFilterValue := urlpkg.PathEscape(fmt.Sprintf("title eq '%s'", eventName))
-			respBody := makeRequestWithHeaders(t, testData.client, fmt.Sprintf("%s/consumptionBundles?$expand=events($filter=(%s))&$format=json", testData.url, escapedFilterValue), testData.headers)
+			params := urlpkg.Values{}
+			params.Add("$expand", fmt.Sprintf("events($filter=(title eq '%s'))", eventName))
+			params.Add("$format", "json")
+			serviceURL := testData.url + "/consumptionBundles?" + strings.ReplaceAll(params.Encode(), "+", "%20")
+			respBody := makeRequestWithHeaders(t, testData.client, serviceURL, testData.headers)
 			require.Equal(t, 1, len(gjson.Get(respBody, "value").Array()))
 
-			escapedFilterValue = urlpkg.PathEscape(fmt.Sprintf("title ne '%s'", eventName))
-			respBody = makeRequestWithHeaders(t, testData.client, fmt.Sprintf("%s/consumptionBundles?$expand=events($filter=(%s))&$format=json", testData.url, escapedFilterValue), testData.headers)
+			params.Set("$expand", fmt.Sprintf("events($filter=(title ne '%s'))", eventName))
+			serviceURL = testData.url + "/consumptionBundles?" + strings.ReplaceAll(params.Encode(), "+", "%20")
+			respBody = makeRequestWithHeaders(t, testData.client, serviceURL, testData.headers)
 			require.Equal(t, totalCount-1, len(gjson.Get(respBody, "value.0.events").Array()))
 		})
 
 		// Projection:
 		t.Run(fmt.Sprintf("Requesting projection of Bundles for tenant %s returns them as expected", testData.msg), func(t *testing.T) {
-			respBody := makeRequestWithHeaders(t, testData.client, testData.url+"/consumptionBundles?$select=title&$format=json", testData.headers)
+			params := urlpkg.Values{}
+
+			params.Add("$select", "title")
+			params.Add("$format", "json")
+			respBody := makeRequestWithHeadersAndQueryParams(t, testData.client, testData.url+"/consumptionBundles?", testData.headers, params)
 			require.Equal(t, 1, len(gjson.Get(respBody, "value").Array()))
 			require.Equal(t, testData.appInput.Bundles[0].Name, gjson.Get(respBody, "value.0.title").String())
 			require.Equal(t, false, gjson.Get(respBody, "value.0.description").Exists())
 		})
 
 		t.Run(fmt.Sprintf("Requesting projection of Bundle APIs for tenant %s returns them as expected", testData.msg), func(t *testing.T) {
-			respBody := makeRequestWithHeaders(t, testData.client, testData.url+"/consumptionBundles?$expand=apis($select=title)&$format=json", testData.headers)
+			params := urlpkg.Values{}
+
+			params.Add("$expand", "apis($select=title)")
+			params.Add("$format", "json")
+			respBody := makeRequestWithHeadersAndQueryParams(t, testData.client, testData.url+"/consumptionBundles?", testData.headers, params)
 
 			apis := gjson.Get(respBody, "value.0.apis").Array()
 			require.Len(t, apis, len(testData.appInput.Bundles[0].APIDefinitions))
@@ -502,7 +601,11 @@ func TestORDService(t *testing.T) {
 		})
 
 		t.Run(fmt.Sprintf("Requesting projection of Bundle Events for tenant %s returns them as expected", testData.msg), func(t *testing.T) {
-			respBody := makeRequestWithHeaders(t, testData.client, testData.url+"/consumptionBundles?$expand=events($select=title)&$format=json", testData.headers)
+			params := urlpkg.Values{}
+
+			params.Add("$expand", "events($select=title)")
+			params.Add("$format", "json")
+			respBody := makeRequestWithHeadersAndQueryParams(t, testData.client, testData.url+"/consumptionBundles?", testData.headers, params)
 
 			events := gjson.Get(respBody, "value.0.events").Array()
 			require.Len(t, events, len(testData.appInput.Bundles[0].EventDefinitions))
@@ -519,16 +622,22 @@ func TestORDService(t *testing.T) {
 
 		//Ordering:
 		t.Run(fmt.Sprintf("Requesting ordering of Bundles for tenant %s returns them as expected", testData.msg), func(t *testing.T) {
-			escapedOrderByValue := urlpkg.PathEscape("title asc,description desc")
-			respBody := makeRequestWithHeaders(t, testData.client, fmt.Sprintf("%s/consumptionBundles?$orderby=%s&$format=json", testData.url, escapedOrderByValue), testData.headers)
+			params := urlpkg.Values{}
+			params.Add("$orderby", "title asc,description desc")
+			params.Add("$format", "json")
+			serviceURL := testData.url + "/consumptionBundles?" + strings.ReplaceAll(params.Encode(), "+", "%20")
+			respBody := makeRequestWithHeaders(t, testData.client, serviceURL, testData.headers)
 			require.Equal(t, 1, len(gjson.Get(respBody, "value").Array()))
 			require.Equal(t, testData.appInput.Bundles[0].Name, gjson.Get(respBody, "value.0.title").String())
 			require.Equal(t, *testData.appInput.Bundles[0].Description, gjson.Get(respBody, "value.0.description").String())
 		})
 
 		t.Run(fmt.Sprintf("Requesting ordering of Bundle APIs for tenant %s returns them as expected", testData.msg), func(t *testing.T) {
-			escapedOrderByValue := urlpkg.PathEscape("title asc,description desc")
-			respBody := makeRequestWithHeaders(t, testData.client, fmt.Sprintf("%s/consumptionBundles?$expand=apis($orderby=%s)&$format=json", testData.url, escapedOrderByValue), testData.headers)
+			params := urlpkg.Values{}
+			params.Add("$expand", fmt.Sprintf("apis($orderby=%s)", "title asc,description desc"))
+			params.Add("$format", "json")
+			serviceURL := testData.url + "/consumptionBundles?" + strings.ReplaceAll(params.Encode(), "+", "%20")
+			respBody := makeRequestWithHeaders(t, testData.client, serviceURL, testData.headers)
 
 			apis := gjson.Get(respBody, "value.0.apis").Array()
 			require.Len(t, apis, len(testData.appInput.Bundles[0].APIDefinitions))
@@ -545,8 +654,12 @@ func TestORDService(t *testing.T) {
 		})
 
 		t.Run(fmt.Sprintf("Requesting ordering of Bundle Events for tenant %s returns them as expected", testData.msg), func(t *testing.T) {
-			escapedOrderByValue := urlpkg.PathEscape("title asc,description desc")
-			respBody := makeRequestWithHeaders(t, testData.client, fmt.Sprintf("%s/consumptionBundles?$expand=events($orderby=%s)&$format=json", testData.url, escapedOrderByValue), testData.headers)
+			params := urlpkg.Values{}
+
+			params.Add("$expand", fmt.Sprintf("events($orderby=%s)", "title asc,description desc"))
+			params.Add("$format", "json")
+			serviceURL := testData.url + "/consumptionBundles?" + strings.ReplaceAll(params.Encode(), "+", "%20")
+			respBody := makeRequestWithHeaders(t, testData.client, serviceURL, testData.headers)
 
 			events := gjson.Get(respBody, "value.0.events").Array()
 			require.Len(t, events, len(testData.appInput.Bundles[0].EventDefinitions))
@@ -564,7 +677,10 @@ func TestORDService(t *testing.T) {
 	}
 
 	t.Run("404 when request to ORD Service for api spec have another tenant header value", func(t *testing.T) {
-		respBody := makeRequestWithHeaders(t, intSystemHttpClient, conf.ORDServiceURL+"/apis?$format=json", map[string][]string{tenantHeader: {defaultTestTenant}})
+		params := urlpkg.Values{}
+
+		params.Add("$format", "json")
+		respBody := makeRequestWithHeadersAndQueryParams(t, intSystemHttpClient, conf.ORDServiceURL+"/apis?", map[string][]string{tenantHeader: {defaultTestTenant}}, params)
 		require.Equal(t, len(appInput.Bundles[0].APIDefinitions), len(gjson.Get(respBody, "value").Array()))
 
 		specs := gjson.Get(respBody, fmt.Sprintf("value.%d.resourceDefinitions", 0)).Array()
@@ -577,7 +693,10 @@ func TestORDService(t *testing.T) {
 	})
 
 	t.Run("404 when request to ORD Service for event spec have another tenant header value", func(t *testing.T) {
-		respBody := makeRequestWithHeaders(t, intSystemHttpClient, conf.ORDServiceURL+"/events?$format=json", map[string][]string{tenantHeader: {defaultTestTenant}})
+		params := urlpkg.Values{}
+
+		params.Add("$format", "json")
+		respBody := makeRequestWithHeadersAndQueryParams(t, intSystemHttpClient, conf.ORDServiceURL+"/events?", map[string][]string{tenantHeader: {defaultTestTenant}}, params)
 		require.Equal(t, len(appInput.Bundles[0].EventDefinitions), len(gjson.Get(respBody, "value").Array()))
 
 		specs := gjson.Get(respBody, fmt.Sprintf("value.%d.resourceDefinitions", 0)).Array()
@@ -590,7 +709,11 @@ func TestORDService(t *testing.T) {
 	})
 
 	t.Run("Errors generate user-friendly message", func(t *testing.T) {
-		respBody := request.MakeRequestWithHeadersAndStatusExpect(t, intSystemHttpClient, conf.ORDServiceURL+"/test?$format=json", map[string][]string{tenantHeader: {defaultTestTenant}}, http.StatusNotFound, conf.ORDServiceDefaultResponseType)
+		params := urlpkg.Values{}
+
+		params.Add("$format", "json")
+		serviceURL := conf.ORDServiceURL + "/test?" + params.Encode()
+		respBody := request.MakeRequestWithHeadersAndStatusExpect(t, intSystemHttpClient, serviceURL, map[string][]string{tenantHeader: {defaultTestTenant}}, http.StatusNotFound, conf.ORDServiceDefaultResponseType)
 
 		require.Contains(t, gjson.Get(respBody, "error.message").String(), "Use odata-debug query parameter with value one of the following formats: json,html,download for more information")
 	})
@@ -626,9 +749,12 @@ func TestORDService(t *testing.T) {
 		defer fixtures.CleanupApplication(t, ctx, certSecuredGraphQLClient, defaultTestTenant, &outputApp)
 		require.NoError(t, err)
 
-		getSystemInstanceURL := fmt.Sprintf("%s/systemInstances(%s)?$format=json", conf.ORDServiceURL, outputApp.ID)
+		params := urlpkg.Values{}
 
-		respBody := makeRequestWithHeaders(t, intSystemHttpClient, getSystemInstanceURL, map[string][]string{tenantHeader: {defaultTestTenant}})
+		params.Add("$format", "json")
+		getSystemInstanceURL := fmt.Sprintf("%s/systemInstances(%s)?", conf.ORDServiceURL, outputApp.ID)
+
+		respBody := makeRequestWithHeadersAndQueryParams(t, intSystemHttpClient, getSystemInstanceURL, map[string][]string{tenantHeader: {defaultTestTenant}}, params)
 
 		require.Equal(t, outputApp.Name, gjson.Get(respBody, "title").String())
 
@@ -727,7 +853,10 @@ func TestORDServiceSystemDiscoveryByApplicationTenantID(t *testing.T) {
 	headers := map[string][]string{applicationTenantIDHeaderKey: {localTenantID}}
 	// Make a request to the ORD service with http client containing custom certificate and application tenant ID header
 	t.Log("Getting application using custom certificate and appplicationTenantId header before a formation is created...")
-	respBody := makeRequestWithHeaders(t, certHttpClient, conf.ORDExternalCertSecuredServiceURL+"/systemInstances?$format=json", headers)
+	params := urlpkg.Values{}
+
+	params.Add("$format", "json")
+	respBody := makeRequestWithHeadersAndQueryParams(t, certHttpClient, conf.ORDExternalCertSecuredServiceURL+"/systemInstances?", headers, params)
 	require.Empty(t, gjson.Get(respBody, "value").Array())
 	t.Log("No system instance details are returned due to missing formation")
 
@@ -754,7 +883,7 @@ func TestORDServiceSystemDiscoveryByApplicationTenantID(t *testing.T) {
 	defer unassignFromFormation(t, ctx, consumerApp.ID, string(directorSchema.FormationObjectTypeApplication), systemDiscoveryFormationName, tenantID)
 
 	t.Log("Getting application using custom certificate and appplicationTenantId header after formation is created...")
-	respBody = makeRequestWithHeaders(t, certHttpClient, conf.ORDExternalCertSecuredServiceURL+"/systemInstances?$format=json", headers)
+	respBody = makeRequestWithHeadersAndQueryParams(t, certHttpClient, conf.ORDExternalCertSecuredServiceURL+"/systemInstances?", headers, params)
 	require.Len(t, gjson.Get(respBody, "value").Array(), 2)
 
 	isSystemFound := false

--- a/tests/pkg/fixtures/application_template_queries.go
+++ b/tests/pkg/fixtures/application_template_queries.go
@@ -2,6 +2,7 @@ package fixtures
 
 import (
 	"context"
+
 	"github.com/kyma-incubator/compass/components/director/pkg/graphql"
 	"github.com/kyma-incubator/compass/tests/pkg/assertions"
 	"github.com/kyma-incubator/compass/tests/pkg/testctx"

--- a/tests/pkg/fixtures/formation_queries.go
+++ b/tests/pkg/fixtures/formation_queries.go
@@ -79,7 +79,7 @@ func CreateFormationFromTemplateWithinTenant(t *testing.T, ctx context.Context, 
 	formationInput := FixFormationInput(formationName, formationTemplateName)
 	formationInputGQL, err := testctx.Tc.Graphqlizer.FormationInputToGQL(formationInput)
 	require.NoError(t, err)
-	return CreateFormationFromTemplateWithInputWithinTenant(t, ctx, gqlClient, tenantID,formationName, formationInputGQL)
+	return CreateFormationFromTemplateWithInputWithinTenant(t, ctx, gqlClient, tenantID, formationName, formationInputGQL)
 }
 
 func CreateFormationFromTemplateWithStateWithinTenant(t *testing.T, ctx context.Context, gqlClient *gcli.Client, tenantID, formationName string, formationTemplateName, formationState *string) graphql.FormationExt {

--- a/tests/pkg/notifications/asserters/formation_assigments_async_custom_config_matcher.go
+++ b/tests/pkg/notifications/asserters/formation_assigments_async_custom_config_matcher.go
@@ -2,12 +2,13 @@ package asserters
 
 import (
 	"context"
+	"testing"
+	"time"
+
 	"github.com/kyma-incubator/compass/tests/pkg/fixtures"
 	context_keys "github.com/kyma-incubator/compass/tests/pkg/notifications/context-keys"
 	"github.com/machinebox/graphql"
 	"github.com/stretchr/testify/require"
-	"testing"
-	"time"
 )
 
 type FormationAssignmentsAsyncCustomConfigMatcherAsserter struct {

--- a/tests/pkg/notifications/asserters/formation_is_deleted.go
+++ b/tests/pkg/notifications/asserters/formation_is_deleted.go
@@ -2,10 +2,11 @@ package asserters
 
 import (
 	"context"
-	context_keys "github.com/kyma-incubator/compass/tests/pkg/notifications/context-keys"
-	testingx "github.com/kyma-incubator/compass/tests/pkg/testing"
 	"testing"
 	"time"
+
+	context_keys "github.com/kyma-incubator/compass/tests/pkg/notifications/context-keys"
+	testingx "github.com/kyma-incubator/compass/tests/pkg/testing"
 
 	"github.com/kyma-incubator/compass/tests/pkg/fixtures"
 	"github.com/machinebox/graphql"

--- a/tests/pkg/notifications/asserters/lifecycle_notification.go
+++ b/tests/pkg/notifications/asserters/lifecycle_notification.go
@@ -2,6 +2,10 @@ package asserters
 
 import (
 	"context"
+	"net/http"
+	"testing"
+	"time"
+
 	gql "github.com/kyma-incubator/compass/components/director/pkg/graphql"
 	"github.com/kyma-incubator/compass/tests/pkg/fixtures"
 	context_keys "github.com/kyma-incubator/compass/tests/pkg/notifications/context-keys"
@@ -9,9 +13,6 @@ import (
 	"github.com/machinebox/graphql"
 	"github.com/stretchr/testify/require"
 	"github.com/tidwall/gjson"
-	"net/http"
-	"testing"
-	"time"
 )
 
 type LifecycleNotificationsAsserter struct {

--- a/tests/pkg/notifications/asserters/notifications.go
+++ b/tests/pkg/notifications/asserters/notifications.go
@@ -3,12 +3,13 @@ package asserters
 import (
 	"context"
 	"fmt"
-	"github.com/kyma-incubator/compass/tests/pkg/certs"
-	"github.com/kyma-incubator/compass/tests/pkg/fixtures"
-	"github.com/machinebox/graphql"
 	"io"
 	"net/http"
 	"testing"
+
+	"github.com/kyma-incubator/compass/tests/pkg/certs"
+	"github.com/kyma-incubator/compass/tests/pkg/fixtures"
+	"github.com/machinebox/graphql"
 
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"

--- a/tests/pkg/notifications/asserters/notifications_unassign.go
+++ b/tests/pkg/notifications/asserters/notifications_unassign.go
@@ -2,10 +2,11 @@ package asserters
 
 import (
 	"context"
-	"github.com/kyma-incubator/compass/tests/pkg/fixtures"
-	"github.com/machinebox/graphql"
 	"net/http"
 	"testing"
+
+	"github.com/kyma-incubator/compass/tests/pkg/fixtures"
+	"github.com/machinebox/graphql"
 
 	context_keys "github.com/kyma-incubator/compass/tests/pkg/notifications/context-keys"
 	"github.com/stretchr/testify/require"

--- a/tests/pkg/notifications/operations/assign_application.go
+++ b/tests/pkg/notifications/operations/assign_application.go
@@ -2,12 +2,13 @@ package operations
 
 import (
 	"context"
+	"testing"
+
 	"github.com/kyma-incubator/compass/components/director/pkg/graphql"
 	"github.com/kyma-incubator/compass/tests/pkg/fixtures"
 	"github.com/kyma-incubator/compass/tests/pkg/notifications/asserters"
 	context_keys "github.com/kyma-incubator/compass/tests/pkg/notifications/context-keys"
 	gcli "github.com/machinebox/graphql"
-	"testing"
 )
 
 type AssignAppToFormationOperation struct {

--- a/tests/pkg/notifications/operations/create_formation.go
+++ b/tests/pkg/notifications/operations/create_formation.go
@@ -2,9 +2,10 @@ package operations
 
 import (
 	"context"
+	"testing"
+
 	"github.com/kyma-incubator/compass/components/director/pkg/graphql"
 	context_keys "github.com/kyma-incubator/compass/tests/pkg/notifications/context-keys"
-	"testing"
 
 	"github.com/kyma-incubator/compass/tests/pkg/fixtures"
 	"github.com/kyma-incubator/compass/tests/pkg/notifications/asserters"

--- a/tests/pkg/notifications/operations/delete_formation.go
+++ b/tests/pkg/notifications/operations/delete_formation.go
@@ -2,8 +2,9 @@ package operations
 
 import (
 	"context"
-	context_keys "github.com/kyma-incubator/compass/tests/pkg/notifications/context-keys"
 	"testing"
+
+	context_keys "github.com/kyma-incubator/compass/tests/pkg/notifications/context-keys"
 
 	"github.com/kyma-incubator/compass/tests/pkg/fixtures"
 	"github.com/kyma-incubator/compass/tests/pkg/notifications/asserters"

--- a/tests/pkg/notifications/operations/update_webhook.go
+++ b/tests/pkg/notifications/operations/update_webhook.go
@@ -2,8 +2,9 @@ package operations
 
 import (
 	"context"
-	context_keys "github.com/kyma-incubator/compass/tests/pkg/notifications/context-keys"
 	"testing"
+
+	context_keys "github.com/kyma-incubator/compass/tests/pkg/notifications/context-keys"
 
 	"github.com/kyma-incubator/compass/components/director/pkg/graphql"
 	"github.com/kyma-incubator/compass/tests/pkg/fixtures"

--- a/tests/pkg/notifications/resource-providers/formation.go
+++ b/tests/pkg/notifications/resource-providers/formation.go
@@ -2,8 +2,9 @@ package resource_providers
 
 import (
 	"context"
-	"github.com/kyma-incubator/compass/components/director/pkg/graphql"
 	"testing"
+
+	"github.com/kyma-incubator/compass/components/director/pkg/graphql"
 
 	"github.com/kyma-incubator/compass/tests/pkg/fixtures"
 	gcli "github.com/machinebox/graphql"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Currently, the ORD Service tests do not encode the OData query parameters of the URL. This can cause unexpected behaviour as a lot of [reserved characters](https://datatracker.ietf.org/doc/html/rfc3986#section-2.2) are used. These reserved characters have their special usage/meaning and we need to only encode whenever these characters deviate from the standard.
Changes proposed in this pull request:
- Encode the OData query parameters of the URL

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- ...

**Pull Request status**
<!-- Feel free to construct the checklist with whatever items seem most reasonable for your change. You could disassemble the Implementation part to even smaller separate checklist items if you're working on something big for example. But do make the effort to provide a checklist of some sort so that the core team as well as the community can have an idea about the progress of your Pull Request.
-->

- [ ] Implementation
- [ ] Unit tests
- [ ] Integration tests
- [ ] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [ ] Mocks are regenerated, using the automated script
