### PR TITLE
Remove deprecated linters

### DIFF
--- a/chart/compass/values.yaml
+++ b/chart/compass/values.yaml
@@ -175,7 +175,7 @@ global:
       name: compass-pairing-adapter
     director:
       dir: dev/incubator/
-      version: "PR-3852"
+      version: "PR-3863"
       name: compass-director
     hydrator:
       dir: dev/incubator/
@@ -187,15 +187,15 @@ global:
       name: compass-ias-adapter
     kyma_adapter:
       dir: dev/incubator/
-      version: "PR-3841"
+      version: "PR-3863"
       name: compass-kyma-adapter
     instance_creator:
       dir: dev/incubator/
-      version: "PR-3842"
+      version: "PR-3863"
       name: compass-instance-creator
     default_tenant_mapping_handler:
       dir: dev/incubator/
-      version: "PR-3841"
+      version: "PR-3863"
       name: compass-default-tenant-mapping-handler
     gateway:
       dir: dev/incubator/

--- a/components/default-tenant-mapping-handler/cmd/main.go
+++ b/components/default-tenant-mapping-handler/cmd/main.go
@@ -6,8 +6,6 @@ import (
 	"os"
 	"time"
 
-	"github.com/kyma-incubator/compass/components/director/pkg/credloader"
-
 	"github.com/gorilla/mux"
 	"github.com/kyma-incubator/compass/components/default-tenant-mapping-handler/internal/claims"
 	"github.com/kyma-incubator/compass/components/default-tenant-mapping-handler/internal/config"
@@ -17,6 +15,7 @@ import (
 	httputildirector "github.com/kyma-incubator/compass/components/director/pkg/auth"
 	authmiddleware "github.com/kyma-incubator/compass/components/director/pkg/auth-middleware"
 	"github.com/kyma-incubator/compass/components/director/pkg/correlation"
+	"github.com/kyma-incubator/compass/components/director/pkg/credloader"
 	timeouthandler "github.com/kyma-incubator/compass/components/director/pkg/handler"
 	"github.com/kyma-incubator/compass/components/director/pkg/header"
 	httputil "github.com/kyma-incubator/compass/components/director/pkg/http"

--- a/components/default-tenant-mapping-handler/golangci.yml
+++ b/components/default-tenant-mapping-handler/golangci.yml
@@ -117,15 +117,12 @@ linters:
   # - wrapcheck
   # - wsl
   enable:
-    - deadcode
     - errcheck
     - gosimple
     - govet
     - staticcheck
-    - structcheck
     - typecheck
     - unused
-    - varcheck
     - asciicheck
     - dogsled
     - durationcheck
@@ -135,7 +132,6 @@ linters:
     - goconst
     - gocritic
     - goprintffuncname
-    - ifshort
     - importas
     - makezero
     - misspell
@@ -179,7 +175,6 @@ issues:
     # Exclude some linters from running on tests files.
     - path: _test\.go
       linters:
-        - deadcode
         - unused
         - goconst
         - gocritic
@@ -211,10 +206,6 @@ issues:
     - linters:
         - forcetypeassert
       text: "type assertion must be checked"
-
-    - linters:
-        - ifshort
-      text: "variable 'errs' is only used in the if-statement"
 
   #    # Exclude known linters from partially hard-vendored code,
   #    # which is impossible to exclude via "nolint" comments.

--- a/components/director/.golangci.yml
+++ b/components/director/.golangci.yml
@@ -117,15 +117,12 @@ linters:
     # - wrapcheck
     # - wsl
   enable:
-    - deadcode
     - errcheck
     - gosimple
     - govet
     - staticcheck
-    - structcheck
     - typecheck
     - unused
-    - varcheck
     - asciicheck
     - dogsled
     - durationcheck
@@ -135,7 +132,6 @@ linters:
     - goconst
     - gocritic
     - goprintffuncname
-    - ifshort
     - importas
     - makezero
     - misspell
@@ -179,7 +175,6 @@ issues:
     # Exclude some linters from running on tests files.
     - path: _test\.go
       linters:
-        - deadcode
         - unused
         - goconst
         - gocritic
@@ -211,10 +206,6 @@ issues:
     - linters:
         - forcetypeassert
       text: "type assertion must be checked"
-
-    - linters:
-        - ifshort
-      text: "variable 'errs' is only used in the if-statement"
 
 #    # Exclude known linters from partially hard-vendored code,
 #    # which is impossible to exclude via "nolint" comments.

--- a/components/director/cmd/director/main.go
+++ b/components/director/cmd/director/main.go
@@ -54,9 +54,8 @@ import (
 	"github.com/kyma-incubator/compass/components/director/pkg/accessstrategy"
 	"github.com/kyma-incubator/compass/components/director/pkg/credloader"
 
-	"github.com/kyma-incubator/compass/components/director/internal/info"
-
 	"github.com/kyma-incubator/compass/components/director/internal/authenticator/claims"
+	"github.com/kyma-incubator/compass/components/director/internal/info"
 	mp_authenticator "github.com/kyma-incubator/compass/components/director/pkg/auth-middleware"
 
 	gqlgen "github.com/99designs/gqlgen/graphql"

--- a/components/instance-creator/cmd/main.go
+++ b/components/instance-creator/cmd/main.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/kyma-incubator/compass/components/instance-creator/internal/client"
 	"github.com/kyma-incubator/compass/components/instance-creator/internal/client/paths"
-
 	"github.com/kyma-incubator/compass/components/instance-creator/internal/handler"
 
 	"github.com/gorilla/mux"

--- a/components/instance-creator/golangci.yml
+++ b/components/instance-creator/golangci.yml
@@ -117,15 +117,12 @@ linters:
     # - wrapcheck
   # - wsl
   enable:
-    - deadcode
     - errcheck
     - gosimple
     - govet
     - staticcheck
-    - structcheck
     - typecheck
     - unused
-    - varcheck
     - asciicheck
     - dogsled
     - durationcheck
@@ -135,7 +132,6 @@ linters:
     - goconst
     - gocritic
     - goprintffuncname
-    - ifshort
     - importas
     - makezero
     - misspell
@@ -179,7 +175,6 @@ issues:
     # Exclude some linters from running on tests files.
     - path: _test\.go
       linters:
-        - deadcode
         - unused
         - goconst
         - gocritic
@@ -211,10 +206,6 @@ issues:
     - linters:
         - forcetypeassert
       text: "type assertion must be checked"
-
-    - linters:
-        - ifshort
-      text: "variable 'errs' is only used in the if-statement"
 
   #    # Exclude known linters from partially hard-vendored code,
   #    # which is impossible to exclude via "nolint" comments.

--- a/components/kyma-adapter/.golangci.yml
+++ b/components/kyma-adapter/.golangci.yml
@@ -117,15 +117,12 @@ linters:
     # - wrapcheck
     # - wsl
   enable:
-    - deadcode
     - errcheck
     - gosimple
     - govet
     - staticcheck
-    - structcheck
     - typecheck
     - unused
-    - varcheck
     - asciicheck
     - dogsled
     - durationcheck
@@ -135,7 +132,6 @@ linters:
     - goconst
     - gocritic
     - goprintffuncname
-    - ifshort
     - importas
     - makezero
     - misspell
@@ -179,7 +175,6 @@ issues:
     # Exclude some linters from running on tests files.
     - path: _test\.go
       linters:
-        - deadcode
         - unused
         - goconst
         - gocritic
@@ -211,10 +206,6 @@ issues:
     - linters:
         - forcetypeassert
       text: "type assertion must be checked"
-
-    - linters:
-        - ifshort
-      text: "variable 'errs' is only used in the if-statement"
 
 #    # Exclude known linters from partially hard-vendored code,
 #    # which is impossible to exclude via "nolint" comments.

--- a/components/kyma-adapter/cmd/main.go
+++ b/components/kyma-adapter/cmd/main.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	gqlClient "github.com/kyma-incubator/compass/components/kyma-adapter/internal/gqlclient"
-
 	"github.com/kyma-incubator/compass/components/kyma-adapter/internal/handler"
 
 	"github.com/gorilla/mux"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Currently, linters are blocking our merging process because there are deprecated linters replaced with the 'unused' linter. This PR removes the deprecated linters.

Changes proposed in this pull request:
- Remove deprecated linters


**Pull Request status**
<!-- Feel free to construct the checklist with whatever items seem most reasonable for your change. You could disassemble the Implementation part to even smaller separate checklist items if you're working on something big for example. But do make the effort to provide a checklist of some sort so that the core team as well as the community can have an idea about the progress of your Pull Request.
-->

- [ ] Implementation
- [ ] Unit tests
- [ ] Integration tests
- [ ] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [ ] Mocks are regenerated, using the automated script
