### PR TITLE
Add tracing IDs in the status API

### DIFF
--- a/components/director/cmd/director/main.go
+++ b/components/director/cmd/director/main.go
@@ -458,7 +458,7 @@ func main() {
 	fmHandler := createFormationMappingHandler(transact, appRepo, cfg, cfg.DestinationCreatorConfig, securedHTTPClient, mtlsHTTPClient)
 
 	asyncFormationAssignmentStatusRouter := mainRouter.PathPrefix(cfg.FormationMappingCfg.AsyncAPIPathPrefix).Subrouter()
-	asyncFormationAssignmentStatusRouter.Use(authMiddleware.Handler(), fmAuthMiddleware.FormationAssignmentHandler()) // order is important
+	asyncFormationAssignmentStatusRouter.Use(correlation.AttachCorrelationIDToContext(), log.RequestLogger(), header.AttachHeadersToContext(), authMiddleware.Handler(), fmAuthMiddleware.FormationAssignmentHandler()) // order is important
 
 	asyncFormationStatusRouter := mainRouter.PathPrefix(cfg.FormationMappingCfg.AsyncAPIPathPrefix).Subrouter()
 	asyncFormationStatusRouter.Use(correlation.AttachCorrelationIDToContext(), log.RequestLogger(), header.AttachHeadersToContext(), authMiddleware.Handler(), fmAuthMiddleware.FormationHandler()) // order is important

--- a/components/director/cmd/director/main.go
+++ b/components/director/cmd/director/main.go
@@ -461,7 +461,7 @@ func main() {
 	asyncFormationAssignmentStatusRouter.Use(authMiddleware.Handler(), fmAuthMiddleware.FormationAssignmentHandler()) // order is important
 
 	asyncFormationStatusRouter := mainRouter.PathPrefix(cfg.FormationMappingCfg.AsyncAPIPathPrefix).Subrouter()
-	asyncFormationStatusRouter.Use(authMiddleware.Handler(), fmAuthMiddleware.FormationHandler()) // order is important
+	asyncFormationStatusRouter.Use(correlation.AttachCorrelationIDToContext(), log.RequestLogger(), header.AttachHeadersToContext(), authMiddleware.Handler(), fmAuthMiddleware.FormationHandler()) // order is important
 
 	logger.Infof("Registering formation tenant mapping endpoints...")
 	asyncFormationAssignmentStatusRouter.HandleFunc(cfg.FormationMappingCfg.AsyncFormationAssignmentStatusAPIEndpoint, fmHandler.UpdateFormationAssignmentStatus).Methods(http.MethodPatch)


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
I noticed that in the status API we don't have tracing IDs(x-request-id, x-span-id, etc.). There is logic to load them from the context but seems we don't have the necessary middlewares which configure them. In the logs we have only `formation-assignment-id` and `formation-id` but they are extracted from the path parameters and added in the logs.

Example:
```
time="2024-05-30T10:43:55.671018513Z" level=info msg="Deleting formation assignment with ID: \"example-assignment-id\"" component="formationassignment/status_service.go:98:formationassignment.(*formationAssignmentStatusService).DeleteWithConstraints" formation-assignment-id=example-assignment-id formation-id=example-formation-id x-request-id=example-request-id
...
time="2024-05-30T10:43:55.757931815Z" level=debug msg="Executing DB query: DELETE FROM public.formation_assignments WHERE tenant_id = $1 AND id = $2" component="repo/delete.go:203:repo.(*universalDeleter).delete" formation-assignment-id=example-assignment-id formation-id=example-formation-id x-request-id=example-request-id
```

Changes proposed in this pull request:
- Add middlewares to the status API router that configure tracing IDs in the context and in the logger.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- ...

**Pull Request status**
<!-- Feel free to construct the checklist with whatever items seem most reasonable for your change. You could disassemble the Implementation part to even smaller separate checklist items if you're working on something big for example. But do make the effort to provide a checklist of some sort so that the core team as well as the community can have an idea about the progress of your Pull Request.
-->

- [x] Implementation
- [ ] Unit tests
- [ ] Integration tests
- [x] `chart/compass/values.yaml` is updated <!-- in case of code changes in the `components` or `tests` directories -->
- [ ] Mocks are regenerated, using the automated script
