### PR TITLE
Fix "Consumer provider with user context header" e2e test

### DIFF
--- a/chart/compass/templates/tests/ord-service/ord-service-test.yaml
+++ b/chart/compass/templates/tests/ord-service/ord-service-test.yaml
@@ -248,6 +248,14 @@ spec:
               value: "https://{{ .Values.global.gateway.tls.secure.oauth.host }}.{{ .Values.global.ingress.domainName }}/director/graphql"
             - name: APP_EXTERNAL_CERT_TEST_OU_SUBACCOUNT
               value: {{ .Values.global.externalCertConfiguration.ouCertSubaccountID }}
+            - name: APP_CONSUMER_CLAIMS_CLIENT_ID_KEY
+              value: {{ .Values.global.hydrator.consumerClaimsKeys.clientIDKey }}
+            - name: APP_CONSUMER_CLAIMS_TENANT_ID_KEY
+              value: {{ .Values.global.hydrator.consumerClaimsKeys.tenantIDKey }}
+            - name: APP_CONSUMER_CLAIMS_USER_NAME_KEY
+              value: {{ .Values.global.hydrator.consumerClaimsKeys.userNameKey }}
+            - name: APP_CONSUMER_CLAIMS_SUBDOMAIN_KEY
+              value: {{ .Values.global.hydrator.consumerClaimsKeys.subdomainKey }}
           volumeMounts:
             - name: dest-svc-instances
               mountPath: {{ .Values.global.destinationFetcher.dependenciesConfig.path }}

--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -228,7 +228,7 @@ global:
       name: compass-external-services-mock
     e2e_tests:
       dir: dev/incubator/
-      version: "PR-3852"
+      version: "PR-3862"
       name: compass-e2e-tests
   isLocalEnv: false
   isForTesting: false

--- a/tests/ord-service/tests/main_test.go
+++ b/tests/ord-service/tests/main_test.go
@@ -84,6 +84,7 @@ type config struct {
 	ApplicationTemplateProductLabel     string        `envconfig:"APP_APPLICATION_TEMPLATE_PRODUCT_LABEL"`
 	GatewayOauth                        string        `envconfig:"APP_GATEWAY_OAUTH"`
 	ExternalCertTestOUSubaccount        string        `envconfig:"APP_EXTERNAL_CERT_TEST_OU_SUBACCOUNT"`
+	ConsumerClaimsKeysConfig            testconfig.ConsumerClaimsKeysConfig
 }
 
 var conf config

