### PR TITLE
Fix scopes synchronizer scheduling

### DIFF
--- a/chart/compass/charts/director/templates/oauth-clients-scopes-sync-job.yaml
+++ b/chart/compass/charts/director/templates/oauth-clients-scopes-sync-job.yaml
@@ -1,11 +1,14 @@
 {{- $jobName := (printf "%s-clients-scopes-synchronization" (include "fullname" .)) }}
 {{- $job := (lookup "batch/v1" "Job" .Release.Namespace $jobName) }}
 {{- $currentChecksum := (.Files.Glob .Values.configFile.name ).AsConfig | sha256sum | quote }}
+{{- $currentChecksumScopes := .Values.global.scopes | toYaml | sha256sum | quote }}
 {{- $jobChecksum := "" }}
+{{- $jobChecksumScopes := "" }}
 {{- if not (empty $job) }}
   {{- $jobChecksum = $job.metadata.annotations.configChecksum | quote }}
+  {{- $jobChecksumScopes = $job.metadata.annotations.configChecksumScopes | quote }}
 {{- end}}
-{{- if ne $currentChecksum $jobChecksum }}
+{{- if or (ne $currentChecksum $jobChecksum) (ne $currentChecksumScopes $jobChecksumScopes) }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -19,6 +22,7 @@ metadata:
     "helm.sh/hook-weight": "1"
     "helm.sh/hook-delete-policy": before-hook-creation
     configChecksum: {{ $currentChecksum }}
+    configChecksumScopes: {{ $currentChecksumScopes }}
 spec:
   template:
     metadata:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Currently, the scopes synchronizer job is only scheduled if there are changes within the `config.yaml` found in the chart directory of the director. This behvaiour is expected as the `clientCredentialsRegistrationGrantTypes` is used by the synchronizer. 

Previoulsy the scopes were also present in this `config.yaml`; however, the scopes were moved to the global Helm overrides under `global.scopes`. The synchronizer is not following the new scopes overrides and is not scheduled whenever they are changed in the Helm values, which is not the expected behvaiour.

Changes proposed in this pull request:
- add additional checksum to follow for changes under `.Values.global.scopes`

**Pull Request status**
<!-- Feel free to construct the checklist with whatever items seem most reasonable for your change. You could disassemble the Implementation part to even smaller separate checklist items if you're working on something big for example. But do make the effort to provide a checklist of some sort so that the core team as well as the community can have an idea about the progress of your Pull Request.
-->

- [x] Implementation
- [ ] Unit tests
- [ ] Integration tests
- [ ] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [ ] Mocks are regenerated, using the automated script
