### PR TITLE
Make global ORD entities visible in systems

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -211,7 +211,7 @@ global:
       name: compass-ord-service
     schema_migrator:
       dir: dev/incubator/
-      version: "PR-3843"
+      version: "PR-3857"
       name: compass-schema-migrator
     system_broker:
       dir: prod/incubator/

--- a/components/schema-migrator/migrations/director/20240430084814_ord-expose-global-entities.down.sql
+++ b/components/schema-migrator/migrations/director/20240430084814_ord-expose-global-entities.down.sql
@@ -1,0 +1,72 @@
+BEGIN;
+
+DROP VIEW IF EXISTS tenants_vendors;
+
+CREATE OR REPLACE VIEW tenants_vendors
+            (tenant_id, formation_id, ord_id, app_id, title, labels, tags, partners, id, documentation_labels)
+AS
+SELECT DISTINCT t_apps.tenant_id,
+                t_apps.formation_id,
+                v.ord_id,
+                v.app_id,
+                v.title,
+                v.labels,
+                v.tags,
+                v.partners,
+                v.id,
+                v.documentation_labels
+FROM vendors v
+         JOIN (SELECT a1.id,
+                      a1.tenant_id,
+                      'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'::uuid AS formation_id
+               FROM tenant_applications a1
+               UNION ALL
+               SELECT af.app_id,
+                      'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'::uuid AS tenant_id,
+                      af.formation_id
+               FROM apps_formations_id af
+               UNION ALL
+               SELECT apps_subaccounts.id,
+                      apps_subaccounts.tenant_id,
+                      'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'::uuid AS formation_id
+               FROM apps_subaccounts) t_apps ON v.app_id = t_apps.id OR v.app_id IS NULL;
+
+-----
+
+DROP VIEW IF EXISTS tenants_products;
+
+CREATE OR REPLACE VIEW tenants_products
+            (tenant_id, formation_id, ord_id, app_id, title, short_description, vendor, parent, labels, tags,
+             correlation_ids, id, documentation_labels, description)
+AS
+SELECT DISTINCT t_apps.tenant_id,
+                t_apps.formation_id,
+                p.ord_id,
+                p.app_id,
+                p.title,
+                p.short_description,
+                p.vendor,
+                p.parent,
+                p.labels,
+                p.tags,
+                p.correlation_ids,
+                p.id,
+                p.documentation_labels,
+                p.description
+FROM products p
+         JOIN (SELECT a1.id,
+                      a1.tenant_id,
+                      'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'::uuid AS formation_id
+               FROM tenant_applications a1
+               UNION ALL
+               SELECT af.app_id,
+                      'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'::uuid AS tenant_id,
+                      af.formation_id
+               FROM apps_formations_id af
+               UNION ALL
+               SELECT apps_subaccounts.id,
+                      apps_subaccounts.tenant_id,
+                      'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'::uuid AS formation_id
+               FROM apps_subaccounts) t_apps ON p.app_id = t_apps.id OR p.app_id IS NULL;
+
+COMMIT;

--- a/components/schema-migrator/migrations/director/20240430084814_ord-expose-global-entities.up.sql
+++ b/components/schema-migrator/migrations/director/20240430084814_ord-expose-global-entities.up.sql
@@ -1,0 +1,73 @@
+BEGIN;
+
+DROP VIEW IF EXISTS tenants_vendors;
+
+CREATE OR REPLACE VIEW tenants_vendors
+            (tenant_id, formation_id, ord_id, app_id, title, labels, tags, partners, id, documentation_labels)
+AS
+SELECT DISTINCT t_apps.tenant_id,
+                t_apps.formation_id,
+                v.ord_id,
+                coalesce(v.app_id, t_apps.id),
+                v.title,
+                v.labels,
+                v.tags,
+                v.partners,
+                v.id,
+                v.documentation_labels
+FROM vendors v
+         JOIN (SELECT a1.id,
+                      a1.tenant_id,
+                      'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'::uuid AS formation_id
+               FROM tenant_applications a1
+               UNION ALL
+               SELECT af.app_id,
+                      'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'::uuid AS tenant_id,
+                      af.formation_id
+               FROM apps_formations_id af
+               UNION ALL
+               SELECT apps_subaccounts.id,
+                      apps_subaccounts.tenant_id,
+                      'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'::uuid AS formation_id
+               FROM apps_subaccounts) t_apps ON v.app_id = t_apps.id OR v.app_id IS NULL;
+
+-----
+
+DROP VIEW IF EXISTS tenants_products;
+
+CREATE OR REPLACE VIEW tenants_products
+            (tenant_id, formation_id, ord_id, app_id, title, short_description, vendor, parent, labels, tags,
+             correlation_ids, id, documentation_labels, description)
+AS
+SELECT DISTINCT t_apps.tenant_id,
+                t_apps.formation_id,
+                p.ord_id,
+                coalesce(p.app_id, t_apps.id),
+                p.title,
+                p.short_description,
+                p.vendor,
+                p.parent,
+                p.labels,
+                p.tags,
+                p.correlation_ids,
+                p.id,
+                p.documentation_labels,
+                p.description
+FROM products p
+         JOIN (SELECT a1.id,
+                      a1.tenant_id,
+                      'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'::uuid AS formation_id
+               FROM tenant_applications a1
+               UNION ALL
+               SELECT af.app_id,
+                      'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb'::uuid AS tenant_id,
+                      af.formation_id
+               FROM apps_formations_id af
+               UNION ALL
+               SELECT apps_subaccounts.id,
+                      apps_subaccounts.tenant_id,
+                      'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa'::uuid AS formation_id
+               FROM apps_subaccounts) t_apps ON p.app_id = t_apps.id OR p.app_id IS NULL;
+
+
+COMMIT;


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

This PR makes the global ORD entities (products, vendors) visible when they are expanded from Systems.

Changes proposed in this pull request:
- in the respective views, for each global entity populate the `app_id` column with each available system so that it can be later joined in the ORD Svc


**Pull Request status**
<!-- Feel free to construct the checklist with whatever items seem most reasonable for your change. You could disassemble the Implementation part to even smaller separate checklist items if you're working on something big for example. But do make the effort to provide a checklist of some sort so that the core team as well as the community can have an idea about the progress of your Pull Request.
-->

- [x] Implementation
- [ ] Unit tests
- [ ] Integration tests
- [x] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [ ] Mocks are regenerated, using the automated script
