### PR TITLE
Fix request body validation when assignment status is reported

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -162,8 +162,8 @@ global:
     containerRegistry:
       path: europe-docker.pkg.dev/kyma-project
     connector:
-      dir: dev/incubator/
-      version: "PR-3741"
+      dir: prod/incubator/
+      version: "v20240318-8734b35c"
       name: compass-connector
     connectivity_adapter:
       dir: dev/incubator/

--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -175,7 +175,7 @@ global:
       name: compass-pairing-adapter
     director:
       dir: dev/incubator/
-      version: "PR-3801"
+      version: "PR-3814"
       name: compass-director
     hydrator:
       dir: dev/incubator/

--- a/components/director/internal/formationmapping/handler.go
+++ b/components/director/internal/formationmapping/handler.go
@@ -110,6 +110,10 @@ func (h *Handler) updateFormationAssignmentStatus(w http.ResponseWriter, r *http
 		return
 	}
 
+	if formationassignmentpkg.IsConfigEmpty(string(assignmentReqBody.Configuration)) {
+		assignmentReqBody.Configuration = nil
+	}
+
 	log.C(ctx).Info("Validating formation assignment request body...")
 	if err = assignmentReqBody.Validate(ctx); err != nil {
 		log.C(ctx).WithError(err).Error("An error occurred while validating the request body")


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
In the "status API" when someone reports status for assignment we incorrectly interpret the configuration property when it's set to `null`. And it seems the config is provided whereas it should be empty/null, resulting in a request body validation error.

Changes proposed in this pull request:
- Check for different "empty" values in the request body's configuration property

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- ...

**Pull Request status**
<!-- Feel free to construct the checklist with whatever items seem most reasonable for your change. You could disassemble the Implementation part to even smaller separate checklist items if you're working on something big for example. But do make the effort to provide a checklist of some sort so that the core team as well as the community can have an idea about the progress of your Pull Request.
-->

- [x] Implementation
- [ ] Unit tests
- [ ] Integration tests
- [x] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [ ] Mocks are regenerated, using the automated script
