### PR TITLE
Fix processing of jsonpath for SLIS select criteria

### DIFF
--- a/components/director/cmd/systemfetcher/main.go
+++ b/components/director/cmd/systemfetcher/main.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"os"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -704,15 +705,15 @@ func calculateTemplateMappings(ctx context.Context, cfg config, transact persist
 }
 
 func getTopParentFromJSONPath(jsonPath string) string {
-	infix := "."
+	trimmedJsonPath := strings.TrimPrefix(jsonPath, systemfetcher.TrimPrefix)
 
-	topParent := strings.TrimPrefix(jsonPath, systemfetcher.TrimPrefix)
-	firstInfixIndex := strings.Index(topParent, infix)
-	if firstInfixIndex == -1 {
-		return topParent
+	regexForTopParent := regexp.MustCompile(`^[^\[.]+`)
+	topParent := regexForTopParent.FindStringSubmatch(trimmedJsonPath)
+	if len(topParent) > 0 {
+		return topParent[0]
 	}
 
-	return topParent[:firstInfixIndex]
+	return trimmedJsonPath
 }
 
 func addPropertiesFromAppTemplatePlaceholders(selectFilterProperties map[string]bool, placeholders []model.ApplicationTemplatePlaceholder) {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Currently when building the select criteria parameter for the SLIS requests in system fetcher jsonpath is separated by comma only. With this PR a regex is used for separation.

Changes proposed in this pull request:
- use regex to match the top parent of json path of a placeholder

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- ...

**Pull Request status**
<!-- Feel free to construct the checklist with whatever items seem most reasonable for your change. You could disassemble the Implementation part to even smaller separate checklist items if you're working on something big for example. But do make the effort to provide a checklist of some sort so that the core team as well as the community can have an idea about the progress of your Pull Request.
-->

- [ ] Implementation
- [ ] Unit tests
- [ ] Integration tests
- [ ] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [ ] Mocks are regenerated, using the automated script
