### PR TITLE
Fix test to use same OU subaccount as in the certSecuredGraphQLClient 

### DIFF
--- a/chart/compass/templates/tests/ord-service/ord-service-test.yaml
+++ b/chart/compass/templates/tests/ord-service/ord-service-test.yaml
@@ -244,6 +244,8 @@ spec:
               value: {{ .Values.global.systemFetcher.appTemplatesProductLabel }}
             - name: APP_GATEWAY_OAUTH
               value: "https://{{ .Values.global.gateway.tls.secure.oauth.host }}.{{ .Values.global.ingress.domainName }}/director/graphql"
+            - name: APP_EXTERNAL_CERT_TEST_OU_SUBACCOUNT
+              value: {{ .Values.global.externalCertConfiguration.ouCertSubaccountID }}
           volumeMounts:
             - name: dest-svc-instances
               mountPath: {{ .Values.global.destinationFetcher.dependenciesConfig.path }}

--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -228,7 +228,7 @@ global:
       name: compass-external-services-mock
     e2e_tests:
       dir: dev/incubator/
-      version: "PR-3845"
+      version: "PR-3846"
       name: compass-e2e-tests
   isLocalEnv: false
   isForTesting: false

--- a/tests/director/tests/application/application_api_test.go
+++ b/tests/director/tests/application/application_api_test.go
@@ -1871,8 +1871,11 @@ func TestMergeApplicationsWithSelfRegDistinguishLabelKey(t *testing.T) {
 	formationTemplateName := "merge-applications-template"
 	nameJSONPath := "$.name-json-path"
 	displayNameJSONPath := "$.display-name-json-path"
-	appTechnicalProviderDirectorCertSecuredClient := certprovider.NewDirectorCertClientWithOtherSubject(t, ctx, conf.ExternalCertProviderConfig, conf.DirectorExternalCertSecuredURL, "app-template-merge-technical-cn", conf.SkipSSLValidation)
-	appProviderDirectorCertSecuredClient := certprovider.NewDirectorCertClientWithOtherSubject(t, ctx, conf.ExternalCertProviderConfig, conf.DirectorExternalCertSecuredURL, "app-template-merge-cn", conf.SkipSSLValidation)
+
+	// Make clients that use a certificate which has a OU value for subaccount the same as the OU in the certSecuredGraphQLClient
+	// in order to maintain the tenant isolation
+	appTechnicalProviderDirectorCertSecuredClient := directorCertSecuredClientWithExternalCertSubaccount(t, ctx, "app-template-merge-technical-cn")
+	appProviderDirectorCertSecuredClient := directorCertSecuredClientWithExternalCertSubaccount(t, ctx, "app-template-merge-cn")
 
 	appTmplInput := fixtures.FixAppTemplateInputWithDefaultDistinguishLabel(expectedProductType, conf.SubscriptionConfig.SelfRegDistinguishLabelKey, conf.SubscriptionConfig.SelfRegDistinguishLabelValue)
 	appTmplInput.ApplicationInput.Name = "{{name}}"
@@ -2287,4 +2290,22 @@ func TestGetApplicationByLocalTenantIDAndAppTemplateID(t *testing.T) {
 	require.Equal(t, outputApp.Application.ID, newApp.Application.ID)
 	require.Equal(t, appTmpl.ID, *newApp.Application.ApplicationTemplateID)
 	require.Equal(t, localTenantID, *newApp.Application.LocalTenantID)
+}
+
+func directorCertSecuredClientWithExternalCertSubaccount(t *testing.T, ctx context.Context, cn string) *gcli.Client {
+	replacer := strings.NewReplacer(conf.TestProviderSubaccountID, conf.ExternalCertTestIntSystemOUSubaccount, conf.TestExternalCertCN, cn)
+	externalCertProviderConfig := certprovider.ExternalCertProviderConfig{
+		ExternalClientCertTestSecretName:      conf.ExternalClientCertTestSecretName,
+		ExternalClientCertTestSecretNamespace: conf.ExternalClientCertTestSecretNamespace,
+		CertSvcInstanceTestSecretName:         conf.CertSvcInstanceTestSecretName,
+		ExternalCertCronjobContainerName:      conf.ExternalCertCronjobContainerName,
+		ExternalCertTestJobName:               conf.ExternalCertTestJobName,
+		TestExternalCertSubject:               replacer.Replace(conf.ExternalCertProviderConfig.TestExternalCertSubject),
+		ExternalClientCertCertKey:             conf.ExternalClientCertCertKey,
+		ExternalClientCertKeyKey:              conf.ExternalClientCertKeyKey,
+		ExternalCertProvider:                  certprovider.CertificateService,
+	}
+
+	pk, cert := certprovider.NewExternalCertFromConfig(t, ctx, externalCertProviderConfig, true)
+	return gql.NewCertAuthorizedGraphQLClientWithCustomURL(conf.DirectorExternalCertSecuredURL, pk, cert, conf.SkipSSLValidation)
 }

--- a/tests/director/tests/application/application_templates_subscription_test.go
+++ b/tests/director/tests/application/application_templates_subscription_test.go
@@ -375,7 +375,7 @@ func TestSubscriptionApplicationTemplateFlow(baseT *testing.T) {
 	})
 
 	t.Run("When creating app template with optional placeholders", func(stdT *testing.T) {
-		appProviderDirectorOnboardingCertSecuredClient = certprovider.NewDirectorCertClientWithOtherSubject(baseT, ctx, conf.ExternalCertProviderConfig, conf.DirectorExternalCertSecuredURL, "app-template-subscription-onboarding-optional-placeholders-cn", conf.SkipSSLValidation)
+		appProviderDirectorOnboardingCertSecuredClient = certprovider.NewDirectorCertClientWithOtherSubject(baseT, ctx, conf.ExternalCertProviderConfig, conf.DirectorExternalCertSecuredURL, "app-template-optional-placeholders", conf.SkipSSLValidation)
 
 		t := testingx.NewT(stdT)
 

--- a/tests/ord-service/tests/api_test.go
+++ b/tests/ord-service/tests/api_test.go
@@ -955,14 +955,14 @@ func TestORDServiceSystemDiscoveryByApplicationTenantIDUsingProviderCSM(t *testi
 	tenantID := tenant.TestTenants.GetDefaultTenantID()
 	cn := "ord-svc-system-with-csm-discovery"
 
-	technicalCertSubject := strings.Replace(conf.ExternalCertProviderConfig.TestExternalCertSubject, conf.ExternalCertProviderConfig.TestExternalCertCN, "csm-discovery-technical", -1)
-	technicalCertProvider := createExternalConfigProvider(technicalCertSubject, conf.CertSvcInstanceTestSecretName)
+	technicalCertSubjectReplacer := strings.NewReplacer(conf.TestProviderSubaccountID, conf.ExternalCertTestOUSubaccount, conf.ExternalCertProviderConfig.TestExternalCertCN, "csm-discovery-technical")
+	technicalCertProvider := createExternalConfigProvider(technicalCertSubjectReplacer.Replace(conf.ExternalCertProviderConfig.TestExternalCertSubject), conf.CertSvcInstanceTestSecretName)
 	technicalProviderClientKey, technicalProviderRawCertChain := certprovider.NewExternalCertFromConfig(t, ctx, technicalCertProvider, false)
 	technicalCertDirectorGQLClient := gql.NewCertAuthorizedGraphQLClientWithCustomURL(conf.DirectorExternalCertSecuredURL, technicalProviderClientKey, technicalProviderRawCertChain, conf.SkipSSLValidation)
 
-	certSubject := strings.Replace(conf.ExternalCertProviderConfig.TestExternalCertSubject, conf.ExternalCertProviderConfig.TestExternalCertCN, cn, -1)
+	certSubjectReplacer := strings.NewReplacer(conf.TestProviderSubaccountID, conf.ExternalCertTestOUSubaccount, conf.ExternalCertProviderConfig.TestExternalCertCN, cn)
 	// We need an externally issued cert with a subject that is not part of the access level mappings
-	externalCertProviderConfig := createExternalConfigProvider(certSubject, conf.CertSvcInstanceTestSecretName)
+	externalCertProviderConfig := createExternalConfigProvider(certSubjectReplacer.Replace(conf.ExternalCertProviderConfig.TestExternalCertSubject), conf.CertSvcInstanceTestSecretName)
 
 	// Prepare provider external client certificate and secret and Build graphql director client configured with certificate
 	providerClientKey, providerRawCertChain := certprovider.NewExternalCertFromConfig(t, ctx, externalCertProviderConfig, false)

--- a/tests/ord-service/tests/main_test.go
+++ b/tests/ord-service/tests/main_test.go
@@ -82,6 +82,7 @@ type config struct {
 	CertSubjectMappingResyncInterval    time.Duration `envconfig:"APP_CERT_SUBJECT_MAPPING_RESYNC_INTERVAL"`
 	ApplicationTemplateProductLabel     string        `envconfig:"APP_APPLICATION_TEMPLATE_PRODUCT_LABEL"`
 	GatewayOauth                        string        `envconfig:"APP_GATEWAY_OAUTH"`
+	ExternalCertTestOUSubaccount        string        `envconfig:"APP_EXTERNAL_CERT_TEST_OU_SUBACCOUNT"`
 }
 
 var conf config


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:
- For TestMergeApplicationsWithSelfRegDistinguishLabelKey the tenant in the certSecuredGraphQLClient and the appProviderDirectorCertSecuredClient have different subaccount in their OU in e2e tests on real env. In order to maintain the tenant isolation and have the certSecuredGraphQLClient to see the applications made by appProviderDirectorCertSecuredClient, we need to unify the OUs in the clients.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- ...

**Pull Request status**
<!-- Feel free to construct the checklist with whatever items seem most reasonable for your change. You could disassemble the Implementation part to even smaller separate checklist items if you're working on something big for example. But do make the effort to provide a checklist of some sort so that the core team as well as the community can have an idea about the progress of your Pull Request.
-->

- [ ] Implementation
- [ ] Unit tests
- [ ] Integration tests
- [ ] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [ ] Mocks are regenerated, using the automated script
