### PR TITLE
Avoid parent OWNERS

### DIFF
--- a/components/connectivity-adapter/OWNERS
+++ b/components/connectivity-adapter/OWNERS
@@ -4,5 +4,6 @@ approvers:
   - team-falcon
 labels:
   - ":eagle: team-falcon"
+  - "do-not-merge/hold"
 options:
   no_parent_owners: true

--- a/components/connector/OWNERS
+++ b/components/connector/OWNERS
@@ -4,5 +4,6 @@ approvers:
   - team-raptor
 labels:
   - ":t-rex: team-raptor"
+  - "do-not-merge/hold"
 options:
   no_parent_owners: true

--- a/components/default-tenant-mapping-handler/OWNERS
+++ b/components/default-tenant-mapping-handler/OWNERS
@@ -4,5 +4,6 @@ approvers:
   - team-raptor
 labels:
   - ":t-rex: team-raptor"
+  - "do-not-merge/hold"
 options:
   no_parent_owners: true

--- a/components/director/cmd/destinationfetcher-svc/OWNERS
+++ b/components/director/cmd/destinationfetcher-svc/OWNERS
@@ -4,5 +4,6 @@ approvers:
   - team-falcon
 labels:
   - ":eagle: team-falcon"
+  - "do-not-merge/hold"
 options:
   no_parent_owners: true

--- a/components/director/cmd/ns-adapter/OWNERS
+++ b/components/director/cmd/ns-adapter/OWNERS
@@ -4,5 +4,6 @@ approvers:
   - team-falcon
 labels:
   - ":eagle: team-falcon"
+  - "do-not-merge/hold"
 options:
   no_parent_owners: true

--- a/components/director/cmd/ordaggregator/OWNERS
+++ b/components/director/cmd/ordaggregator/OWNERS
@@ -4,5 +4,6 @@ approvers:
   - team-falcon
 labels:
   - ":eagle: team-falcon"
+  - "do-not-merge/hold"
 options:
   no_parent_owners: true

--- a/components/director/cmd/scopessynchronizer/OWNERS
+++ b/components/director/cmd/scopessynchronizer/OWNERS
@@ -4,5 +4,6 @@ approvers:
   - team-raptor
 labels:
   - ":t-rex: team-raptor"
+  - "do-not-merge/hold"
 options:
   no_parent_owners: true

--- a/components/director/cmd/systemfetcher/OWNERS
+++ b/components/director/cmd/systemfetcher/OWNERS
@@ -4,5 +4,6 @@ approvers:
   - team-falcon
 labels:
   - ":eagle: team-falcon"
+  - "do-not-merge/hold"
 options:
   no_parent_owners: true

--- a/components/director/cmd/tenantfetcher-svc/OWNERS
+++ b/components/director/cmd/tenantfetcher-svc/OWNERS
@@ -4,5 +4,6 @@ approvers:
   - team-falcon
 labels:
   - ":eagle: team-falcon"
+  - "do-not-merge/hold"
 options:
   no_parent_owners: true

--- a/components/director/internal/domain/certsubjectmapping/OWNERS
+++ b/components/director/internal/domain/certsubjectmapping/OWNERS
@@ -4,5 +4,6 @@ approvers:
   - team-raptor
 labels:
   - ":t-rex: team-raptor"
+  - "do-not-merge/hold"
 options:
   no_parent_owners: true

--- a/components/director/internal/domain/formation/OWNERS
+++ b/components/director/internal/domain/formation/OWNERS
@@ -4,5 +4,6 @@ approvers:
   - team-raptor
 labels:
   - ":t-rex: team-raptor"
+  - "do-not-merge/hold"
 options:
   no_parent_owners: true

--- a/components/director/internal/domain/formationassignment/OWNERS
+++ b/components/director/internal/domain/formationassignment/OWNERS
@@ -4,5 +4,6 @@ approvers:
   - team-raptor
 labels:
   - ":t-rex: team-raptor"
+  - "do-not-merge/hold"
 options:
   no_parent_owners: true

--- a/components/director/internal/domain/formationconstraint/OWNERS
+++ b/components/director/internal/domain/formationconstraint/OWNERS
@@ -4,5 +4,6 @@ approvers:
   - team-raptor
 labels:
   - ":t-rex: team-raptor"
