### PR TITLE
Allow async flow control operator to be attached to synchronous participants

### DIFF
--- a/components/director/internal/domain/formationconstraint/operators/utils.go
+++ b/components/director/internal/domain/formationconstraint/operators/utils.go
@@ -18,6 +18,7 @@ import (
 // reqBodyNameRegex is a regex defined by the destination creator API specifying what destination names are allowed
 var reqBodyNameRegex = "[a-zA-Z0-9_-]{1,64}"
 
+// GlobalSubaccountLabelKey is a label that holds the external subaccount ID of an entity
 const GlobalSubaccountLabelKey = "global_subaccount_id"
 
 func isConfigEmpty(config string) bool {

--- a/components/director/internal/domain/formationconstraint/operators/utils.go
+++ b/components/director/internal/domain/formationconstraint/operators/utils.go
@@ -18,6 +18,8 @@ import (
 // reqBodyNameRegex is a regex defined by the destination creator API specifying what destination names are allowed
 var reqBodyNameRegex = "[a-zA-Z0-9_-]{1,64}"
 
+const GlobalSubaccountLabelKey = "global_subaccount_id"
+
 func isConfigEmpty(config string) bool {
 	return config == "" || config == "{}" || config == "\"\"" || config == "null"
 }

--- a/components/director/pkg/formationconstraint/formation_constraint_input.go
+++ b/components/director/pkg/formationconstraint/formation_constraint_input.go
@@ -88,6 +88,8 @@ type RedirectNotificationInput struct {
 // AsynchronousFlowControlOperatorInput is an input for AsynchronousFlowControlOperator operator
 type AsynchronousFlowControlOperatorInput struct {
 	RedirectNotificationInput
+	FailOnSyncParticipants                bool    `json:"fail_on_sync_participants"`
+	FailOnNonBTPParticipants              bool    `json:"fail_on_non_btp_participants"`
 	NotificationStatusReportMemoryAddress uintptr `json:"notification_status_report_memory_address"`
 	FAMemoryAddress                       uintptr `json:"formation_assignment_memory_address"`         // contains the memory address of the join point details' formation assignment in form of an integer
 	ReverseFAMemoryAddress                uintptr `json:"reverse_formation_assignment_memory_address"` // contains the memory address of the join point details' reverse formation assignment in form of an integer

--- a/tests/director/tests/notifications/application_only_notifications_new_format_test.go
+++ b/tests/director/tests/notifications/application_only_notifications_new_format_test.go
@@ -39,31 +39,14 @@ func TestFormationNotificationsWithApplicationOnlyParticipantsNewFormat(t *testi
 
 	formationTemplateName := "app-only-formation-template-name"
 
-	certSubjectMappingCustomSubject := strings.Replace(conf.ExternalCertProviderConfig.TestExternalCertSubject, conf.TestExternalCertCN, "instance-creator", -1)
-
-	externalCertProviderConfig := certprovider.ExternalCertProviderConfig{
-		ExternalClientCertTestSecretName:      conf.ExternalCertProviderConfig.ExternalClientCertTestSecretName,
-		ExternalClientCertTestSecretNamespace: conf.ExternalCertProviderConfig.ExternalClientCertTestSecretNamespace,
-		CertSvcInstanceTestSecretName:         conf.CertSvcInstanceTestSecretName,
-		ExternalCertCronjobContainerName:      conf.ExternalCertProviderConfig.ExternalCertCronjobContainerName,
-		ExternalCertTestJobName:               conf.ExternalCertProviderConfig.ExternalCertTestJobName,
-		TestExternalCertSubject:               certSubjectMappingCustomSubject,
-		ExternalClientCertCertKey:             conf.ExternalCertProviderConfig.ExternalClientCertCertKey,
-		ExternalClientCertKeyKey:              conf.ExternalCertProviderConfig.ExternalClientCertKeyKey,
-		ExternalCertProvider:                  certprovider.CertificateService,
-	}
-
-	pk, cert := certprovider.NewExternalCertFromConfig(t, ctx, externalCertProviderConfig, true)
-	instanceCreatorCertClient := gql.NewCertAuthorizedHTTPClient(pk, cert, conf.SkipSSLValidation)
-
 	certSubjectMappingCN := "csm-async-new-format-callback-cn"
 	certSubjectMappingCNSecond := "csm-async-new-format-callback-cn-second"
-	certSubjectMappingCustomSubject = strings.Replace(conf.ExternalCertProviderConfig.TestExternalCertSubject, conf.TestExternalCertCN, certSubjectMappingCN, -1)
+	certSubjectMappingCustomSubject := strings.Replace(conf.ExternalCertProviderConfig.TestExternalCertSubject, conf.TestExternalCertCN, certSubjectMappingCN, -1)
 	certSubjectMappingCustomSubjectSecond := strings.Replace(conf.ExternalCertProviderConfig.TestExternalCertSubject, conf.TestExternalCertCN, certSubjectMappingCNSecond, -1)
 
 	// We need an externally issued cert with a custom subject that will be used to create a certificate subject mapping through the GraphQL API,
 	// which later will be loaded in-memory from the hydrator component
-	externalCertProviderConfig = certprovider.ExternalCertProviderConfig{
+	externalCertProviderConfig := certprovider.ExternalCertProviderConfig{
 		ExternalClientCertTestSecretName:      conf.ExternalCertProviderConfig.ExternalClientCertTestSecretName,
 		ExternalClientCertTestSecretNamespace: conf.ExternalCertProviderConfig.ExternalClientCertTestSecretNamespace,
 		CertSvcInstanceTestSecretName:         conf.CertSvcInstanceTestSecretName,
@@ -1623,154 +1606,4 @@ func TestFormationNotificationsWithApplicationOnlyParticipantsNewFormat(t *testi
 		op.Execute(t, ctx, certSecuredGraphQLClient)
 	})
 
-	t.Run("Flow control operator test", func(t *testing.T) {
-		redirectedTntID := "custom-redirected-tenant-id"
-		redirectPath := "/formation-callback/async-no-response/" + redirectedTntID + "/" + app2ID
-		redirectURL := fmt.Sprintf("%s%s", conf.ExternalServicesMockMtlsSecuredURL, redirectPath)
-		redirectURLTemplate := fmt.Sprintf("{\\\\\\\"path\\\\\\\":\\\\\\\"%s\\\\\\\",\\\\\\\"method\\\\\\\":\\\\\\\"{{if eq .Operation \\\"assign\\\"}}PATCH{{else}}DELETE{{end}}\\\\\\\"}", redirectURL)
-		op := operations.NewAddConstraintOperation("e2e-flow-control-operator-constraint-status-returned").
-			WithTargetOperation(graphql.TargetOperationNotificationStatusReturned).
-			WithOperator(formationconstraintpkg.AsynchronousFlowControlOperator).
-			WithResourceType(graphql.ResourceTypeApplication).
-			WithResourceSubtype(applicationType1).
-			WithInputTemplate(fmt.Sprintf("{\\\"url_template\\\": \\\"%s\\\",\\\"url\\\": \\\"%s\\\",{{ if .NotificationStatusReport }}\\\"notification_status_report_memory_address\\\":{{ .NotificationStatusReport.GetAddress }},{{ end }}{{ if .FormationAssignment }}\\\"formation_assignment_memory_address\\\":{{ .FormationAssignment.GetAddress }},{{ end }}{{ if .ReverseFormationAssignment }}\\\"reverse_formation_assignment_memory_address\\\":{{ .ReverseFormationAssignment.GetAddress }},{{ end }}\\\"resource_type\\\": \\\"{{.ResourceType}}\\\",\\\"resource_subtype\\\": \\\"{{.ResourceSubtype}}\\\",\\\"operation\\\": \\\"{{.Operation}}\\\",\\\"join_point_location\\\": {\\\"OperationName\\\":\\\"{{.Location.OperationName}}\\\",\\\"ConstraintType\\\":\\\"{{.Location.ConstraintType}}\\\"}}", redirectURLTemplate, redirectURL)).
-			WithTenant(tnt).Operation()
-		defer op.Cleanup(t, ctx, certSecuredGraphQLClient)
-		op.Execute(t, ctx, certSecuredGraphQLClient)
-
-		op = operations.NewAddConstraintOperation("e2e-flow-control-operator-constraint-send-notification").
-			WithTargetOperation(graphql.TargetOperationSendNotification).
-			WithOperator(formationconstraintpkg.AsynchronousFlowControlOperator).
-			WithResourceType(graphql.ResourceTypeApplication).
-			WithResourceSubtype(applicationType1).
-			WithInputTemplate(fmt.Sprintf("{\\\"url_template\\\": \\\"%s\\\",\\\"url\\\": \\\"%s\\\",{{ if .Webhook }}\\\"webhook_memory_address\\\":{{ .Webhook.GetAddress }},{{ end }}{{ if .FormationAssignment }}\\\"formation_assignment_memory_address\\\":{{ .FormationAssignment.GetAddress }},{{ end }}\\\"resource_type\\\": \\\"{{.ResourceType}}\\\",\\\"resource_subtype\\\": \\\"{{.ResourceSubtype}}\\\",\\\"operation\\\": \\\"{{.Operation}}\\\",\\\"join_point_location\\\": {\\\"OperationName\\\":\\\"{{.Location.OperationName}}\\\",\\\"ConstraintType\\\":\\\"{{.Location.ConstraintType}}\\\"}}", redirectURLTemplate, redirectURL)).
-			WithTenant(tnt).Operation()
-		defer op.Cleanup(t, ctx, certSecuredGraphQLClient)
-		op.Execute(t, ctx, certSecuredGraphQLClient)
-
-		t.Logf("Add webhook with type: %q and mode: %q to application with ID: %q", graphql.WebhookTypeApplicationTenantMapping, graphql.WebhookModeSync, app1ID)
-		op = operations.NewAddWebhookToObjectOperation(graphql.WebhookTypeApplicationTenantMapping, operations.WebhookReferenceObjectTypeApplication, app1ID, tnt).
-			WithWebhookMode(graphql.WebhookModeAsyncCallback).
-			WithURLTemplate("{\\\"path\\\":\\\"" + conf.ExternalServicesMockMtlsSecuredURL + "/formation-callback/async-old/{{.TargetApplication.LocalTenantID}}{{if eq .Operation \\\"unassign\\\"}}/{{.SourceApplication.ID}}{{end}}\\\",\\\"method\\\":\\\"{{if eq .Operation \\\"assign\\\"}}PATCH{{else}}DELETE{{end}}\\\"}").
-			WithInputTemplate("{\\\"context\\\":{\\\"crmId\\\":\\\"{{.CustomerTenantContext.CustomerID}}\\\",\\\"globalAccountId\\\":\\\"{{.CustomerTenantContext.AccountID}}\\\",\\\"uclFormationId\\\":\\\"{{.FormationID}}\\\",\\\"uclFormationName\\\":\\\"{{.Formation.Name}}\\\",\\\"operation\\\":\\\"{{.Operation}}\\\"},\\\"receiverTenant\\\":{\\\"state\\\":\\\"{{.Assignment.State}}\\\",\\\"uclAssignmentId\\\":\\\"{{.Assignment.ID}}\\\",\\\"deploymentRegion\\\":\\\"{{if .TargetApplication.Labels.region}}{{.TargetApplication.Labels.region}}{{else}}{{.TargetApplicationTemplate.Labels.region}}{{end}}\\\",\\\"applicationNamespace\\\":\\\"{{.TargetApplicationTemplate.ApplicationNamespace}}\\\",\\\"applicationUrl\\\":\\\"{{.TargetApplication.BaseURL}}\\\",\\\"applicationTenantId\\\":\\\"{{.TargetApplication.LocalTenantID}}\\\",\\\"uclSystemName\\\":\\\"{{.TargetApplication.Name}}\\\",\\\"uclSystemTenantId\\\":\\\"{{.TargetApplication.ID}}\\\",\\\"configuration\\\":{{.Assignment.Value}}},\\\"assignedTenant\\\":{\\\"state\\\":\\\"{{.ReverseAssignment.State}}\\\",\\\"uclAssignmentId\\\":\\\"{{.ReverseAssignment.ID}}\\\",\\\"deploymentRegion\\\":\\\"{{if .SourceApplication.Labels.region}}{{.SourceApplication.Labels.region}}{{else}}{{.SourceApplicationTemplate.Labels.region}}{{end}}\\\",\\\"applicationNamespace\\\":\\\"{{.SourceApplicationTemplate.ApplicationNamespace}}\\\",\\\"applicationUrl\\\":\\\"{{.SourceApplication.BaseURL}}\\\",\\\"applicationTenantId\\\":\\\"{{.SourceApplication.LocalTenantID}}\\\",\\\"uclSystemName\\\":\\\"{{.SourceApplication.Name}}\\\",\\\"uclSystemTenantId\\\":\\\"{{.SourceApplication.ID}}\\\",\\\"configuration\\\":{{.ReverseAssignment.Value}}}}").
-			WithOutputTemplate("{\\\"config\\\":\\\"{{.Body.configuration}}\\\", \\\"location\\\":\\\"{{.Headers.Location}}\\\",\\\"error\\\": \\\"{{.Body.error}}\\\",\\\"success_status_code\\\": 202}").Operation()
-		defer op.Cleanup(t, ctx, certSecuredGraphQLClient)
-		op.Execute(t, ctx, certSecuredGraphQLClient)
-
-		t.Logf("Assign application 2 to formation: %s", formationName)
-		expectationsBuilder = mock_data.NewFAExpectationsBuilder().WithParticipant(app2ID)
-		asserter := asserters.NewFormationAssignmentAsserter(expectationsBuilder.GetExpectations(), expectationsBuilder.GetExpectedAssignmentsCount(), certSecuredGraphQLClient, tnt)
-		statusAsserter := asserters.NewFormationStatusAsserter(tnt, certSecuredGraphQLClient)
-		op = operations.NewAssignAppToFormationOperation(app2ID, tnt).WithAsserters(asserter, statusAsserter).Operation()
-		defer op.Cleanup(t, ctx, certSecuredGraphQLClient)
-		op.Execute(t, ctx, certSecuredGraphQLClient)
-
-		t.Logf("Cleanup notifications")
-		op = operations.NewCleanupNotificationsOperation().WithExternalServicesMockMtlsSecuredURL(conf.ExternalServicesMockMtlsSecuredURL).WithHTTPClient(certSecuredHTTPClient).Operation()
-		defer op.Cleanup(t, ctx, certSecuredGraphQLClient)
-		op.Execute(t, ctx, certSecuredGraphQLClient)
-
-		t.Logf("Assign application 1 to formation: %s", formationName)
-		expectationsBuilder = mock_data.NewFAExpectationsBuilder().
-			WithParticipant(app1ID).
-			WithParticipant(app2ID).
-			WithNotifications([]*mock_data.NotificationData{
-				mock_data.NewNotificationData(app2ID, app1ID, readyAssignmentState, fixtures.StatusAPIAsyncConfigJSON, nil),
-			})
-		faAsyncAsserter := asserters.NewFormationAssignmentAsyncAsserter(expectationsBuilder.GetExpectations(), expectationsBuilder.GetExpectedAssignmentsCount(), certSecuredGraphQLClient, tnt)
-		statusAsserter = asserters.NewFormationStatusAsserter(tnt, certSecuredGraphQLClient)
-		notificationsAsserter := asserters.NewNotificationsAsserter(1, assignOperation, localTenantID, app2ID, localTenantID, appNamespace, appRegion, tnt, tntParentCustomer, &emptyConfig, conf.ExternalServicesMockMtlsSecuredURL, certSecuredHTTPClient)
-		op = operations.NewAssignAppToFormationOperation(app1ID, tnt).WithAsserters(faAsyncAsserter, statusAsserter, notificationsAsserter).Operation()
-		defer op.Cleanup(t, ctx, certSecuredGraphQLClient)
-		op.Execute(t, ctx, certSecuredGraphQLClient)
-
-		t.Logf("Cleanup notifications")
-		op = operations.NewCleanupNotificationsOperation().WithExternalServicesMockMtlsSecuredURL(conf.ExternalServicesMockMtlsSecuredURL).WithHTTPClient(certSecuredHTTPClient).Operation()
-		defer op.Cleanup(t, ctx, certSecuredGraphQLClient)
-		op.Execute(t, ctx, certSecuredGraphQLClient)
-
-		t.Logf("Unassign application 2 from formation: %s", formationName)
-		expectationsBuilder = mock_data.NewFAExpectationsBuilder().
-			WithCustomParticipants([]string{app1ID, app2ID}).
-			WithNotifications([]*mock_data.NotificationData{
-				mock_data.NewNotificationData(app2ID, app1ID, deletingAssignmentState, nil, nil),
-				mock_data.NewNotificationData(app1ID, app1ID, readyAssignmentState, nil, nil),
-			}).
-			WithOperations([]*fixtures.Operation{
-				fixtures.NewOperation(app1ID, app1ID, "ASSIGN", "ASSIGN_OBJECT", true),
-				fixtures.NewOperation(app2ID, app1ID, "ASSIGN", "ASSIGN_OBJECT", true),
-				fixtures.NewOperation(app2ID, app1ID, "UNASSIGN", "UNASSIGN_OBJECT", false),
-				fixtures.NewOperation(app2ID, app1ID, "INSTANCE_CREATOR_UNASSIGN", "UNASSIGN_OBJECT", false),
-			})
-		faAsyncAsserter = asserters.NewFormationAssignmentAsyncAsserter(expectationsBuilder.GetExpectations(), expectationsBuilder.GetExpectedAssignmentsCount(), certSecuredGraphQLClient, tnt)
-		statusAsserter = asserters.NewFormationStatusAsserter(tnt, certSecuredGraphQLClient).WithCondition(graphql.FormationStatusConditionInProgress)
-		notificationCountAsyncAsserter := asserters.NewNotificationsCountAsyncAsserter(1, unassignOperation, localTenantID, conf.ExternalServicesMockMtlsSecuredURL, certSecuredHTTPClient)
-		notificationsUnassignAsserter := asserters.NewUnassignNotificationsAsserter(1, localTenantID, app2ID, localTenantID, appNamespace, appRegion, tnt, tntParentCustomer, "", conf.ExternalServicesMockMtlsSecuredURL, certSecuredHTTPClient)
-		notificationCountRedirectNotificationAsyncAsserter := asserters.NewNotificationsCountAsyncAsserter(1, unassignOperation, redirectedTntID, conf.ExternalServicesMockMtlsSecuredURL, certSecuredHTTPClient)
-		notificationsUnassignRedirectedAsserter := asserters.NewUnassignNotificationsAsserter(1, redirectedTntID, app2ID, localTenantID, appNamespace, appRegion, tnt, tntParentCustomer, "", conf.ExternalServicesMockMtlsSecuredURL, certSecuredHTTPClient).WithState(deletingAssignmentState)
-		op = operations.NewUnassignAppFromFormationOperation(app2ID, tnt).WithAsserters(faAsyncAsserter, statusAsserter, notificationCountAsyncAsserter, notificationsUnassignAsserter, notificationCountRedirectNotificationAsyncAsserter, notificationsUnassignRedirectedAsserter).Operation()
-		defer op.Cleanup(t, ctx, certSecuredGraphQLClient)
-		op.Execute(t, ctx, certSecuredGraphQLClient)
-
-		t.Logf("Cleanup notifications")
-		op = operations.NewCleanupNotificationsOperation().WithExternalServicesMockMtlsSecuredURL(conf.ExternalServicesMockMtlsSecuredURL).WithHTTPClient(certSecuredHTTPClient).Operation()
-		defer op.Cleanup(t, ctx, certSecuredGraphQLClient)
-		op.Execute(t, ctx, certSecuredGraphQLClient)
-
-		t.Logf("Unassign application 2 from formation: %s should only send notification to instance creator", formationName)
-		expectationsBuilder = mock_data.NewFAExpectationsBuilder().
-			WithCustomParticipants([]string{app1ID, app2ID}).
-			WithNotifications([]*mock_data.NotificationData{
-				mock_data.NewNotificationData(app2ID, app1ID, deletingAssignmentState, nil, nil),
-				mock_data.NewNotificationData(app1ID, app1ID, readyAssignmentState, nil, nil),
-			}).
-			WithOperations([]*fixtures.Operation{
-				fixtures.NewOperation(app1ID, app1ID, "ASSIGN", "ASSIGN_OBJECT", true),
-				fixtures.NewOperation(app2ID, app1ID, "ASSIGN", "ASSIGN_OBJECT", true),
-				fixtures.NewOperation(app2ID, app1ID, "UNASSIGN", "UNASSIGN_OBJECT", false),
-				fixtures.NewOperation(app2ID, app1ID, "INSTANCE_CREATOR_UNASSIGN", "UNASSIGN_OBJECT", false),
-				fixtures.NewOperation(app2ID, app1ID, "UNASSIGN", "UNASSIGN_OBJECT", false),
-				fixtures.NewOperation(app2ID, app1ID, "INSTANCE_CREATOR_UNASSIGN", "UNASSIGN_OBJECT", false),
-			})
-		faAsyncAsserter = asserters.NewFormationAssignmentAsyncAsserter(expectationsBuilder.GetExpectations(), expectationsBuilder.GetExpectedAssignmentsCount(), certSecuredGraphQLClient, tnt)
-		op = operations.NewUnassignAppFromFormationOperation(app2ID, tnt).WithAsserters(faAsyncAsserter, statusAsserter, notificationCountRedirectNotificationAsyncAsserter, notificationsUnassignRedirectedAsserter).Operation()
-		defer op.Cleanup(t, ctx, certSecuredGraphQLClient)
-		op.Execute(t, ctx, certSecuredGraphQLClient)
-
-		t.Logf("Cleanup notifications")
-		op = operations.NewCleanupNotificationsOperation().WithExternalServicesMockMtlsSecuredURL(conf.ExternalServicesMockMtlsSecuredURL).WithHTTPClient(certSecuredHTTPClient).Operation()
-		defer op.Cleanup(t, ctx, certSecuredGraphQLClient)
-		op.Execute(t, ctx, certSecuredGraphQLClient)
-
-		op = operations.NewExecuteStatusReportOperation().WithTenant(tnt).
-			WithFormationAssignment(app2ID, app1ID).
-			WithHTTPClient(appCertClient).
-			WithExternalServicesMockMtlsSecuredURL(conf.DirectorExternalCertFAAsyncStatusURL).
-			WithAsserters(faAsyncAsserter, statusAsserter).
-			Operation()
-		defer op.Cleanup(t, ctx, certSecuredGraphQLClient)
-		op.Execute(t, ctx, certSecuredGraphQLClient)
-
-		expectationsBuilder = mock_data.NewFAExpectationsBuilder().
-			WithParticipant(app1ID)
-		faAsyncAsserter = asserters.NewFormationAssignmentAsyncAsserter(expectationsBuilder.GetExpectations(), expectationsBuilder.GetExpectedAssignmentsCount(), certSecuredGraphQLClient, tnt)
-		statusAsserter = asserters.NewFormationStatusAsserter(tnt, certSecuredGraphQLClient)
-
-		op = operations.NewExecuteStatusReportOperation().WithTenant(tnt).
-			WithFormationAssignment(app2ID, app1ID).
-			WithHTTPClient(instanceCreatorCertClient).
-			WithExternalServicesMockMtlsSecuredURL(conf.DirectorExternalCertFAAsyncStatusURL).
-			WithAsserters(faAsyncAsserter, statusAsserter).
-			Operation()
-		defer op.Cleanup(t, ctx, certSecuredGraphQLClient)
-		op.Execute(t, ctx, certSecuredGraphQLClient)
-
-		t.Logf("Unassign Application 1 from formation: %s", formationName)
-		expectationsBuilder = mock_data.NewFAExpectationsBuilder()
-		faAsyncAsserter = asserters.NewFormationAssignmentAsyncAsserter(expectationsBuilder.GetExpectations(), expectationsBuilder.GetExpectedAssignmentsCount(), certSecuredGraphQLClient, tnt)
-		statusAsserter = asserters.NewFormationStatusAsserter(tnt, certSecuredGraphQLClient)
-		op = operations.NewUnassignAppFromFormationOperation(app1ID, tnt).WithAsserters(faAsyncAsserter, statusAsserter).Operation()
-		defer op.Cleanup(t, ctx, certSecuredGraphQLClient)
-		op.Execute(t, ctx, certSecuredGraphQLClient)
-	})
 }

--- a/tests/instance-creator/tests/config.go
+++ b/tests/instance-creator/tests/config.go
@@ -17,20 +17,21 @@ type InstanceCreatorConfig struct {
 	DirectorExternalCertSecuredURL string
 	CertLoaderConfig               credloader.CertConfig
 	certprovider.ExternalCertProviderConfig
-	SubscriptionConfig                  subscription.Config
-	DestinationsConfig                  directorcfg.DestinationsConfig
-	ProviderDestinationConfig           config.ProviderDestinationConfig
-	TestProviderSubaccountID            string
-	TestConsumerAccountID               string
-	TestConsumerSubaccountID            string
-	TestConsumerTenantID                string
-	ExternalServicesMockBaseURL         string
-	ExternalServicesMockMtlsSecuredURL  string
-	TokenPath                           string
-	SubscriptionProviderAppNameValue    string
-	GlobalSubaccountIDLabelKey          string        `envconfig:"APP_GLOBAL_SUBACCOUNT_ID_LABEL_KEY"`
-	SubscriptionProviderAppNameProperty string        `envconfig:"APP_TENANT_PROVIDER_SUBSCRIPTION_PROVIDER_APP_NAME_PROPERTY"`
-	CertSubjectMappingResyncInterval    time.Duration `envconfig:"APP_CERT_SUBJECT_MAPPING_RESYNC_INTERVAL"`
-	InstanceCreatorRegion               string        `envconfig:"APP_INSTANCE_CREATOR_REGION,default=eu-1"`
-	SkipSSLValidation                   bool          `envconfig:"default=false"`
+	SubscriptionConfig                   subscription.Config
+	DestinationsConfig                   directorcfg.DestinationsConfig
+	ProviderDestinationConfig            config.ProviderDestinationConfig
+	TestProviderSubaccountID             string
+	TestConsumerAccountID                string
+	TestConsumerSubaccountID             string
+	TestConsumerTenantID                 string
+	ExternalServicesMockBaseURL          string
+	ExternalServicesMockMtlsSecuredURL   string
+	TokenPath                            string
+	SubscriptionProviderAppNameValue     string
+	DirectorExternalCertFAAsyncStatusURL string        `envconfig:"APP_DIRECTOR_EXTERNAL_CERT_FORMATION_ASSIGNMENT_ASYNC_STATUS_URL"`
+	GlobalSubaccountIDLabelKey           string        `envconfig:"APP_GLOBAL_SUBACCOUNT_ID_LABEL_KEY"`
+	SubscriptionProviderAppNameProperty  string        `envconfig:"APP_TENANT_PROVIDER_SUBSCRIPTION_PROVIDER_APP_NAME_PROPERTY"`
+	CertSubjectMappingResyncInterval     time.Duration `envconfig:"APP_CERT_SUBJECT_MAPPING_RESYNC_INTERVAL"`
+	InstanceCreatorRegion                string        `envconfig:"APP_INSTANCE_CREATOR_REGION,default=eu-1"`
+	SkipSSLValidation                    bool          `envconfig:"default=false"`
 }

--- a/tests/instance-creator/tests/instance_creator_test.go
+++ b/tests/instance-creator/tests/instance_creator_test.go
@@ -35,9 +35,12 @@ import (
 )
 
 const (
-	consumerType          = "Integration System" // should be a valid consumer type
-	readyAssignmentState  = "READY"
-	emptyParentCustomerID = ""
+	consumerType            = "Integration System" // should be a valid consumer type
+	assignOperation         = "assign"
+	unassignOperation       = "unassign"
+	readyAssignmentState    = "READY"
+	deletingAssignmentState = "DELETING"
+	emptyParentCustomerID   = ""
 
 	uriKey      = "uri"
 	usernameKey = "username"
@@ -69,14 +72,31 @@ func TestInstanceCreator(t *testing.T) {
 
 	formationTemplateName := "instance-creator-formation-template-name"
 
+	certSubjectMappingCustomSubject := strings.Replace(conf.ExternalCertProviderConfig.TestExternalCertSubject, conf.TestExternalCertCN, "instance-creator", -1)
+
+	externalCertProviderConfig := certprovider.ExternalCertProviderConfig{
+		ExternalClientCertTestSecretName:      conf.ExternalCertProviderConfig.ExternalClientCertTestSecretName,
+		ExternalClientCertTestSecretNamespace: conf.ExternalCertProviderConfig.ExternalClientCertTestSecretNamespace,
+		CertSvcInstanceTestSecretName:         conf.CertSvcInstanceTestSecretName,
+		ExternalCertCronjobContainerName:      conf.ExternalCertProviderConfig.ExternalCertCronjobContainerName,
+		ExternalCertTestJobName:               conf.ExternalCertProviderConfig.ExternalCertTestJobName,
+		TestExternalCertSubject:               certSubjectMappingCustomSubject,
+		ExternalClientCertCertKey:             conf.ExternalCertProviderConfig.ExternalClientCertCertKey,
+		ExternalClientCertKeyKey:              conf.ExternalCertProviderConfig.ExternalClientCertKeyKey,
+		ExternalCertProvider:                  certprovider.CertificateService,
+	}
+
+	pk, cert := certprovider.NewExternalCertFromConfig(t, ctx, externalCertProviderConfig, true)
+	instanceCreatorCertClient := gql.NewCertAuthorizedHTTPClient(pk, cert, conf.SkipSSLValidation)
+
 	certSubjectMappingCN := "csm-async-ic-callback-cn"
 	certSubjectMappingCNSecond := "csm-async-ic-callback-cn-second"
-	certSubjectMappingCustomSubject := strings.Replace(conf.ExternalCertProviderConfig.TestExternalCertSubject, conf.TestExternalCertCN, certSubjectMappingCN, -1)
+	certSubjectMappingCustomSubject = strings.Replace(conf.ExternalCertProviderConfig.TestExternalCertSubject, conf.TestExternalCertCN, certSubjectMappingCN, -1)
 	certSubjectMappingCustomSubjectSecond := strings.Replace(conf.ExternalCertProviderConfig.TestExternalCertSubject, conf.TestExternalCertCN, certSubjectMappingCNSecond, -1)
 
 	// We need an externally issued cert with a custom subject that will be used to create a certificate subject mapping through the GraphQL API,
 	// which later will be loaded in-memory from the hydrator component
-	externalCertProviderConfig := certprovider.ExternalCertProviderConfig{
+	externalCertProviderConfig = certprovider.ExternalCertProviderConfig{
 		ExternalClientCertTestSecretName:      conf.ExternalCertProviderConfig.ExternalClientCertTestSecretName,
 		ExternalClientCertTestSecretNamespace: conf.ExternalCertProviderConfig.ExternalClientCertTestSecretNamespace,
 		CertSvcInstanceTestSecretName:         conf.CertSvcInstanceTestSecretName,
@@ -91,6 +111,7 @@ func TestInstanceCreator(t *testing.T) {
 	// We need only to create the secret so in the external-services-mock an HTTP client with certificate to be created and used to call the formation status API
 	providerClientKey, providerRawCertChain := certprovider.NewExternalCertFromConfig(t, ctx, externalCertProviderConfig, false)
 	appProviderDirectorCertSecuredClient := gql.NewCertAuthorizedGraphQLClientWithCustomURL(conf.DirectorExternalCertSecuredURL, providerClientKey, providerRawCertChain, conf.SkipSSLValidation)
+	appCertClient := gql.NewCertAuthorizedHTTPClient(providerClientKey, providerRawCertChain, conf.SkipSSLValidation)
 
 	// The external cert secret created by the NewExternalCertFromConfig above is used by the external-services-mock for the async formation status API call,
 	// that's why in the function above there is a false parameter that don't delete it and an explicit defer deletion func is added here
@@ -278,7 +299,7 @@ func TestInstanceCreator(t *testing.T) {
 			WithTargetOperation(graphql.TargetOperationNotificationStatusReturned).
 			WithOperator(formationconstraintpkg.AsynchronousFlowControlOperator).
 			WithResourceType(graphql.ResourceTypeApplication).
-			WithResourceSubtype(applicationType1).
+			WithResourceSubtype("ANY").
 			WithInputTemplate(fmt.Sprintf("{\\\"url_template\\\": \\\"{\\\\\\\"path\\\\\\\":\\\\\\\"%s\\\\\\\",\\\\\\\"method\\\\\\\":\\\\\\\"PATCH\\\\\\\"}\\\",{{ if .NotificationStatusReport }}\\\"notification_status_report_memory_address\\\":{{ .NotificationStatusReport.GetAddress }},{{ end }}{{ if .FormationAssignment }}\\\"formation_assignment_memory_address\\\":{{ .FormationAssignment.GetAddress }},{{ end }}{{ if .ReverseFormationAssignment }}\\\"reverse_formation_assignment_memory_address\\\":{{ .ReverseFormationAssignment.GetAddress }},{{ end }}\\\"resource_type\\\": \\\"{{.ResourceType}}\\\",\\\"resource_subtype\\\": \\\"{{.ResourceSubtype}}\\\",\\\"operation\\\": \\\"{{.Operation}}\\\",\\\"join_point_location\\\": {\\\"OperationName\\\":\\\"{{.Location.OperationName}}\\\",\\\"ConstraintType\\\":\\\"{{.Location.ConstraintType}}\\\"}}", redirectURL)).
 			WithTenant(tnt).Operation()
 		defer op.Cleanup(t, ctx, certSecuredGraphQLClient)
@@ -290,7 +311,7 @@ func TestInstanceCreator(t *testing.T) {
 			WithTargetOperation(graphql.TargetOperationSendNotification).
 			WithOperator(formationconstraintpkg.AsynchronousFlowControlOperator).
 			WithResourceType(graphql.ResourceTypeApplication).
-			WithResourceSubtype(applicationType1).
+			WithResourceSubtype("ANY").
 			WithInputTemplate(redirectInputTemplate).
 			WithTenant(tnt).Operation()
 		defer op.Cleanup(t, ctx, certSecuredGraphQLClient)
@@ -355,6 +376,157 @@ func TestInstanceCreator(t *testing.T) {
 		faAsserter = asserters.NewFormationAssignmentAsyncAsserter(expectationsBuilder.GetExpectations(), expectationsBuilder.GetExpectedAssignmentsCount(), certSecuredGraphQLClient, tnt)
 		statusAsserter = asserters.NewFormationStatusAsserter(tnt, certSecuredGraphQLClient)
 		op = operations.NewUnassignAppToFormationOperationGlobal(app2ID).WithAsserters(faAsserter, statusAsserter).Operation()
+		defer op.Cleanup(t, ctx, certSecuredGraphQLClient)
+		op.Execute(t, ctx, certSecuredGraphQLClient)
+	})
+	t.Run("Flow control operator test", func(t *testing.T) {
+		redirectedTntID := "custom-redirected-tenant-id"
+		redirectPath := "/formation-callback/async-no-response/" + redirectedTntID + "/" + app2ID
+		redirectURL := fmt.Sprintf("%s%s", conf.ExternalServicesMockMtlsSecuredURL, redirectPath)
+		redirectURLTemplate := fmt.Sprintf("{\\\\\\\"path\\\\\\\":\\\\\\\"%s\\\\\\\",\\\\\\\"method\\\\\\\":\\\\\\\"{{if eq .Operation \\\"assign\\\"}}PATCH{{else}}DELETE{{end}}\\\\\\\"}", redirectURL)
+		op := operations.NewAddConstraintOperation("e2e-flow-control-operator-constraint-status-returned").
+			WithTargetOperation(graphql.TargetOperationNotificationStatusReturned).
+			WithOperator(formationconstraintpkg.AsynchronousFlowControlOperator).
+			WithResourceType(graphql.ResourceTypeApplication).
+			WithResourceSubtype("ANY").
+			WithInputTemplate(fmt.Sprintf("{\\\"url_template\\\": \\\"%s\\\",\\\"url\\\": \\\"%s\\\",{{ if .NotificationStatusReport }}\\\"notification_status_report_memory_address\\\":{{ .NotificationStatusReport.GetAddress }},{{ end }}{{ if .FormationAssignment }}\\\"formation_assignment_memory_address\\\":{{ .FormationAssignment.GetAddress }},{{ end }}{{ if .ReverseFormationAssignment }}\\\"reverse_formation_assignment_memory_address\\\":{{ .ReverseFormationAssignment.GetAddress }},{{ end }}\\\"resource_type\\\": \\\"{{.ResourceType}}\\\",\\\"resource_subtype\\\": \\\"{{.ResourceSubtype}}\\\",\\\"operation\\\": \\\"{{.Operation}}\\\",\\\"join_point_location\\\": {\\\"OperationName\\\":\\\"{{.Location.OperationName}}\\\",\\\"ConstraintType\\\":\\\"{{.Location.ConstraintType}}\\\"}}", redirectURLTemplate, redirectURL)).
+			WithTenant(tnt).Operation()
+		defer op.Cleanup(t, ctx, certSecuredGraphQLClient)
+		op.Execute(t, ctx, certSecuredGraphQLClient)
+
+		op = operations.NewAddConstraintOperation("e2e-flow-control-operator-constraint-send-notification").
+			WithTargetOperation(graphql.TargetOperationSendNotification).
+			WithOperator(formationconstraintpkg.AsynchronousFlowControlOperator).
+			WithResourceType(graphql.ResourceTypeApplication).
+			WithResourceSubtype("ANY").
+			WithInputTemplate(fmt.Sprintf("{\\\"url_template\\\": \\\"%s\\\",\\\"url\\\": \\\"%s\\\",{{ if .Webhook }}\\\"webhook_memory_address\\\":{{ .Webhook.GetAddress }},{{ end }}{{ if .FormationAssignment }}\\\"formation_assignment_memory_address\\\":{{ .FormationAssignment.GetAddress }},{{ end }}\\\"resource_type\\\": \\\"{{.ResourceType}}\\\",\\\"resource_subtype\\\": \\\"{{.ResourceSubtype}}\\\",\\\"operation\\\": \\\"{{.Operation}}\\\",\\\"join_point_location\\\": {\\\"OperationName\\\":\\\"{{.Location.OperationName}}\\\",\\\"ConstraintType\\\":\\\"{{.Location.ConstraintType}}\\\"}}", redirectURLTemplate, redirectURL)).
+			WithTenant(tnt).Operation()
+		defer op.Cleanup(t, ctx, certSecuredGraphQLClient)
+		op.Execute(t, ctx, certSecuredGraphQLClient)
+
+		t.Logf("Add webhook with type: %q and mode: %q to application with ID: %q", graphql.WebhookTypeApplicationTenantMapping, graphql.WebhookModeAsyncCallback, app1ID)
+		op = operations.NewAddWebhookToObjectOperation(graphql.WebhookTypeApplicationTenantMapping, operations.WebhookReferenceObjectTypeApplication, app1ID, tnt).
+			WithWebhookMode(graphql.WebhookModeAsyncCallback).
+			WithURLTemplate("{\\\"path\\\":\\\"" + conf.ExternalServicesMockMtlsSecuredURL + "/formation-callback/async-old/{{.TargetApplication.LocalTenantID}}{{if eq .Operation \\\"unassign\\\"}}/{{.SourceApplication.ID}}{{end}}\\\",\\\"method\\\":\\\"{{if eq .Operation \\\"assign\\\"}}PATCH{{else}}DELETE{{end}}\\\"}").
+			WithInputTemplate("{\\\"context\\\":{\\\"crmId\\\":\\\"{{.CustomerTenantContext.CustomerID}}\\\",\\\"globalAccountId\\\":\\\"{{.CustomerTenantContext.AccountID}}\\\",\\\"uclFormationId\\\":\\\"{{.FormationID}}\\\",\\\"uclFormationName\\\":\\\"{{.Formation.Name}}\\\",\\\"operation\\\":\\\"{{.Operation}}\\\"},\\\"receiverTenant\\\":{\\\"state\\\":\\\"{{.Assignment.State}}\\\",\\\"uclAssignmentId\\\":\\\"{{.Assignment.ID}}\\\",\\\"deploymentRegion\\\":\\\"{{if .TargetApplication.Labels.region}}{{.TargetApplication.Labels.region}}{{else}}{{.TargetApplicationTemplate.Labels.region}}{{end}}\\\",\\\"applicationNamespace\\\":\\\"{{.TargetApplicationTemplate.ApplicationNamespace}}\\\",\\\"applicationUrl\\\":\\\"{{.TargetApplication.BaseURL}}\\\",\\\"applicationTenantId\\\":\\\"{{.TargetApplication.LocalTenantID}}\\\",\\\"uclSystemName\\\":\\\"{{.TargetApplication.Name}}\\\",\\\"uclSystemTenantId\\\":\\\"{{.TargetApplication.ID}}\\\",\\\"configuration\\\":{{.Assignment.Value}}},\\\"assignedTenant\\\":{\\\"state\\\":\\\"{{.ReverseAssignment.State}}\\\",\\\"uclAssignmentId\\\":\\\"{{.ReverseAssignment.ID}}\\\",\\\"deploymentRegion\\\":\\\"{{if .SourceApplication.Labels.region}}{{.SourceApplication.Labels.region}}{{else}}{{.SourceApplicationTemplate.Labels.region}}{{end}}\\\",\\\"applicationNamespace\\\":\\\"{{.SourceApplicationTemplate.ApplicationNamespace}}\\\",\\\"applicationUrl\\\":\\\"{{.SourceApplication.BaseURL}}\\\",\\\"applicationTenantId\\\":\\\"{{.SourceApplication.LocalTenantID}}\\\",\\\"uclSystemName\\\":\\\"{{.SourceApplication.Name}}\\\",\\\"uclSystemTenantId\\\":\\\"{{.SourceApplication.ID}}\\\",\\\"configuration\\\":{{.ReverseAssignment.Value}}}}").
+			WithOutputTemplate("{\\\"config\\\":\\\"{{.Body.configuration}}\\\", \\\"location\\\":\\\"{{.Headers.Location}}\\\",\\\"error\\\": \\\"{{.Body.error}}\\\",\\\"success_status_code\\\": 202}").Operation()
+		defer op.Cleanup(t, ctx, certSecuredGraphQLClient)
+		op.Execute(t, ctx, certSecuredGraphQLClient)
+
+		t.Logf("Assign application 2 to formation: %s", formationName)
+		expectationsBuilder = mock_data.NewFAExpectationsBuilder().WithParticipant(app2ID)
+		asserter := asserters.NewFormationAssignmentAsserter(expectationsBuilder.GetExpectations(), expectationsBuilder.GetExpectedAssignmentsCount(), certSecuredGraphQLClient, tnt)
+		statusAsserter := asserters.NewFormationStatusAsserter(tnt, certSecuredGraphQLClient)
+		op = operations.NewAssignAppToFormationOperation(app2ID, tnt).WithAsserters(asserter, statusAsserter).Operation()
+		defer op.Cleanup(t, ctx, certSecuredGraphQLClient)
+		op.Execute(t, ctx, certSecuredGraphQLClient)
+
+		t.Logf("Cleanup notifications")
+		op = operations.NewCleanupNotificationsOperation().WithExternalServicesMockMtlsSecuredURL(conf.ExternalServicesMockMtlsSecuredURL).WithHTTPClient(certSecuredHTTPClient).Operation()
+		defer op.Cleanup(t, ctx, certSecuredGraphQLClient)
+		op.Execute(t, ctx, certSecuredGraphQLClient)
+
+		t.Logf("Assign application 1 to formation: %s", formationName)
+		expectationsBuilder = mock_data.NewFAExpectationsBuilder().
+			WithParticipant(app1ID).
+			WithParticipant(app2ID).
+			WithNotifications([]*mock_data.NotificationData{
+				mock_data.NewNotificationData(app2ID, app1ID, readyAssignmentState, fixtures.StatusAPIAsyncConfigJSON, nil),
+			})
+		emptyConfig := ""
+		faAsyncAsserter := asserters.NewFormationAssignmentAsyncAsserter(expectationsBuilder.GetExpectations(), expectationsBuilder.GetExpectedAssignmentsCount(), certSecuredGraphQLClient, tnt)
+		statusAsserter = asserters.NewFormationStatusAsserter(tnt, certSecuredGraphQLClient)
+		notificationsAsserter := asserters.NewNotificationsAsserter(1, assignOperation, subscriptionConsumerTenantID, app2ID, subscriptionConsumerTenantID, appNamespace, appRegion, tnt, "", &emptyConfig, conf.ExternalServicesMockMtlsSecuredURL, certSecuredHTTPClient)
+		op = operations.NewAssignAppToFormationOperation(app1ID, tnt).WithAsserters(faAsyncAsserter, statusAsserter, notificationsAsserter).Operation()
+		defer op.Cleanup(t, ctx, certSecuredGraphQLClient)
+		op.Execute(t, ctx, certSecuredGraphQLClient)
+
+		t.Logf("Cleanup notifications")
+		op = operations.NewCleanupNotificationsOperation().WithExternalServicesMockMtlsSecuredURL(conf.ExternalServicesMockMtlsSecuredURL).WithHTTPClient(certSecuredHTTPClient).Operation()
+		defer op.Cleanup(t, ctx, certSecuredGraphQLClient)
+		op.Execute(t, ctx, certSecuredGraphQLClient)
+
+		t.Logf("Unassign application 2 from formation: %s", formationName)
+		expectationsBuilder = mock_data.NewFAExpectationsBuilder().
+			WithCustomParticipants([]string{app1ID, app2ID}).
+			WithNotifications([]*mock_data.NotificationData{
+				mock_data.NewNotificationData(app2ID, app1ID, deletingAssignmentState, nil, nil),
+				mock_data.NewNotificationData(app1ID, app1ID, readyAssignmentState, nil, nil),
+			}).
+			WithOperations([]*fixtures.Operation{
+				fixtures.NewOperation(app1ID, app1ID, "ASSIGN", "ASSIGN_OBJECT", true),
+				fixtures.NewOperation(app2ID, app1ID, "ASSIGN", "ASSIGN_OBJECT", true),
+				fixtures.NewOperation(app2ID, app1ID, "UNASSIGN", "UNASSIGN_OBJECT", false),
+				fixtures.NewOperation(app2ID, app1ID, "INSTANCE_CREATOR_UNASSIGN", "UNASSIGN_OBJECT", false),
+			})
+		faAsyncAsserter = asserters.NewFormationAssignmentAsyncAsserter(expectationsBuilder.GetExpectations(), expectationsBuilder.GetExpectedAssignmentsCount(), certSecuredGraphQLClient, tnt)
+		statusAsserter = asserters.NewFormationStatusAsserter(tnt, certSecuredGraphQLClient).WithCondition(graphql.FormationStatusConditionInProgress)
+		notificationCountAsyncAsserter := asserters.NewNotificationsCountAsyncAsserter(1, unassignOperation, subscriptionConsumerTenantID, conf.ExternalServicesMockMtlsSecuredURL, certSecuredHTTPClient)
+		notificationsUnassignAsserter := asserters.NewUnassignNotificationsAsserter(1, subscriptionConsumerTenantID, app2ID, subscriptionConsumerTenantID, appNamespace, appRegion, tnt, "", "", conf.ExternalServicesMockMtlsSecuredURL, certSecuredHTTPClient)
+		notificationCountRedirectNotificationAsyncAsserter := asserters.NewNotificationsCountAsyncAsserter(1, unassignOperation, redirectedTntID, conf.ExternalServicesMockMtlsSecuredURL, certSecuredHTTPClient)
+		notificationsUnassignRedirectedAsserter := asserters.NewUnassignNotificationsAsserter(1, redirectedTntID, app2ID, subscriptionConsumerTenantID, appNamespace, appRegion, tnt, "", "", conf.ExternalServicesMockMtlsSecuredURL, certSecuredHTTPClient).WithState(deletingAssignmentState)
+		op = operations.NewUnassignAppFromFormationOperation(app2ID, tnt).WithAsserters(faAsyncAsserter, statusAsserter, notificationCountAsyncAsserter, notificationsUnassignAsserter, notificationCountRedirectNotificationAsyncAsserter, notificationsUnassignRedirectedAsserter).Operation()
+		defer op.Cleanup(t, ctx, certSecuredGraphQLClient)
+		op.Execute(t, ctx, certSecuredGraphQLClient)
+
+		t.Logf("Cleanup notifications")
+		op = operations.NewCleanupNotificationsOperation().WithExternalServicesMockMtlsSecuredURL(conf.ExternalServicesMockMtlsSecuredURL).WithHTTPClient(certSecuredHTTPClient).Operation()
+		defer op.Cleanup(t, ctx, certSecuredGraphQLClient)
+		op.Execute(t, ctx, certSecuredGraphQLClient)
+
+		t.Logf("Unassign application 2 from formation: %s should only send notification to instance creator", formationName)
+		expectationsBuilder = mock_data.NewFAExpectationsBuilder().
+			WithCustomParticipants([]string{app1ID, app2ID}).
+			WithNotifications([]*mock_data.NotificationData{
+				mock_data.NewNotificationData(app2ID, app1ID, deletingAssignmentState, nil, nil),
+				mock_data.NewNotificationData(app1ID, app1ID, readyAssignmentState, nil, nil),
+			}).
+			WithOperations([]*fixtures.Operation{
+				fixtures.NewOperation(app1ID, app1ID, "ASSIGN", "ASSIGN_OBJECT", true),
+				fixtures.NewOperation(app2ID, app1ID, "ASSIGN", "ASSIGN_OBJECT", true),
+				fixtures.NewOperation(app2ID, app1ID, "UNASSIGN", "UNASSIGN_OBJECT", false),
+				fixtures.NewOperation(app2ID, app1ID, "INSTANCE_CREATOR_UNASSIGN", "UNASSIGN_OBJECT", false),
+				fixtures.NewOperation(app2ID, app1ID, "UNASSIGN", "UNASSIGN_OBJECT", false),
+				fixtures.NewOperation(app2ID, app1ID, "INSTANCE_CREATOR_UNASSIGN", "UNASSIGN_OBJECT", false),
+			})
+		faAsyncAsserter = asserters.NewFormationAssignmentAsyncAsserter(expectationsBuilder.GetExpectations(), expectationsBuilder.GetExpectedAssignmentsCount(), certSecuredGraphQLClient, tnt)
+		op = operations.NewUnassignAppFromFormationOperation(app2ID, tnt).WithAsserters(faAsyncAsserter, statusAsserter, notificationCountRedirectNotificationAsyncAsserter, notificationsUnassignRedirectedAsserter).Operation()
+		defer op.Cleanup(t, ctx, certSecuredGraphQLClient)
+		op.Execute(t, ctx, certSecuredGraphQLClient)
+
+		t.Logf("Cleanup notifications")
+		op = operations.NewCleanupNotificationsOperation().WithExternalServicesMockMtlsSecuredURL(conf.ExternalServicesMockMtlsSecuredURL).WithHTTPClient(certSecuredHTTPClient).Operation()
+		defer op.Cleanup(t, ctx, certSecuredGraphQLClient)
+		op.Execute(t, ctx, certSecuredGraphQLClient)
+
+		op = operations.NewExecuteStatusReportOperation().WithTenant(tnt).
+			WithFormationAssignment(app2ID, app1ID).
+			WithHTTPClient(appCertClient).
+			WithExternalServicesMockMtlsSecuredURL(conf.DirectorExternalCertFAAsyncStatusURL).
+			WithAsserters(faAsyncAsserter, statusAsserter).
+			Operation()
+		defer op.Cleanup(t, ctx, certSecuredGraphQLClient)
+		op.Execute(t, ctx, certSecuredGraphQLClient)
+
+		expectationsBuilder = mock_data.NewFAExpectationsBuilder().
+			WithParticipant(app1ID)
+		faAsyncAsserter = asserters.NewFormationAssignmentAsyncAsserter(expectationsBuilder.GetExpectations(), expectationsBuilder.GetExpectedAssignmentsCount(), certSecuredGraphQLClient, tnt)
+		statusAsserter = asserters.NewFormationStatusAsserter(tnt, certSecuredGraphQLClient)
+
+		op = operations.NewExecuteStatusReportOperation().WithTenant(tnt).
+			WithFormationAssignment(app2ID, app1ID).
+			WithHTTPClient(instanceCreatorCertClient).
+			WithExternalServicesMockMtlsSecuredURL(conf.DirectorExternalCertFAAsyncStatusURL).
+			WithAsserters(faAsyncAsserter, statusAsserter).
+			Operation()
+		defer op.Cleanup(t, ctx, certSecuredGraphQLClient)
+		op.Execute(t, ctx, certSecuredGraphQLClient)
+
+		t.Logf("Unassign Application 1 from formation: %s", formationName)
+		expectationsBuilder = mock_data.NewFAExpectationsBuilder()
+		faAsyncAsserter = asserters.NewFormationAssignmentAsyncAsserter(expectationsBuilder.GetExpectations(), expectationsBuilder.GetExpectedAssignmentsCount(), certSecuredGraphQLClient, tnt)
+		statusAsserter = asserters.NewFormationStatusAsserter(tnt, certSecuredGraphQLClient)
+		op = operations.NewUnassignAppFromFormationOperation(app1ID, tnt).WithAsserters(faAsyncAsserter, statusAsserter).Operation()
 		defer op.Cleanup(t, ctx, certSecuredGraphQLClient)
 		op.Execute(t, ctx, certSecuredGraphQLClient)
 	})


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:
- make it so that the asynchronous flow control operator does not try to redirect notifications to the instance creator in the cases where it is not supported (synchronous participants)
- move flow control operator test to the instance creator test
- add unit tests

**Pull Request status**

- [x] Implementation
- [x] Unit tests
- [x] Integration tests
- [x] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [x] [N/A] Mocks are regenerated, using the automated script
