### PR TITLE
Adopt Destination Creator keystore API changes

### DIFF
--- a/components/director/internal/destinationcreator/service.go
+++ b/components/director/internal/destinationcreator/service.go
@@ -609,7 +609,8 @@ func (s *Service) CreateCertificate(ctx context.Context, destinationsDetails []o
 		return nil, errors.Wrapf(err, "while building certificate URL")
 	}
 
-	certReqBody := &CertificateRequestBody{Name: certName}
+	certNameWithFileExtension := certName + destinationcreatorpkg.JavaKeyStoreFileExtension
+	certReqBody := &CertificateRequestBody{FileName: certNameWithFileExtension}
 	if useSelfSignedCert {
 		certReqBody.SelfSigned = true
 	}
@@ -694,8 +695,14 @@ func (s *Service) DeleteCertificate(ctx context.Context, certificateName, extern
 		return errors.Wrapf(err, "while getting region label for tenant with ID: %s", subaccountID)
 	}
 
+	if certificateName == "" {
+		return errors.New("Certificate name should not be empty")
+	}
+
+	certNameWithFileExtension := certificateName + destinationcreatorpkg.JavaKeyStoreFileExtension
+
 	strURL, err := buildCertificateURL(ctx, s.config.CertificateAPIConfig, URLParameters{
-		EntityName:   certificateName,
+		EntityName:   certNameWithFileExtension,
 		Region:       region,
 		SubaccountID: subaccountID,
 		InstanceID:   instanceID,
@@ -704,8 +711,8 @@ func (s *Service) DeleteCertificate(ctx context.Context, certificateName, extern
 		return errors.Wrapf(err, "while building certificate URL")
 	}
 
-	log.C(ctx).Infof("Deleting destination certificate with name: %q and subaccount ID: %q from destination service", certificateName, subaccountID)
-	err = s.executeDeleteRequest(ctx, strURL, certificateName, subaccountID)
+	log.C(ctx).Infof("Deleting destination certificate with name: %q and subaccount ID: %q from destination service", certNameWithFileExtension, subaccountID)
+	err = s.executeDeleteRequest(ctx, strURL, certNameWithFileExtension, subaccountID)
 	if err != nil {
 		return err
 	}

--- a/components/director/internal/destinationcreator/types.go
+++ b/components/director/internal/destinationcreator/types.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"regexp"
+	"strings"
 
 	destinationcreatorpkg "github.com/kyma-incubator/compass/components/director/pkg/destinationcreator"
 
@@ -86,7 +87,7 @@ type OAuth2mTLSDestinationRequestBody struct {
 
 // CertificateRequestBody contains the necessary fields for the destination creator certificate request body
 type CertificateRequestBody struct {
-	Name       string `json:"name"`
+	FileName   string `json:"fileName"`
 	SelfSigned bool   `json:"selfSigned"`
 }
 
@@ -174,7 +175,22 @@ func (b *OAuth2mTLSDestinationRequestBody) Validate() error {
 // Validate validates that the SAML assertion certificate request body contains the required fields, and they are valid
 func (c *CertificateRequestBody) Validate() error {
 	return validation.ValidateStruct(c,
-		validation.Field(&c.Name, validation.Required, validation.Length(1, destinationcreatorpkg.MaxDestinationNameLength), validation.Match(regexp.MustCompile(reqBodyNameRegex))),
+		validation.Field(&c.FileName, validation.Required, validation.By(func(value interface{}) error {
+			split := strings.Split(c.FileName, ".")
+			if len(split) != 2 {
+				return fmt.Errorf("file name %q must contain a single '.'", c.FileName)
+			}
+
+			if len(split[0]) > destinationcreatorpkg.MaxDestinationNameLength {
+				return fmt.Errorf("file name %q must have a length of at most %d without the file extension", c.FileName, destinationcreatorpkg.MaxDestinationNameLength)
+			}
+
+			matched := regexp.MustCompile(reqBodyNameRegex).MatchString(split[0])
+			if !matched {
+				return fmt.Errorf("file name %s must match the regex %s without the file extension", c.FileName, reqBodyNameRegex)
+			}
+			return nil
+		})),
 	)
 }
 

--- a/components/external-services-mock/internal/destinationsvc/fixtures_test.go
+++ b/components/external-services-mock/internal/destinationsvc/fixtures_test.go
@@ -20,11 +20,10 @@ var (
 	testRegion              = "testRegion"
 	testSubaccountID        = "testSubaccountID"
 	testServiceInstanceID   = "testServiceInstanceID"
-	testDestinationCertName = "test-destination-cert-name"
+	testDestinationCertName = "test-destination-cert-name" + destinationcreatorpkg.JavaKeyStoreFileExtension
 	testDestinationName     = "test-dest-name"
 
-	testCertChain                    = esmdestinationcreator.CertChain
-	testDestinationCertWithExtension = testDestinationCertName + destinationcreatorpkg.JavaKeyStoreFileExtension
+	testCertChain = esmdestinationcreator.CertChain
 
 	url = "https://target-url.com"
 
@@ -49,8 +48,8 @@ var (
 
 	destinationCreatorReqBodyWithoutAuthType = fmt.Sprintf(`{"name":"%s","url":"http://localhost","type":"HTTP","proxyType":"Internet","additionalProperties":{"customKey":"customValue"}}`, noAuthDestName)
 
-	destinationCreatorCertReqBody                              = fmt.Sprintf(`{"name":"%s"}`, testDestinationCertName)
-	destinationServiceCertResponseBody                         = fmt.Sprintf(`{"Name":"%s","Content":"%s"}`, testDestinationCertWithExtension, testCertChain)
+	destinationCreatorCertReqBody                              = fmt.Sprintf(`{"fileName":"%s"}`, testDestinationCertName)
+	destinationServiceCertResponseBody                         = fmt.Sprintf(`{"Name":"%s","Content":"%s"}`, testDestinationCertName, testCertChain)
 	destinationServiceSAMLDestCertResponseBody                 = fmt.Sprintf(`{"Name":"%s","Content":"%s"}`, testDestKeyStoreLocation, testCertChain)
 	destinationServiceFindAPIResponseBodyForSAMLAssertionDest  = fmt.Sprintf(esmdestinationcreator.FindAPISAMLAssertionDestResponseTemplate, testSubaccountID, testServiceInstanceID, samlAssertionDestName, testDestType, testSecureDestURL, "SAMLAssertion", "SAMLAssertion", testDestProxyType, testSecureDestURL, testDestKeyStoreLocation, testDestKeyStoreLocation)
 	destinationServiceFindAPIResponseBodyForBasicAssertionDest = fmt.Sprintf(esmdestinationcreator.FindAPIBasicDestResponseTemplate, testSubaccountID, testServiceInstanceID, basicAuthDestName, testDestType, testSecureDestURL, "BasicAuthentication", "BasicAuthentication", testDestProxyType, basicUsername, basicPassword)

--- a/components/external-services-mock/internal/destinationsvc/handler.go
+++ b/components/external-services-mock/internal/destinationsvc/handler.go
@@ -5,11 +5,12 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"github.com/tidwall/sjson"
 	"io"
 	"net/http"
 	"strconv"
 	"strings"
+
+	"github.com/tidwall/sjson"
 
 	"github.com/google/uuid"
 	destinationcreatorpkg "github.com/kyma-incubator/compass/components/director/pkg/destinationcreator"
@@ -181,7 +182,7 @@ func (h *Handler) CreateCertificate(writer http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	certName := reqBody.Name + destinationcreatorpkg.JavaKeyStoreFileExtension
+	certName := reqBody.FileName
 	certificateIdentifier := h.buildDestinationCertificateIdentifier(routeVars, certName)
 	if _, ok := h.DestinationSvcCertificates[certificateIdentifier]; ok {
 		log.C(ctx).Infof("Certificate with name: %q and identifier: %q already exists. Returning 409 Conflict...", certName, certificateIdentifier)
@@ -231,8 +232,7 @@ func (h *Handler) DeleteCertificate(writer http.ResponseWriter, r *http.Request)
 		httphelpers.RespondWithError(ctx, writer, err, err.Error(), correlationID, http.StatusBadRequest)
 		return
 	}
-	certNameParamValue := routeVars[h.Config.CertificateAPIConfig.CertificateNameParam]
-	certName := certNameParamValue + destinationcreatorpkg.JavaKeyStoreFileExtension
+	certName := routeVars[h.Config.CertificateAPIConfig.CertificateNameParam]
 
 	certificateIdentifier := h.buildDestinationCertificateIdentifier(routeVars, certName)
 	if _, isDestinationSvcCertExists := h.DestinationSvcCertificates[certificateIdentifier]; !isDestinationSvcCertExists {

--- a/components/external-services-mock/internal/destinationsvc/handler_test.go
+++ b/components/external-services-mock/internal/destinationsvc/handler_test.go
@@ -5,13 +5,14 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/kyma-incubator/compass/components/director/pkg/correlation"
-	"github.com/tidwall/gjson"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
+
+	"github.com/kyma-incubator/compass/components/director/pkg/correlation"
+	"github.com/tidwall/gjson"
 
 	"github.com/kyma-incubator/compass/components/external-services-mock/internal/httphelpers"
 
@@ -26,8 +27,8 @@ var (
 	testSecretKey                                              = []byte("testSecretKey")
 	noAuthDestIdentifierWithSubaccountID                       = fmt.Sprintf(destinationsvc.UniqueEntityNameIdentifier, noAuthDestName, testSubaccountID, "")
 	samlAssertionDestIdentifierWithSubaccountIDAndInstanceID   = fmt.Sprintf(destinationsvc.UniqueEntityNameIdentifier, samlAssertionDestName, testSubaccountID, testServiceInstanceID)
-	destinationCertIdentifierWithSubaccountID                  = fmt.Sprintf(destinationsvc.UniqueEntityNameIdentifier, testDestinationCertWithExtension, testSubaccountID, "")
-	destinationCertIdentifierWithSubaccountIDAndInstanceID     = fmt.Sprintf(destinationsvc.UniqueEntityNameIdentifier, testDestinationCertWithExtension, testSubaccountID, testServiceInstanceID)
+	destinationCertIdentifierWithSubaccountID                  = fmt.Sprintf(destinationsvc.UniqueEntityNameIdentifier, testDestinationCertName, testSubaccountID, "")
+	destinationCertIdentifierWithSubaccountIDAndInstanceID     = fmt.Sprintf(destinationsvc.UniqueEntityNameIdentifier, testDestinationCertName, testSubaccountID, testServiceInstanceID)
 	samlDestinationCertIdentifierWithSubaccountIDAndInstanceID = fmt.Sprintf(destinationsvc.UniqueEntityNameIdentifier, testDestKeyStoreLocation, testSubaccountID, testServiceInstanceID)
 )
 
@@ -717,7 +718,7 @@ func TestHandler_GetDestinationCertificateByNameFromDestinationSvc(t *testing.T)
 			Name:                 "Success when getting certificate by name from Destination Service",
 			AuthorizationToken:   tokenWithSubaccountIDAndInstanceID,
 			ExpectedResponseCode: http.StatusOK,
-			CertNameParam:        testDestinationCertWithExtension,
+			CertNameParam:        testDestinationCertName,
 			ExistingCertificate:  fixCertMappings(destinationCertIdentifierWithSubaccountIDAndInstanceID, json.RawMessage(destinationServiceCertResponseBody)),
 			ExpectedCertificate:  json.RawMessage(destinationServiceCertResponseBody),
 		},
@@ -752,7 +753,7 @@ func TestHandler_GetDestinationCertificateByNameFromDestinationSvc(t *testing.T)
 			Name:                 "Error when marshalling",
 			AuthorizationToken:   tokenWithSubaccountIDAndInstanceID,
 			ExpectedResponseCode: http.StatusInternalServerError,
-			CertNameParam:        testDestinationCertWithExtension,
+			CertNameParam:        testDestinationCertName,
 			ExistingCertificate:  map[string]json.RawMessage{destinationCertIdentifierWithSubaccountIDAndInstanceID: json.RawMessage("invalid-json")},
 		},
 	}

--- a/components/external-services-mock/internal/formationnotification/handler.go
+++ b/components/external-services-mock/internal/formationnotification/handler.go
@@ -545,7 +545,8 @@ func (h *Handler) syncFAResponse(ctx context.Context, writer http.ResponseWriter
 type AsyncFAResponseFn func(client *http.Client, correlationID, traceID, spanID, parentSpanID, formationID, formationAssignmentID, config string)
 
 // AsyncNoopFAResponseFn is an empty implementation of the AsyncFAResponseFn function
-var AsyncNoopFAResponseFn = func(client *http.Client, correlationID, traceID, spanID, parentSpanID, formationID, formationAssignmentID, config string) {}
+var AsyncNoopFAResponseFn = func(client *http.Client, correlationID, traceID, spanID, parentSpanID, formationID, formationAssignmentID, config string) {
+}
 
 // Async handles asynchronous formation assignment notification requests for Assign operation using the new receiverTenant/assignedTenant request body format
 func (h *Handler) Async(writer http.ResponseWriter, r *http.Request) {
@@ -1047,7 +1048,8 @@ func (h *Handler) synchronousFormationResponse(writer http.ResponseWriter, r *ht
 type FormationResponseFn func(client *http.Client, correlationID, traceID, spanID, parentSpanID, formationError, formationID string)
 
 // NoopFormationResponseFn is an empty implementation of the FormationResponseFn function
-var NoopFormationResponseFn = func(client *http.Client, correlationID, traceID, spanID, parentSpanID, formationError, formationID string) {}
+var NoopFormationResponseFn = func(client *http.Client, correlationID, traceID, spanID, parentSpanID, formationError, formationID string) {
+}
 
 // AsyncPostFormation handles asynchronous formation notification requests for CreateFormation operation.
 func (h *Handler) AsyncPostFormation(writer http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
The Destination Creator API now expects to find the certificate name under different key - "fileName" and also expects the name to contain the extension type
Changes proposed in this pull request:
- Use the new property in request body
- add extension to certificate name

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- ...

**Pull Request status**
<!-- Feel free to construct the checklist with whatever items seem most reasonable for your change. You could disassemble the Implementation part to even smaller separate checklist items if you're working on something big for example. But do make the effort to provide a checklist of some sort so that the core team as well as the community can have an idea about the progress of your Pull Request.
-->

- [ ] Implementation
- [ ] Unit tests
- [ ] Integration tests
- [ ] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [ ] Mocks are regenerated, using the automated script