+  - "do-not-merge/hold"
 options:
   no_parent_owners: true

--- a/components/director/internal/domain/formationtemplate/OWNERS
+++ b/components/director/internal/domain/formationtemplate/OWNERS
@@ -4,5 +4,6 @@ approvers:
   - team-raptor
 labels:
   - ":t-rex: team-raptor"
+  - "do-not-merge/hold"
 options:
   no_parent_owners: true

--- a/components/director/internal/domain/formationtemplateconstraintreferences/OWNERS
+++ b/components/director/internal/domain/formationtemplateconstraintreferences/OWNERS
@@ -4,5 +4,6 @@ approvers:
   - team-raptor
 labels:
   - ":t-rex: team-raptor"
+  - "do-not-merge/hold"
 options:
   no_parent_owners: true

--- a/components/director/internal/formationmapping/OWNERS
+++ b/components/director/internal/formationmapping/OWNERS
@@ -4,5 +4,6 @@ approvers:
   - team-raptor
 labels:
   - ":t-rex: team-raptor"
+  - "do-not-merge/hold"
 options:
   no_parent_owners: true

--- a/components/director/internal/info/OWNERS
+++ b/components/director/internal/info/OWNERS
@@ -4,5 +4,6 @@ approvers:
   - team-raptor
 labels:
   - ":t-rex: team-raptor"
+  - "do-not-merge/hold"
 options:
   no_parent_owners: true

--- a/components/director/internal/nsadapter/OWNERS
+++ b/components/director/internal/nsadapter/OWNERS
@@ -4,5 +4,6 @@ approvers:
   - team-falcon
 labels:
   - ":eagle: team-falcon"
+  - "do-not-merge/hold"
 options:
   no_parent_owners: true

--- a/components/director/internal/open_resource_discovery/OWNERS
+++ b/components/director/internal/open_resource_discovery/OWNERS
@@ -4,5 +4,6 @@ approvers:
   - team-falcon
 labels:
   - ":eagle: team-falcon"
+  - "do-not-merge/hold"
 options:
   no_parent_owners: true

--- a/components/director/internal/scopes_sync/OWNERS
+++ b/components/director/internal/scopes_sync/OWNERS
@@ -4,5 +4,6 @@ approvers:
   - team-raptor
 labels:
   - ":t-rex: team-raptor"
+  - "do-not-merge/hold"
 options:
   no_parent_owners: true

--- a/components/director/internal/systemfetcher/OWNERS
+++ b/components/director/internal/systemfetcher/OWNERS
@@ -4,5 +4,6 @@ approvers:
   - team-falcon
 labels:
   - ":eagle: team-falcon"
+  - "do-not-merge/hold"
 options:
   no_parent_owners: true

--- a/components/director/internal/tenantfetchersvc/OWNERS
+++ b/components/director/internal/tenantfetchersvc/OWNERS
@@ -4,5 +4,6 @@ approvers:
   - team-falcon
 labels:
   - ":eagle: team-falcon"
+  - "do-not-merge/hold"
 options:
   no_parent_owners: true

--- a/components/director/pkg/accessstrategy/OWNERS
+++ b/components/director/pkg/accessstrategy/OWNERS
@@ -4,5 +4,6 @@ approvers:
   - team-falcon
 labels:
   - ":eagle: team-falcon"
+  - "do-not-merge/hold"
 options:
   no_parent_owners: true

--- a/components/director/pkg/operation/OWNERS
+++ b/components/director/pkg/operation/OWNERS
@@ -4,5 +4,6 @@ approvers:
   - team-falcon
 labels:
   - ":eagle: team-falcon"
+  - "do-not-merge/hold"
 options:
   no_parent_owners: true

--- a/components/director/pkg/scenario/OWNERS
+++ b/components/director/pkg/scenario/OWNERS
@@ -4,5 +4,6 @@ approvers:
   - team-raptor
 labels:
   - ":t-rex: team-raptor"
+  - "do-not-merge/hold"
 options:
   no_parent_owners: true