--- a/tests/ord-service/tests/subscription_flow_test.go
+++ b/tests/ord-service/tests/subscription_flow_test.go
@@ -961,10 +961,10 @@ func TestConsumerProviderFlow(stdT *testing.T) {
 		// After successful subscription from above we call the director component with "double authentication(token + user_context header)" in order to test claims validation is successful
 		consumerToken := token.GetUserToken(stdT, ctx, conf.ConsumerTokenURL+conf.TokenPath, conf.ProviderClientID, conf.ProviderClientSecret, conf.BasicUsername, conf.BasicPassword, claims.SubscriptionClaimKey)
 		consumerClaims := token.FlattenTokenClaims(stdT, consumerToken)
-		clientID := gjson.Get(consumerClaims, "client_id")
-		subaccountID := gjson.Get(consumerClaims, "subaccountid")
-		userName := gjson.Get(consumerClaims, "user_name")
-		subdomain := gjson.Get(consumerClaims, "subdomain")
+		clientID := gjson.Get(consumerClaims, conf.ConsumerClaimsKeysConfig.ClientIDKey)
+		subaccountID := gjson.Get(consumerClaims, conf.ConsumerClaimsKeysConfig.TenantIDKey)
+		userName := gjson.Get(consumerClaims, conf.ConsumerClaimsKeysConfig.UserNameKey)
+		subdomain := gjson.Get(consumerClaims, conf.ConsumerClaimsKeysConfig.SubdomainKey)
 		userContextHeader := buildUserContextHeader(t, clientID.String(), subaccountID.String(), userName.String(), subdomain.String())
 		headers := map[string][]string{subscription.UserContextHeader: {userContextHeader}}
 
@@ -1174,13 +1174,13 @@ func generateDestinationName(name string) string {
 }
 
 func buildUserContextHeader(t *testing.T, clientID, subaccountID, userName, subdomain string) string {
-	consumerClaims, err := sjson.Set("{}", "client_id", clientID)
+	consumerClaims, err := sjson.Set("{}", conf.ConsumerClaimsKeysConfig.ClientIDKey, clientID)
 	require.NoError(t, err)
-	consumerClaims, err = sjson.Set(consumerClaims, "subaccountid", subaccountID)
+	consumerClaims, err = sjson.Set(consumerClaims, conf.ConsumerClaimsKeysConfig.TenantIDKey, subaccountID)
 	require.NoError(t, err)
-	consumerClaims, err = sjson.Set(consumerClaims, "user_name", userName)
+	consumerClaims, err = sjson.Set(consumerClaims, conf.ConsumerClaimsKeysConfig.UserNameKey, userName)
 	require.NoError(t, err)
-	consumerClaims, err = sjson.Set(consumerClaims, "subdomain", subdomain)
+	consumerClaims, err = sjson.Set(consumerClaims, conf.ConsumerClaimsKeysConfig.SubdomainKey, subdomain)
 	require.NoError(t, err)
 	consumerClaims, err = sjson.Set(consumerClaims, "encodedValue", "test+n%C3%B8n+as%C3%A7ii+ch%C3%A5%C2%AEacte%C2%AE")
 	require.NoError(t, err)

--- a/tests/ord-service/tests/subscription_flow_test.go
+++ b/tests/ord-service/tests/subscription_flow_test.go
@@ -961,9 +961,12 @@ func TestConsumerProviderFlow(stdT *testing.T) {
 		// After successful subscription from above we call the director component with "double authentication(token + user_context header)" in order to test claims validation is successful
 		consumerToken := token.GetUserToken(stdT, ctx, conf.ConsumerTokenURL+conf.TokenPath, conf.ProviderClientID, conf.ProviderClientSecret, conf.BasicUsername, conf.BasicPassword, claims.SubscriptionClaimKey)
 		consumerClaims := token.FlattenTokenClaims(stdT, consumerToken)
-		consumerClaimsWithEncodedValue, err := sjson.Set(consumerClaims, "encodedValue", "test+n%C3%B8n+as%C3%A7ii+ch%C3%A5%C2%AEacte%C2%AE")
-		require.NoError(t, err)
-		headers := map[string][]string{subscription.UserContextHeader: {consumerClaimsWithEncodedValue}}
+		clientID := gjson.Get(consumerClaims, "client_id")
+		subaccountID := gjson.Get(consumerClaims, "subaccountid")
+		userName := gjson.Get(consumerClaims, "user_name")
+		subdomain := gjson.Get(consumerClaims, "subdomain")
+		userContextHeader := buildUserContextHeader(t, clientID.String(), subaccountID.String(), userName.String(), subdomain.String())
+		headers := map[string][]string{subscription.UserContextHeader: {userContextHeader}}
 
 		stdT.Log("Calling director to verify claims validation is successful...")
 		getRtmReq := fixtures.FixGetRuntimeRequest(runtime.ID)
@@ -1168,4 +1171,18 @@ func verifyFormationDetails(stdT *testing.T, systemInstance gjson.Result, expect
 
 func generateDestinationName(name string) string {
 	return fmt.Sprintf("%s-%s", name, strconv.FormatInt(time.Now().Unix(), 10))
+}
+
+func buildUserContextHeader(t *testing.T, clientID, subaccountID, userName, subdomain string) string {
+	consumerClaims, err := sjson.Set("{}", "client_id", clientID)
+	require.NoError(t, err)
+	consumerClaims, err = sjson.Set(consumerClaims, "subaccountid", subaccountID)
+	require.NoError(t, err)
+	consumerClaims, err = sjson.Set(consumerClaims, "user_name", userName)
+	require.NoError(t, err)
+	consumerClaims, err = sjson.Set(consumerClaims, "subdomain", subdomain)
+	require.NoError(t, err)
+	consumerClaims, err = sjson.Set(consumerClaims, "encodedValue", "test+n%C3%B8n+as%C3%A7ii+ch%C3%A5%C2%AEacte%C2%AE")
+	require.NoError(t, err)
+	return consumerClaims
 }

--- a/tests/ord-service/tests/subscription_flow_test.go
+++ b/tests/ord-service/tests/subscription_flow_test.go
@@ -962,9 +962,13 @@ func TestConsumerProviderFlow(stdT *testing.T) {
 		consumerToken := token.GetUserToken(stdT, ctx, conf.ConsumerTokenURL+conf.TokenPath, conf.ProviderClientID, conf.ProviderClientSecret, conf.BasicUsername, conf.BasicPassword, claims.SubscriptionClaimKey)
 		consumerClaims := token.FlattenTokenClaims(stdT, consumerToken)
 		clientID := gjson.Get(consumerClaims, conf.ConsumerClaimsKeysConfig.ClientIDKey)
+		require.NotEmpty(t, clientID)
 		subaccountID := gjson.Get(consumerClaims, conf.ConsumerClaimsKeysConfig.TenantIDKey)
+		require.NotEmpty(t, subaccountID)
 		userName := gjson.Get(consumerClaims, conf.ConsumerClaimsKeysConfig.UserNameKey)
+		require.NotEmpty(t, userName)
 		subdomain := gjson.Get(consumerClaims, conf.ConsumerClaimsKeysConfig.SubdomainKey)
+		require.NotEmpty(t, subdomain)
 		userContextHeader := buildUserContextHeader(t, clientID.String(), subaccountID.String(), userName.String(), subdomain.String())
 		headers := map[string][]string{subscription.UserContextHeader: {userContextHeader}}
 

--- a/tests/ord-service/tests/subscription_flow_test.go
+++ b/tests/ord-service/tests/subscription_flow_test.go
@@ -961,15 +961,15 @@ func TestConsumerProviderFlow(stdT *testing.T) {
 		// After successful subscription from above we call the director component with "double authentication(token + user_context header)" in order to test claims validation is successful
 		consumerToken := token.GetUserToken(stdT, ctx, conf.ConsumerTokenURL+conf.TokenPath, conf.ProviderClientID, conf.ProviderClientSecret, conf.BasicUsername, conf.BasicPassword, claims.SubscriptionClaimKey)
 		consumerClaims := token.FlattenTokenClaims(stdT, consumerToken)
-		clientID := gjson.Get(consumerClaims, conf.ConsumerClaimsKeysConfig.ClientIDKey)
+		clientID := gjson.Get(consumerClaims, conf.ConsumerClaimsKeysConfig.ClientIDKey).String()
 		require.NotEmpty(t, clientID)
-		subaccountID := gjson.Get(consumerClaims, conf.ConsumerClaimsKeysConfig.TenantIDKey)
+		subaccountID := gjson.Get(consumerClaims, conf.ConsumerClaimsKeysConfig.TenantIDKey).String()
 		require.NotEmpty(t, subaccountID)
-		userName := gjson.Get(consumerClaims, conf.ConsumerClaimsKeysConfig.UserNameKey)
+		userName := gjson.Get(consumerClaims, conf.ConsumerClaimsKeysConfig.UserNameKey).String()
 		require.NotEmpty(t, userName)
-		subdomain := gjson.Get(consumerClaims, conf.ConsumerClaimsKeysConfig.SubdomainKey)
+		subdomain := gjson.Get(consumerClaims, conf.ConsumerClaimsKeysConfig.SubdomainKey).String()
 		require.NotEmpty(t, subdomain)
-		userContextHeader := buildUserContextHeader(t, clientID.String(), subaccountID.String(), userName.String(), subdomain.String())
+		userContextHeader := buildUserContextHeader(t, clientID, subaccountID, userName, subdomain)
 		headers := map[string][]string{subscription.UserContextHeader: {userContextHeader}}
 
 		stdT.Log("Calling director to verify claims validation is successful...")

--- a/tests/ord-service/tests/subscription_flow_test.go
+++ b/tests/ord-service/tests/subscription_flow_test.go
@@ -968,7 +968,6 @@ func TestConsumerProviderFlow(stdT *testing.T) {
 		userName := gjson.Get(consumerClaims, conf.ConsumerClaimsKeysConfig.UserNameKey).String()
 		require.NotEmpty(t, userName)
 		subdomain := gjson.Get(consumerClaims, conf.ConsumerClaimsKeysConfig.SubdomainKey).String()
-		require.NotEmpty(t, subdomain)
 		userContextHeader := buildUserContextHeader(t, clientID, subaccountID, userName, subdomain)
 		headers := map[string][]string{subscription.UserContextHeader: {userContextHeader}}
 

--- a/tests/pkg/config/director.go
+++ b/tests/pkg/config/director.go
@@ -9,3 +9,11 @@ type ProviderDestinationConfig struct {
 	ServiceURL   string `envconfig:"APP_PROVIDER_DESTINATION_SERVICE_URL"`
 	Dependency   string `envconfig:"APP_PROVIDER_DESTINATION_DEPENDENCY"`
 }
+
+// ConsumerClaimsKeysConfig holds customer claims keys
+type ConsumerClaimsKeysConfig struct {
+	ClientIDKey  string `envconfig:"APP_CONSUMER_CLAIMS_CLIENT_ID_KEY"`
+	TenantIDKey  string `envconfig:"APP_CONSUMER_CLAIMS_TENANT_ID_KEY"`
+	UserNameKey  string `envconfig:"APP_CONSUMER_CLAIMS_USER_NAME_KEY"`
+	SubdomainKey string `envconfig:"APP_CONSUMER_CLAIMS_SUBDOMAIN_KEY"`
+}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:
- Introduce new method for building of UserContext header value. 


**Pull Request status**
<!-- Feel free to construct the checklist with whatever items seem most reasonable for your change. You could disassemble the Implementation part to even smaller separate checklist items if you're working on something big for example. But do make the effort to provide a checklist of some sort so that the core team as well as the community can have an idea about the progress of your Pull Request.
-->

- [x] Implementation
- [ ] Unit tests
- [ ] Integration tests
- [x] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [ ] Mocks are regenerated, using the automated script