--- a/components/gateway/OWNERS
+++ b/components/gateway/OWNERS
@@ -4,5 +4,6 @@ approvers:
   - team-raptor
 labels:
   - ":t-rex: team-raptor"
+  - "do-not-merge/hold"
 options:
   no_parent_owners: true

--- a/components/hydrator/OWNERS
+++ b/components/hydrator/OWNERS
@@ -4,5 +4,6 @@ approvers:
   - team-raptor
 labels:
   - ":t-rex: team-raptor"
+  - "do-not-merge/hold"
 options:
   no_parent_owners: true

--- a/components/ias-adapter/OWNERS
+++ b/components/ias-adapter/OWNERS
@@ -4,5 +4,6 @@ approvers:
   - team-atlas
 labels:
   - ":atlas: team-atlas"
+  - "do-not-merge/hold"
 options:
   no_parent_owners: true

--- a/components/instance-creator/OWNERS
+++ b/components/instance-creator/OWNERS
@@ -4,5 +4,6 @@ approvers:
   - team-raptor
 labels:
   - ":t-rex: team-raptor"
+  - "do-not-merge/hold"
 options:
   no_parent_owners: true

--- a/components/kyma-adapter/OWNERS
+++ b/components/kyma-adapter/OWNERS
@@ -4,5 +4,6 @@ approvers:
   - team-raptor
 labels:
   - ":t-rex: team-raptor"
+  - "do-not-merge/hold"
 options:
   no_parent_owners: true

--- a/components/operations-controller/OWNERS
+++ b/components/operations-controller/OWNERS
@@ -4,5 +4,6 @@ approvers:
   - team-falcon
 labels:
   - ":eagle: team-falcon"
+  - "do-not-merge/hold"
 options:
   no_parent_owners: true

--- a/components/pairing-adapter/OWNERS
+++ b/components/pairing-adapter/OWNERS
@@ -4,5 +4,6 @@ approvers:
   - team-falcon
 labels:
   - ":eagle: team-falcon"
+  - "do-not-merge/hold"
 options:
   no_parent_owners: true

--- a/installation/scripts/OWNERS
+++ b/installation/scripts/OWNERS
@@ -4,5 +4,6 @@ approvers:
   - team-raptor
 labels:
   - ":t-rex: team-raptor"
+  - "do-not-merge/hold"
 options:
   no_parent_owners: true

--- a/installation/scripts/prow/OWNERS
+++ b/installation/scripts/prow/OWNERS
@@ -4,5 +4,7 @@ reviewers:
 approvers:
   - team-falcon
   - team-raptor
+labels:
+  - "do-not-merge/hold"
 options:
   no_parent_owners: true

--- a/tests/connectivity-adapter/OWNERS
+++ b/tests/connectivity-adapter/OWNERS
@@ -4,5 +4,6 @@ approvers:
   - team-falcon
 labels:
   - ":eagle: team-falcon"
+  - "do-not-merge/hold"
 options:
   no_parent_owners: true

--- a/tests/connector/OWNERS
+++ b/tests/connector/OWNERS
@@ -4,5 +4,6 @@ approvers:
   - team-raptor
 labels:
   - ":t-rex: team-raptor"
+  - "do-not-merge/hold"
 options:
   no_parent_owners: true

--- a/tests/director/tests/formation/OWNERS
+++ b/tests/director/tests/formation/OWNERS
@@ -4,5 +4,6 @@ approvers:
   - team-raptor
 labels:
   - ":t-rex: team-raptor"
+  - "do-not-merge/hold"
 options:
   no_parent_owners: true

--- a/tests/director/tests/notifications/OWNERS
+++ b/tests/director/tests/notifications/OWNERS
@@ -4,5 +4,6 @@ approvers:
   - team-raptor
 labels:
   - ":t-rex: team-raptor"
+  - "do-not-merge/hold"
 options:
   no_parent_owners: true

--- a/tests/director/tests/runtime/OWNERS
+++ b/tests/director/tests/runtime/OWNERS
@@ -4,5 +4,6 @@ approvers:
   - team-raptor
 labels:
   - ":t-rex: team-raptor"
+  - "do-not-merge/hold"
 options:
   no_parent_owners: true

--- a/tests/gateway/OWNERS
+++ b/tests/gateway/OWNERS
@@ -4,5 +4,6 @@ approvers:
   - team-raptor
 labels:
   - ":t-rex: team-raptor"
+  - "do-not-merge/hold"
 options:
   no_parent_owners: true

--- a/tests/instance-creator/OWNERS
+++ b/tests/instance-creator/OWNERS
@@ -4,5 +4,6 @@ approvers:
   - team-raptor
 labels:
   - ":t-rex: team-raptor"
+  - "do-not-merge/hold"
 options:
   no_parent_owners: true

--- a/tests/istio/OWNERS
+++ b/tests/istio/OWNERS
@@ -4,5 +4,6 @@ approvers:
   - team-raptor
 labels:
   - ":t-rex: team-raptor"
+  - "do-not-merge/hold"
 options:
   no_parent_owners: true

--- a/tests/ns-adapter/OWNERS
+++ b/tests/ns-adapter/OWNERS
@@ -4,5 +4,6 @@ approvers:
   - team-falcon
 labels:
   - ":eagle: team-falcon"
+  - "do-not-merge/hold"
 options:
   no_parent_owners: true

--- a/tests/ord-aggregator/OWNERS
+++ b/tests/ord-aggregator/OWNERS
@@ -4,5 +4,6 @@ approvers:
   - team-falcon
 labels:
   - ":eagle: team-falcon"
+  - "do-not-merge/hold"
 options:
   no_parent_owners: true

--- a/tests/ord-aggregator/tests/main_test.go
+++ b/tests/ord-aggregator/tests/main_test.go
@@ -87,7 +87,6 @@ func TestMain(m *testing.M) {
 	ctx := context.Background()
 
 	certCache, err = credloader.StartCertLoader(ctx, testConfig.CertLoaderConfig)
-	
 	if err != nil {
 		log.D().Fatal(errors.Wrap(err, "while starting cert cache"))
 	}

--- a/tests/ord-aggregator/tests/main_test.go
+++ b/tests/ord-aggregator/tests/main_test.go
@@ -87,6 +87,7 @@ func TestMain(m *testing.M) {
 	ctx := context.Background()
 
 	certCache, err = credloader.StartCertLoader(ctx, testConfig.CertLoaderConfig)
+	
 	if err != nil {
 		log.D().Fatal(errors.Wrap(err, "while starting cert cache"))
 	}

--- a/tests/ord-service/OWNERS
+++ b/tests/ord-service/OWNERS
@@ -4,5 +4,6 @@ approvers:
   - team-raptor
 labels:
   - ":t-rex: team-raptor"
+  - "do-not-merge/hold"
 options:
   no_parent_owners: true

--- a/tests/pairing-adapter/OWNERS
+++ b/tests/pairing-adapter/OWNERS
@@ -4,5 +4,6 @@ approvers:
   - team-falcon
 labels:
   - ":eagle: team-falcon"
+  - "do-not-merge/hold"
 options:
   no_parent_owners: true

--- a/tests/pkg/notifications/OWNERS
+++ b/tests/pkg/notifications/OWNERS
@@ -4,5 +4,6 @@ approvers:
   - team-raptor
 labels:
   - ":t-rex: team-raptor"
+  - "do-not-merge/hold"
 options:
   no_parent_owners: true

--- a/tests/system-fetcher/OWNERS
+++ b/tests/system-fetcher/OWNERS
@@ -4,5 +4,6 @@ approvers:
   - team-falcon
 labels:
   - ":eagle: team-falcon"
+  - "do-not-merge/hold"
 options:
   no_parent_owners: true

--- a/tests/tenant-fetcher/OWNERS
+++ b/tests/tenant-fetcher/OWNERS
@@ -4,5 +4,6 @@ approvers:
   - team-falcon
 labels:
   - ":eagle: team-falcon"
+  - "do-not-merge/hold"
 options:
   no_parent_owners: true


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Previously, the hold label was added to the root `OWNERS` file to automatically add `hold` label when a PR is opened. However, there are nested OWNERS files that have the flag `no_parent_owners: true` - this ignores the root OWNERS' configuration.

Changes proposed in this pull request:
- add hold label to all OWNERS

